### PR TITLE
feat: use json style in output for complex fields

### DIFF
--- a/openstack_cli/src/block_storage/v3/type/create.rs
+++ b/openstack_cli/src/block_storage/v3/type/create.rs
@@ -34,10 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val_opt;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::r#type::create;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -83,23 +84,9 @@ struct VolumeType {
     os_volume_type_access_is_public: Option<bool>,
 }
 
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Type response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl TypeCommand {
     /// Perform command action
@@ -144,8 +131,10 @@ impl TypeCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/create.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/create.rs
@@ -34,9 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val_opt;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::r#type::extra_spec::create;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -66,22 +68,9 @@ struct PathParameters {
     #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
     type_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Option<String>>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0.iter().map(|(k, v)| {
-                Vec::from([k.clone(), v.clone().unwrap_or("".to_string()).to_string()])
-            }),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpec response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecCommand {
     /// Perform command action
@@ -110,8 +99,10 @@ impl ExtraSpecCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/list.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/list.rs
@@ -33,9 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::r#type::extra_spec::list;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Returns the list of extra specs for a given volume type.
 ///
@@ -62,22 +64,9 @@ struct PathParameters {
     #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
     type_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Option<String>>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0.iter().map(|(k, v)| {
-                Vec::from([k.clone(), v.clone().unwrap_or("".to_string()).to_string()])
-            }),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpecs response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecsCommand {
     /// Perform command action
@@ -102,8 +91,10 @@ impl ExtraSpecsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/set.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/set.rs
@@ -34,9 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val_opt;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::r#type::extra_spec::set;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -71,22 +73,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Option<String>>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0.iter().map(|(k, v)| {
-                Vec::from([k.clone(), v.clone().unwrap_or("".to_string()).to_string()])
-            }),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpec response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecCommand {
     /// Perform command action
@@ -119,8 +108,10 @@ impl ExtraSpecCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/show.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/show.rs
@@ -33,9 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::r#type::extra_spec::get;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Return a single extra spec item.
 ///
@@ -67,22 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Option<String>>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0.iter().map(|(k, v)| {
-                Vec::from([k.clone(), v.clone().unwrap_or("".to_string()).to_string()])
-            }),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpec response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecCommand {
     /// Perform command action
@@ -108,8 +97,10 @@ impl ExtraSpecCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/type/list.rs
+++ b/openstack_cli/src/block_storage/v3/type/list.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::block_storage::v3::r#type::list;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Returns the list of volume types.
@@ -74,8 +73,8 @@ struct ResponseData {
     /// use.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    extra_specs: Option<HashMapStringOptionString>,
+    #[structable(optional, pretty, wide)]
+    extra_specs: Option<Value>,
 
     /// The UUID of the volume type.
     ///
@@ -106,22 +105,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     qos_specs_id: Option<String>,
-}
-/// HashMap of `Option<String>` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringOptionString(HashMap<String, Option<String>>);
-impl fmt::Display for HashMapStringOptionString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1.clone().unwrap_or("".to_string())))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl TypesCommand {

--- a/openstack_cli/src/block_storage/v3/type/set.rs
+++ b/openstack_cli/src/block_storage/v3/type/set.rs
@@ -37,8 +37,7 @@ use openstack_sdk::api::block_storage::v3::r#type::find;
 use openstack_sdk::api::block_storage::v3::r#type::set;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
@@ -97,8 +96,8 @@ struct ResponseData {
     /// use.
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_specs: Option<HashMapStringOptionString>,
+    #[structable(optional, pretty)]
+    extra_specs: Option<Value>,
 
     /// The UUID of the volume type.
     ///
@@ -129,22 +128,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     qos_specs_id: Option<String>,
-}
-/// HashMap of `Option<String>` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringOptionString(HashMap<String, Option<String>>);
-impl fmt::Display for HashMapStringOptionString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1.clone().unwrap_or("".to_string())))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl TypeCommand {

--- a/openstack_cli/src/block_storage/v3/type/show.rs
+++ b/openstack_cli/src/block_storage/v3/type/show.rs
@@ -36,8 +36,7 @@ use crate::StructTable;
 use openstack_sdk::api::block_storage::v3::r#type::find;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Return a single volume type item.
@@ -80,8 +79,8 @@ struct ResponseData {
     /// use.
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_specs: Option<HashMapStringOptionString>,
+    #[structable(optional, pretty)]
+    extra_specs: Option<Value>,
 
     /// The UUID of the volume type.
     ///
@@ -112,22 +111,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     qos_specs_id: Option<String>,
-}
-/// HashMap of `Option<String>` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringOptionString(HashMap<String, Option<String>>);
-impl fmt::Display for HashMapStringOptionString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1.clone().unwrap_or("".to_string())))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl TypeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/create_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_30.rs
@@ -37,8 +37,6 @@ use crate::common::parse_key_val;
 use openstack_sdk::api::block_storage::v3::volume::create_30;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a new volume.
@@ -176,8 +174,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -376,22 +374,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/create_313.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_313.rs
@@ -37,8 +37,6 @@ use crate::common::parse_key_val;
 use openstack_sdk::api::block_storage::v3::volume::create_313;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a new volume.
@@ -179,8 +177,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -379,22 +377,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/create_347.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_347.rs
@@ -37,8 +37,6 @@ use crate::common::parse_key_val;
 use openstack_sdk::api::block_storage::v3::volume::create_347;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a new volume.
@@ -186,8 +184,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -386,22 +384,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/create_353.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_353.rs
@@ -37,8 +37,6 @@ use crate::common::parse_key_val;
 use openstack_sdk::api::block_storage::v3::volume::create_353;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a new volume.
@@ -186,8 +184,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -386,22 +384,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/encryption/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/encryption/list.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::volume::encryption::list;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Returns the encryption metadata for a given volume.
 ///
