### PR TITLE
chore: add clippy exception on common tag module

### DIFF
--- a/openstack_cli/src/network/v2/_tag.rs_
+++ b/openstack_cli/src/network/v2/_tag.rs_
@@ -16,6 +16,8 @@
 //!
 //! This module is defined once and symlinked into individual resources. This way code is
 //! de-duplicated while also ensuring the same command interface is being maintained.
+#![allow(clippy::duplicate_mod)]
+
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;


### PR DESCRIPTION
tell clippy to ignore tag module being included multiple times since
this is exactly what we want.
