### PR TITLE
fix: Respect headers passed into the `api` command

### DIFF
--- a/doc/src/osc.md
+++ b/doc/src/osc.md
@@ -427,7 +427,7 @@ Example:
   - `delete`:
     DELETE
 
-* `--header <key=value>` — Additional headers
+* `-H`, `--header <key=value>` — Additional headers
 * `--body <BODY>` — Request body to be used
 
 

--- a/openstack_cli/src/error.rs
+++ b/openstack_cli/src/error.rs
@@ -99,6 +99,22 @@ pub enum OpenStackCliError {
     #[error("Cloud connection for `{0:?}` cannot be found")]
     ConnectionNotFound(String),
 
+    /// Invalid header name
+    #[error("Invalid header name `{}`", source)]
+    InvalidHeaderName {
+        /// The source of the error.
+        #[from]
+        source: http::header::InvalidHeaderName,
+    },
+
+    /// Invalid header value
+    #[error("Invalid header value `{}`", source)]
+    InvalidHeaderValue {
+        /// The source of the error.
+        #[from]
+        source: http::header::InvalidHeaderValue,
+    },
+
     /// Others
     #[error(transparent)]
     Other(#[from] anyhow::Error),


### PR DESCRIPTION
`api` command declared support for additional headers to be sent with
the request, but it actually ignored them. Fix that making it possible
to set microversion header.
Add `-H` alias to the headers making it close to that of `curl`.