@@ -63,23 +64,9 @@ struct PathParameters {
     #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
     volume_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Encryptions response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl EncryptionsCommand {
     /// Perform command action
@@ -104,8 +91,10 @@ impl EncryptionsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/volume/encryption/show.rs
+++ b/openstack_cli/src/block_storage/v3/volume/encryption/show.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::volume::encryption::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Return a single encryption item.
 ///
@@ -68,23 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Encryption response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl EncryptionCommand {
     /// Perform command action
@@ -110,8 +97,10 @@ impl EncryptionCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/volume/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/list.rs
@@ -37,8 +37,6 @@ use openstack_sdk::api::block_storage::v3::volume::list_detailed;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Returns a detailed list of volumes.
@@ -164,8 +162,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty, wide)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -366,22 +364,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumesCommand {

--- a/openstack_cli/src/block_storage/v3/volume/metadata/create.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/create.rs
@@ -34,9 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::volume::metadata::create;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -66,22 +68,9 @@ struct PathParameters {
     #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
     volume_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadata response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadataCommand {
     /// Perform command action
@@ -110,8 +99,10 @@ impl MetadataCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/volume/metadata/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/list.rs
@@ -33,9 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::volume::metadata::list;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Returns the list of metadata for a given volume.
 ///
@@ -62,22 +64,9 @@ struct PathParameters {
     #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
     volume_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadatas response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadatasCommand {
     /// Perform command action
@@ -102,8 +91,10 @@ impl MetadatasCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/volume/metadata/replace.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/replace.rs
@@ -34,9 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::volume::metadata::replace;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -66,22 +68,9 @@ struct PathParameters {
     #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
     volume_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadata response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadataCommand {
     /// Perform command action
@@ -110,8 +99,10 @@ impl MetadataCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/volume/metadata/show.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/show.rs
@@ -33,9 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::volume::metadata::get;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Return a single metadata item.
 ///
@@ -67,22 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadata response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadataCommand {
     /// Perform command action
@@ -108,8 +97,10 @@ impl MetadataCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/block_storage/v3/volume/set_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/set_30.rs
@@ -39,8 +39,6 @@ use openstack_sdk::api::block_storage::v3::volume::set_30;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Update a volume.
@@ -115,8 +113,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -315,22 +313,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/set_353.rs
+++ b/openstack_cli/src/block_storage/v3/volume/set_353.rs
@@ -39,8 +39,6 @@ use openstack_sdk::api::block_storage::v3::volume::set_353;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Update a volume.
@@ -115,8 +113,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -315,22 +313,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/show.rs
+++ b/openstack_cli/src/block_storage/v3/volume/show.rs
@@ -37,8 +37,6 @@ use openstack_sdk::api::block_storage::v3::volume::find;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Return data about the given volume.
@@ -91,8 +89,8 @@ struct ResponseData {
     /// that are associated with the volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// To create a volume from an existing snapshot, specify the UUID of the
     /// volume snapshot. The volume is created in same availability zone and
@@ -291,22 +289,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     consumes_quota: Option<bool>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/summary/get.rs
+++ b/openstack_cli/src/block_storage/v3/volume/summary/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::block_storage::v3::volume::summary::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Return summary of volumes.
 ///
@@ -58,23 +59,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {}
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Summary response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl SummaryCommand {
     /// Perform command action
@@ -98,8 +85,10 @@ impl SummaryCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/aggregate/add_host.rs
+++ b/openstack_cli/src/compute/v2/aggregate/add_host.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::add_host;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
@@ -132,14 +131,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -165,38 +164,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/create_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_20.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::create_20;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Creates an aggregate. If specifying an option availability_zone, the
@@ -145,14 +144,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -178,38 +177,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/create_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_21.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::create_21;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Creates an aggregate. If specifying an option availability_zone, the
@@ -145,14 +144,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -178,38 +177,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/list.rs
+++ b/openstack_cli/src/compute/v2/aggregate/list.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::list;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Lists all aggregates. Includes the ID, name, and availability zone for each
@@ -123,14 +122,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty, wide)]
+    metadata: Option<Value>,
 
     /// A list of host ids in this aggregate.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -156,38 +155,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregatesCommand {

--- a/openstack_cli/src/compute/v2/aggregate/remove_host.rs
+++ b/openstack_cli/src/compute/v2/aggregate/remove_host.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::remove_host;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
@@ -132,14 +131,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -165,38 +164,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/set_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_20.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::set_20;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Updates either or both the name and availability zone for an aggregate. If
@@ -156,14 +155,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -189,38 +188,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/set_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_21.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::set_21;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Updates either or both the name and availability zone for an aggregate. If
@@ -156,14 +155,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -189,38 +188,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/set_metadata.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_metadata.rs
@@ -36,8 +36,7 @@ use crate::StructTable;
 use crate::common::parse_key_val_opt;
 use openstack_sdk::api::compute::v2::aggregate::set_metadata;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
@@ -133,14 +132,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -166,38 +165,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/show.rs
+++ b/openstack_cli/src/compute/v2/aggregate/show.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::get;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Shows details for an aggregate. Details include hosts and metadata.
@@ -127,14 +126,14 @@ struct ResponseData {
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// An array of host information.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<VecString>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -160,38 +159,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uuid: Option<String>,
-}
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/availability_zone/get.rs
+++ b/openstack_cli/src/compute/v2/availability_zone/get.rs
@@ -76,8 +76,8 @@ struct ResponseData {
     /// The current state of the availability zone.
     ///
     #[serde(rename = "zoneState")]
-    #[structable(optional, title = "zoneState")]
-    zone_state: Option<ResponseZoneState>,
+    #[structable(optional, pretty, title = "zoneState")]
+    zone_state: Option<Value>,
 
     /// It is always `null`.
     ///

--- a/openstack_cli/src/compute/v2/availability_zone/list.rs
+++ b/openstack_cli/src/compute/v2/availability_zone/list.rs
@@ -36,7 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::compute::v2::availability_zone::list_detailed;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -79,8 +78,8 @@ struct ResponseData {
     /// The current state of the availability zone.
     ///
     #[serde(rename = "zoneState")]
-    #[structable(optional, title = "zoneState", wide)]
-    zone_state: Option<ResponseZoneState>,
+    #[structable(optional, pretty, title = "zoneState", wide)]
+    zone_state: Option<Value>,
 
     /// An object containing a list of host information. The host information
     /// is comprised of host and service objects. The service object returns
@@ -88,8 +87,8 @@ struct ResponseData {
     /// `available`, and `updated_at`.
     ///
     #[serde()]
-    #[structable(optional)]
-    hosts: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    hosts: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -106,22 +105,6 @@ impl fmt::Display for ResponseZoneState {
                 .unwrap_or("".to_string())
         )]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/flavor/create_20.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_20.rs
@@ -38,8 +38,6 @@ use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::create_20;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a flavor.
@@ -211,8 +209,8 @@ struct ResponseData {
     /// **New in version 2.61**
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_specs: Option<HashMapStringNumString>,
+    #[structable(optional, pretty)]
+    extra_specs: Option<Value>,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
@@ -221,22 +219,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     links: Option<Value>,
-}
-/// HashMap of `NumString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringNumString(HashMap<String, NumString>);
-impl fmt::Display for HashMapStringNumString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/create_21.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_21.rs
@@ -38,8 +38,6 @@ use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::create_21;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a flavor.
@@ -211,8 +209,8 @@ struct ResponseData {
     /// **New in version 2.61**
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_specs: Option<HashMapStringNumString>,
+    #[structable(optional, pretty)]
+    extra_specs: Option<Value>,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
@@ -221,22 +219,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     links: Option<Value>,
-}
-/// HashMap of `NumString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringNumString(HashMap<String, NumString>);
-impl fmt::Display for HashMapStringNumString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/create_255.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_255.rs
@@ -38,8 +38,6 @@ use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::create_255;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a flavor.
@@ -219,8 +217,8 @@ struct ResponseData {
     /// **New in version 2.61**
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_specs: Option<HashMapStringNumString>,
+    #[structable(optional, pretty)]
+    extra_specs: Option<Value>,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
@@ -229,22 +227,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     links: Option<Value>,
-}
-/// HashMap of `NumString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringNumString(HashMap<String, NumString>);
-impl fmt::Display for HashMapStringNumString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/create.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/create.rs
@@ -34,10 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
-use crate::common::NumString;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::flavor::extra_spec::create;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Creates extra specs for a flavor, by ID.
 ///
@@ -73,22 +74,9 @@ struct PathParameters {
     #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
     flavor_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, NumString>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.to_string()])),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpec response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecCommand {
     /// Perform command action
@@ -117,8 +105,10 @@ impl ExtraSpecCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/list.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::NumString;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::flavor::extra_spec::list;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Lists all extra specs for a flavor, by ID.
 ///
@@ -68,22 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
     flavor_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, NumString>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.to_string()])),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpecs response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecsCommand {
     /// Perform command action
@@ -108,8 +96,10 @@ impl ExtraSpecsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/set.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/set.rs
@@ -34,10 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
-use crate::common::NumString;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::flavor::extra_spec::set;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Updates an extra spec, by key, for a flavor, by ID.
 ///
@@ -78,22 +79,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, NumString>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.to_string()])),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpec response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecCommand {
     /// Perform command action
@@ -122,8 +110,10 @@ impl ExtraSpecCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/show.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/show.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::NumString;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::flavor::extra_spec::get;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Shows an extra spec, by key, for a flavor, by ID.
 ///
@@ -73,22 +74,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, NumString>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.to_string()])),
-        );
-        (headers, rows)
-    }
-}
+/// ExtraSpec response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ExtraSpecCommand {
     /// Perform command action
@@ -114,8 +102,10 @@ impl ExtraSpecCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/flavor/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/list.rs
@@ -39,8 +39,6 @@ use openstack_sdk::api::compute::v2::flavor::list_detailed;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Lists flavors with details.
@@ -173,8 +171,8 @@ struct ResponseData {
     /// **New in version 2.61**
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    extra_specs: Option<HashMapStringNumString>,
+    #[structable(optional, pretty, wide)]
+    extra_specs: Option<Value>,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
@@ -183,22 +181,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     links: Option<Value>,
-}
-/// HashMap of `NumString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringNumString(HashMap<String, NumString>);
-impl fmt::Display for HashMapStringNumString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl FlavorsCommand {

--- a/openstack_cli/src/compute/v2/flavor/set.rs
+++ b/openstack_cli/src/compute/v2/flavor/set.rs
@@ -40,8 +40,6 @@ use openstack_sdk::api::compute::v2::flavor::set;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Updates a flavor description.
@@ -174,8 +172,8 @@ struct ResponseData {
     /// **New in version 2.61**
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_specs: Option<HashMapStringNumString>,
+    #[structable(optional, pretty)]
+    extra_specs: Option<Value>,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
@@ -184,22 +182,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     links: Option<Value>,
-}
-/// HashMap of `NumString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringNumString(HashMap<String, NumString>);
-impl fmt::Display for HashMapStringNumString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/show.rs
+++ b/openstack_cli/src/compute/v2/flavor/show.rs
@@ -39,8 +39,6 @@ use openstack_sdk::api::compute::v2::flavor::find;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows details for a flavor.
@@ -153,8 +151,8 @@ struct ResponseData {
     /// **New in version 2.61**
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_specs: Option<HashMapStringNumString>,
+    #[structable(optional, pretty)]
+    extra_specs: Option<Value>,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
@@ -163,22 +161,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     links: Option<Value>,
-}
-/// HashMap of `NumString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringNumString(HashMap<String, NumString>);
-impl fmt::Display for HashMapStringNumString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/hypervisor/list.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/list.rs
@@ -38,7 +38,6 @@ use openstack_sdk::api::compute::v2::hypervisor::list_detailed;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -102,8 +101,8 @@ struct ResponseData {
     /// **Available until version 2.87**
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    cpu_info: Option<HashMapStringValue>,
+    #[structable(optional, pretty, wide)]
+    cpu_info: Option<Value>,
 
     /// The current_workload is the number of tasks the hypervisor is
     /// responsible for. This will be equal or greater than the number of
@@ -218,8 +217,8 @@ struct ResponseData {
     /// The hypervisor service object.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    service: Option<ResponseService>,
+    #[structable(optional, pretty, wide)]
+    service: Option<Value>,
 
     /// The total uptime of the hypervisor and information about average load.
     /// Only reported for active hosts where the virt driver supports this
@@ -276,22 +275,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     servers: Option<Value>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/compute/v2/hypervisor/search/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/search/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::hypervisor::search::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Search hypervisor by a given hypervisor host name or portion of it.
 ///
@@ -72,23 +73,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Search response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl SearchCommand {
     /// Perform command action
@@ -113,8 +100,10 @@ impl SearchCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/hypervisor/server/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/server/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::hypervisor::server::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// List all servers belong to each hypervisor whose host name is matching a
 /// given hypervisor host name or portion of it.
@@ -73,23 +74,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Server response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ServerCommand {
     /// Perform command action
@@ -114,8 +101,10 @@ impl ServerCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/hypervisor/show.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/show.rs
@@ -37,7 +37,6 @@ use crate::common::IntString;
 use openstack_sdk::api::compute::v2::hypervisor::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -94,8 +93,8 @@ struct ResponseData {
     /// **Available until version 2.87**
     ///
     #[serde()]
-    #[structable(optional)]
-    cpu_info: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    cpu_info: Option<Value>,
 
     /// The current_workload is the number of tasks the hypervisor is
     /// responsible for. This will be equal or greater than the number of
@@ -210,8 +209,8 @@ struct ResponseData {
     /// The hypervisor service object.
     ///
     #[serde()]
-    #[structable(optional)]
-    service: Option<ResponseService>,
+    #[structable(optional, pretty)]
+    service: Option<Value>,
 
     /// The total uptime of the hypervisor and information about average load.
     /// Only reported for active hosts where the virt driver supports this
@@ -268,22 +267,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     servers: Option<Value>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/compute/v2/hypervisor/statistic/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/statistic/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::hypervisor::statistic::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Shows summary statistics for all enabled hypervisors over all compute
 /// nodes.
@@ -68,23 +69,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {}
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Statistic response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl StatisticCommand {
     /// Perform command action
@@ -108,8 +95,10 @@ impl StatisticCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/hypervisor/uptime/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/uptime/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::hypervisor::uptime::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Shows the uptime for a given hypervisor.
 ///
@@ -73,23 +74,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Uptime response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl UptimeCommand {
     /// Perform command action
@@ -114,8 +101,10 @@ impl UptimeCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/server/create_237.rs
+++ b/openstack_cli/src/compute/v2/server/create_237.rs
@@ -508,14 +508,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_237::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_237::NetworksEnum::F2(
-                create_237::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_237::NetworksEnum::F2(
                 create_237::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_237::NetworksEnum::F2(
+                create_237::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_242.rs
+++ b/openstack_cli/src/compute/v2/server/create_242.rs
@@ -508,14 +508,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_242::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_242::NetworksEnum::F2(
-                create_242::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_242::NetworksEnum::F2(
                 create_242::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_242::NetworksEnum::F2(
+                create_242::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_252.rs
+++ b/openstack_cli/src/compute/v2/server/create_252.rs
@@ -523,14 +523,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_252::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_252::NetworksEnum::F2(
-                create_252::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_252::NetworksEnum::F2(
                 create_252::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_252::NetworksEnum::F2(
+                create_252::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_257.rs
+++ b/openstack_cli/src/compute/v2/server/create_257.rs
@@ -513,14 +513,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_257::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_257::NetworksEnum::F2(
-                create_257::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_257::NetworksEnum::F2(
                 create_257::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_257::NetworksEnum::F2(
+                create_257::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_263.rs
+++ b/openstack_cli/src/compute/v2/server/create_263.rs
@@ -524,14 +524,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_263::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_263::NetworksEnum::F2(
-                create_263::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_263::NetworksEnum::F2(
                 create_263::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_263::NetworksEnum::F2(
+                create_263::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_267.rs
+++ b/openstack_cli/src/compute/v2/server/create_267.rs
@@ -524,14 +524,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_267::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_267::NetworksEnum::F2(
-                create_267::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_267::NetworksEnum::F2(
                 create_267::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_267::NetworksEnum::F2(
+                create_267::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_274.rs
+++ b/openstack_cli/src/compute/v2/server/create_274.rs
@@ -542,14 +542,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_274::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_274::NetworksEnum::F2(
-                create_274::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_274::NetworksEnum::F2(
                 create_274::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_274::NetworksEnum::F2(
+                create_274::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_290.rs
+++ b/openstack_cli/src/compute/v2/server/create_290.rs
@@ -558,14 +558,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_290::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_290::NetworksEnum::F2(
-                create_290::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_290::NetworksEnum::F2(
                 create_290::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_290::NetworksEnum::F2(
+                create_290::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_294.rs
+++ b/openstack_cli/src/compute/v2/server/create_294.rs
@@ -558,14 +558,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_294::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.none_networks {
-            server_builder.networks(create_294::NetworksEnum::F2(
-                create_294::NetworksStringEnum::None,
-            ));
-        }
         if args.networks.auto_networks {
             server_builder.networks(create_294::NetworksEnum::F2(
                 create_294::NetworksStringEnum::Auto,
+            ));
+        }
+        if args.networks.none_networks {
+            server_builder.networks(create_294::NetworksEnum::F2(
+                create_294::NetworksStringEnum::None,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/diagnostic/get.rs
+++ b/openstack_cli/src/compute/v2/server/diagnostic/get.rs
@@ -36,8 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::compute::v2::server::diagnostic::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows basic usage data for a server.
@@ -87,8 +85,8 @@ struct ResponseData {
     /// **New in version 2.48**
     ///
     #[serde()]
-    #[structable(optional)]
-    cpu_details: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty)]
+    cpu_details: Option<Value>,
 
     /// The list of dictionaries with detailed information about VM disks.
     /// Following fields are presented in each dictionary:
@@ -102,8 +100,8 @@ struct ResponseData {
     /// **New in version 2.48**
     ///
     #[serde()]
-    #[structable(optional)]
-    disk_details: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty)]
+    disk_details: Option<Value>,
 
     /// The driver on which the VM is running. Possible values are:
     ///
@@ -160,8 +158,8 @@ struct ResponseData {
     /// **New in version 2.48**
     ///
     #[serde()]
-    #[structable(optional)]
-    memory_details: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty)]
+    memory_details: Option<Value>,
 
     /// Name
     ///
@@ -237,38 +235,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     uptime: Option<i32>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl DiagnosticCommand {

--- a/openstack_cli/src/compute/v2/server/list.rs
+++ b/openstack_cli/src/compute/v2/server/list.rs
@@ -37,7 +37,6 @@ use openstack_sdk::api::compute::v2::server::list_detailed;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -271,14 +270,14 @@ struct ResponseData {
     /// addresses information.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    addresses: Option<HashMapStringValue>,
+    #[structable(optional, pretty, wide)]
+    addresses: Option<Value>,
 
     /// The attached volumes, if any.
     ///
     #[serde(rename = "os-extended-volumes:volumes_attached")]
-    #[structable(optional, title = "os-extended-volumes:volumes_attached", wide)]
-    os_extended_volumes_volumes_attached: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, title = "os-extended-volumes:volumes_attached", wide)]
+    os_extended_volumes_volumes_attached: Option<Value>,
 
     /// The availability zone name.
     ///
@@ -342,8 +341,8 @@ struct ResponseData {
     /// `DELETED` and a fault occurred.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    fault: Option<ResponseFault>,
+    #[structable(optional, pretty, wide)]
+    fault: Option<Value>,
 
     /// Before microversion 2.47 this contains the ID and links for the flavor
     /// used to boot the server instance. This can be an empty object in case
@@ -354,8 +353,8 @@ struct ResponseData {
     /// dictionary.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    flavor: Option<ResponseFlavor>,
+    #[structable(optional, pretty, wide)]
+    flavor: Option<Value>,
 
     /// An ID string representing the host. This is a hashed value so will not
     /// actually look like a hostname, and is hashed with data from the
@@ -421,8 +420,8 @@ struct ResponseData {
     /// object will be an empty string when you boot the server from a volume.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    image: Option<ResponseImage>,
+    #[structable(optional, pretty, wide)]
+    image: Option<Value>,
 
     /// The instance name. The Compute API generates the instance name from the
     /// instance name template. Appears in the response for administrative
@@ -497,8 +496,8 @@ struct ResponseData {
     /// backward compatibility.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty, wide)]
+    metadata: Option<Value>,
 
     /// The server name.
     ///
@@ -576,8 +575,8 @@ struct ResponseData {
     /// this can contain at most one entry.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    server_groups: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    server_groups: Option<Value>,
 
     /// The server status.
     ///
@@ -590,8 +589,8 @@ struct ResponseData {
     /// **New in version 2.26**
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// The task state of the instance.
     ///
@@ -626,7 +625,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    trusted_image_certificates: Option<VecString>,
+    trusted_image_certificates: Option<Value>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
@@ -664,38 +663,6 @@ struct ResponseData {
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     os_ext_sts_vm_state: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -738,22 +705,6 @@ impl fmt::Display for ResponseFault {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseFlavor {
@@ -765,7 +716,7 @@ struct ResponseFlavor {
     ephemeral: Option<i32>,
     swap: Option<i32>,
     original_name: Option<String>,
-    extra_specs: Option<HashMapStringString>,
+    extra_specs: Option<Value>,
 }
 
 impl fmt::Display for ResponseFlavor {
@@ -851,22 +802,6 @@ impl fmt::Display for ResponseImage {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/server/metadata/create.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/create.rs
@@ -34,9 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::server::metadata::create;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Create or update one or more metadata items for a server.
 ///
@@ -80,22 +82,9 @@ struct PathParameters {
     #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
     server_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadata response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadataCommand {
     /// Perform command action
@@ -124,8 +113,10 @@ impl MetadataCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/server/metadata/list.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/list.rs
@@ -33,9 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::server::metadata::list;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Lists all metadata for a server.
 ///
@@ -71,22 +73,9 @@ struct PathParameters {
     #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
     server_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadatas response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadatasCommand {
     /// Perform command action
@@ -111,8 +100,10 @@ impl MetadatasCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/server/metadata/replace.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/replace.rs
@@ -34,9 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::server::metadata::replace;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Replaces one or more metadata items for a server.
 ///
@@ -80,22 +82,9 @@ struct PathParameters {
     #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
     server_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadata response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadataCommand {
     /// Perform command action
@@ -124,8 +113,10 @@ impl MetadataCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/server/metadata/set.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/set.rs
@@ -34,10 +34,11 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::server::metadata::set;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Creates or replaces a metadata item, by key, for a server.
 ///
@@ -86,23 +87,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Metadata response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadataCommand {
     /// Perform command action
@@ -132,8 +119,10 @@ impl MetadataCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/server/metadata/show.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/show.rs
@@ -33,9 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::compute::v2::server::metadata::get;
-use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Shows details for a metadata item, by key, for a server.
 ///
@@ -76,22 +78,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, String>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(
-            self.0
-                .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
-        );
-        (headers, rows)
-    }
-}
+/// Metadata response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl MetadataCommand {
     /// Perform command action
@@ -117,8 +106,10 @@ impl MetadataCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/compute/v2/server/set_20.rs
+++ b/openstack_cli/src/compute/v2/server/set_20.rs
@@ -39,7 +39,6 @@ use openstack_sdk::api::compute::v2::server::set_20;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -144,16 +143,16 @@ struct ResponseData {
     /// addresses information.
     ///
     #[serde()]
-    #[structable(optional)]
-    addresses: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    addresses: Option<Value>,
 
     /// The attached volumes, if any.
     ///
     /// **New in version 2.75**
     ///
     #[serde(rename = "os-extended-volumes:volumes_attached")]
-    #[structable(optional, title = "os-extended-volumes:volumes_attached")]
-    os_extended_volumes_volumes_attached: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, title = "os-extended-volumes:volumes_attached")]
+    os_extended_volumes_volumes_attached: Option<Value>,
 
     /// The availability zone name.
     ///
@@ -223,8 +222,8 @@ struct ResponseData {
     /// `DELETED` and a fault occurred.
     ///
     #[serde()]
-    #[structable(optional)]
-    fault: Option<ResponseFault>,
+    #[structable(optional, pretty)]
+    fault: Option<Value>,
 
     /// Before microversion 2.47 this contains the ID and links for the flavor
     /// used to boot the server instance. This can be an empty object in case
@@ -235,8 +234,8 @@ struct ResponseData {
     /// dictionary.
     ///
     #[serde()]
-    #[structable(optional)]
-    flavor: Option<ResponseFlavor>,
+    #[structable(optional, pretty)]
+    flavor: Option<Value>,
 
     /// An ID string representing the host. This is a hashed value so will not
     /// actually look like a hostname, and is hashed with data from the
@@ -304,8 +303,8 @@ struct ResponseData {
     /// object will be an empty string when you boot the server from a volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    image: Option<ResponseImage>,
+    #[structable(optional, pretty)]
+    image: Option<Value>,
 
     /// The instance name. The Compute API generates the instance name from the
     /// instance name template. Appears in the response for administrative
@@ -386,8 +385,8 @@ struct ResponseData {
     /// backward compatibility.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// The server name.
     ///
@@ -471,8 +470,8 @@ struct ResponseData {
     /// **New in version 2.71**
     ///
     #[serde()]
-    #[structable(optional)]
-    server_groups: Option<VecString>,
+    #[structable(optional, pretty)]
+    server_groups: Option<Value>,
 
     /// The server status.
     ///
@@ -485,8 +484,8 @@ struct ResponseData {
     /// **New in version 2.26**
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The task state of the instance.
     ///
@@ -525,7 +524,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    trusted_image_certificates: Option<VecString>,
+    trusted_image_certificates: Option<Value>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
@@ -565,38 +564,6 @@ struct ResponseData {
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state")]
     os_ext_sts_vm_state: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -639,22 +606,6 @@ impl fmt::Display for ResponseFault {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseFlavor {
@@ -666,7 +617,7 @@ struct ResponseFlavor {
     ephemeral: Option<i32>,
     swap: Option<i32>,
     original_name: Option<String>,
-    extra_specs: Option<HashMapStringString>,
+    extra_specs: Option<Value>,
 }
 
 impl fmt::Display for ResponseFlavor {
@@ -752,22 +703,6 @@ impl fmt::Display for ResponseImage {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/server/set_21.rs
+++ b/openstack_cli/src/compute/v2/server/set_21.rs
@@ -39,7 +39,6 @@ use openstack_sdk::api::compute::v2::server::set_21;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -144,16 +143,16 @@ struct ResponseData {
     /// addresses information.
     ///
     #[serde()]
-    #[structable(optional)]
-    addresses: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    addresses: Option<Value>,
 
     /// The attached volumes, if any.
     ///
     /// **New in version 2.75**
     ///
     #[serde(rename = "os-extended-volumes:volumes_attached")]
-    #[structable(optional, title = "os-extended-volumes:volumes_attached")]
-    os_extended_volumes_volumes_attached: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, title = "os-extended-volumes:volumes_attached")]
+    os_extended_volumes_volumes_attached: Option<Value>,
 
     /// The availability zone name.
     ///
@@ -223,8 +222,8 @@ struct ResponseData {
     /// `DELETED` and a fault occurred.
     ///
     #[serde()]
-    #[structable(optional)]
-    fault: Option<ResponseFault>,
+    #[structable(optional, pretty)]
+    fault: Option<Value>,
 
     /// Before microversion 2.47 this contains the ID and links for the flavor
     /// used to boot the server instance. This can be an empty object in case
@@ -235,8 +234,8 @@ struct ResponseData {
     /// dictionary.
     ///
     #[serde()]
-    #[structable(optional)]
-    flavor: Option<ResponseFlavor>,
+    #[structable(optional, pretty)]
+    flavor: Option<Value>,
 
     /// An ID string representing the host. This is a hashed value so will not
     /// actually look like a hostname, and is hashed with data from the
@@ -304,8 +303,8 @@ struct ResponseData {
     /// object will be an empty string when you boot the server from a volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    image: Option<ResponseImage>,
+    #[structable(optional, pretty)]
+    image: Option<Value>,
 
     /// The instance name. The Compute API generates the instance name from the
     /// instance name template. Appears in the response for administrative
@@ -386,8 +385,8 @@ struct ResponseData {
     /// backward compatibility.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// The server name.
     ///
@@ -471,8 +470,8 @@ struct ResponseData {
     /// **New in version 2.71**
     ///
     #[serde()]
-    #[structable(optional)]
-    server_groups: Option<VecString>,
+    #[structable(optional, pretty)]
+    server_groups: Option<Value>,
 
     /// The server status.
     ///
@@ -485,8 +484,8 @@ struct ResponseData {
     /// **New in version 2.26**
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The task state of the instance.
     ///
@@ -525,7 +524,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    trusted_image_certificates: Option<VecString>,
+    trusted_image_certificates: Option<Value>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
@@ -565,38 +564,6 @@ struct ResponseData {
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state")]
     os_ext_sts_vm_state: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -639,22 +606,6 @@ impl fmt::Display for ResponseFault {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseFlavor {
@@ -666,7 +617,7 @@ struct ResponseFlavor {
     ephemeral: Option<i32>,
     swap: Option<i32>,
     original_name: Option<String>,
-    extra_specs: Option<HashMapStringString>,
+    extra_specs: Option<Value>,
 }
 
 impl fmt::Display for ResponseFlavor {
@@ -752,22 +703,6 @@ impl fmt::Display for ResponseImage {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/server/set_219.rs
+++ b/openstack_cli/src/compute/v2/server/set_219.rs
@@ -39,7 +39,6 @@ use openstack_sdk::api::compute::v2::server::set_219;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -152,16 +151,16 @@ struct ResponseData {
     /// addresses information.
     ///
     #[serde()]
-    #[structable(optional)]
-    addresses: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    addresses: Option<Value>,
 
     /// The attached volumes, if any.
     ///
     /// **New in version 2.75**
     ///
     #[serde(rename = "os-extended-volumes:volumes_attached")]
-    #[structable(optional, title = "os-extended-volumes:volumes_attached")]
-    os_extended_volumes_volumes_attached: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, title = "os-extended-volumes:volumes_attached")]
+    os_extended_volumes_volumes_attached: Option<Value>,
 
     /// The availability zone name.
     ///
@@ -231,8 +230,8 @@ struct ResponseData {
     /// `DELETED` and a fault occurred.
     ///
     #[serde()]
-    #[structable(optional)]
-    fault: Option<ResponseFault>,
+    #[structable(optional, pretty)]
+    fault: Option<Value>,
 
     /// Before microversion 2.47 this contains the ID and links for the flavor
     /// used to boot the server instance. This can be an empty object in case
@@ -243,8 +242,8 @@ struct ResponseData {
     /// dictionary.
     ///
     #[serde()]
-    #[structable(optional)]
-    flavor: Option<ResponseFlavor>,
+    #[structable(optional, pretty)]
+    flavor: Option<Value>,
 
     /// An ID string representing the host. This is a hashed value so will not
     /// actually look like a hostname, and is hashed with data from the
@@ -312,8 +311,8 @@ struct ResponseData {
     /// object will be an empty string when you boot the server from a volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    image: Option<ResponseImage>,
+    #[structable(optional, pretty)]
+    image: Option<Value>,
 
     /// The instance name. The Compute API generates the instance name from the
     /// instance name template. Appears in the response for administrative
@@ -394,8 +393,8 @@ struct ResponseData {
     /// backward compatibility.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// The server name.
     ///
@@ -479,8 +478,8 @@ struct ResponseData {
     /// **New in version 2.71**
     ///
     #[serde()]
-    #[structable(optional)]
-    server_groups: Option<VecString>,
+    #[structable(optional, pretty)]
+    server_groups: Option<Value>,
 
     /// The server status.
     ///
@@ -493,8 +492,8 @@ struct ResponseData {
     /// **New in version 2.26**
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The task state of the instance.
     ///
@@ -533,7 +532,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    trusted_image_certificates: Option<VecString>,
+    trusted_image_certificates: Option<Value>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
@@ -573,38 +572,6 @@ struct ResponseData {
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state")]
     os_ext_sts_vm_state: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -647,22 +614,6 @@ impl fmt::Display for ResponseFault {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseFlavor {
@@ -674,7 +625,7 @@ struct ResponseFlavor {
     ephemeral: Option<i32>,
     swap: Option<i32>,
     original_name: Option<String>,
-    extra_specs: Option<HashMapStringString>,
+    extra_specs: Option<Value>,
 }
 
 impl fmt::Display for ResponseFlavor {
@@ -760,22 +711,6 @@ impl fmt::Display for ResponseImage {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/server/set_290.rs
+++ b/openstack_cli/src/compute/v2/server/set_290.rs
@@ -39,7 +39,6 @@ use openstack_sdk::api::compute::v2::server::set_290;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -168,16 +167,16 @@ struct ResponseData {
     /// addresses information.
     ///
     #[serde()]
-    #[structable(optional)]
-    addresses: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    addresses: Option<Value>,
 
     /// The attached volumes, if any.
     ///
     /// **New in version 2.75**
     ///
     #[serde(rename = "os-extended-volumes:volumes_attached")]
-    #[structable(optional, title = "os-extended-volumes:volumes_attached")]
-    os_extended_volumes_volumes_attached: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, title = "os-extended-volumes:volumes_attached")]
+    os_extended_volumes_volumes_attached: Option<Value>,
 
     /// The availability zone name.
     ///
@@ -247,8 +246,8 @@ struct ResponseData {
     /// `DELETED` and a fault occurred.
     ///
     #[serde()]
-    #[structable(optional)]
-    fault: Option<ResponseFault>,
+    #[structable(optional, pretty)]
+    fault: Option<Value>,
 
     /// Before microversion 2.47 this contains the ID and links for the flavor
     /// used to boot the server instance. This can be an empty object in case
@@ -259,8 +258,8 @@ struct ResponseData {
     /// dictionary.
     ///
     #[serde()]
-    #[structable(optional)]
-    flavor: Option<ResponseFlavor>,
+    #[structable(optional, pretty)]
+    flavor: Option<Value>,
 
     /// An ID string representing the host. This is a hashed value so will not
     /// actually look like a hostname, and is hashed with data from the
@@ -328,8 +327,8 @@ struct ResponseData {
     /// object will be an empty string when you boot the server from a volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    image: Option<ResponseImage>,
+    #[structable(optional, pretty)]
+    image: Option<Value>,
 
     /// The instance name. The Compute API generates the instance name from the
     /// instance name template. Appears in the response for administrative
@@ -410,8 +409,8 @@ struct ResponseData {
     /// backward compatibility.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// The server name.
     ///
@@ -495,8 +494,8 @@ struct ResponseData {
     /// **New in version 2.71**
     ///
     #[serde()]
-    #[structable(optional)]
-    server_groups: Option<VecString>,
+    #[structable(optional, pretty)]
+    server_groups: Option<Value>,
 
     /// The server status.
     ///
@@ -509,8 +508,8 @@ struct ResponseData {
     /// **New in version 2.26**
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The task state of the instance.
     ///
@@ -549,7 +548,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    trusted_image_certificates: Option<VecString>,
+    trusted_image_certificates: Option<Value>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
@@ -589,38 +588,6 @@ struct ResponseData {
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state")]
     os_ext_sts_vm_state: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -663,22 +630,6 @@ impl fmt::Display for ResponseFault {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseFlavor {
@@ -690,7 +641,7 @@ struct ResponseFlavor {
     ephemeral: Option<i32>,
     swap: Option<i32>,
     original_name: Option<String>,
-    extra_specs: Option<HashMapStringString>,
+    extra_specs: Option<Value>,
 }
 
 impl fmt::Display for ResponseFlavor {
@@ -776,22 +727,6 @@ impl fmt::Display for ResponseImage {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/server/set_294.rs
+++ b/openstack_cli/src/compute/v2/server/set_294.rs
@@ -39,7 +39,6 @@ use openstack_sdk::api::compute::v2::server::set_294;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -168,16 +167,16 @@ struct ResponseData {
     /// addresses information.
     ///
     #[serde()]
-    #[structable(optional)]
-    addresses: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    addresses: Option<Value>,
 
     /// The attached volumes, if any.
     ///
     /// **New in version 2.75**
     ///
     #[serde(rename = "os-extended-volumes:volumes_attached")]
-    #[structable(optional, title = "os-extended-volumes:volumes_attached")]
-    os_extended_volumes_volumes_attached: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, title = "os-extended-volumes:volumes_attached")]
+    os_extended_volumes_volumes_attached: Option<Value>,
 
     /// The availability zone name.
     ///
@@ -247,8 +246,8 @@ struct ResponseData {
     /// `DELETED` and a fault occurred.
     ///
     #[serde()]
-    #[structable(optional)]
-    fault: Option<ResponseFault>,
+    #[structable(optional, pretty)]
+    fault: Option<Value>,
 
     /// Before microversion 2.47 this contains the ID and links for the flavor
     /// used to boot the server instance. This can be an empty object in case
@@ -259,8 +258,8 @@ struct ResponseData {
     /// dictionary.
     ///
     #[serde()]
-    #[structable(optional)]
-    flavor: Option<ResponseFlavor>,
+    #[structable(optional, pretty)]
+    flavor: Option<Value>,
 
     /// An ID string representing the host. This is a hashed value so will not
     /// actually look like a hostname, and is hashed with data from the
@@ -328,8 +327,8 @@ struct ResponseData {
     /// object will be an empty string when you boot the server from a volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    image: Option<ResponseImage>,
+    #[structable(optional, pretty)]
+    image: Option<Value>,
 
     /// The instance name. The Compute API generates the instance name from the
     /// instance name template. Appears in the response for administrative
@@ -410,8 +409,8 @@ struct ResponseData {
     /// backward compatibility.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// The server name.
     ///
@@ -495,8 +494,8 @@ struct ResponseData {
     /// **New in version 2.71**
     ///
     #[serde()]
-    #[structable(optional)]
-    server_groups: Option<VecString>,
+    #[structable(optional, pretty)]
+    server_groups: Option<Value>,
 
     /// The server status.
     ///
@@ -509,8 +508,8 @@ struct ResponseData {
     /// **New in version 2.26**
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The task state of the instance.
     ///
@@ -549,7 +548,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    trusted_image_certificates: Option<VecString>,
+    trusted_image_certificates: Option<Value>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
@@ -589,38 +588,6 @@ struct ResponseData {
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state")]
     os_ext_sts_vm_state: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -663,22 +630,6 @@ impl fmt::Display for ResponseFault {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseFlavor {
@@ -690,7 +641,7 @@ struct ResponseFlavor {
     ephemeral: Option<i32>,
     swap: Option<i32>,
     original_name: Option<String>,
-    extra_specs: Option<HashMapStringString>,
+    extra_specs: Option<Value>,
 }
 
 impl fmt::Display for ResponseFlavor {
@@ -776,22 +727,6 @@ impl fmt::Display for ResponseImage {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/server/show.rs
+++ b/openstack_cli/src/compute/v2/server/show.rs
@@ -37,7 +37,6 @@ use openstack_sdk::api::compute::v2::server::find;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -107,16 +106,16 @@ struct ResponseData {
     /// addresses information.
     ///
     #[serde()]
-    #[structable(optional)]
-    addresses: Option<HashMapStringValue>,
+    #[structable(optional, pretty)]
+    addresses: Option<Value>,
 
     /// The attached volumes, if any.
     ///
     /// **New in version 2.75**
     ///
     #[serde(rename = "os-extended-volumes:volumes_attached")]
-    #[structable(optional, title = "os-extended-volumes:volumes_attached")]
-    os_extended_volumes_volumes_attached: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, title = "os-extended-volumes:volumes_attached")]
+    os_extended_volumes_volumes_attached: Option<Value>,
 
     /// The availability zone name.
     ///
@@ -186,8 +185,8 @@ struct ResponseData {
     /// `DELETED` and a fault occurred.
     ///
     #[serde()]
-    #[structable(optional)]
-    fault: Option<ResponseFault>,
+    #[structable(optional, pretty)]
+    fault: Option<Value>,
 
     /// Before microversion 2.47 this contains the ID and links for the flavor
     /// used to boot the server instance. This can be an empty object in case
@@ -198,8 +197,8 @@ struct ResponseData {
     /// dictionary.
     ///
     #[serde()]
-    #[structable(optional)]
-    flavor: Option<ResponseFlavor>,
+    #[structable(optional, pretty)]
+    flavor: Option<Value>,
 
     /// An ID string representing the host. This is a hashed value so will not
     /// actually look like a hostname, and is hashed with data from the
@@ -267,8 +266,8 @@ struct ResponseData {
     /// object will be an empty string when you boot the server from a volume.
     ///
     #[serde()]
-    #[structable(optional)]
-    image: Option<ResponseImage>,
+    #[structable(optional, pretty)]
+    image: Option<Value>,
 
     /// The instance name. The Compute API generates the instance name from the
     /// instance name template. Appears in the response for administrative
@@ -349,8 +348,8 @@ struct ResponseData {
     /// backward compatibility.
     ///
     #[serde()]
-    #[structable(optional)]
-    metadata: Option<HashMapStringString>,
+    #[structable(optional, pretty)]
+    metadata: Option<Value>,
 
     /// The server name.
     ///
@@ -434,8 +433,8 @@ struct ResponseData {
     /// **New in version 2.71**
     ///
     #[serde()]
-    #[structable(optional)]
-    server_groups: Option<VecString>,
+    #[structable(optional, pretty)]
+    server_groups: Option<Value>,
 
     /// The server status.
     ///
@@ -448,8 +447,8 @@ struct ResponseData {
     /// **New in version 2.26**
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The task state of the instance.
     ///
@@ -488,7 +487,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    trusted_image_certificates: Option<VecString>,
+    trusted_image_certificates: Option<Value>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
@@ -528,38 +527,6 @@ struct ResponseData {
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state")]
     os_ext_sts_vm_state: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -602,22 +569,6 @@ impl fmt::Display for ResponseFault {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringString(HashMap<String, String>);
-impl fmt::Display for HashMapStringString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseFlavor {
@@ -629,7 +580,7 @@ struct ResponseFlavor {
     ephemeral: Option<i32>,
     swap: Option<i32>,
     original_name: Option<String>,
-    extra_specs: Option<HashMapStringString>,
+    extra_specs: Option<Value>,
 }
 
 impl fmt::Display for ResponseFlavor {
@@ -715,22 +666,6 @@ impl fmt::Display for ResponseImage {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/compute/v2/server/topology/list.rs
+++ b/openstack_cli/src/compute/v2/server/topology/list.rs
@@ -35,8 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::server::topology::list;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Shows NUMA topology information for a server.
@@ -79,20 +78,20 @@ struct ResponseData {
     /// The mapping of server cores to host physical CPU
     ///
     #[serde()]
-    #[structable(optional)]
-    cpu_pinning: Option<HashMapStringi32>,
+    #[structable(optional, pretty)]
+    cpu_pinning: Option<Value>,
 
     /// A list of IDs of the virtual CPU assigned to this NUMA node.
     ///
     #[serde()]
-    #[structable(optional)]
-    vcpu_set: Option<Veci32>,
+    #[structable(optional, pretty)]
+    vcpu_set: Option<Value>,
 
     /// A mapping of host cpus thread sibling.
     ///
     #[serde()]
-    #[structable(optional)]
-    siblings: Option<Veci32>,
+    #[structable(optional, pretty)]
+    siblings: Option<Value>,
 
     /// The amount of memory assigned to this NUMA node in MB.
     ///
@@ -112,38 +111,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     pagesize_kb: Option<i32>,
-}
-/// HashMap of `i32` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringi32(HashMap<String, i32>);
-impl fmt::Display for HashMapStringi32 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `i32` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct Veci32(Vec<i32>);
-impl fmt::Display for Veci32 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl TopologiesCommand {

--- a/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/create.rs
@@ -36,7 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::identity::v3::auth::os_federation::identity_provider::protocol::websso::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -89,8 +88,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A catalog object.
     ///
@@ -122,30 +121,14 @@ struct ResponseData {
     /// responsible for determining the total number of authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A user object
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -175,30 +158,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {

--- a/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/get.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/get.rs
@@ -36,7 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::identity::v3::auth::os_federation::identity_provider::protocol::websso::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -89,8 +88,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A catalog object.
     ///
@@ -122,30 +121,14 @@ struct ResponseData {
     /// responsible for determining the total number of authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A user object
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -175,30 +158,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/get.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::auth::os_federation::saml2::ecp::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// GET operation on /v3/auth/OS-FEDERATION/saml2/ecp
 ///
@@ -58,23 +59,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {}
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Ecp response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl EcpCommand {
     /// Perform command action
@@ -98,8 +85,10 @@ impl EcpCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/get.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::auth::os_federation::saml2::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// GET operation on /v3/auth/OS-FEDERATION/saml2
 ///
@@ -58,23 +59,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {}
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Saml2 response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl Saml2Command {
     /// Perform command action
@@ -98,8 +85,10 @@ impl Saml2Command {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/auth/os_federation/websso/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/websso/create.rs
@@ -36,7 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::identity::v3::auth::os_federation::websso::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -80,8 +79,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A catalog object.
     ///
@@ -113,30 +112,14 @@ struct ResponseData {
     /// responsible for determining the total number of authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A user object
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -166,30 +149,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {

--- a/openstack_cli/src/identity/v3/auth/os_federation/websso/show.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/websso/show.rs
@@ -36,7 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::identity::v3::auth::os_federation::websso::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -80,8 +79,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A catalog object.
     ///
@@ -113,30 +112,14 @@ struct ResponseData {
     /// responsible for determining the total number of authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A user object
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -166,30 +149,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {

--- a/openstack_cli/src/identity/v3/auth/token/create.rs
+++ b/openstack_cli/src/identity/v3/auth/token/create.rs
@@ -38,7 +38,6 @@ use dialoguer::Password;
 use openstack_sdk::api::identity::v3::auth::token::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -375,8 +374,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A `catalog` object.
     ///
@@ -421,14 +420,14 @@ struct ResponseData {
     /// authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A `user` object.
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 
     #[serde()]
     #[structable(optional)]
@@ -439,16 +438,16 @@ struct ResponseData {
     /// a domain.
     ///
     #[serde()]
-    #[structable(optional)]
-    domain: Option<ResponseDomainStructResponse>,
+    #[structable(optional, pretty)]
+    domain: Option<Value>,
 
     /// A `project` object including the `id`, `name` and `domain` object
     /// representing the project the token is scoped to. This is only included
     /// in tokens that are scoped to a project.
     ///
     #[serde()]
-    #[structable(optional)]
-    project: Option<ResponseProject>,
+    #[structable(optional, pretty)]
+    project: Option<Value>,
 
     /// A list of `role` objects
     ///
@@ -462,24 +461,8 @@ struct ResponseData {
     /// This is only included in tokens that are scoped to the system.
     ///
     #[serde()]
-    #[structable(optional)]
-    system: Option<HashMapStringbool>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    system: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -509,30 +492,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {
@@ -631,22 +598,6 @@ impl fmt::Display for ResponseProject {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// HashMap of `bool` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringbool(HashMap<String, bool>);
-impl fmt::Display for HashMapStringbool {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
     }
 }
 

--- a/openstack_cli/src/identity/v3/auth/token/get.rs
+++ b/openstack_cli/src/identity/v3/auth/token/get.rs
@@ -36,7 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::identity::v3::auth::token::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -84,8 +83,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A `catalog` object.
     ///
@@ -130,14 +129,14 @@ struct ResponseData {
     /// authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A `user` object.
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 
     #[serde()]
     #[structable(optional)]
@@ -148,16 +147,16 @@ struct ResponseData {
     /// a domain.
     ///
     #[serde()]
-    #[structable(optional)]
-    domain: Option<ResponseDomainStructResponse>,
+    #[structable(optional, pretty)]
+    domain: Option<Value>,
 
     /// A `project` object including the `id`, `name` and `domain` object
     /// representing the project the token is scoped to. This is only included
     /// in tokens that are scoped to a project.
     ///
     #[serde()]
-    #[structable(optional)]
-    project: Option<ResponseProject>,
+    #[structable(optional, pretty)]
+    project: Option<Value>,
 
     /// A list of `role` objects
     ///
@@ -171,24 +170,8 @@ struct ResponseData {
     /// This is only included in tokens that are scoped to the system.
     ///
     #[serde()]
-    #[structable(optional)]
-    system: Option<HashMapStringbool>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    system: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -218,30 +201,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {
@@ -340,22 +307,6 @@ impl fmt::Display for ResponseProject {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// HashMap of `bool` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringbool(HashMap<String, bool>);
-impl fmt::Display for HashMapStringbool {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
     }
 }
 

--- a/openstack_cli/src/identity/v3/auth/token/os_pki/revoked/get.rs
+++ b/openstack_cli/src/identity/v3/auth/token/os_pki/revoked/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::auth::token::os_pki::revoked::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Lists revoked PKI tokens.
 ///
@@ -62,23 +63,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {}
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Revoked response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RevokedCommand {
     /// Perform command action
@@ -102,8 +89,10 @@ impl RevokedCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/endpoint/os_endpoint_policy/policy/get.rs
+++ b/openstack_cli/src/identity/v3/endpoint/os_endpoint_policy/policy/get.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::endpoint::os_endpoint_policy::policy::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// GET operation on /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy
 ///
@@ -64,23 +65,9 @@ struct PathParameters {
     #[arg(id = "path_param_endpoint_id", value_name = "ENDPOINT_ID")]
     endpoint_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Policy response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl PolicyCommand {
     /// Perform command action
@@ -105,8 +92,10 @@ impl PolicyCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/group/user/list.rs
+++ b/openstack_cli/src/identity/v3/group/user/list.rs
@@ -149,40 +149,8 @@ struct ResponseData {
     /// `ignore_user_inactivity`.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `VecString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecVecString(Vec<VecString>);
-impl fmt::Display for VecVecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty, wide)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -192,7 +160,7 @@ struct ResponseOptions {
     ignore_lockout_failure_attempts: Option<bool>,
     lock_password: Option<bool>,
     ignore_user_inactivity: Option<bool>,
-    multi_factor_auth_rules: Option<VecVecString>,
+    multi_factor_auth_rules: Option<Value>,
     multi_factor_auth_enabled: Option<bool>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::os_federation::identity_provider::create;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Create an idp resource for federated authentication.
@@ -128,24 +128,8 @@ struct ResponseData {
     /// List of the unique Identity Provider’s remote IDs
     ///
     #[serde()]
-    #[structable(optional)]
-    remote_ids: Option<VecString>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    remote_ids: Option<Value>,
 }
 
 impl IdentityProviderCommand {

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/list.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/list.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::os_federation::identity_provider::list;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// GET operation on /v3/OS-FEDERATION/identity_providers
@@ -105,24 +105,8 @@ struct ResponseData {
     /// List of the unique Identity Provider’s remote IDs
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    remote_ids: Option<VecString>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty, wide)]
+    remote_ids: Option<Value>,
 }
 
 impl IdentityProvidersCommand {

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
@@ -38,7 +38,6 @@ use crate::common::parse_key_val;
 use openstack_sdk::api::identity::v3::os_federation::identity_provider::protocol::auth::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -95,8 +94,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A catalog object.
     ///
@@ -128,30 +127,14 @@ struct ResponseData {
     /// responsible for determining the total number of authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A user object
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -181,30 +164,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
@@ -36,7 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::identity::v3::os_federation::identity_provider::protocol::auth::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -90,8 +89,8 @@ struct ResponseData {
     /// non-privileged users.
     ///
     #[serde()]
-    #[structable(optional)]
-    audit_ids: Option<VecString>,
+    #[structable(optional, pretty)]
+    audit_ids: Option<Value>,
 
     /// A catalog object.
     ///
@@ -123,30 +122,14 @@ struct ResponseData {
     /// responsible for determining the total number of authentication factors.
     ///
     #[serde()]
-    #[structable(optional)]
-    methods: Option<VecString>,
+    #[structable(optional, pretty)]
+    methods: Option<Value>,
 
     /// A user object
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -176,30 +159,14 @@ impl fmt::Display for ResponseDomain {
         write!(f, "{}", data.join(";"))
     }
 }
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
     password_expires_at: Option<String>,
-    os_federation: Option<HashMapStringValue>,
+    os_federation: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::os_federation::identity_provider::set;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// PATCH operation on /v3/OS-FEDERATION/identity_providers/{idp_id}
@@ -123,24 +123,8 @@ struct ResponseData {
     /// List of the unique Identity Provider’s remote IDs
     ///
     #[serde()]
-    #[structable(optional)]
-    remote_ids: Option<VecString>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    remote_ids: Option<Value>,
 }
 
 impl IdentityProviderCommand {

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/show.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/show.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::os_federation::identity_provider::get;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// GET operation on /v3/OS-FEDERATION/identity_providers/{idp_id}
@@ -101,24 +101,8 @@ struct ResponseData {
     /// List of the unique Identity Provider’s remote IDs
     ///
     #[serde()]
-    #[structable(optional)]
-    remote_ids: Option<VecString>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    remote_ids: Option<Value>,
 }
 
 impl IdentityProviderCommand {

--- a/openstack_cli/src/identity/v3/project/create.rs
+++ b/openstack_cli/src/identity/v3/project/create.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::project::create;
 use openstack_sdk::api::QueryAsync;
-
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -175,31 +175,15 @@ struct ResponseData {
     /// A list of simple strings assigned to a project.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The resource options for the project. Available resource options are
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/project/group/role/list.rs
+++ b/openstack_cli/src/identity/v3/project/group/role/list.rs
@@ -35,6 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::project::group::role::list;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -98,8 +99,8 @@ struct ResponseData {
     /// The link to the resources in question.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    links: Option<ResponseLinks>,
+    #[structable(optional, pretty, wide)]
+    links: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/project/list.rs
+++ b/openstack_cli/src/identity/v3/project/list.rs
@@ -35,6 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::project::list;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -142,31 +143,15 @@ struct ResponseData {
     /// A list of simple strings assigned to a project.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// The resource options for the project. Available resource options are
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty, wide)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/project/set.rs
+++ b/openstack_cli/src/identity/v3/project/set.rs
@@ -37,7 +37,7 @@ use openstack_sdk::api::find;
 use openstack_sdk::api::identity::v3::project::find;
 use openstack_sdk::api::identity::v3::project::set;
 use openstack_sdk::api::QueryAsync;
-
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -183,31 +183,15 @@ struct ResponseData {
     /// A list of simple strings assigned to a project.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The resource options for the project. Available resource options are
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/project/show.rs
+++ b/openstack_cli/src/identity/v3/project/show.rs
@@ -36,6 +36,7 @@ use crate::StructTable;
 use openstack_sdk::api::find;
 use openstack_sdk::api::identity::v3::project::find;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -121,31 +122,15 @@ struct ResponseData {
     /// A list of simple strings assigned to a project.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The resource options for the project. Available resource options are
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/project/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/list.rs
@@ -35,6 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::project::user::role::list;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -98,8 +99,8 @@ struct ResponseData {
     /// The link to the resources in question.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    links: Option<ResponseLinks>,
+    #[structable(optional, pretty, wide)]
+    links: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/role/create.rs
+++ b/openstack_cli/src/identity/v3/role/create.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::role::create;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -106,8 +106,8 @@ struct ResponseData {
     /// The link to the resources in question.
     ///
     #[serde()]
-    #[structable(optional)]
-    links: Option<HashMapStringOptionString>,
+    #[structable(optional, pretty)]
+    links: Option<Value>,
 
     /// The role name.
     ///
@@ -125,24 +125,8 @@ struct ResponseData {
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// HashMap of `Option<String>` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringOptionString(HashMap<String, Option<String>>);
-impl fmt::Display for HashMapStringOptionString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1.clone().unwrap_or("".to_string())))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/role/imply/list.rs
+++ b/openstack_cli/src/identity/v3/role/imply/list.rs
@@ -75,8 +75,8 @@ struct ResponseData {
     /// A prior role object.
     ///
     #[serde()]
-    #[structable(optional)]
-    prior_role: Option<ResponsePriorRole>,
+    #[structable(optional, pretty)]
+    prior_role: Option<Value>,
 
     /// An array of implied role objects.
     ///
@@ -108,7 +108,7 @@ struct ResponsePriorRole {
     id: Option<String>,
     name: Option<String>,
     description: Option<String>,
-    links: Option<ResponseLinks>,
+    links: Option<Value>,
 }
 
 impl fmt::Display for ResponsePriorRole {

--- a/openstack_cli/src/identity/v3/role/imply/show.rs
+++ b/openstack_cli/src/identity/v3/role/imply/show.rs
@@ -35,6 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::role::imply::get;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -80,14 +81,14 @@ struct ResponseData {
     /// A prior role object.
     ///
     #[serde()]
-    #[structable(optional)]
-    prior_role: Option<ResponsePriorRole>,
+    #[structable(optional, pretty)]
+    prior_role: Option<Value>,
 
     /// A prior role object.
     ///
     #[serde()]
-    #[structable(optional)]
-    implies: Option<ResponseImplies>,
+    #[structable(optional, pretty)]
+    implies: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -113,7 +114,7 @@ struct ResponsePriorRole {
     id: Option<String>,
     name: Option<String>,
     description: Option<String>,
-    links: Option<ResponseLinks>,
+    links: Option<Value>,
 }
 
 impl fmt::Display for ResponsePriorRole {
@@ -175,7 +176,7 @@ struct ResponseImplies {
     id: Option<String>,
     name: Option<String>,
     description: Option<String>,
-    links: Option<ResponseImpliesLinks>,
+    links: Option<Value>,
 }
 
 impl fmt::Display for ResponseImplies {

--- a/openstack_cli/src/identity/v3/role/list.rs
+++ b/openstack_cli/src/identity/v3/role/list.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::role::list;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -80,8 +80,8 @@ struct ResponseData {
     /// The link to the resources in question.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    links: Option<HashMapStringOptionString>,
+    #[structable(optional, pretty, wide)]
+    links: Option<Value>,
 
     /// The role name.
     ///
@@ -99,24 +99,8 @@ struct ResponseData {
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    options: Option<ResponseOptions>,
-}
-/// HashMap of `Option<String>` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringOptionString(HashMap<String, Option<String>>);
-impl fmt::Display for HashMapStringOptionString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1.clone().unwrap_or("".to_string())))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
+    #[structable(optional, pretty, wide)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/role/set.rs
+++ b/openstack_cli/src/identity/v3/role/set.rs
@@ -37,7 +37,7 @@ use openstack_sdk::api::find;
 use openstack_sdk::api::identity::v3::role::find;
 use openstack_sdk::api::identity::v3::role::set;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -113,8 +113,8 @@ struct ResponseData {
     /// The link to the resources in question.
     ///
     #[serde()]
-    #[structable(optional)]
-    links: Option<HashMapStringOptionString>,
+    #[structable(optional, pretty)]
+    links: Option<Value>,
 
     /// The role name.
     ///
@@ -132,24 +132,8 @@ struct ResponseData {
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// HashMap of `Option<String>` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringOptionString(HashMap<String, Option<String>>);
-impl fmt::Display for HashMapStringOptionString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1.clone().unwrap_or("".to_string())))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/role/show.rs
+++ b/openstack_cli/src/identity/v3/role/show.rs
@@ -36,7 +36,7 @@ use crate::StructTable;
 use openstack_sdk::api::find;
 use openstack_sdk::api::identity::v3::role::find;
 use openstack_sdk::api::QueryAsync;
-use std::collections::HashMap;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -81,8 +81,8 @@ struct ResponseData {
     /// The link to the resources in question.
     ///
     #[serde()]
-    #[structable(optional)]
-    links: Option<HashMapStringOptionString>,
+    #[structable(optional, pretty)]
+    links: Option<Value>,
 
     /// The role name.
     ///
@@ -100,24 +100,8 @@ struct ResponseData {
     /// `immutable`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// HashMap of `Option<String>` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringOptionString(HashMap<String, Option<String>>);
-impl fmt::Display for HashMapStringOptionString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1.clone().unwrap_or("".to_string())))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]

--- a/openstack_cli/src/identity/v3/role_assignment/list.rs
+++ b/openstack_cli/src/identity/v3/role_assignment/list.rs
@@ -35,6 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::identity::v3::role_assignment::list;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use std::fmt;
 use structable_derive::StructTable;
 
@@ -187,8 +188,8 @@ struct ResponseData {
     /// A prior role object.
     ///
     #[serde()]
-    #[structable(optional)]
-    role: Option<ResponseRole>,
+    #[structable(optional, pretty)]
+    role: Option<Value>,
 
     /// The authorization scope, including the system (Since v3.10), a project,
     /// or a domain (Since v3.4). If multiple scopes are specified in the same
@@ -201,22 +202,22 @@ struct ResponseData {
     /// the domain’s ID or name with equivalent results.
     ///
     #[serde()]
-    #[structable(optional)]
-    scope: Option<ResponseScope>,
+    #[structable(optional, pretty)]
+    scope: Option<Value>,
 
     /// A user object
     ///
     #[serde()]
-    #[structable(optional)]
-    user: Option<ResponseUser>,
+    #[structable(optional, pretty)]
+    user: Option<Value>,
 
     #[serde()]
-    #[structable(optional)]
-    group: Option<ResponseGroup>,
+    #[structable(optional, pretty)]
+    group: Option<Value>,
 
     #[serde()]
-    #[structable(optional)]
-    links: Option<ResponseLinksStructResponse>,
+    #[structable(optional, pretty)]
+    links: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -242,7 +243,7 @@ struct ResponseRole {
     id: Option<String>,
     name: Option<String>,
     description: Option<String>,
-    links: Option<ResponseLinks>,
+    links: Option<Value>,
 }
 
 impl fmt::Display for ResponseRole {
@@ -313,7 +314,7 @@ impl fmt::Display for ResponseDomain {
 struct ResponseProject {
     name: Option<String>,
     id: Option<String>,
-    domain: Option<ResponseDomain>,
+    domain: Option<Value>,
 }
 
 impl fmt::Display for ResponseProject {
@@ -408,10 +409,10 @@ impl fmt::Display for ResponseSystem {
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
 struct ResponseScope {
-    project: Option<ResponseProject>,
-    domain: Option<ResponseScopeDomain>,
-    os_trust_trust: Option<ResponseOsTrustTrust>,
-    system: Option<ResponseSystem>,
+    project: Option<Value>,
+    domain: Option<Value>,
+    os_trust_trust: Option<Value>,
+    system: Option<Value>,
 }
 
 impl fmt::Display for ResponseScope {
@@ -482,7 +483,7 @@ impl fmt::Display for ResponseUserDomain {
 struct ResponseUser {
     id: Option<String>,
     name: Option<String>,
-    domain: Option<ResponseUserDomain>,
+    domain: Option<Value>,
 }
 
 impl fmt::Display for ResponseUser {

--- a/openstack_cli/src/identity/v3/role_inference/list.rs
+++ b/openstack_cli/src/identity/v3/role_inference/list.rs
@@ -69,8 +69,8 @@ struct ResponseData {
     /// A prior role object.
     ///
     #[serde()]
-    #[structable(optional)]
-    prior_role: Option<ResponsePriorRole>,
+    #[structable(optional, pretty)]
+    prior_role: Option<Value>,
 
     /// An implied role object.
     ///
@@ -102,7 +102,7 @@ struct ResponsePriorRole {
     id: Option<String>,
     name: Option<String>,
     description: Option<String>,
-    links: Option<ResponseLinks>,
+    links: Option<Value>,
 }
 
 impl fmt::Display for ResponsePriorRole {

--- a/openstack_cli/src/identity/v3/user/list.rs
+++ b/openstack_cli/src/identity/v3/user/list.rs
@@ -175,40 +175,8 @@ struct ResponseData {
     /// `ignore_user_inactivity`.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `VecString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecVecString(Vec<VecString>);
-impl fmt::Display for VecVecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty, wide)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -218,7 +186,7 @@ struct ResponseOptions {
     ignore_lockout_failure_attempts: Option<bool>,
     lock_password: Option<bool>,
     ignore_user_inactivity: Option<bool>,
-    multi_factor_auth_rules: Option<VecVecString>,
+    multi_factor_auth_rules: Option<Value>,
     multi_factor_auth_enabled: Option<bool>,
 }
 

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/list.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/list.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::list;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// List OAuth1 Access Tokens for user.
 ///
@@ -66,23 +67,9 @@ struct PathParameters {
     #[arg(id = "path_param_user_id", value_name = "USER_ID")]
     user_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// AccessTokens response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl AccessTokensCommand {
     /// Perform command action
@@ -107,8 +94,10 @@ impl AccessTokensCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/list.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/list.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::role::list;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// List roles for a user access token.
 ///
@@ -74,23 +75,9 @@ struct PathParameters {
     #[arg(id = "path_param_access_token_id", value_name = "ACCESS_TOKEN_ID")]
     access_token_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Roles response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RolesCommand {
     /// Perform command action
@@ -116,8 +103,10 @@ impl RolesCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/show.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/show.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::role::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Get role for access token.
 ///
@@ -81,23 +82,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Role response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RoleCommand {
     /// Perform command action
@@ -124,8 +111,10 @@ impl RoleCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/show.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/show.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Get specific access token.
 ///
@@ -73,23 +74,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// AccessToken response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl AccessTokenCommand {
     /// Perform command action
@@ -115,8 +102,10 @@ impl AccessTokenCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/user/set.rs
+++ b/openstack_cli/src/identity/v3/user/set.rs
@@ -239,40 +239,8 @@ struct ResponseData {
     /// `ignore_user_inactivity`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `VecString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecVecString(Vec<VecString>);
-impl fmt::Display for VecVecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -282,7 +250,7 @@ struct ResponseOptions {
     ignore_lockout_failure_attempts: Option<bool>,
     lock_password: Option<bool>,
     ignore_user_inactivity: Option<bool>,
-    multi_factor_auth_rules: Option<VecVecString>,
+    multi_factor_auth_rules: Option<Value>,
     multi_factor_auth_enabled: Option<bool>,
 }
 

--- a/openstack_cli/src/identity/v3/user/show.rs
+++ b/openstack_cli/src/identity/v3/user/show.rs
@@ -142,40 +142,8 @@ struct ResponseData {
     /// `ignore_user_inactivity`.
     ///
     #[serde()]
-    #[structable(optional)]
-    options: Option<ResponseOptions>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `VecString` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecVecString(Vec<VecString>);
-impl fmt::Display for VecVecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    options: Option<Value>,
 }
 /// `struct` response type
 #[derive(Default, Clone, Deserialize, Serialize)]
@@ -185,7 +153,7 @@ struct ResponseOptions {
     ignore_lockout_failure_attempts: Option<bool>,
     lock_password: Option<bool>,
     ignore_user_inactivity: Option<bool>,
-    multi_factor_auth_rules: Option<VecVecString>,
+    multi_factor_auth_rules: Option<Value>,
     multi_factor_auth_enabled: Option<bool>,
 }
 

--- a/openstack_cli/src/image/v2/image/list.rs
+++ b/openstack_cli/src/image/v2/image/list.rs
@@ -37,7 +37,6 @@ use openstack_sdk::api::image::v2::image::list;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Lists public virtual machine (VM) images. *(Since Image API v2.0)*
@@ -383,8 +382,8 @@ struct ResponseData {
     /// List of strings related to the image
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// URL to access the image file kept in external store
     ///
@@ -435,22 +434,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     locations: Option<Value>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl ImagesCommand {

--- a/openstack_cli/src/image/v2/image/show.rs
+++ b/openstack_cli/src/image/v2/image/show.rs
@@ -37,7 +37,6 @@ use openstack_sdk::api::find;
 use openstack_sdk::api::image::v2::image::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows details for an image. *(Since Image API v2.0)*
@@ -265,8 +264,8 @@ struct ResponseData {
     /// List of tags for this image, possibly an empty list.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// The URL to access the image file kept in external store. *It is present
     /// only if the* `show_image_direct_url` *option is* `true` *in the Image
@@ -329,22 +328,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     locations: Option<Value>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl ImageCommand {

--- a/openstack_cli/src/image/v2/image/stage/stage.rs
+++ b/openstack_cli/src/image/v2/image/stage/stage.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::image::v2::image::stage::stage;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the images/image_id/stage:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
     image_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Stage response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl StageCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl StageCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/image/v2/image/tag/set.rs
+++ b/openstack_cli/src/image/v2/image/tag/set.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::image::v2::image::tag::set;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -73,23 +75,9 @@ struct PathParameters {
     #[arg(id = "path_param_tag_value", value_name = "TAG_VALUE")]
     tag_value: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Tag response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl TagCommand {
     /// Perform command action
@@ -118,8 +106,10 @@ impl TagCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/image/v2/image/task/list.rs
+++ b/openstack_cli/src/image/v2/image/task/list.rs
@@ -36,8 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::image::v2::image::task::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows tasks associated with an image. *(Since Image API v2.12)*
@@ -100,13 +98,13 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    input: Option<HashMapStringValue>,
+    input: Option<Value>,
 
     /// The result of current task, JSON blob
     ///
     #[serde()]
     #[structable(optional, wide)]
-    result: Option<HashMapStringValue>,
+    result: Option<Value>,
 
     /// An identifier for the owner of this task
     ///
@@ -164,22 +162,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     schema: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl TasksCommand {

--- a/openstack_cli/src/network/v2/floatingip/create.rs
+++ b/openstack_cli/src/network/v2/floatingip/create.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::network::v2::floatingip::create;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Creates a floating IP, and, if you specify port information, associates the
@@ -225,8 +225,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -281,22 +281,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl FloatingipCommand {

--- a/openstack_cli/src/network/v2/floatingip/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/list.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::network::v2::floatingip::list;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Lists floating IPs visible to the user.
@@ -204,8 +204,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -260,22 +260,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl FloatingipsCommand {

--- a/openstack_cli/src/network/v2/floatingip/set.rs
+++ b/openstack_cli/src/network/v2/floatingip/set.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::network::v2::floatingip::set;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Updates a floating IP and its association with an internal port.
@@ -176,8 +176,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -232,22 +232,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl FloatingipCommand {

--- a/openstack_cli/src/network/v2/floatingip/show.rs
+++ b/openstack_cli/src/network/v2/floatingip/show.rs
@@ -35,7 +35,7 @@ use crate::StructTable;
 
 use openstack_sdk::api::network::v2::floatingip::get;
 use openstack_sdk::api::QueryAsync;
-use std::fmt;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Shows details for a floating IP.
@@ -142,8 +142,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -198,22 +198,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl FloatingipCommand {

--- a/openstack_cli/src/network/v2/network/create.rs
+++ b/openstack_cli/src/network/v2/network/create.rs
@@ -39,7 +39,6 @@ use crate::common::IntString;
 use openstack_sdk::api::network::v2::network::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a network.
@@ -182,8 +181,8 @@ struct ResponseData {
     /// The associated subnets.
     ///
     #[serde()]
-    #[structable(optional)]
-    subnets: Option<VecString>,
+    #[structable(optional, pretty)]
+    subnets: Option<Value>,
 
     /// The administrative state of the network, which is up (`true`) or down
     /// (`false`).
@@ -257,14 +256,14 @@ struct ResponseData {
     /// The availability zone for the network.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidate for the network.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zone_hints: Option<Value>,
 
     /// The port security status of the network. Valid values are enabled
     /// (`true`) and disabled (`false`). This value is used as the default
@@ -301,8 +300,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -333,22 +332,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl NetworkCommand {

--- a/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::network::dhcp_agent::list;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Lists DHCP agents hosting a network.
 ///
@@ -68,23 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
     network_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// DhcpAgents response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl DhcpAgentsCommand {
     /// Perform command action
@@ -109,8 +96,10 @@ impl DhcpAgentsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/network/dhcp_agent/set.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/set.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::network::dhcp_agent::set;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -73,23 +75,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// DhcpAgent response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl DhcpAgentCommand {
     /// Perform command action
@@ -118,8 +106,10 @@ impl DhcpAgentCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/network/dhcp_agent/show.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/show.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::network::dhcp_agent::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -68,23 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// DhcpAgent response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl DhcpAgentCommand {
     /// Perform command action
@@ -110,8 +97,10 @@ impl DhcpAgentCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/network/list.rs
+++ b/openstack_cli/src/network/v2/network/list.rs
@@ -38,7 +38,6 @@ use crate::common::IntString;
 use openstack_sdk::api::network::v2::network::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Lists networks to which the project has access.
@@ -188,8 +187,8 @@ struct ResponseData {
     /// The associated subnets.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    subnets: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    subnets: Option<Value>,
 
     /// The administrative state of the network, which is up (`true`) or down
     /// (`false`).
@@ -263,14 +262,14 @@ struct ResponseData {
     /// The availability zone for the network.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidate for the network.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    availability_zone_hints: Option<Value>,
 
     /// The port security status of the network. Valid values are enabled
     /// (`true`) and disabled (`false`). This value is used as the default
@@ -307,8 +306,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -339,22 +338,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl NetworksCommand {

--- a/openstack_cli/src/network/v2/network/set.rs
+++ b/openstack_cli/src/network/v2/network/set.rs
@@ -41,7 +41,6 @@ use openstack_sdk::api::network::v2::network::find;
 use openstack_sdk::api::network::v2::network::set;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Updates a network.
@@ -170,8 +169,8 @@ struct ResponseData {
     /// The associated subnets.
     ///
     #[serde()]
-    #[structable(optional)]
-    subnets: Option<VecString>,
+    #[structable(optional, pretty)]
+    subnets: Option<Value>,
 
     /// The administrative state of the network, which is up (`true`) or down
     /// (`false`).
@@ -245,14 +244,14 @@ struct ResponseData {
     /// The availability zone for the network.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidate for the network.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zone_hints: Option<Value>,
 
     /// The port security status of the network. Valid values are enabled
     /// (`true`) and disabled (`false`). This value is used as the default
@@ -289,8 +288,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -321,22 +320,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl NetworkCommand {

--- a/openstack_cli/src/network/v2/network/show.rs
+++ b/openstack_cli/src/network/v2/network/show.rs
@@ -39,7 +39,6 @@ use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::network::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows details for a network.
@@ -94,8 +93,8 @@ struct ResponseData {
     /// The associated subnets.
     ///
     #[serde()]
-    #[structable(optional)]
-    subnets: Option<VecString>,
+    #[structable(optional, pretty)]
+    subnets: Option<Value>,
 
     /// The administrative state of the network, which is up (`true`) or down
     /// (`false`).
@@ -169,14 +168,14 @@ struct ResponseData {
     /// The availability zone for the network.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidate for the network.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zone_hints: Option<Value>,
 
     /// The port security status of the network. Valid values are enabled
     /// (`true`) and disabled (`false`). This value is used as the default
@@ -213,8 +212,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -245,22 +244,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl NetworkCommand {

--- a/openstack_cli/src/network/v2/port/add_allowed_address_pairs.rs
+++ b/openstack_cli/src/network/v2/port/add_allowed_address_pairs.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::port::add_allowed_address_pairs;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the ports/port_id/add_allowed_address_pairs:put operation
 ///
@@ -70,23 +72,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Port response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl PortCommand {
     /// Perform command action
@@ -114,8 +102,10 @@ impl PortCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/port/binding/activate/activate.rs
+++ b/openstack_cli/src/network/v2/port/binding/activate/activate.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::port::binding::activate::activate;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the ports/port_id/bindings/id/activate:put operation
 ///
@@ -75,23 +77,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Activate response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl ActivateCommand {
     /// Perform command action
@@ -120,8 +108,10 @@ impl ActivateCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/port/binding/create.rs
+++ b/openstack_cli/src/network/v2/port/binding/create.rs
@@ -39,8 +39,6 @@ use clap::ValueEnum;
 use openstack_sdk::api::network::v2::port::binding::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
@@ -125,7 +123,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    profile: Option<HashMapStringValue>,
+    profile: Option<Value>,
 
     #[serde()]
     #[structable(optional)]
@@ -134,22 +132,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     project_id: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl BindingCommand {

--- a/openstack_cli/src/network/v2/port/binding/list.rs
+++ b/openstack_cli/src/network/v2/port/binding/list.rs
@@ -36,8 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::network::v2::port::binding::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Normal response codes: 200
@@ -141,7 +139,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    profile: Option<HashMapStringValue>,
+    profile: Option<Value>,
 
     #[serde()]
     #[structable(optional)]
@@ -150,22 +148,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     project_id: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl BindingsCommand {

--- a/openstack_cli/src/network/v2/port/binding/set.rs
+++ b/openstack_cli/src/network/v2/port/binding/set.rs
@@ -39,8 +39,6 @@ use clap::ValueEnum;
 use openstack_sdk::api::network::v2::port::binding::set;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
@@ -127,7 +125,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    profile: Option<HashMapStringValue>,
+    profile: Option<Value>,
 
     #[serde()]
     #[structable(optional)]
@@ -136,22 +134,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     project_id: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl BindingCommand {

--- a/openstack_cli/src/network/v2/port/binding/show.rs
+++ b/openstack_cli/src/network/v2/port/binding/show.rs
@@ -36,8 +36,6 @@ use crate::StructTable;
 use openstack_sdk::api::network::v2::port::binding::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
@@ -92,7 +90,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    profile: Option<HashMapStringValue>,
+    profile: Option<Value>,
 
     #[serde()]
     #[structable(optional)]
@@ -101,22 +99,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     project_id: Option<String>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
 }
 
 impl BindingCommand {

--- a/openstack_cli/src/network/v2/port/create.rs
+++ b/openstack_cli/src/network/v2/port/create.rs
@@ -40,8 +40,6 @@ use clap::ValueEnum;
 use openstack_sdk::api::network::v2::port::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a port on a network.
@@ -373,8 +371,8 @@ struct ResponseData {
     /// of an option value and name.
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_dhcp_opts: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty)]
+    extra_dhcp_opts: Option<Value>,
 
     /// Indicates when ports use either `deferred`, `immediate` or no IP
     /// allocation (`none`).
@@ -394,7 +392,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    hints: Option<HashMapStringValue>,
+    hints: Option<Value>,
 
     /// The port NUMA affinity policy requested during the virtual machine
     /// scheduling. Values: `None`, `required`, `preferred` or `legacy`.
@@ -444,8 +442,8 @@ struct ResponseData {
     /// be used.
     ///
     #[serde(rename = "binding:vif_details")]
-    #[structable(optional, title = "binding:vif_details")]
-    binding_vif_details: Option<HashMapStringValue>,
+    #[structable(optional, pretty, title = "binding:vif_details")]
+    binding_vif_details: Option<Value>,
 
     /// The type of vNIC which this port should be attached to. This is used to
     /// determine which mechanism driver(s) to be used to bind the port. The
@@ -471,7 +469,7 @@ struct ResponseData {
     ///
     #[serde(rename = "binding:profile")]
     #[structable(optional, title = "binding:profile")]
-    binding_profile: Option<HashMapStringValue>,
+    binding_profile: Option<Value>,
 
     /// The port security status. A valid value is enabled (`true`) or disabled
     /// (`false`). If port security is enabled for the port, security group
@@ -503,8 +501,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -553,56 +551,8 @@ struct ResponseData {
     /// The IDs of security groups applied to the port.
     ///
     #[serde()]
-    #[structable(optional)]
-    security_groups: Option<VecString>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    security_groups: Option<Value>,
 }
 
 impl PortCommand {

--- a/openstack_cli/src/network/v2/port/list.rs
+++ b/openstack_cli/src/network/v2/port/list.rs
@@ -37,8 +37,6 @@ use crate::common::BoolString;
 use openstack_sdk::api::network::v2::port::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Lists ports to which the user has access.
@@ -270,8 +268,8 @@ struct ResponseData {
     /// of an option value and name.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    extra_dhcp_opts: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty, wide)]
+    extra_dhcp_opts: Option<Value>,
 
     /// Indicates when ports use either `deferred`, `immediate` or no IP
     /// allocation (`none`).
@@ -291,7 +289,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    hints: Option<HashMapStringValue>,
+    hints: Option<Value>,
 
     /// The port NUMA affinity policy requested during the virtual machine
     /// scheduling. Values: `None`, `required`, `preferred` or `legacy`.
@@ -341,8 +339,8 @@ struct ResponseData {
     /// be used.
     ///
     #[serde(rename = "binding:vif_details")]
-    #[structable(optional, title = "binding:vif_details", wide)]
-    binding_vif_details: Option<HashMapStringValue>,
+    #[structable(optional, pretty, title = "binding:vif_details", wide)]
+    binding_vif_details: Option<Value>,
 
     /// The type of vNIC which this port should be attached to. This is used to
     /// determine which mechanism driver(s) to be used to bind the port. The
@@ -368,7 +366,7 @@ struct ResponseData {
     ///
     #[serde(rename = "binding:profile")]
     #[structable(optional, title = "binding:profile", wide)]
-    binding_profile: Option<HashMapStringValue>,
+    binding_profile: Option<Value>,
 
     /// The port security status. A valid value is enabled (`true`) or disabled
     /// (`false`). If port security is enabled for the port, security group
@@ -400,8 +398,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -450,56 +448,8 @@ struct ResponseData {
     /// The IDs of security groups applied to the port.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    security_groups: Option<VecString>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty, wide)]
+    security_groups: Option<Value>,
 }
 
 impl PortsCommand {

--- a/openstack_cli/src/network/v2/port/set.rs
+++ b/openstack_cli/src/network/v2/port/set.rs
@@ -42,8 +42,6 @@ use openstack_sdk::api::network::v2::port::find;
 use openstack_sdk::api::network::v2::port::set;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Updates a port.
@@ -386,8 +384,8 @@ struct ResponseData {
     /// of an option value and name.
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_dhcp_opts: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty)]
+    extra_dhcp_opts: Option<Value>,
 
     /// Indicates when ports use either `deferred`, `immediate` or no IP
     /// allocation (`none`).
@@ -407,7 +405,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    hints: Option<HashMapStringValue>,
+    hints: Option<Value>,
 
     /// The port NUMA affinity policy requested during the virtual machine
     /// scheduling. Values: `None`, `required`, `preferred` or `legacy`.
@@ -457,8 +455,8 @@ struct ResponseData {
     /// be used.
     ///
     #[serde(rename = "binding:vif_details")]
-    #[structable(optional, title = "binding:vif_details")]
-    binding_vif_details: Option<HashMapStringValue>,
+    #[structable(optional, pretty, title = "binding:vif_details")]
+    binding_vif_details: Option<Value>,
 
     /// The type of vNIC which this port should be attached to. This is used to
     /// determine which mechanism driver(s) to be used to bind the port. The
@@ -484,7 +482,7 @@ struct ResponseData {
     ///
     #[serde(rename = "binding:profile")]
     #[structable(optional, title = "binding:profile")]
-    binding_profile: Option<HashMapStringValue>,
+    binding_profile: Option<Value>,
 
     /// The port security status. A valid value is enabled (`true`) or disabled
     /// (`false`). If port security is enabled for the port, security group
@@ -516,8 +514,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -566,56 +564,8 @@ struct ResponseData {
     /// The IDs of security groups applied to the port.
     ///
     #[serde()]
-    #[structable(optional)]
-    security_groups: Option<VecString>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    security_groups: Option<Value>,
 }
 
 impl PortCommand {

--- a/openstack_cli/src/network/v2/port/show.rs
+++ b/openstack_cli/src/network/v2/port/show.rs
@@ -38,8 +38,6 @@ use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::port::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows details for a port.
@@ -171,8 +169,8 @@ struct ResponseData {
     /// of an option value and name.
     ///
     #[serde()]
-    #[structable(optional)]
-    extra_dhcp_opts: Option<VecHashMapStringValue>,
+    #[structable(optional, pretty)]
+    extra_dhcp_opts: Option<Value>,
 
     /// Indicates when ports use either `deferred`, `immediate` or no IP
     /// allocation (`none`).
@@ -192,7 +190,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    hints: Option<HashMapStringValue>,
+    hints: Option<Value>,
 
     /// The port NUMA affinity policy requested during the virtual machine
     /// scheduling. Values: `None`, `required`, `preferred` or `legacy`.
@@ -242,8 +240,8 @@ struct ResponseData {
     /// be used.
     ///
     #[serde(rename = "binding:vif_details")]
-    #[structable(optional, title = "binding:vif_details")]
-    binding_vif_details: Option<HashMapStringValue>,
+    #[structable(optional, pretty, title = "binding:vif_details")]
+    binding_vif_details: Option<Value>,
 
     /// The type of vNIC which this port should be attached to. This is used to
     /// determine which mechanism driver(s) to be used to bind the port. The
@@ -269,7 +267,7 @@ struct ResponseData {
     ///
     #[serde(rename = "binding:profile")]
     #[structable(optional, title = "binding:profile")]
-    binding_profile: Option<HashMapStringValue>,
+    binding_profile: Option<Value>,
 
     /// The port security status. A valid value is enabled (`true`) or disabled
     /// (`false`). If port security is enabled for the port, security group
@@ -301,8 +299,8 @@ struct ResponseData {
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -351,56 +349,8 @@ struct ResponseData {
     /// The IDs of security groups applied to the port.
     ///
     #[serde()]
-    #[structable(optional)]
-    security_groups: Option<VecString>,
-}
-/// HashMap of `Value` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct HashMapStringValue(HashMap<String, Value>);
-impl fmt::Display for HashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{{}}}",
-            self.0
-                .iter()
-                .map(|v| format!("{}={}", v.0, v.1))
-                .collect::<Vec<String>>()
-                .join("\n")
-        )
-    }
-}
-/// Vector of `HashMapStringValue` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecHashMapStringValue(Vec<HashMapStringValue>);
-impl fmt::Display for VecHashMapStringValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
+    #[structable(optional, pretty)]
+    security_groups: Option<Value>,
 }
 
 impl PortCommand {

--- a/openstack_cli/src/network/v2/router/add_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/add_external_gateways.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::add_external_gateways;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the routers/id/add_external_gateways:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Router response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RouterCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl RouterCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/add_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/add_extraroutes.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::add_extraroutes;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the routers/id/add_extraroutes:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Router response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RouterCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl RouterCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/add_router_interface.rs
+++ b/openstack_cli/src/network/v2/router/add_router_interface.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::add_router_interface;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the routers/id/add_router_interface:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Router response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RouterCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl RouterCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/create.rs
+++ b/openstack_cli/src/network/v2/router/create.rs
@@ -200,8 +200,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional)]
-    external_gateway_info: Option<ResponseExternalGatewayInfo>,
+    #[structable(optional, pretty)]
+    external_gateway_info: Option<Value>,
 
     /// `true` indicates a highly-available router. It is available when
     /// `l3-ha` extension is enabled.
@@ -237,21 +237,21 @@ struct ResponseData {
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidates for the router. It is available when
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zone_hints: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -322,22 +322,6 @@ impl fmt::Display for ResponseExternalGatewayInfo {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/network/v2/router/l3_agent/list.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/list.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::l3_agent::list;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Lists l3 agents hosting a specific router.
 ///
@@ -68,23 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
     router_id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// L3Agents response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl L3AgentsCommand {
     /// Perform command action
@@ -109,8 +96,10 @@ impl L3AgentsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/l3_agent/set.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/set.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::l3_agent::set;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -73,23 +75,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// L3Agent response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl L3AgentCommand {
     /// Perform command action
@@ -118,8 +106,10 @@ impl L3AgentCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/l3_agent/show.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/show.rs
@@ -33,10 +33,11 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::l3_agent::get;
-use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
-use std::collections::HashMap;
+use openstack_sdk::api::RawQueryAsync;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -68,23 +69,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// L3Agent response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl L3AgentCommand {
     /// Perform command action
@@ -110,8 +97,10 @@ impl L3AgentCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/list.rs
+++ b/openstack_cli/src/network/v2/router/list.rs
@@ -165,8 +165,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    external_gateway_info: Option<ResponseExternalGatewayInfo>,
+    #[structable(optional, pretty, wide)]
+    external_gateway_info: Option<Value>,
 
     /// `true` indicates a highly-available router. It is available when
     /// `l3-ha` extension is enabled.
@@ -202,21 +202,21 @@ struct ResponseData {
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidates for the router. It is available when
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    availability_zone_hints: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -287,22 +287,6 @@ impl fmt::Display for ResponseExternalGatewayInfo {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/network/v2/router/remove_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/remove_external_gateways.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::remove_external_gateways;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the routers/id/remove_external_gateways:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Router response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RouterCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl RouterCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/remove_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/remove_extraroutes.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::remove_extraroutes;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the routers/id/remove_extraroutes:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Router response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RouterCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl RouterCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/remove_router_interface.rs
+++ b/openstack_cli/src/network/v2/router/remove_router_interface.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::remove_router_interface;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the routers/id/remove_router_interface:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Router response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RouterCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl RouterCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/router/set.rs
+++ b/openstack_cli/src/network/v2/router/set.rs
@@ -191,8 +191,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional)]
-    external_gateway_info: Option<ResponseExternalGatewayInfo>,
+    #[structable(optional, pretty)]
+    external_gateway_info: Option<Value>,
 
     /// `true` indicates a highly-available router. It is available when
     /// `l3-ha` extension is enabled.
@@ -228,21 +228,21 @@ struct ResponseData {
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidates for the router. It is available when
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zone_hints: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -313,22 +313,6 @@ impl fmt::Display for ResponseExternalGatewayInfo {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/network/v2/router/show.rs
+++ b/openstack_cli/src/network/v2/router/show.rs
@@ -116,8 +116,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional)]
-    external_gateway_info: Option<ResponseExternalGatewayInfo>,
+    #[structable(optional, pretty)]
+    external_gateway_info: Option<Value>,
 
     /// `true` indicates a highly-available router. It is available when
     /// `l3-ha` extension is enabled.
@@ -153,21 +153,21 @@ struct ResponseData {
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zones: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zones: Option<Value>,
 
     /// The availability zone candidates for the router. It is available when
     /// `router_availability_zone` extension is enabled.
     ///
     #[serde()]
-    #[structable(optional)]
-    availability_zone_hints: Option<VecString>,
+    #[structable(optional, pretty)]
+    availability_zone_hints: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -238,22 +238,6 @@ impl fmt::Display for ResponseExternalGatewayInfo {
             ),
         ]);
         write!(f, "{}", data.join(";"))
-    }
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
     }
 }
 

--- a/openstack_cli/src/network/v2/router/update_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/update_external_gateways.rs
@@ -35,10 +35,12 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use bytes::Bytes;
+use http::Response;
 use openstack_sdk::api::network::v2::router::update_external_gateways;
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RawQueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Request of the routers/id/update_external_gateways:put operation
 ///
@@ -69,23 +71,9 @@ struct PathParameters {
     #[arg(id = "path_param_id", value_name = "ID")]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
-
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
-}
+/// Router response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {}
 
 impl RouterCommand {
     /// Perform command action
@@ -113,8 +101,10 @@ impl RouterCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<ResponseData>(data)?;
+        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let data = ResponseData {};
+        // Maybe output some headers metadata
+        op.output_human::<ResponseData>(&data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/network/v2/subnet/create.rs
+++ b/openstack_cli/src/network/v2/subnet/create.rs
@@ -39,7 +39,6 @@ use clap::ValueEnum;
 use openstack_sdk::api::network::v2::subnet::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a subnet on a network.
@@ -290,8 +289,8 @@ struct ResponseData {
     /// List of dns name servers associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional)]
-    dns_nameservers: Option<VecString>,
+    #[structable(optional, pretty)]
+    dns_nameservers: Option<Value>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters.
@@ -336,14 +335,14 @@ struct ResponseData {
     /// The service types associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional)]
-    service_types: Option<VecString>,
+    #[structable(optional, pretty)]
+    service_types: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -375,22 +374,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     segment_id: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl SubnetCommand {

--- a/openstack_cli/src/network/v2/subnet/list.rs
+++ b/openstack_cli/src/network/v2/subnet/list.rs
@@ -37,7 +37,6 @@ use crate::common::BoolString;
 use openstack_sdk::api::network::v2::subnet::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Lists subnets that the project has access to.
@@ -225,8 +224,8 @@ struct ResponseData {
     /// List of dns name servers associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    dns_nameservers: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    dns_nameservers: Option<Value>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters.
@@ -271,14 +270,14 @@ struct ResponseData {
     /// The service types associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    service_types: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    service_types: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty, wide)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -310,22 +309,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     segment_id: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl SubnetsCommand {

--- a/openstack_cli/src/network/v2/subnet/set.rs
+++ b/openstack_cli/src/network/v2/subnet/set.rs
@@ -40,7 +40,6 @@ use openstack_sdk::api::network::v2::subnet::find;
 use openstack_sdk::api::network::v2::subnet::set;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Updates a subnet.
@@ -201,8 +200,8 @@ struct ResponseData {
     /// List of dns name servers associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional)]
-    dns_nameservers: Option<VecString>,
+    #[structable(optional, pretty)]
+    dns_nameservers: Option<Value>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters.
@@ -247,14 +246,14 @@ struct ResponseData {
     /// The service types associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional)]
-    service_types: Option<VecString>,
+    #[structable(optional, pretty)]
+    service_types: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -286,22 +285,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     segment_id: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl SubnetCommand {

--- a/openstack_cli/src/network/v2/subnet/show.rs
+++ b/openstack_cli/src/network/v2/subnet/show.rs
@@ -38,7 +38,6 @@ use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::subnet::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows details for a subnet.
@@ -128,8 +127,8 @@ struct ResponseData {
     /// List of dns name servers associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional)]
-    dns_nameservers: Option<VecString>,
+    #[structable(optional, pretty)]
+    dns_nameservers: Option<Value>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters.
@@ -174,14 +173,14 @@ struct ResponseData {
     /// The service types associated with the subnet.
     ///
     #[serde()]
-    #[structable(optional)]
-    service_types: Option<VecString>,
+    #[structable(optional, pretty)]
+    service_types: Option<Value>,
 
     /// The list of tags on the resource.
     ///
     #[serde()]
-    #[structable(optional)]
-    tags: Option<VecString>,
+    #[structable(optional, pretty)]
+    tags: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///
@@ -213,22 +212,6 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     segment_id: Option<String>,
-}
-/// Vector of `String` response type
-#[derive(Default, Clone, Deserialize, Serialize)]
-struct VecString(Vec<String>);
-impl fmt::Display for VecString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}]",
-            self.0
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
 }
 
 impl SubnetCommand {

--- a/structable_derive/src/structable.rs
+++ b/structable_derive/src/structable.rs
@@ -40,6 +40,10 @@ pub(crate) struct TableStructFieldReceiver {
     /// Whether option is returned is optional or not
     #[darling(default)]
     optional: bool,
+
+    /// apply `to_string_pretty` instead of `to_string` for the value
+    #[darling(default)]
+    pretty: bool,
 }
 
 impl ToTokens for TableStructInputReceiver {


### PR DESCRIPTION
switch to use of json syntax directly for all complex fields that were
previously attempted to be rendered individualy. This caused lot of
additional code, dump of undefined values  and sometimes not obvious
syntax. With json directly we could use predefined to_string_pretty
method to keep it even more configurable.