### PR TITLE
feat(auth): implement stub `osc auth login` command

### DIFF
--- a/doc/src/osc.md
+++ b/doc/src/osc.md
@@ -7,6 +7,7 @@ This document contains the help content for the `osc` command-line program.
 * [`osc`↴](#osc)
 * [`osc api`↴](#osc-api)
 * [`osc auth`↴](#osc-auth)
+* [`osc auth login`↴](#osc-auth-login)
 * [`osc auth show`↴](#osc-auth-show)
 * [`osc block-storage`↴](#osc-block-storage)
 * [`osc block-storage volume`↴](#osc-block-storage-volume)
@@ -207,7 +208,18 @@ Cloud Authentication operations
 
 ###### **Subcommands:**
 
+* `login` — Login to the cloud and get a valid authorization token
 * `show` — Show current auth information
+
+
+
+## `osc auth login`
+
+Fetch a new valid authorization token for the cloud.
+
+This command writes token to the stdout
+
+**Usage:** `osc auth login`
 
 
 

--- a/doc/src/osc.md
+++ b/doc/src/osc.md
@@ -219,7 +219,14 @@ Fetch a new valid authorization token for the cloud.
 
 This command writes token to the stdout
 
-**Usage:** `osc auth login`
+**Usage:** `osc auth login [OPTIONS]`
+
+###### **Options:**
+
+* `--renew` — Require token renewal
+
+  Possible values: `true`, `false`
+
 
 
 

--- a/openstack_cli/src/auth/login.rs
+++ b/openstack_cli/src/auth/login.rs
@@ -1,0 +1,53 @@
+//! Perform cloud login
+use anyhow::anyhow;
+use async_trait::async_trait;
+use clap::Args;
+use std::io::{self, Write};
+use tracing::info;
+
+use crate::output::{self, OutputProcessor};
+use crate::Cli;
+use crate::OutputConfig;
+use crate::StructTable;
+use crate::{error::OpenStackCliError, Command};
+use structable_derive::StructTable;
+
+use openstack_sdk::types::identity::v3::AuthResponse;
+use openstack_sdk::AsyncOpenStack;
+
+/// Command arguments
+#[derive(Args, Clone, Debug)]
+pub struct AuthArgs {
+    /// Require token renewal
+    #[arg(long, action=clap::ArgAction::SetTrue)]
+    pub renew: bool,
+}
+
+/// login command
+pub struct AuthCmd {
+    pub args: AuthArgs,
+}
+
+#[async_trait]
+impl Command for AuthCmd {
+    async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        info!("Show auth info");
+
+        let op = OutputProcessor::from_args(parsed_args);
+
+        // TODO(gtema): here would be the Webbrowser based login
+        // implementation
+
+        if let Some(token) = client.get_auth_token() {
+            let mut stdout = io::stdout().lock();
+
+            stdout.write_all(&token.into_bytes())?;
+            return Ok(());
+        }
+        Err(anyhow!("Authorization information missing").into())
+    }
+}

--- a/openstack_cli/src/auth/mod.rs
+++ b/openstack_cli/src/auth/mod.rs
@@ -1,7 +1,8 @@
 //! Authorization operations
 //!
 //!
-mod show;
+pub mod login;
+pub mod show;
 use clap::{Args, Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
@@ -13,24 +14,27 @@ use crate::{Command, ResourceCommands, ServiceCommands};
 pub struct AuthArgs {
     /// Authentication commands
     #[command(subcommand)]
-    command: AuthCommands,
+    pub(crate) command: AuthCommands,
 }
 
 #[derive(Clone, Subcommand)]
 pub enum AuthCommands {
+    /// Fetch a new valid authorization token for the cloud.
+    ///
+    /// This command writes token to the stdout
+    #[command(about = "Login to the cloud and get a valid authorization token")]
+    Login(login::AuthArgs),
     /// Show current authorization information for the cloud
     ///
-    /// This command returns authentication and
-    /// authorization information for the currently
-    /// active connection. It includes issue and
-    /// expiration information, user data, list of
-    /// granted roles and project/domain information.
+    /// This command returns authentication and authorization information for
+    /// the currently active connection. It includes issue and expiration
+    /// information, user data, list of granted roles and project/domain
+    /// information.
     ///
-    /// **NOTE**: The command does not support selecting
-    /// individual fields in the output, but it supports
-    /// `-o json` command and returns full available
-    /// information in json format what allows further
-    /// processing with `jq`
+    /// **NOTE**: The command does not support selecting individual fields in
+    /// the output, but it supports `-o json` command and returns full
+    /// available information in json format what allows further processing
+    /// with `jq`
     #[command(about = "Show current auth information")]
     Show(show::AuthArgs),
 }
@@ -42,6 +46,7 @@ pub struct AuthCommand {
 impl ServiceCommands for AuthCommand {
     fn get_command(&self, session: &mut AsyncOpenStack) -> Box<dyn Command> {
         match &self.args.command {
+            AuthCommands::Login(args) => Box::new(login::AuthCmd { args: args.clone() }),
             AuthCommands::Show(args) => Box::new(show::AuthCmd { args: args.clone() }),
         }
     }

--- a/openstack_sdk/src/state.rs
+++ b/openstack_sdk/src/state.rs
@@ -225,16 +225,24 @@ impl State {
                             trace!("Cached Auth info: {:?}", auth);
                             Some(auth)
                         }
-                        _ => None,
+                        Err(x) => {
+                            warn!(
+                                "Corrupted cache file {}: {:?}. Removing ",
+                                fname.display(),
+                                x
+                            );
+                            let _ = std::fs::remove_file(fname);
+                            None
+                        }
                     },
                     _ => {
-                        warn!("Error reading file {:?}", fname);
+                        warn!("Error reading file {}", fname.display());
                         None
                     }
                 }
             }
             _ => {
-                warn!("Error opening file {:?}", fname);
+                warn!("Error opening file {}", fname.display());
                 None
             }
         }

--- a/openstack_sdk/src/types/identity/v3.rs
+++ b/openstack_sdk/src/types/identity/v3.rs
@@ -42,8 +42,13 @@ pub struct User {
     pub domain: Option<Domain>,
     pub name: String,
     pub id: String,
-    #[serde(deserialize_with = "deser_ok_or_default")]
-    pub password_expires_at: Option<DateTime<Local>>,
+    // Note(gtema): some clouds return empty string instead of null when
+    // password doesnot expire. It is technically possible to use
+    // deserialize_with to capture errors, but that leads bincode to fail
+    // when deserializing. For now just leave it as optional string instead
+    // of DateTime
+    // #[serde(deserialize_with = "deser_ok_or_default")]
+    pub password_expires_at: Option<String>,
 }
 
 /// Authorization project details.


### PR DESCRIPTION
Implement basic `osc auth login` command that ensures there is cloud
connection and writes token to the stdout. It is instended that this
invokes different session creation path in the SDK that allows
interactive mode.
