### PR TITLE
fix(sdk): flatten _properties of extensible structs

### DIFF
--- a/openstack_cli/src/compute/v2/server/create_237.rs
+++ b/openstack_cli/src/compute/v2/server/create_237.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_242.rs
+++ b/openstack_cli/src/compute/v2/server/create_242.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_252.rs
+++ b/openstack_cli/src/compute/v2/server/create_252.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_257.rs
+++ b/openstack_cli/src/compute/v2/server/create_257.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_263.rs
+++ b/openstack_cli/src/compute/v2/server/create_263.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_267.rs
+++ b/openstack_cli/src/compute/v2/server/create_267.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_274.rs
+++ b/openstack_cli/src/compute/v2/server/create_274.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_290.rs
+++ b/openstack_cli/src/compute/v2/server/create_290.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/compute/v2/server/create_294.rs
+++ b/openstack_cli/src/compute/v2/server/create_294.rs
@@ -113,11 +113,11 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
-    networks: Option<Vec<Value>>,
-
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     auto_networks: bool,
+
+    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    networks: Option<Vec<Value>>,
 
     #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
     none_networks: bool,

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
@@ -91,6 +91,10 @@ struct Domain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct User {
+    /// A `domain` object
+    #[command(flatten)]
+    domain: Option<Domain>,
+
     /// The ID of the user. Required if you do not
     /// specify the user name.
     #[arg(long)]
@@ -105,10 +109,6 @@ struct User {
     /// User Password
     #[arg(long)]
     password: Option<String>,
-
-    /// A `domain` object
-    #[command(flatten)]
-    domain: Option<Domain>,
 }
 
 /// Password Body data
@@ -144,6 +144,9 @@ struct UserDomainStructInput {
 #[derive(Args)]
 #[group(required = true, multiple = true)]
 struct TotpUser {
+    #[command(flatten)]
+    domain: Option<UserDomainStructInput>,
+
     /// The user ID
     #[arg(long)]
     id: Option<String>,
@@ -151,9 +154,6 @@ struct TotpUser {
     /// The user name
     #[arg(long)]
     name: Option<String>,
-
-    #[command(flatten)]
-    domain: Option<UserDomainStructInput>,
 
     /// MFA passcode
     #[arg(long, required = false)]
@@ -172,6 +172,9 @@ struct Totp {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ApplicationCredentialUser {
+    #[command(flatten)]
+    domain: Option<UserDomainStructInput>,
+
     /// The user ID
     #[arg(long)]
     id: Option<String>,
@@ -179,9 +182,6 @@ struct ApplicationCredentialUser {
     /// The user name
     #[arg(long)]
     name: Option<String>,
-
-    #[command(flatten)]
-    domain: Option<UserDomainStructInput>,
 }
 
 /// ApplicationCredential Body data
@@ -208,6 +208,10 @@ struct ApplicationCredential {
 #[derive(Args)]
 #[group(required = true, multiple = true)]
 struct Identity {
+    /// An application credential object.
+    #[command(flatten)]
+    application_credential: Option<ApplicationCredential>,
+
     /// The authentication method. For password
     /// authentication, specify `password`.
     #[arg(action=clap::ArgAction::Append, long, required=false)]
@@ -224,10 +228,6 @@ struct Identity {
     /// Multi Factor Authentication information
     #[command(flatten)]
     totp: Option<Totp>,
-
-    /// An application credential object.
-    #[command(flatten)]
-    application_credential: Option<ApplicationCredential>,
 }
 
 /// ProjectDomain Body data
@@ -247,16 +247,16 @@ struct ProjectDomain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Project {
-    /// Project Name
-    #[arg(long)]
-    name: Option<String>,
+    #[command(flatten)]
+    domain: Option<ProjectDomain>,
 
     /// Project Id
     #[arg(long)]
     id: Option<String>,
 
-    #[command(flatten)]
-    domain: Option<ProjectDomain>,
+    /// Project Name
+    #[arg(long)]
+    name: Option<String>,
 }
 
 /// ScopeDomain Body data
@@ -293,13 +293,13 @@ struct System {
 #[group(required = false, multiple = true)]
 struct Scope {
     #[command(flatten)]
-    project: Option<Project>,
-
-    #[command(flatten)]
     domain: Option<ScopeDomain>,
 
     #[command(flatten)]
     os_trust_trust: Option<OsTrustTrust>,
+
+    #[command(flatten)]
+    project: Option<Project>,
 
     #[command(flatten)]
     system: Option<System>,

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
@@ -91,6 +91,10 @@ struct Domain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct User {
+    /// A `domain` object
+    #[command(flatten)]
+    domain: Option<Domain>,
+
     /// The ID of the user. Required if you do not
     /// specify the user name.
     #[arg(long)]
@@ -105,10 +109,6 @@ struct User {
     /// User Password
     #[arg(long)]
     password: Option<String>,
-
-    /// A `domain` object
-    #[command(flatten)]
-    domain: Option<Domain>,
 }
 
 /// Password Body data
@@ -144,6 +144,9 @@ struct UserDomainStructInput {
 #[derive(Args)]
 #[group(required = true, multiple = true)]
 struct TotpUser {
+    #[command(flatten)]
+    domain: Option<UserDomainStructInput>,
+
     /// The user ID
     #[arg(long)]
     id: Option<String>,
@@ -151,9 +154,6 @@ struct TotpUser {
     /// The user name
     #[arg(long)]
     name: Option<String>,
-
-    #[command(flatten)]
-    domain: Option<UserDomainStructInput>,
 
     /// MFA passcode
     #[arg(long, required = false)]
@@ -172,6 +172,9 @@ struct Totp {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ApplicationCredentialUser {
+    #[command(flatten)]
+    domain: Option<UserDomainStructInput>,
+
     /// The user ID
     #[arg(long)]
     id: Option<String>,
@@ -179,9 +182,6 @@ struct ApplicationCredentialUser {
     /// The user name
     #[arg(long)]
     name: Option<String>,
-
-    #[command(flatten)]
-    domain: Option<UserDomainStructInput>,
 }
 
 /// ApplicationCredential Body data
@@ -208,6 +208,10 @@ struct ApplicationCredential {
 #[derive(Args)]
 #[group(required = true, multiple = true)]
 struct Identity {
+    /// An application credential object.
+    #[command(flatten)]
+    application_credential: Option<ApplicationCredential>,
+
     /// The authentication method. For password
     /// authentication, specify `password`.
     #[arg(action=clap::ArgAction::Append, long, required=false)]
@@ -224,10 +228,6 @@ struct Identity {
     /// Multi Factor Authentication information
     #[command(flatten)]
     totp: Option<Totp>,
-
-    /// An application credential object.
-    #[command(flatten)]
-    application_credential: Option<ApplicationCredential>,
 }
 
 /// ProjectDomain Body data
@@ -247,16 +247,16 @@ struct ProjectDomain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Project {
-    /// Project Name
-    #[arg(long)]
-    name: Option<String>,
+    #[command(flatten)]
+    domain: Option<ProjectDomain>,
 
     /// Project Id
     #[arg(long)]
     id: Option<String>,
 
-    #[command(flatten)]
-    domain: Option<ProjectDomain>,
+    /// Project Name
+    #[arg(long)]
+    name: Option<String>,
 }
 
 /// ScopeDomain Body data
@@ -293,13 +293,13 @@ struct System {
 #[group(required = false, multiple = true)]
 struct Scope {
     #[command(flatten)]
-    project: Option<Project>,
-
-    #[command(flatten)]
     domain: Option<ScopeDomain>,
 
     #[command(flatten)]
     os_trust_trust: Option<OsTrustTrust>,
+
+    #[command(flatten)]
+    project: Option<Project>,
 
     #[command(flatten)]
     system: Option<System>,

--- a/openstack_cli/src/identity/v3/auth/token/create.rs
+++ b/openstack_cli/src/identity/v3/auth/token/create.rs
@@ -99,6 +99,10 @@ struct Domain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct User {
+    /// A `domain` object
+    #[command(flatten)]
+    domain: Option<Domain>,
+
     /// The ID of the user. Required if you do not
     /// specify the user name.
     #[arg(long)]
@@ -113,10 +117,6 @@ struct User {
     /// User Password
     #[arg(long)]
     password: Option<String>,
-
-    /// A `domain` object
-    #[command(flatten)]
-    domain: Option<Domain>,
 }
 
 /// Password Body data
@@ -152,6 +152,9 @@ struct UserDomainStructInput {
 #[derive(Args)]
 #[group(required = true, multiple = true)]
 struct TotpUser {
+    #[command(flatten)]
+    domain: Option<UserDomainStructInput>,
+
     /// The user ID
     #[arg(long)]
     id: Option<String>,
@@ -159,9 +162,6 @@ struct TotpUser {
     /// The user name
     #[arg(long)]
     name: Option<String>,
-
-    #[command(flatten)]
-    domain: Option<UserDomainStructInput>,
 
     /// MFA passcode
     #[arg(long, required = false)]
@@ -180,6 +180,9 @@ struct Totp {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ApplicationCredentialUser {
+    #[command(flatten)]
+    domain: Option<UserDomainStructInput>,
+
     /// The user ID
     #[arg(long)]
     id: Option<String>,
@@ -187,9 +190,6 @@ struct ApplicationCredentialUser {
     /// The user name
     #[arg(long)]
     name: Option<String>,
-
-    #[command(flatten)]
-    domain: Option<UserDomainStructInput>,
 }
 
 /// ApplicationCredential Body data
@@ -216,6 +216,10 @@ struct ApplicationCredential {
 #[derive(Args)]
 #[group(required = true, multiple = true)]
 struct Identity {
+    /// An application credential object.
+    #[command(flatten)]
+    application_credential: Option<ApplicationCredential>,
+
     /// The authentication method. For password
     /// authentication, specify `password`.
     #[arg(action=clap::ArgAction::Append, long, required=false)]
@@ -232,10 +236,6 @@ struct Identity {
     /// Multi Factor Authentication information
     #[command(flatten)]
     totp: Option<Totp>,
-
-    /// An application credential object.
-    #[command(flatten)]
-    application_credential: Option<ApplicationCredential>,
 }
 
 /// ProjectDomain Body data
@@ -255,16 +255,16 @@ struct ProjectDomain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Project {
-    /// Project Name
-    #[arg(long)]
-    name: Option<String>,
+    #[command(flatten)]
+    domain: Option<ProjectDomain>,
 
     /// Project Id
     #[arg(long)]
     id: Option<String>,
 
-    #[command(flatten)]
-    domain: Option<ProjectDomain>,
+    /// Project Name
+    #[arg(long)]
+    name: Option<String>,
 }
 
 /// ScopeDomain Body data
@@ -301,13 +301,13 @@ struct System {
 #[group(required = false, multiple = true)]
 struct Scope {
     #[command(flatten)]
-    project: Option<Project>,
-
-    #[command(flatten)]
     domain: Option<ScopeDomain>,
 
     #[command(flatten)]
     os_trust_trust: Option<OsTrustTrust>,
+
+    #[command(flatten)]
+    project: Option<Project>,
 
     #[command(flatten)]
     system: Option<System>,

--- a/openstack_cli/src/identity/v3/user/create.rs
+++ b/openstack_cli/src/identity/v3/user/create.rs
@@ -74,22 +74,22 @@ struct Options {
     ignore_change_password_upon_first_use: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
+    ignore_lockout_failure_attempts: Option<bool>,
+
+    #[arg(action=clap::ArgAction::Set, long)]
     ignore_password_expiry: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
-    ignore_lockout_failure_attempts: Option<bool>,
+    ignore_user_inactivity: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
     lock_password: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
-    ignore_user_inactivity: Option<bool>,
+    multi_factor_auth_enabled: Option<bool>,
 
     #[arg(action=clap::ArgAction::Append, long)]
     multi_factor_auth_rules: Option<Vec<String>>,
-
-    #[arg(action=clap::ArgAction::Set, long)]
-    multi_factor_auth_enabled: Option<bool>,
 }
 
 /// User Body data

--- a/openstack_cli/src/identity/v3/user/set.rs
+++ b/openstack_cli/src/identity/v3/user/set.rs
@@ -85,22 +85,22 @@ struct Options {
     ignore_change_password_upon_first_use: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
+    ignore_lockout_failure_attempts: Option<bool>,
+
+    #[arg(action=clap::ArgAction::Set, long)]
     ignore_password_expiry: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
-    ignore_lockout_failure_attempts: Option<bool>,
+    ignore_user_inactivity: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
     lock_password: Option<bool>,
 
     #[arg(action=clap::ArgAction::Set, long)]
-    ignore_user_inactivity: Option<bool>,
+    multi_factor_auth_enabled: Option<bool>,
 
     #[arg(action=clap::ArgAction::Append, long)]
     multi_factor_auth_rules: Option<Vec<String>>,
-
-    #[arg(action=clap::ArgAction::Set, long)]
-    multi_factor_auth_enabled: Option<bool>,
 }
 
 /// User Body data

--- a/openstack_cli/src/network/v2/router/create.rs
+++ b/openstack_cli/src/network/v2/router/create.rs
@@ -82,14 +82,14 @@ struct PathParameters {}
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ExternalGatewayInfo {
-    #[arg(long, required = false)]
-    network_id: String,
-
     #[arg(action=clap::ArgAction::Set, long)]
     enable_snat: Option<bool>,
 
     #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
     external_fixed_ips: Option<Vec<Value>>,
+
+    #[arg(long, required = false)]
+    network_id: String,
 }
 
 /// Router Body data

--- a/openstack_cli/src/network/v2/router/set.rs
+++ b/openstack_cli/src/network/v2/router/set.rs
@@ -82,14 +82,14 @@ struct PathParameters {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ExternalGatewayInfo {
-    #[arg(long, required = false)]
-    network_id: String,
-
     #[arg(action=clap::ArgAction::Set, long)]
     enable_snat: Option<bool>,
 
     #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
     external_fixed_ips: Option<Vec<Value>>,
+
+    #[arg(long, required = false)]
+    network_id: String,
 }
 
 /// Router Body data

--- a/openstack_sdk/src/api/block_storage/v3/type/encryption/create.rs
+++ b/openstack_sdk/src/api/block_storage/v3/type/encryption/create.rs
@@ -55,6 +55,7 @@ pub struct Encryption<'a> {
     pub(crate) cipher: Option<Option<Cow<'a, str>>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/block_storage/v3/type/encryption/set.rs
+++ b/openstack_sdk/src/api/block_storage/v3/type/encryption/set.rs
@@ -55,6 +55,7 @@ pub struct Encryption<'a> {
     pub(crate) cipher: Option<Option<Cow<'a, str>>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/create_30.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/create_30.rs
@@ -120,6 +120,7 @@ pub struct Volume<'a> {
     pub(crate) image_ref: Option<Option<Cow<'a, str>>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/create_313.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/create_313.rs
@@ -124,6 +124,7 @@ pub struct Volume<'a> {
     pub(crate) group_id: Option<Option<Cow<'a, str>>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/create_347.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/create_347.rs
@@ -132,6 +132,7 @@ pub struct Volume<'a> {
     pub(crate) backup_id: Option<Option<Cow<'a, str>>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_20.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_20.rs
@@ -675,6 +675,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -773,6 +774,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_21.rs
@@ -651,6 +651,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -749,6 +750,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_219.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_219.rs
@@ -661,6 +661,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -759,6 +760,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_232.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_232.rs
@@ -669,6 +669,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -767,6 +768,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_233.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_233.rs
@@ -665,6 +665,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -763,6 +764,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_237.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_237.rs
@@ -671,6 +671,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -769,6 +770,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_242.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_242.rs
@@ -679,6 +679,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -777,6 +778,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_252.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_252.rs
@@ -696,6 +696,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -794,6 +795,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_257.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_257.rs
@@ -672,6 +672,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -770,6 +771,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_263.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_263.rs
@@ -684,6 +684,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -782,6 +783,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_267.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_267.rs
@@ -688,6 +688,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -786,6 +787,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_274.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_274.rs
@@ -708,6 +708,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -806,6 +807,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_290.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_290.rs
@@ -731,6 +731,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -829,6 +830,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/compute/v2/server/create_294.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_294.rs
@@ -731,6 +731,7 @@ pub struct OsSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 
@@ -829,6 +830,7 @@ pub struct OsSchHntSchedulerHints<'a> {
     pub(crate) cidr: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/identity/v3/project/create.rs
+++ b/openstack_sdk/src/api/identity/v3/project/create.rs
@@ -128,6 +128,7 @@ pub struct Project<'a> {
     pub(crate) options: Option<Options>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/identity/v3/project/set.rs
+++ b/openstack_sdk/src/api/identity/v3/project/set.rs
@@ -95,6 +95,7 @@ pub struct Project<'a> {
     pub(crate) options: Option<Options>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/identity/v3/user/application_credential/create.rs
+++ b/openstack_sdk/src/api/identity/v3/user/application_credential/create.rs
@@ -113,6 +113,7 @@ pub struct ApplicationCredential<'a> {
     pub(crate) access_rules: Option<Vec<AccessRules<'a>>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/identity/v3/user/create.rs
+++ b/openstack_sdk/src/api/identity/v3/user/create.rs
@@ -161,6 +161,7 @@ pub struct User<'a> {
     pub(crate) options: Option<Options<'a>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/api/identity/v3/user/set.rs
+++ b/openstack_sdk/src/api/identity/v3/user/set.rs
@@ -164,6 +164,7 @@ pub struct User<'a> {
     pub(crate) options: Option<Options<'a>>,
 
     #[builder(setter(name = "_properties"), default, private)]
+    #[serde(flatten)]
     _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 

--- a/openstack_sdk/src/auth/v3websso.rs
+++ b/openstack_sdk/src/auth/v3websso.rs
@@ -258,7 +258,7 @@ mod tests {
             .await
             .unwrap();
 
-        let _res = websso_handle.await.unwrap().unwrap();
+        websso_handle.await.unwrap().unwrap();
         assert_eq!(*state.lock().unwrap(), Some(params[0].1.to_string()));
     }
 
@@ -292,7 +292,7 @@ mod tests {
             .await
             .unwrap();
 
-        let _res = websso_handle.await.unwrap().unwrap();
+        websso_handle.await.unwrap().unwrap();
         assert_eq!(*state.lock().unwrap(), None);
     }
 }


### PR DESCRIPTION
when an object is marked in OpenAPI with `additionalAttributes: xxx` we
gather them under the `_properties` attribute. Previously a
`serde(flatten)` macro was missed to serialize them properly.