### PR TITLE
feat(output): group command args in help message

### DIFF
--- a/openstack_cli/src/block_storage/v3/type/add_project_access.rs
+++ b/openstack_cli/src/block_storage/v3/type/add_project_access.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/types/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AddProjectAccess Body data
 #[derive(Args)]
 struct AddProjectAccess {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     project: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/type/create.rs
+++ b/openstack_cli/src/block_storage/v3/type/create.rs
@@ -65,22 +65,26 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/types/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// VolumeType Body data
 #[derive(Args)]
 struct VolumeType {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
     extra_specs: Option<Vec<(String, Option<String>)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     os_volume_type_access_is_public: Option<bool>,
 }
 

--- a/openstack_cli/src/block_storage/v3/type/delete.rs
+++ b/openstack_cli/src/block_storage/v3/type/delete.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/types/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Type response representation

--- a/openstack_cli/src/block_storage/v3/type/encryption/create.rs
+++ b/openstack_cli/src/block_storage/v3/type/encryption/create.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 }
 
@@ -79,16 +83,16 @@ enum ControlLocation {
 /// Encryption Body data
 #[derive(Args)]
 struct Encryption {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cipher: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     control_location: ControlLocation,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_size: Option<Option<i32>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/type/encryption/delete.rs
+++ b/openstack_cli/src/block_storage/v3/type/encryption/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 
     /// id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Encryption response representation

--- a/openstack_cli/src/block_storage/v3/type/encryption/list.rs
+++ b/openstack_cli/src/block_storage/v3/type/encryption/list.rs
@@ -59,7 +59,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 }
 /// Encryptions response representation

--- a/openstack_cli/src/block_storage/v3/type/encryption/set.rs
+++ b/openstack_cli/src/block_storage/v3/type/encryption/set.rs
@@ -66,12 +66,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 
     /// id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -84,16 +92,16 @@ enum ControlLocation {
 /// Encryption Body data
 #[derive(Args)]
 struct Encryption {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cipher: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     control_location: Option<ControlLocation>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_size: Option<Option<i32>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider: Option<String>,
 }
 

--- a/openstack_cli/src/block_storage/v3/type/encryption/show.rs
+++ b/openstack_cli/src/block_storage/v3/type/encryption/show.rs
@@ -59,12 +59,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 
     /// id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Encryption response representation

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/create.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/create.rs
@@ -52,7 +52,7 @@ pub struct ExtraSpecCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
     extra_specs: Vec<(String, Option<String>)>,
 }
 
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/delete.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 
     /// id parameter for /v3/types/{type_id}/extra_specs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/list.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/list.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 }
 /// ExtraSpecs response representation

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/set.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/set.rs
@@ -53,6 +53,7 @@ pub struct ExtraSpecCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Option<String>)>>,
 }
 
@@ -65,12 +66,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 
     /// id parameter for /v3/types/{type_id}/extra_specs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/block_storage/v3/type/extra_spec/show.rs
+++ b/openstack_cli/src/block_storage/v3/type/extra_spec/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 
     /// id parameter for /v3/types/{type_id}/extra_specs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/block_storage/v3/type/remove_project_access.rs
+++ b/openstack_cli/src/block_storage/v3/type/remove_project_access.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/types/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// RemoveProjectAccess Body data
 #[derive(Args)]
 struct RemoveProjectAccess {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     project: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/type/set.rs
+++ b/openstack_cli/src/block_storage/v3/type/set.rs
@@ -65,19 +65,23 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/types/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// VolumeType Body data
 #[derive(Args)]
 struct VolumeType {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     is_public: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -149,6 +153,7 @@ impl TypeCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters

--- a/openstack_cli/src/block_storage/v3/type/show.rs
+++ b/openstack_cli/src/block_storage/v3/type/show.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/types/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Type response representation

--- a/openstack_cli/src/block_storage/v3/type/volume_type_access/get.rs
+++ b/openstack_cli/src/block_storage/v3/type/volume_type_access/get.rs
@@ -59,7 +59,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// type_id parameter for /v3/types/{type_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_type_id", value_name = "TYPE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_type_id",
+        value_name = "TYPE_ID"
+    )]
     type_id: String,
 }
 /// VolumeTypeAccess response representation

--- a/openstack_cli/src/block_storage/v3/volume/create_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_30.rs
@@ -54,8 +54,13 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    /// The dictionary of data to send to the scheduler.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     os_sch_hnt_scheduler_hints: Option<Vec<(String, Value)>>,
+
+    /// A `volume` object.
+    ///
     #[command(flatten)]
     volume: Volume,
 }
@@ -72,38 +77,38 @@ struct PathParameters {}
 struct Volume {
     /// The name of the availability zone.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
 
     /// The volume description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// To enable this volume to attach to more than one server, set this value
@@ -111,27 +116,27 @@ struct Volume {
     /// volumes depends on the volume type being used. See
     /// [valid boolean values](#valid-boolean-values)
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multiattach: Option<Option<bool>>,
 
     /// The volume name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The size of the volume, in gibibytes (GiB).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
 
     /// The volume type (either name or ID). To create an environment with
@@ -145,7 +150,7 @@ struct Volume {
     /// volume types to create multiple- storage back ends, see
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/create_313.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_313.rs
@@ -54,8 +54,13 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    /// The dictionary of data to send to the scheduler.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     os_sch_hnt_scheduler_hints: Option<Vec<(String, Value)>>,
+
+    /// A `volume` object.
+    ///
     #[command(flatten)]
     volume: Volume,
 }
@@ -72,41 +77,41 @@ struct PathParameters {}
 struct Volume {
     /// The name of the availability zone.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
 
     /// The volume description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// To enable this volume to attach to more than one server, set this value
@@ -114,27 +119,27 @@ struct Volume {
     /// volumes depends on the volume type being used. See
     /// [valid boolean values](#valid-boolean-values)
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multiattach: Option<Option<bool>>,
 
     /// The volume name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The size of the volume, in gibibytes (GiB).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
 
     /// The volume type (either name or ID). To create an environment with
@@ -148,7 +153,7 @@ struct Volume {
     /// volume types to create multiple- storage back ends, see
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/create_347.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_347.rs
@@ -54,8 +54,13 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    /// The dictionary of data to send to the scheduler.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     os_sch_hnt_scheduler_hints: Option<Vec<(String, Value)>>,
+
+    /// A `volume` object.
+    ///
     #[command(flatten)]
     volume: Volume,
 }
@@ -72,48 +77,48 @@ struct PathParameters {}
 struct Volume {
     /// The name of the availability zone.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The UUID of the backup.
     ///
     /// **New in version 3.47**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     backup_id: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
 
     /// The volume description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// To enable this volume to attach to more than one server, set this value
@@ -121,27 +126,27 @@ struct Volume {
     /// volumes depends on the volume type being used. See
     /// [valid boolean values](#valid-boolean-values)
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multiattach: Option<Option<bool>>,
 
     /// The volume name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The size of the volume, in gibibytes (GiB).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
 
     /// The volume type (either name or ID). To create an environment with
@@ -155,7 +160,7 @@ struct Volume {
     /// volume types to create multiple- storage back ends, see
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/create_353.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_353.rs
@@ -54,8 +54,13 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    /// The dictionary of data to send to the scheduler.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     os_sch_hnt_scheduler_hints: Option<Vec<(String, Value)>>,
+
+    /// A `volume` object.
+    ///
     #[command(flatten)]
     volume: Volume,
 }
@@ -72,48 +77,48 @@ struct PathParameters {}
 struct Volume {
     /// The name of the availability zone.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The UUID of the backup.
     ///
     /// **New in version 3.47**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     backup_id: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
 
     /// The volume description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// To enable this volume to attach to more than one server, set this value
@@ -121,27 +126,27 @@ struct Volume {
     /// volumes depends on the volume type being used. See
     /// [valid boolean values](#valid-boolean-values)
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multiattach: Option<Option<bool>>,
 
     /// The volume name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The size of the volume, in gibibytes (GiB).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
     /// The UUID of the consistency group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
 
     /// The volume type (either name or ID). To create an environment with
@@ -155,7 +160,7 @@ struct Volume {
     /// volume types to create multiple- storage back ends, see
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/delete.rs
+++ b/openstack_cli/src/block_storage/v3/volume/delete.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/encryption/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/encryption/list.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 }
 /// Encryptions response representation

--- a/openstack_cli/src/block_storage/v3/volume/encryption/show.rs
+++ b/openstack_cli/src/block_storage/v3/volume/encryption/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 
     /// id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Encryption response representation

--- a/openstack_cli/src/block_storage/v3/volume/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/list.rs
@@ -61,7 +61,7 @@ pub struct VolumesCommand {
 struct QueryParameters {
     /// Shows details for all project. Admin only.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     all_tenans: Option<bool>,
 
     /// Filters results by consumes_quota field. Resources that don’t use
@@ -70,13 +70,13 @@ struct QueryParameters {
     /// not be always possible in a cloud, see List Resource Filters to
     /// determine whether this filter is available in your cloud.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     consumes_quota: Option<bool>,
 
     /// Filters reuslts by a time that resources are created at with time
     /// comparison operators: gt/gte/eq/neq/lt/lte.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     created_at: Option<String>,
 
     /// Requests a page size of items. Returns a number of items up to a limit
@@ -84,34 +84,34 @@ struct QueryParameters {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 
     /// Used in conjunction with limit to return a slice of items. offset is
     /// where to start in the list.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
     /// form of \< key > \[: \< direction > \]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     sort: Option<String>,
 
     /// Sorts by one or more sets of attribute and sort direction combinations.
     /// If you omit the sort direction in a set, default is desc. Deprecated in
     /// favour of the combined sort parameter.
     ///
-    #[arg(long, value_parser = ["asc","desc"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
     sort_dir: Option<String>,
 
     /// Sorts by an attribute. A valid value is name, status, container_format,
@@ -119,18 +119,18 @@ struct QueryParameters {
     /// created_at. The API uses the natural sorting direction of the sort_key
     /// attribute value. Deprecated in favour of the combined sort parameter.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     sort_key: Option<String>,
 
     /// Filters reuslts by a time that resources are updated at with time
     /// comparison operators: gt/gte/eq/neq/lt/lte.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     updated_at: Option<String>,
 
     /// Whether to show count in API response or not, default is False.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     with_count: Option<bool>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/metadata/create.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/create.rs
@@ -52,7 +52,10 @@ pub struct MetadataCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    /// One or more metadata key and value pairs that are associated with the
+    /// volume.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Vec<(String, String)>,
 }
 
@@ -65,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/block_storage/v3/volume/metadata/delete.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 
     /// id parameter for /v3/volumes/{volume_id}/metadata/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/block_storage/v3/volume/metadata/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/list.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 }
 /// Metadatas response representation

--- a/openstack_cli/src/block_storage/v3/volume/metadata/replace.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/replace.rs
@@ -52,7 +52,10 @@ pub struct MetadataCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    /// One or more metadata key and value pairs that are associated with the
+    /// volume.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Vec<(String, String)>,
 }
 
@@ -65,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/block_storage/v3/volume/metadata/set.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/set.rs
@@ -52,7 +52,7 @@ pub struct MetadataCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     meta: Vec<(String, String)>,
 }
 
@@ -65,12 +65,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 
     /// id parameter for /v3/volumes/{volume_id}/metadata/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/block_storage/v3/volume/metadata/show.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// volume_id parameter for /v3/volumes/{volume_id}/encryption/{id} API
     ///
-    #[arg(id = "path_param_volume_id", value_name = "VOLUME_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_volume_id",
+        value_name = "VOLUME_ID"
+    )]
     volume_id: String,
 
     /// id parameter for /v3/volumes/{volume_id}/metadata/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_attach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_attach.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -78,16 +82,16 @@ enum Mode {
 /// OsAttach Body data
 #[derive(Args)]
 struct OsAttach {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     instance_uuid: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mode: Option<Mode>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mountpoint: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_begin_detaching.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_begin_detaching.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_detach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_detach.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsDetach Body data
 #[derive(Args)]
 struct OsDetach {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     attachment_id: Option<String>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_extend.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_extend.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsExtend Body data
 #[derive(Args)]
 struct OsExtend {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     new_size: i32,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_force_delete.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_force_delete.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_force_detach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_force_detach.rs
@@ -66,16 +66,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsForceDetach Body data
 #[derive(Args)]
 struct OsForceDetach {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     attachment_id: Option<String>,
 
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     connector: Option<Option<Value>>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_initialize_connection.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_initialize_connection.rs
@@ -66,13 +66,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsInitializeConnection Body data
 #[derive(Args)]
 struct OsInitializeConnection {
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     connector: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_30.rs
@@ -64,19 +64,23 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsMigrateVolume Body data
 #[derive(Args)]
 struct OsMigrateVolume {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     force_host_copy: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: String,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     lock_volume: Option<bool>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_316.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_316.rs
@@ -64,22 +64,26 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsMigrateVolume Body data
 #[derive(Args)]
 struct OsMigrateVolume {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cluster: Option<String>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     force_host_copy: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     lock_volume: Option<bool>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_completion.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_completion.rs
@@ -64,16 +64,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsMigrateVolumeCompletion Body data
 #[derive(Args)]
 struct OsMigrateVolumeCompletion {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     error: Option<Option<bool>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     new_volume: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_reimage_368.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_reimage_368.rs
@@ -64,16 +64,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsReimage Body data
 #[derive(Args)]
 struct OsReimage {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_id: String,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     reimage_reserved: Option<bool>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_reserve.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_reserve.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_reset_status.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_reset_status.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_retype.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_retype.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -78,10 +82,10 @@ enum MigrationPolicy {
 /// OsRetype Body data
 #[derive(Args)]
 struct OsRetype {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     migration_policy: Option<MigrationPolicy>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     new_type: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_roll_detaching.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_roll_detaching.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_set_bootable.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_set_bootable.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsSetBootable Body data
 #[derive(Args)]
 struct OsSetBootable {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     bootable: bool,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_set_image_metadata.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_set_image_metadata.rs
@@ -65,13 +65,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsSetImageMetadata Body data
 #[derive(Args)]
 struct OsSetImageMetadata {
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Vec<(String, String)>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_show_image_metadata.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_show_image_metadata.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_terminate_connection.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_terminate_connection.rs
@@ -66,13 +66,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsTerminateConnection Body data
 #[derive(Args)]
 struct OsTerminateConnection {
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     connector: Option<Value>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_unmanage.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unmanage.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_unreserve.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unreserve.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/os_unset_image_metadata.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unset_image_metadata.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsUnsetImageMetadata Body data
 #[derive(Args)]
 struct OsUnsetImageMetadata {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_update_readonly_flag.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_update_readonly_flag.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsUpdateReadonlyFlag Body data
 #[derive(Args)]
 struct OsUpdateReadonlyFlag {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     readonly: bool,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_30.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -83,16 +87,16 @@ enum DiskFormat {
 /// OsVolumeUploadImage Body data
 #[derive(Args)]
 struct OsVolumeUploadImage {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     container_format: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     disk_format: Option<DiskFormat>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     force: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_name: String,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_31.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_31.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -91,22 +95,22 @@ enum Visibility {
 /// OsVolumeUploadImage Body data
 #[derive(Args)]
 struct OsVolumeUploadImage {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     container_format: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     disk_format: Option<DiskFormat>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     force: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_name: String,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     protected: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     visibility: Option<Visibility>,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/revert.rs
+++ b/openstack_cli/src/block_storage/v3/volume/revert.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/set_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/set_30.rs
@@ -66,25 +66,29 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume Body data
 #[derive(Args)]
 struct Volume {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -335,6 +339,7 @@ impl VolumeCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set_30::Request::builder();
         ep_builder.header("OpenStack-API-Version", "volume 3.0");
 

--- a/openstack_cli/src/block_storage/v3/volume/set_353.rs
+++ b/openstack_cli/src/block_storage/v3/volume/set_353.rs
@@ -66,25 +66,29 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume Body data
 #[derive(Args)]
 struct Volume {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -335,6 +339,7 @@ impl VolumeCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set_353::Request::builder();
         ep_builder.header("OpenStack-API-Version", "volume 3.53");
 

--- a/openstack_cli/src/block_storage/v3/volume/show.rs
+++ b/openstack_cli/src/block_storage/v3/volume/show.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v3/volumes/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Volume response representation

--- a/openstack_cli/src/block_storage/v3/volume/summary/get.rs
+++ b/openstack_cli/src/block_storage/v3/volume/summary/get.rs
@@ -75,7 +75,7 @@ impl SummaryCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/compute/v2/aggregate/add_host.rs
+++ b/openstack_cli/src/compute/v2/aggregate/add_host.rs
@@ -63,13 +63,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AddHost Body data
 #[derive(Args)]
 struct AddHost {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: String,
 }
 

--- a/openstack_cli/src/compute/v2/aggregate/create_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_20.rs
@@ -58,6 +58,8 @@ pub struct AggregateCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The host aggregate object.
+    ///
     #[command(flatten)]
     aggregate: Aggregate,
 }
@@ -77,12 +79,12 @@ struct Aggregate {
     /// os-availability-zone API. The availability zone must not include ‘:’ in
     /// its name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The name of the host aggregate.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 }
 

--- a/openstack_cli/src/compute/v2/aggregate/create_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_21.rs
@@ -58,6 +58,8 @@ pub struct AggregateCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The host aggregate object.
+    ///
     #[command(flatten)]
     aggregate: Aggregate,
 }
@@ -77,12 +79,12 @@ struct Aggregate {
     /// os-availability-zone API. The availability zone must not include ‘:’ in
     /// its name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The name of the host aggregate.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 }
 

--- a/openstack_cli/src/compute/v2/aggregate/delete.rs
+++ b/openstack_cli/src/compute/v2/aggregate/delete.rs
@@ -67,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Aggregate response representation

--- a/openstack_cli/src/compute/v2/aggregate/image/cache_281.rs
+++ b/openstack_cli/src/compute/v2/aggregate/image/cache_281.rs
@@ -60,7 +60,9 @@ pub struct ImageCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    /// A list of image objects to cache.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     cache: Vec<String>,
 }
 
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Image response representation

--- a/openstack_cli/src/compute/v2/aggregate/remove_host.rs
+++ b/openstack_cli/src/compute/v2/aggregate/remove_host.rs
@@ -63,13 +63,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// RemoveHost Body data
 #[derive(Args)]
 struct RemoveHost {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: String,
 }
 

--- a/openstack_cli/src/compute/v2/aggregate/set_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_20.rs
@@ -58,6 +58,8 @@ pub struct AggregateCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The host aggregate object.
+    ///
     #[command(flatten)]
     aggregate: Aggregate,
 }
@@ -71,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Aggregate Body data
@@ -88,12 +94,12 @@ struct Aggregate {
     /// when that aggregate has hosts which contain servers in it since that
     /// may impact the ability for those servers to move to another host.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The name of the host aggregate.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/aggregate/set_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_21.rs
@@ -58,6 +58,8 @@ pub struct AggregateCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The host aggregate object.
+    ///
     #[command(flatten)]
     aggregate: Aggregate,
 }
@@ -71,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Aggregate Body data
@@ -88,12 +94,12 @@ struct Aggregate {
     /// when that aggregate has hosts which contain servers in it since that
     /// may impact the ability for those servers to move to another host.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
     /// The name of the host aggregate.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/aggregate/set_metadata.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_metadata.rs
@@ -64,13 +64,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// SetMetadata Body data
 #[derive(Args)]
 struct SetMetadata {
-    #[arg(long, value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
     metadata: Vec<(String, Option<String>)>,
 }
 

--- a/openstack_cli/src/compute/v2/aggregate/show.rs
+++ b/openstack_cli/src/compute/v2/aggregate/show.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-aggregates/{id}/images API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Aggregate response representation

--- a/openstack_cli/src/compute/v2/availability_zone/get.rs
+++ b/openstack_cli/src/compute/v2/availability_zone/get.rs
@@ -115,7 +115,7 @@ impl AvailabilityZoneCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/compute/v2/extension/show.rs
+++ b/openstack_cli/src/compute/v2/extension/show.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/extensions/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Extension response representation

--- a/openstack_cli/src/compute/v2/flavor/add_tenant_access.rs
+++ b/openstack_cli/src/compute/v2/flavor/add_tenant_access.rs
@@ -58,6 +58,8 @@ pub struct FlavorCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     add_tenant_access: AddTenantAccess,
 }
@@ -71,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/flavors/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AddTenantAccess Body data
@@ -79,7 +85,7 @@ struct PathParameters {
 struct AddTenantAccess {
     /// The UUID of the tenant in a multi-tenancy cloud.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tenant: String,
 }
 

--- a/openstack_cli/src/compute/v2/flavor/create_20.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_20.rs
@@ -61,6 +61,9 @@ pub struct FlavorCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The ID and links for the flavor for your server instance. A flavor is a
+    /// combination of memory, disk size, and CPUs.
+    ///
     #[command(flatten)]
     flavor: Flavor,
 }
@@ -78,54 +81,54 @@ struct Flavor {
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     disk: String,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
     /// UUID will be assigned.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The display name of a flavor.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// Whether the flavor is public (available to all projects) or scoped to a
     /// set of projects. Default is True if not specified.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     os_flavor_access_is_public: Option<bool>,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_flv_ext_data_ephemeral: Option<String>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     ram: String,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
     /// ignored. It defaults to 1.0.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     rxtx_factor: Option<String>,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     swap: Option<String>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     vcpus: String,
 }
 

--- a/openstack_cli/src/compute/v2/flavor/create_21.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_21.rs
@@ -61,6 +61,9 @@ pub struct FlavorCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The ID and links for the flavor for your server instance. A flavor is a
+    /// combination of memory, disk size, and CPUs.
+    ///
     #[command(flatten)]
     flavor: Flavor,
 }
@@ -78,54 +81,54 @@ struct Flavor {
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     disk: String,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
     /// UUID will be assigned.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The display name of a flavor.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// Whether the flavor is public (available to all projects) or scoped to a
     /// set of projects. Default is True if not specified.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     os_flavor_access_is_public: Option<bool>,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_flv_ext_data_ephemeral: Option<String>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     ram: String,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
     /// ignored. It defaults to 1.0.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     rxtx_factor: Option<String>,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     swap: Option<String>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     vcpus: String,
 }
 

--- a/openstack_cli/src/compute/v2/flavor/create_255.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_255.rs
@@ -61,6 +61,9 @@ pub struct FlavorCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The ID and links for the flavor for your server instance. A flavor is a
+    /// combination of memory, disk size, and CPUs.
+    ///
     #[command(flatten)]
     flavor: Flavor,
 }
@@ -80,60 +83,60 @@ struct Flavor {
     ///
     /// **New in version 2.55**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     disk: String,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
     /// UUID will be assigned.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The display name of a flavor.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// Whether the flavor is public (available to all projects) or scoped to a
     /// set of projects. Default is True if not specified.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     os_flavor_access_is_public: Option<bool>,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_flv_ext_data_ephemeral: Option<String>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     ram: String,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
     /// ignored. It defaults to 1.0.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     rxtx_factor: Option<String>,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     swap: Option<String>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     vcpus: String,
 }
 

--- a/openstack_cli/src/compute/v2/flavor/delete.rs
+++ b/openstack_cli/src/compute/v2/flavor/delete.rs
@@ -70,7 +70,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/flavors/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Flavor response representation

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/create.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/create.rs
@@ -58,7 +58,11 @@ pub struct ExtraSpecCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    /// A dictionary of the flavor’s extra-specs key-and-value pairs. It
+    /// appears in the os-extra-specs’ “create” REQUEST body, as well as the
+    /// os-extra-specs’ “create” and “list” RESPONSE body.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     extra_specs: Vec<(String, String)>,
 }
 
@@ -71,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// flavor_id parameter for /v2.1/flavors/{flavor_id}/os-flavor-access API
     ///
-    #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_flavor_id",
+        value_name = "FLAVOR_ID"
+    )]
     flavor_id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/delete.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/delete.rs
@@ -66,12 +66,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// flavor_id parameter for /v2.1/flavors/{flavor_id}/os-flavor-access API
     ///
-    #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_flavor_id",
+        value_name = "FLAVOR_ID"
+    )]
     flavor_id: String,
 
     /// id parameter for /v2.1/flavors/{flavor_id}/os-extra_specs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/list.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// flavor_id parameter for /v2.1/flavors/{flavor_id}/os-flavor-access API
     ///
-    #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_flavor_id",
+        value_name = "FLAVOR_ID"
+    )]
     flavor_id: String,
 }
 /// ExtraSpecs response representation

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/set.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/set.rs
@@ -59,6 +59,7 @@ pub struct ExtraSpecCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, String)>>,
 }
 
@@ -71,12 +72,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// flavor_id parameter for /v2.1/flavors/{flavor_id}/os-flavor-access API
     ///
-    #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_flavor_id",
+        value_name = "FLAVOR_ID"
+    )]
     flavor_id: String,
 
     /// id parameter for /v2.1/flavors/{flavor_id}/os-extra_specs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/show.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/show.rs
@@ -66,12 +66,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// flavor_id parameter for /v2.1/flavors/{flavor_id}/os-flavor-access API
     ///
-    #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_flavor_id",
+        value_name = "FLAVOR_ID"
+    )]
     flavor_id: String,
 
     /// id parameter for /v2.1/flavors/{flavor_id}/os-extra_specs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ExtraSpec response representation

--- a/openstack_cli/src/compute/v2/flavor/flavor_access/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/flavor_access/list.rs
@@ -64,7 +64,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// flavor_id parameter for /v2.1/flavors/{flavor_id}/os-flavor-access API
     ///
-    #[arg(id = "path_param_flavor_id", value_name = "FLAVOR_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_flavor_id",
+        value_name = "FLAVOR_ID"
+    )]
     flavor_id: String,
 }
 /// FlavorAccesses response representation

--- a/openstack_cli/src/compute/v2/flavor/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/list.rs
@@ -66,25 +66,25 @@ pub struct FlavorsCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     is_public: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     min_disk: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     min_ram: Option<String>,
 
-    #[arg(long, value_parser = ["asc","desc"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
     sort_dir: Option<String>,
 
-    #[arg(long, value_parser = ["created_at","description","disabled","ephemeral_gb","flavorid","id","is_public","memory_mb","name","root_gb","rxtx_factor","swap","updated_at","vcpu_weight","vcpus"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["created_at","description","disabled","ephemeral_gb","flavorid","id","is_public","memory_mb","name","root_gb","rxtx_factor","swap","updated_at","vcpu_weight","vcpus"])]
     sort_key: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/flavor/remove_tenant_access.rs
+++ b/openstack_cli/src/compute/v2/flavor/remove_tenant_access.rs
@@ -59,6 +59,8 @@ pub struct FlavorCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     remove_tenant_access: RemoveTenantAccess,
 }
@@ -72,7 +74,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/flavors/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// RemoveTenantAccess Body data
@@ -80,7 +86,7 @@ struct PathParameters {
 struct RemoveTenantAccess {
     /// The UUID of the tenant in a multi-tenancy cloud.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tenant: String,
 }
 

--- a/openstack_cli/src/compute/v2/flavor/set.rs
+++ b/openstack_cli/src/compute/v2/flavor/set.rs
@@ -66,6 +66,9 @@ pub struct FlavorCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The ID and links for the flavor for your server instance. A flavor is a
+    /// combination of memory, disk size, and CPUs.
+    ///
     #[command(flatten)]
     flavor: Flavor,
 }
@@ -79,7 +82,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/flavors/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Flavor Body data
@@ -88,7 +95,7 @@ struct Flavor {
     /// A free form description of the flavor. Limited to 65535 characters in
     /// length. Only printable characters are allowed.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: String,
 }
 
@@ -203,6 +210,7 @@ impl FlavorCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters

--- a/openstack_cli/src/compute/v2/flavor/show.rs
+++ b/openstack_cli/src/compute/v2/flavor/show.rs
@@ -68,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/flavors/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Flavor response representation

--- a/openstack_cli/src/compute/v2/hypervisor/list.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/list.rs
@@ -70,16 +70,16 @@ pub struct HypervisorsCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     hypervisor_hostname_pattern: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     with_servers: Option<bool>,
 }
 

--- a/openstack_cli/src/compute/v2/hypervisor/search/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/search/get.rs
@@ -70,7 +70,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-hypervisors/{id}/uptime API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Search response representation

--- a/openstack_cli/src/compute/v2/hypervisor/server/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/server/get.rs
@@ -71,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-hypervisors/{id}/uptime API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/hypervisor/show.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/show.rs
@@ -66,7 +66,7 @@ pub struct HypervisorCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     with_servers: Option<bool>,
 }
 
@@ -75,7 +75,11 @@ struct QueryParameters {
 struct PathParameters {
     /// id parameter for /v2.1/os-hypervisors/{id}/uptime API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Hypervisor response representation

--- a/openstack_cli/src/compute/v2/hypervisor/statistic/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/statistic/get.rs
@@ -85,7 +85,7 @@ impl StatisticCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/compute/v2/hypervisor/uptime/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/uptime/get.rs
@@ -71,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/os-hypervisors/{id}/uptime API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Uptime response representation

--- a/openstack_cli/src/compute/v2/keypair/create_20.rs
+++ b/openstack_cli/src/compute/v2/keypair/create_20.rs
@@ -55,6 +55,8 @@ pub struct KeypairCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Keypair object
+    ///
     #[command(flatten)]
     keypair: Keypair,
 }
@@ -77,13 +79,13 @@ struct Keypair {
     /// `[a-zA-Z]`, digits `[0-9]` and the following special characters:
     /// `[@._- ]`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The public ssh key to import. Was optional before microversion 2.92 :
     /// if you were omitting this value, a keypair was generated for you.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     public_key: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/keypair/create_21.rs
+++ b/openstack_cli/src/compute/v2/keypair/create_21.rs
@@ -55,6 +55,8 @@ pub struct KeypairCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Keypair object
+    ///
     #[command(flatten)]
     keypair: Keypair,
 }
@@ -77,13 +79,13 @@ struct Keypair {
     /// `[a-zA-Z]`, digits `[0-9]` and the following special characters:
     /// `[@._- ]`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The public ssh key to import. Was optional before microversion 2.92 :
     /// if you were omitting this value, a keypair was generated for you.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     public_key: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/keypair/create_210.rs
+++ b/openstack_cli/src/compute/v2/keypair/create_210.rs
@@ -56,6 +56,8 @@ pub struct KeypairCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Keypair object
+    ///
     #[command(flatten)]
     keypair: Keypair,
 }
@@ -85,20 +87,20 @@ struct Keypair {
     /// `[a-zA-Z]`, digits `[0-9]` and the following special characters:
     /// `[@._- ]`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The public ssh key to import. Was optional before microversion 2.92 :
     /// if you were omitting this value, a keypair was generated for you.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     public_key: Option<String>,
 
     /// The type of the keypair. Allowed values are `ssh` or `x509`.
     ///
     /// **New in version 2.2**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Option<Type>,
 
     /// The user_id for a keypair. This allows administrative users to upload
@@ -106,7 +108,7 @@ struct Keypair {
     ///
     /// **New in version 2.10**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_id: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/keypair/create_22.rs
+++ b/openstack_cli/src/compute/v2/keypair/create_22.rs
@@ -56,6 +56,8 @@ pub struct KeypairCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Keypair object
+    ///
     #[command(flatten)]
     keypair: Keypair,
 }
@@ -85,20 +87,20 @@ struct Keypair {
     /// `[a-zA-Z]`, digits `[0-9]` and the following special characters:
     /// `[@._- ]`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The public ssh key to import. Was optional before microversion 2.92 :
     /// if you were omitting this value, a keypair was generated for you.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     public_key: Option<String>,
 
     /// The type of the keypair. Allowed values are `ssh` or `x509`.
     ///
     /// **New in version 2.2**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Option<Type>,
 }
 

--- a/openstack_cli/src/compute/v2/keypair/create_292.rs
+++ b/openstack_cli/src/compute/v2/keypair/create_292.rs
@@ -56,6 +56,8 @@ pub struct KeypairCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Keypair object
+    ///
     #[command(flatten)]
     keypair: Keypair,
 }
@@ -85,20 +87,20 @@ struct Keypair {
     /// `[a-zA-Z]`, digits `[0-9]` and the following special characters:
     /// `[@._- ]`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The public ssh key to import. Was optional before microversion 2.92 :
     /// if you were omitting this value, a keypair was generated for you.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     public_key: String,
 
     /// The type of the keypair. Allowed values are `ssh` or `x509`.
     ///
     /// **New in version 2.2**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Option<Type>,
 
     /// The user_id for a keypair. This allows administrative users to upload
@@ -106,7 +108,7 @@ struct Keypair {
     ///
     /// **New in version 2.10**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_id: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/keypair/delete.rs
+++ b/openstack_cli/src/compute/v2/keypair/delete.rs
@@ -60,7 +60,7 @@ pub struct KeypairCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     user_id: Option<String>,
 }
 
@@ -69,7 +69,11 @@ struct QueryParameters {
 struct PathParameters {
     /// id parameter for /v2.1/os-keypairs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Keypair response representation

--- a/openstack_cli/src/compute/v2/keypair/list.rs
+++ b/openstack_cli/src/compute/v2/keypair/list.rs
@@ -63,13 +63,13 @@ pub struct KeypairsCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     user_id: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/keypair/show.rs
+++ b/openstack_cli/src/compute/v2/keypair/show.rs
@@ -59,7 +59,7 @@ pub struct KeypairCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     user_id: Option<String>,
 }
 
@@ -68,7 +68,11 @@ struct QueryParameters {
 struct PathParameters {
     /// id parameter for /v2.1/os-keypairs/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Keypair response representation

--- a/openstack_cli/src/compute/v2/server/add_fixed_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/add_fixed_ip_21.rs
@@ -65,6 +65,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to add a fixed ip address to a server.
+    ///
     #[command(flatten)]
     add_fixed_ip: AddFixedIp,
 }
@@ -78,7 +80,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AddFixedIp Body data
@@ -86,7 +92,7 @@ struct PathParameters {
 struct AddFixedIp {
     /// The network ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     network_id: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/add_floating_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/add_floating_ip_21.rs
@@ -79,6 +79,9 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action. Contains required floating IP `address` and optional
+    /// `fixed_address`.
+    ///
     #[command(flatten)]
     add_floating_ip: AddFloatingIp,
 }
@@ -92,7 +95,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AddFloatingIp Body data
@@ -101,13 +108,13 @@ struct AddFloatingIp {
     /// The fixed IP address with which you want to associate the floating IP
     /// address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     address: String,
 
     /// The fixed IP address with which you want to associate the floating IP
     /// address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     fixed_address: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/add_security_group.rs
+++ b/openstack_cli/src/compute/v2/server/add_security_group.rs
@@ -69,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/change_password.rs
+++ b/openstack_cli/src/compute/v2/server/change_password.rs
@@ -63,6 +63,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to change an administrative password of the server.
+    ///
     #[command(flatten)]
     change_password: ChangePassword,
 }
@@ -76,7 +78,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ChangePassword Body data
@@ -84,7 +90,7 @@ struct PathParameters {
 struct ChangePassword {
     /// The administrative password for the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/confirm_resize.rs
+++ b/openstack_cli/src/compute/v2/server/confirm_resize.rs
@@ -94,7 +94,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/create_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_20.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -112,18 +135,18 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// Key pair name.
@@ -133,10 +156,10 @@ struct Server {
     /// The `null` value was allowed in the Nova legacy v2 API, but due to
     /// strict input validation, it is not allowed in the Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -165,7 +188,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -176,20 +199,20 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// Key pair name.
@@ -199,19 +222,19 @@ struct Server {
     /// The `null` value was allowed in the Nova legacy v2 API, but due to
     /// strict input validation, it is not allowed in the Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// Key pair name.
@@ -221,7 +244,7 @@ struct Server {
     /// The `null` value was allowed in the Nova legacy v2 API, but due to
     /// strict input validation, it is not allowed in the Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -262,7 +285,7 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -282,7 +305,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -292,7 +315,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -303,7 +326,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -311,7 +334,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -322,7 +345,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -333,7 +356,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -342,7 +365,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -350,14 +373,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -366,7 +389,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -379,21 +402,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_21.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -112,28 +135,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -162,7 +185,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -173,46 +196,46 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -253,7 +276,7 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -273,7 +296,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -283,7 +306,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -294,7 +317,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -302,7 +325,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -313,7 +336,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -324,7 +347,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -333,7 +356,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -341,14 +364,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -357,7 +380,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -370,21 +393,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_219.rs
+++ b/openstack_cli/src/compute/v2/server/create_219.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -112,28 +135,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -162,7 +185,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -173,7 +196,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -181,46 +204,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -261,7 +284,7 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -281,7 +304,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -291,7 +314,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -302,7 +325,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -310,7 +333,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -321,7 +344,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -332,7 +355,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -341,7 +364,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -349,14 +372,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -365,7 +388,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -378,21 +401,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_232.rs
+++ b/openstack_cli/src/compute/v2/server/create_232.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -112,28 +135,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -162,7 +185,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -173,7 +196,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -181,46 +204,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -261,7 +284,7 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -281,7 +304,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -291,7 +314,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -302,7 +325,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -310,7 +333,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -321,7 +344,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -332,7 +355,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -341,7 +364,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -349,14 +372,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -365,7 +388,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -378,21 +401,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_233.rs
+++ b/openstack_cli/src/compute/v2/server/create_233.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -112,28 +135,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -162,7 +185,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -173,7 +196,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -181,46 +204,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -261,7 +284,7 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -281,7 +304,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -291,7 +314,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -302,7 +325,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -310,7 +333,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -321,7 +344,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -332,7 +355,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -341,7 +364,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -349,14 +372,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -365,7 +388,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -378,21 +401,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_237.rs
+++ b/openstack_cli/src/compute/v2/server/create_237.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,46 +224,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -301,7 +324,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -311,7 +334,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -322,7 +345,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -330,7 +353,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -341,7 +364,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -352,7 +375,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -361,7 +384,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -369,14 +392,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -385,7 +408,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -398,21 +421,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -549,14 +572,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_237::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_237::NetworksEnum::F2(
-                create_237::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_237::NetworksEnum::F2(
                 create_237::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_237::NetworksEnum::F2(
+                create_237::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_242.rs
+++ b/openstack_cli/src/compute/v2/server/create_242.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,46 +224,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -301,7 +324,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -311,7 +334,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -322,7 +345,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -330,7 +353,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -341,7 +364,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -352,7 +375,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -361,7 +384,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -369,14 +392,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -385,7 +408,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -398,21 +421,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -549,14 +572,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_242::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_242::NetworksEnum::F2(
-                create_242::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_242::NetworksEnum::F2(
                 create_242::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_242::NetworksEnum::F2(
+                create_242::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_252.rs
+++ b/openstack_cli/src/compute/v2/server/create_252.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,46 +224,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -301,7 +324,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -311,7 +334,7 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -322,7 +345,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -330,7 +353,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// A list of tags. Tags have the following restrictions:
@@ -345,7 +368,7 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -356,7 +379,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -367,7 +390,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -376,7 +399,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -384,14 +407,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -400,7 +423,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -413,21 +436,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -564,14 +587,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_252::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_252::NetworksEnum::F2(
-                create_252::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_252::NetworksEnum::F2(
                 create_252::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_252::NetworksEnum::F2(
+                create_252::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_257.rs
+++ b/openstack_cli/src/compute/v2/server/create_257.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,46 +224,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -301,7 +324,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -312,7 +335,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -320,7 +343,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// A list of tags. Tags have the following restrictions:
@@ -335,7 +358,7 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -346,7 +369,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -357,7 +380,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -366,7 +389,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -374,14 +397,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -390,7 +413,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -403,21 +426,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -554,14 +577,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_257::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_257::NetworksEnum::F2(
-                create_257::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_257::NetworksEnum::F2(
                 create_257::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_257::NetworksEnum::F2(
+                create_257::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_263.rs
+++ b/openstack_cli/src/compute/v2/server/create_263.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,46 +224,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -301,7 +324,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -312,7 +335,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -320,7 +343,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// A list of tags. Tags have the following restrictions:
@@ -335,7 +358,7 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -346,7 +369,7 @@ struct Server {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -357,7 +380,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -368,7 +391,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -377,7 +400,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -385,14 +408,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -401,7 +424,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -414,21 +437,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -565,14 +588,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_263::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_263::NetworksEnum::F2(
-                create_263::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_263::NetworksEnum::F2(
                 create_263::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_263::NetworksEnum::F2(
+                create_263::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_267.rs
+++ b/openstack_cli/src/compute/v2/server/create_267.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,46 +224,46 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -301,7 +324,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -312,7 +335,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -320,7 +343,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// A list of tags. Tags have the following restrictions:
@@ -335,7 +358,7 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -346,7 +369,7 @@ struct Server {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -357,7 +380,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -368,7 +391,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -377,7 +400,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -385,14 +408,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -401,7 +424,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -414,21 +437,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -565,14 +588,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_267::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_267::NetworksEnum::F2(
-                create_267::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_267::NetworksEnum::F2(
                 create_267::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_267::NetworksEnum::F2(
+                create_267::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_274.rs
+++ b/openstack_cli/src/compute/v2/server/create_274.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,13 +224,13 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The hostname of the hypervisor on which the server is to be created.
@@ -216,7 +239,7 @@ struct Server {
     ///
     /// **New in version 2.74**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 
     /// The hostname of the hypervisor on which the server is to be created.
@@ -225,40 +248,40 @@ struct Server {
     ///
     /// **New in version 2.74**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hypervisor_hostname: Option<String>,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -319,7 +342,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -330,7 +353,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -338,7 +361,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// A list of tags. Tags have the following restrictions:
@@ -353,7 +376,7 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -364,7 +387,7 @@ struct Server {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -375,7 +398,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -386,7 +409,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -395,7 +418,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -403,14 +426,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -419,7 +442,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -432,21 +455,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -583,14 +606,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_274::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_274::NetworksEnum::F2(
-                create_274::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_274::NetworksEnum::F2(
                 create_274::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_274::NetworksEnum::F2(
+                create_274::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_290.rs
+++ b/openstack_cli/src/compute/v2/server/create_290.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,13 +224,13 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The hostname of the hypervisor on which the server is to be created.
@@ -216,7 +239,7 @@ struct Server {
     ///
     /// **New in version 2.74**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 
     /// The hostname to configure for the instance in the metadata service.
@@ -232,7 +255,7 @@ struct Server {
     ///
     /// **New in version 2.90**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hostname: Option<String>,
 
     /// The hostname of the hypervisor on which the server is to be created.
@@ -241,40 +264,40 @@ struct Server {
     ///
     /// **New in version 2.74**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hypervisor_hostname: Option<String>,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -335,7 +358,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -346,7 +369,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -354,7 +377,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// A list of tags. Tags have the following restrictions:
@@ -369,7 +392,7 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -380,7 +403,7 @@ struct Server {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -391,7 +414,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -402,7 +425,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -411,7 +434,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -419,14 +442,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -435,7 +458,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -448,21 +471,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -599,14 +622,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_290::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_290::NetworksEnum::F2(
-                create_290::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_290::NetworksEnum::F2(
                 create_290::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_290::NetworksEnum::F2(
+                create_290::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_294.rs
+++ b/openstack_cli/src/compute/v2/server/create_294.rs
@@ -87,8 +87,31 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The dictionary of data to send to the scheduler. Alternatively, you can
+    /// specify `OS-SCH-HNT:scheduler_hints` as the key in the request body.
+    ///
+    /// Note
+    ///
+    /// This is a top-level key in the request body, not part of the server
+    /// portion of the request body.
+    ///
+    /// There are a few caveats with scheduler hints:
+    ///
+    /// - The request validation schema is per hint. For example, some require
+    ///   a single string value, and some accept a list of values.
+    /// - Hints are only used based on the cloud scheduler configuration, which
+    ///   varies per deployment.
+    /// - Hints are pluggable per deployment, meaning that a cloud can have
+    ///   custom hints which may not be available in another cloud.
+    ///
+    /// For these reasons, it is important to consult each cloud’s user
+    /// documentation to know what is available for scheduler hints.
+    ///
     #[command(flatten)]
     os_scheduler_hints: Option<OsSchedulerHints>,
+
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -111,13 +134,13 @@ enum NetworksStringEnum {
 #[derive(Args)]
 #[group(required = true, multiple = false)]
 struct NetworksEnumGroupStruct {
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
-    #[arg(action=clap::ArgAction::SetTrue, long, required=false)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     none_networks: bool,
 }
 
@@ -132,28 +155,28 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
     /// Enables fine grained control of the block device mapping for an
@@ -182,7 +205,7 @@ struct Server {
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -193,7 +216,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     config_drive: Option<bool>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -201,13 +224,13 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// The hostname of the hypervisor on which the server is to be created.
@@ -216,7 +239,7 @@ struct Server {
     ///
     /// **New in version 2.74**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 
     /// The hostname to configure for the instance in the metadata service.
@@ -232,7 +255,7 @@ struct Server {
     ///
     /// **New in version 2.90**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hostname: Option<String>,
 
     /// The hostname of the hypervisor on which the server is to be created.
@@ -241,40 +264,40 @@ struct Server {
     ///
     /// **New in version 2.74**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hypervisor_hostname: Option<String>,
 
     /// The UUID of the image to use for your server instance. This is not
     /// required in case of boot from volume. In all other cases it is required
     /// and must be a valid UUID otherwise API will return 400.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     max_count: Option<i32>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     min_count: Option<i32>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// A list of `network` object. Required parameter when there are multiple
@@ -335,7 +358,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether a config drive enables metadata injection. The
@@ -346,7 +369,7 @@ struct Server {
     /// all cloud providers enable the `config_drive`. Read more in the
     /// [OpenStack End User Guide](https://docs.openstack.org/nova/latest/user/config-drive.html).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     return_reservation_id: Option<bool>,
 
     /// One or more security groups. Specify the name of the security group in
@@ -354,7 +377,7 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// A list of tags. Tags have the following restrictions:
@@ -369,7 +392,7 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -380,7 +403,7 @@ struct Server {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon launch. Must be Base64
@@ -391,7 +414,7 @@ struct Server {
     /// The `null` value allowed in Nova legacy v2 API, but due to the strict
     /// input validation, it isn’t allowed in Nova v2.1 API.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 
@@ -402,7 +425,7 @@ struct OsSchedulerHints {
     /// parameter and a cidr (`os:scheduler_hints.cidr`). It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     build_near_host_ip: Option<String>,
 
     /// Schedule the server on a host in the network specified with an IP
@@ -411,7 +434,7 @@ struct OsSchedulerHints {
     /// parameter is omitted, `/24` is used. It is available when
     /// `SimpleCIDRAffinityFilter` is available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A list of cell routes or a cell route (string). Schedule the server in
@@ -419,14 +442,14 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
 
     /// The server group UUID. Schedule the server according to a policy of the
@@ -435,7 +458,7 @@ struct OsSchedulerHints {
     /// `ServerGroupAntiAffinityFilter`, `ServerGroupSoftAntiAffinityWeigher`,
     /// `ServerGroupSoftAffinityWeigher` are available on cloud side.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     group: Option<String>,
 
     /// Schedule the server by using a custom filter in JSON format. For
@@ -448,21 +471,21 @@ struct OsSchedulerHints {
     ///
     /// It is available when `JsonFilter` is available on cloud side.
     ///
-    #[arg(long, value_name="JSON", value_parser=parse_json)]
+    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     query: Option<Value>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,
 
     /// A target cell name. Schedule the server in a host in the cell
     /// specified. It is available when `TargetCellFilter` is available on
     /// cloud side that is cell v1 environment.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     target_cell: Option<String>,
 }
 
@@ -599,14 +622,14 @@ impl ServerCommand {
                 .collect();
             server_builder.networks(create_294::NetworksEnum::F1(networks_builder));
         }
-        if args.networks.auto_networks {
-            server_builder.networks(create_294::NetworksEnum::F2(
-                create_294::NetworksStringEnum::Auto,
-            ));
-        }
         if args.networks.none_networks {
             server_builder.networks(create_294::NetworksEnum::F2(
                 create_294::NetworksStringEnum::None,
+            ));
+        }
+        if args.networks.auto_networks {
+            server_builder.networks(create_294::NetworksEnum::F2(
+                create_294::NetworksStringEnum::Auto,
             ));
         }
 

--- a/openstack_cli/src/compute/v2/server/create_backup_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_20.rs
@@ -51,6 +51,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     create_backup: CreateBackup,
 }
@@ -64,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// CreateBackup Body data
@@ -72,24 +78,24 @@ struct PathParameters {
 struct CreateBackup {
     /// The type of the backup, for example, `daily`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     backup_type: String,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The name of the image to be backed up.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The rotation of the back up image, the oldest image will be removed
     /// when image count exceed the rotation count.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     rotation: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_backup_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_21.rs
@@ -51,6 +51,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     create_backup: CreateBackup,
 }
@@ -64,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// CreateBackup Body data
@@ -72,24 +78,24 @@ struct PathParameters {
 struct CreateBackup {
     /// The type of the backup, for example, `daily`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     backup_type: String,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The name of the image to be backed up.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The rotation of the back up image, the oldest image will be removed
     /// when image count exceed the rotation count.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     rotation: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_image_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_image_20.rs
@@ -51,6 +51,9 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to create a snapshot of the image or the volume(s) of the
+    /// server.
+    ///
     #[command(flatten)]
     create_image: CreateImage,
 }
@@ -64,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// CreateImage Body data
@@ -73,12 +80,12 @@ struct CreateImage {
     /// Metadata key and value pairs for the image. The maximum size for each
     /// metadata key and value pair is 255 bytes.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The display name of an Image.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/create_image_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_image_21.rs
@@ -51,6 +51,9 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to create a snapshot of the image or the volume(s) of the
+    /// server.
+    ///
     #[command(flatten)]
     create_image: CreateImage,
 }
@@ -64,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// CreateImage Body data
@@ -73,12 +80,12 @@ struct CreateImage {
     /// Metadata key and value pairs for the image. The maximum size for each
     /// metadata key and value pair is 255 bytes.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The display name of an Image.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/delete.rs
+++ b/openstack_cli/src/compute/v2/server/delete.rs
@@ -80,7 +80,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/diagnostic/get.rs
+++ b/openstack_cli/src/compute/v2/server/diagnostic/get.rs
@@ -69,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Diagnostic response representation

--- a/openstack_cli/src/compute/v2/server/evacuate_20.rs
+++ b/openstack_cli/src/compute/v2/server/evacuate_20.rs
@@ -50,6 +50,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to evacuate a server to another host.
+    ///
     #[command(flatten)]
     evacuate: Evacuate,
 }
@@ -63,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Evacuate Body data
@@ -74,7 +80,7 @@ struct Evacuate {
     /// version 2.13, if `onSharedStorage` is set to `True` and this parameter
     /// is specified, an error is raised.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// The name or ID of the host to which the server is evacuated. If you
@@ -89,7 +95,7 @@ struct Evacuate {
     /// pick one, or specify a host with microversion >= 2.29 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 
     /// Server on shared storage.
@@ -102,7 +108,7 @@ struct Evacuate {
     ///
     /// **Available until version 2.13**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     on_shared_storage: bool,
 }
 

--- a/openstack_cli/src/compute/v2/server/evacuate_214.rs
+++ b/openstack_cli/src/compute/v2/server/evacuate_214.rs
@@ -50,6 +50,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to evacuate a server to another host.
+    ///
     #[command(flatten)]
     evacuate: Evacuate,
 }
@@ -63,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Evacuate Body data
@@ -74,7 +80,7 @@ struct Evacuate {
     /// version 2.13, if `onSharedStorage` is set to `True` and this parameter
     /// is specified, an error is raised.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// The name or ID of the host to which the server is evacuated. If you
@@ -89,7 +95,7 @@ struct Evacuate {
     /// pick one, or specify a host with microversion >= 2.29 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/evacuate_229.rs
+++ b/openstack_cli/src/compute/v2/server/evacuate_229.rs
@@ -50,6 +50,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to evacuate a server to another host.
+    ///
     #[command(flatten)]
     evacuate: Evacuate,
 }
@@ -63,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Evacuate Body data
@@ -74,7 +80,7 @@ struct Evacuate {
     /// version 2.13, if `onSharedStorage` is set to `True` and this parameter
     /// is specified, an error is raised.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// Force an evacuation by not verifying the provided destination host by
@@ -96,7 +102,7 @@ struct Evacuate {
     ///
     /// **Available until version 2.67**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     force: Option<bool>,
 
     /// The name or ID of the host to which the server is evacuated. If you
@@ -111,7 +117,7 @@ struct Evacuate {
     /// pick one, or specify a host with microversion >= 2.29 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/evacuate_268.rs
+++ b/openstack_cli/src/compute/v2/server/evacuate_268.rs
@@ -50,6 +50,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to evacuate a server to another host.
+    ///
     #[command(flatten)]
     evacuate: Evacuate,
 }
@@ -63,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Evacuate Body data
@@ -74,7 +80,7 @@ struct Evacuate {
     /// version 2.13, if `onSharedStorage` is set to `True` and this parameter
     /// is specified, an error is raised.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// The name or ID of the host to which the server is evacuated. If you
@@ -89,7 +95,7 @@ struct Evacuate {
     /// pick one, or specify a host with microversion >= 2.29 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/evacuate_295.rs
+++ b/openstack_cli/src/compute/v2/server/evacuate_295.rs
@@ -50,6 +50,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to evacuate a server to another host.
+    ///
     #[command(flatten)]
     evacuate: Evacuate,
 }
@@ -63,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Evacuate Body data
@@ -74,7 +80,7 @@ struct Evacuate {
     /// version 2.13, if `onSharedStorage` is set to `True` and this parameter
     /// is specified, an error is raised.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// The name or ID of the host to which the server is evacuated. If you
@@ -89,7 +95,7 @@ struct Evacuate {
     /// pick one, or specify a host with microversion >= 2.29 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/force_delete.rs
+++ b/openstack_cli/src/compute/v2/server/force_delete.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/inject_network_info.rs
+++ b/openstack_cli/src/compute/v2/server/inject_network_info.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/instance_action/list.rs
+++ b/openstack_cli/src/compute/v2/server/instance_action/list.rs
@@ -72,16 +72,16 @@ pub struct InstanceActionsCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     changes_before: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     changes_since: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 }
 
@@ -90,7 +90,11 @@ struct QueryParameters {
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// InstanceActions response representation

--- a/openstack_cli/src/compute/v2/server/instance_action/show.rs
+++ b/openstack_cli/src/compute/v2/server/instance_action/show.rs
@@ -72,12 +72,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/os-instance-actions/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// InstanceAction response representation

--- a/openstack_cli/src/compute/v2/server/interface/create_20.rs
+++ b/openstack_cli/src/compute/v2/server/interface/create_20.rs
@@ -57,6 +57,8 @@ pub struct InterfaceCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Specify the `interfaceAttachment` action in the request body.
+    ///
     #[command(flatten)]
     interface_attachment: InterfaceAttachment,
 }
@@ -70,7 +72,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// InterfaceAttachment Body data
@@ -79,7 +85,7 @@ struct InterfaceAttachment {
     /// Fixed IP addresses. If you request a specific fixed IP address without
     /// a `net_id`, the request returns a `Bad Request (400)` response code.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     fixed_ips: Option<Vec<String>>,
 
     /// The ID of the network for which you want to create a port interface.
@@ -88,7 +94,7 @@ struct InterfaceAttachment {
     /// uses the network information cache that is associated with the
     /// instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     net_id: Option<String>,
 
     /// The ID of the port for which you want to create an interface. The
@@ -96,7 +102,7 @@ struct InterfaceAttachment {
     /// specify the `port_id` parameter, the OpenStack Networking API v2.0
     /// allocates a port and creates an interface for it on the network.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/interface/create_249.rs
+++ b/openstack_cli/src/compute/v2/server/interface/create_249.rs
@@ -57,6 +57,8 @@ pub struct InterfaceCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Specify the `interfaceAttachment` action in the request body.
+    ///
     #[command(flatten)]
     interface_attachment: InterfaceAttachment,
 }
@@ -70,7 +72,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// InterfaceAttachment Body data
@@ -79,7 +85,7 @@ struct InterfaceAttachment {
     /// Fixed IP addresses. If you request a specific fixed IP address without
     /// a `net_id`, the request returns a `Bad Request (400)` response code.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     fixed_ips: Option<Vec<String>>,
 
     /// The ID of the network for which you want to create a port interface.
@@ -88,7 +94,7 @@ struct InterfaceAttachment {
     /// uses the network information cache that is associated with the
     /// instance.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     net_id: Option<String>,
 
     /// The ID of the port for which you want to create an interface. The
@@ -96,7 +102,7 @@ struct InterfaceAttachment {
     /// specify the `port_id` parameter, the OpenStack Networking API v2.0
     /// allocates a port and creates an interface for it on the network.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 
     /// A device role tag that can be applied to a network interface when
@@ -106,7 +112,7 @@ struct InterfaceAttachment {
     ///
     /// **New in version 2.49**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tag: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/interface/delete.rs
+++ b/openstack_cli/src/compute/v2/server/interface/delete.rs
@@ -67,12 +67,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/os-interface/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Interface response representation

--- a/openstack_cli/src/compute/v2/server/interface/list.rs
+++ b/openstack_cli/src/compute/v2/server/interface/list.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Interfaces response representation

--- a/openstack_cli/src/compute/v2/server/interface/show.rs
+++ b/openstack_cli/src/compute/v2/server/interface/show.rs
@@ -65,12 +65,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/os-interface/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Interface response representation

--- a/openstack_cli/src/compute/v2/server/ip/list.rs
+++ b/openstack_cli/src/compute/v2/server/ip/list.rs
@@ -68,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Ips response representation

--- a/openstack_cli/src/compute/v2/server/ip/show.rs
+++ b/openstack_cli/src/compute/v2/server/ip/show.rs
@@ -68,12 +68,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/ips/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Ip response representation

--- a/openstack_cli/src/compute/v2/server/list.rs
+++ b/openstack_cli/src/compute/v2/server/list.rs
@@ -74,175 +74,175 @@ pub struct ServersCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     access_ip_v4: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     access_ip_v6: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     all_tenants: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     auto_disk_config: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     block_device_mapping: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     changes_before: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     changes_since: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     config_drive: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     created_at: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     deleted: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     display_description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     display_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     flavor: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     host: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     hostname: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     image: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     image_ref: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     info_cache: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     ip: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     ip6: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     kernel_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     key_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     launch_index: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     launched_at: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     locked: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     locked_by: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     metadata: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     node: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     not_tags: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     not_tags_any: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     pci_devices: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     power_state: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     progress: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     project_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     ramdisk_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     reservation_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     root_device_name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     security_groups: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     services: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     soft_deleted: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     sort_dir: Option<String>,
 
-    #[arg(long, value_parser = ["access_ip_v4","access_ip_v6","auto_disk_config","availability_zone","config_drive","created_at","display_description","display_name","host","hostname","image_ref","instance_type_id","kernel_id","key_name","launch_index","launched_at","locked","locked_by","node","power_state","progress","project_id","ramdisk_id","root_device_name","task_state","terminated_at","updated_at","user_id","uuid","vm_state"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["access_ip_v4","access_ip_v6","auto_disk_config","availability_zone","config_drive","created_at","display_description","display_name","host","hostname","image_ref","instance_type_id","kernel_id","key_name","launch_index","launched_at","locked","locked_by","node","power_state","progress","project_id","ramdisk_id","root_device_name","task_state","terminated_at","updated_at","user_id","uuid","vm_state"])]
     sort_key: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     status: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     system_metadata: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tags: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tags_any: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     task_state: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tenant_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     terminated_at: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     user_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     uuid: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     vm_state: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/lock_273.rs
+++ b/openstack_cli/src/compute/v2/server/lock_273.rs
@@ -82,6 +82,9 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to lock a server. This parameter can be `null`. Up to
+    /// microversion 2.73, this parameter should be `null`.
+    ///
     #[command(flatten)]
     lock: Option<Lock>,
 }
@@ -95,13 +98,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Lock Body data
 #[derive(Args)]
 struct Lock {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     locked_reason: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/metadata/create.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/create.rs
@@ -66,7 +66,10 @@ pub struct MetadataCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    /// Metadata key and value pairs. The maximum size for each metadata key
+    /// and value pair is 255 bytes.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Vec<(String, String)>,
 }
 
@@ -79,7 +82,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/compute/v2/server/metadata/delete.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/delete.rs
@@ -71,12 +71,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/metadata/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/compute/v2/server/metadata/list.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/list.rs
@@ -70,7 +70,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Metadatas response representation

--- a/openstack_cli/src/compute/v2/server/metadata/replace.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/replace.rs
@@ -66,7 +66,10 @@ pub struct MetadataCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    /// Metadata key and value pairs. The maximum size for each metadata key
+    /// and value pair is 255 bytes.
+    ///
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Vec<(String, String)>,
 }
 
@@ -79,7 +82,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/compute/v2/server/metadata/set.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/set.rs
@@ -66,7 +66,7 @@ pub struct MetadataCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     meta: Vec<(String, String)>,
 }
 
@@ -79,12 +79,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/metadata/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/compute/v2/server/metadata/show.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/show.rs
@@ -70,12 +70,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/metadata/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Metadata response representation

--- a/openstack_cli/src/compute/v2/server/migrate_256.rs
+++ b/openstack_cli/src/compute/v2/server/migrate_256.rs
@@ -77,6 +77,9 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to cold migrate a server. This parameter can be `null`. Up
+    /// to microversion 2.55, this parameter should be `null`.
+    ///
     #[command(flatten)]
     migrate: Option<Migrate>,
 }
@@ -90,13 +93,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Migrate Body data
 #[derive(Args)]
 struct Migrate {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/migration/delete.rs
+++ b/openstack_cli/src/compute/v2/server/migration/delete.rs
@@ -95,12 +95,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/migrations/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Migration response representation

--- a/openstack_cli/src/compute/v2/server/migration/force_complete_222.rs
+++ b/openstack_cli/src/compute/v2/server/migration/force_complete_222.rs
@@ -96,12 +96,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/migrations/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Migration response representation

--- a/openstack_cli/src/compute/v2/server/migration/list.rs
+++ b/openstack_cli/src/compute/v2/server/migration/list.rs
@@ -68,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Migrations response representation

--- a/openstack_cli/src/compute/v2/server/migration/show.rs
+++ b/openstack_cli/src/compute/v2/server/migration/show.rs
@@ -68,12 +68,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/migrations/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Migration response representation

--- a/openstack_cli/src/compute/v2/server/os_get_console_output.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_console_output.rs
@@ -62,6 +62,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to get console output of the server.
+    ///
     #[command(flatten)]
     os_get_console_output: OsGetConsoleOutput,
 }
@@ -75,7 +77,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsGetConsoleOutput Body data
@@ -89,7 +95,7 @@ struct OsGetConsoleOutput {
     /// This parameter can be specified as not only ‘integer’ but also
     /// ‘string’.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     length: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_get_rdpconsole_21.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_rdpconsole_21.rs
@@ -62,6 +62,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_get_rdpconsole: OsGetRdpconsole,
 }
@@ -75,7 +77,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -89,7 +95,7 @@ enum Type {
 struct OsGetRdpconsole {
     /// The type of RDP console. The only valid value is `rdp-html5`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_get_serial_console_21.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_serial_console_21.rs
@@ -63,6 +63,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_get_serial_console: OsGetSerialConsole,
 }
@@ -76,7 +78,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -90,7 +96,7 @@ enum Type {
 struct OsGetSerialConsole {
     /// The type of serial console. The only valid value is `serial`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_get_spiceconsole_21.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_spiceconsole_21.rs
@@ -63,6 +63,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_get_spiceconsole: OsGetSpiceconsole,
 }
@@ -76,7 +78,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -90,7 +96,7 @@ enum Type {
 struct OsGetSpiceconsole {
     /// The type of SPICE console. The only valid value is `spice-html5`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_get_vncconsole_21.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_vncconsole_21.rs
@@ -58,6 +58,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_get_vncconsole: OsGetVncconsole,
 }
@@ -71,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -86,7 +92,7 @@ enum Type {
 struct OsGetVncconsole {
     /// The type of VNC console. The only valid value is `novnc`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_20.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_20.rs
@@ -52,6 +52,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_migrate_live: OsMigrateLive,
 }
@@ -65,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsMigrateLive Body data
@@ -77,7 +83,7 @@ struct OsMigrateLive {
     ///
     /// **Available until version 2.25**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     block_migration: bool,
 
     /// Set to `True` to enable over commit when the destination host is
@@ -86,7 +92,7 @@ struct OsMigrateLive {
     ///
     /// **Available until version 2.25**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     disk_over_commit: bool,
 
     /// The host to which to migrate the server. If this parameter is `None`,
@@ -101,7 +107,7 @@ struct OsMigrateLive {
     /// pick one, or specify a host with microversion >= 2.30 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_225.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_225.rs
@@ -52,6 +52,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_migrate_live: OsMigrateLive,
 }
@@ -65,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsMigrateLive Body data
@@ -81,7 +87,7 @@ struct OsMigrateLive {
     ///
     /// **New in version 2.25**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     block_migration: bool,
 
     /// The host to which to migrate the server. If this parameter is `None`,
@@ -96,7 +102,7 @@ struct OsMigrateLive {
     /// pick one, or specify a host with microversion >= 2.30 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_230.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_230.rs
@@ -52,6 +52,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_migrate_live: OsMigrateLive,
 }
@@ -65,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsMigrateLive Body data
@@ -81,7 +87,7 @@ struct OsMigrateLive {
     ///
     /// **New in version 2.25**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     block_migration: bool,
 
     /// Force a live-migration by not verifying the provided destination host
@@ -98,7 +104,7 @@ struct OsMigrateLive {
     ///
     /// **Available until version 2.67**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     force: Option<bool>,
 
     /// The host to which to migrate the server. If this parameter is `None`,
@@ -113,7 +119,7 @@ struct OsMigrateLive {
     /// pick one, or specify a host with microversion >= 2.30 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_268.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_268.rs
@@ -52,6 +52,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_migrate_live: OsMigrateLive,
 }
@@ -65,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// OsMigrateLive Body data
@@ -81,7 +87,7 @@ struct OsMigrateLive {
     ///
     /// **New in version 2.25**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     block_migration: bool,
 
     /// The host to which to migrate the server. If this parameter is `None`,
@@ -96,7 +102,7 @@ struct OsMigrateLive {
     /// pick one, or specify a host with microversion >= 2.30 and without
     /// `force=True` set.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_reset_state.rs
+++ b/openstack_cli/src/compute/v2/server/os_reset_state.rs
@@ -63,6 +63,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     os_reset_state: OsResetState,
 }
@@ -76,7 +78,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -91,7 +97,7 @@ enum State {
 struct OsResetState {
     /// The state of the server to be set, `active` or `error` are valid.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     state: State,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_start.rs
+++ b/openstack_cli/src/compute/v2/server/os_start.rs
@@ -87,7 +87,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/os_stop.rs
+++ b/openstack_cli/src/compute/v2/server/os_stop.rs
@@ -82,7 +82,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/pause.rs
+++ b/openstack_cli/src/compute/v2/server/pause.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/reboot.rs
+++ b/openstack_cli/src/compute/v2/server/reboot.rs
@@ -75,6 +75,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to reboot a server.
+    ///
     #[command(flatten)]
     reboot: Reboot,
 }
@@ -88,7 +90,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -106,7 +112,7 @@ struct Reboot {
     /// A `HARD` reboot attempts a forced shutdown and restart of the server.
     /// The `HARD` reboot corresponds to the power cycles of the server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_20.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_20.rs
@@ -56,6 +56,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -69,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -84,18 +90,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -108,18 +114,18 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -139,7 +145,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -149,7 +155,7 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -161,7 +167,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_21.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_21.rs
@@ -56,6 +56,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -69,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -84,18 +90,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -108,18 +114,18 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -139,7 +145,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -149,7 +155,7 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -161,7 +167,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_219.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_219.rs
@@ -56,6 +56,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -69,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -84,18 +90,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -103,7 +109,7 @@ struct Rebuild {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -116,18 +122,18 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -147,7 +153,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -157,7 +163,7 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -169,7 +175,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_254.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_254.rs
@@ -56,6 +56,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -69,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -84,18 +90,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -103,7 +109,7 @@ struct Rebuild {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -116,7 +122,7 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Key pair name for rebuild API. If `null` is specified, the existing
@@ -132,18 +138,18 @@ struct Rebuild {
     ///
     /// **New in version 2.54**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -163,7 +169,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// The file path and contents, text only, to inject into the server at
@@ -173,7 +179,7 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -185,7 +191,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_257.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_257.rs
@@ -54,6 +54,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -67,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -82,18 +88,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -101,7 +107,7 @@ struct Rebuild {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -114,7 +120,7 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Key pair name for rebuild API. If `null` is specified, the existing
@@ -130,18 +136,18 @@ struct Rebuild {
     ///
     /// **New in version 2.54**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -161,7 +167,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -173,7 +179,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 
     /// Configuration information or scripts to use upon rebuild. Must be
@@ -182,7 +188,7 @@ struct Rebuild {
     ///
     /// **New in version 2.57**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_263.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_263.rs
@@ -54,6 +54,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -67,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -82,18 +88,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -101,7 +107,7 @@ struct Rebuild {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -114,7 +120,7 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Key pair name for rebuild API. If `null` is specified, the existing
@@ -130,18 +136,18 @@ struct Rebuild {
     ///
     /// **New in version 2.54**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -161,7 +167,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -173,7 +179,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -187,7 +193,7 @@ struct Rebuild {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon rebuild. Must be
@@ -196,7 +202,7 @@ struct Rebuild {
     ///
     /// **New in version 2.57**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_290.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_290.rs
@@ -54,6 +54,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -67,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -82,18 +88,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -101,7 +107,7 @@ struct Rebuild {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The hostname to configure for the instance in the metadata service.
@@ -117,7 +123,7 @@ struct Rebuild {
     ///
     /// **New in version 2.90**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hostname: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -130,7 +136,7 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Key pair name for rebuild API. If `null` is specified, the existing
@@ -146,18 +152,18 @@ struct Rebuild {
     ///
     /// **New in version 2.54**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -177,7 +183,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -189,7 +195,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -203,7 +209,7 @@ struct Rebuild {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon rebuild. Must be
@@ -212,7 +218,7 @@ struct Rebuild {
     ///
     /// **New in version 2.57**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/rebuild_294.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_294.rs
@@ -54,6 +54,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rebuild a server.
+    ///
     #[command(flatten)]
     rebuild: Rebuild,
 }
@@ -67,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -82,18 +88,18 @@ enum OsDcfDiskConfig {
 struct Rebuild {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The administrative password of the server. If you omit this parameter,
     /// the operation generates a new password.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -101,7 +107,7 @@ struct Rebuild {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The hostname to configure for the instance in the metadata service.
@@ -117,7 +123,7 @@ struct Rebuild {
     ///
     /// **New in version 2.90**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hostname: Option<String>,
 
     /// The UUID of the image to rebuild for your server instance. It must be a
@@ -130,7 +136,7 @@ struct Rebuild {
     /// acceptable for the current compute host on which the server exists. If
     /// the new image is not valid, the server will go into `ERROR` status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     image_ref: String,
 
     /// Key pair name for rebuild API. If `null` is specified, the existing
@@ -146,18 +152,18 @@ struct Rebuild {
     ///
     /// **New in version 2.54**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -177,7 +183,7 @@ struct Rebuild {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 
     /// Indicates whether the server is rebuilt with the preservation of the
@@ -189,7 +195,7 @@ struct Rebuild {
     /// to any other server instance results in a fault and will prevent the
     /// rebuild from happening.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     preserve_ephemeral: Option<bool>,
 
     /// A list of trusted certificate IDs, which are used during image
@@ -203,7 +209,7 @@ struct Rebuild {
     ///
     /// **New in version 2.63**
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 
     /// Configuration information or scripts to use upon rebuild. Must be
@@ -212,7 +218,7 @@ struct Rebuild {
     ///
     /// **New in version 2.57**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/remote_console/create_26.rs
+++ b/openstack_cli/src/compute/v2/server/remote_console/create_26.rs
@@ -60,6 +60,8 @@ pub struct RemoteConsoleCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The remote console object.
+    ///
     #[command(flatten)]
     remote_console: RemoteConsole,
 }
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 
@@ -101,14 +107,14 @@ struct RemoteConsole {
     /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
     /// Microversion `2.8`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     protocol: Protocol,
 
     /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `serial`, and `webmks`. The type `webmks` is added since
     /// Microversion `2.8`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
 

--- a/openstack_cli/src/compute/v2/server/remote_console/create_28.rs
+++ b/openstack_cli/src/compute/v2/server/remote_console/create_28.rs
@@ -60,6 +60,8 @@ pub struct RemoteConsoleCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The remote console object.
+    ///
     #[command(flatten)]
     remote_console: RemoteConsole,
 }
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 
@@ -103,14 +109,14 @@ struct RemoteConsole {
     /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
     /// Microversion `2.8`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     protocol: Protocol,
 
     /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `serial`, and `webmks`. The type `webmks` is added since
     /// Microversion `2.8`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
 

--- a/openstack_cli/src/compute/v2/server/remove_fixed_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/remove_fixed_ip_21.rs
@@ -65,6 +65,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to remove a fixed ip address from a server.
+    ///
     #[command(flatten)]
     remove_fixed_ip: RemoveFixedIp,
 }
@@ -78,7 +80,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// RemoveFixedIp Body data
@@ -86,7 +92,7 @@ struct PathParameters {
 struct RemoveFixedIp {
     /// The IP address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     address: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/remove_floating_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/remove_floating_ip_21.rs
@@ -66,6 +66,9 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to remove or disassociate a floating IP address from the
+    /// server.
+    ///
     #[command(flatten)]
     remove_floating_ip: RemoveFloatingIp,
 }
@@ -79,7 +82,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// RemoveFloatingIp Body data
@@ -87,7 +94,7 @@ struct PathParameters {
 struct RemoveFloatingIp {
     /// The floating IP address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     address: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/remove_security_group.rs
+++ b/openstack_cli/src/compute/v2/server/remove_security_group.rs
@@ -69,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/rescue.rs
+++ b/openstack_cli/src/compute/v2/server/rescue.rs
@@ -66,6 +66,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to rescue a server.
+    ///
     #[command(flatten)]
     rescue: Option<Rescue>,
 }
@@ -79,16 +81,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Rescue Body data
 #[derive(Args)]
 struct Rescue {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     admin_pass: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     rescue_image_ref: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/reset_network.rs
+++ b/openstack_cli/src/compute/v2/server/reset_network.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/resize.rs
+++ b/openstack_cli/src/compute/v2/server/resize.rs
@@ -75,6 +75,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action to resize a server.
+    ///
     #[command(flatten)]
     resize: Resize,
 }
@@ -88,7 +90,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -108,7 +114,7 @@ struct Resize {
     /// If a specified flavor ID is the same as the current one of the server,
     /// the request returns a `Bad Request (400)` response code.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_ref: String,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -128,7 +134,7 @@ struct Resize {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 }
 

--- a/openstack_cli/src/compute/v2/server/restore.rs
+++ b/openstack_cli/src/compute/v2/server/restore.rs
@@ -74,7 +74,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/resume.rs
+++ b/openstack_cli/src/compute/v2/server/resume.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/revert_resize.rs
+++ b/openstack_cli/src/compute/v2/server/revert_resize.rs
@@ -95,7 +95,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/security_group/list.rs
+++ b/openstack_cli/src/compute/v2/server/security_group/list.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// SecurityGroups response representation

--- a/openstack_cli/src/compute/v2/server/server_password/delete.rs
+++ b/openstack_cli/src/compute/v2/server/server_password/delete.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// ServerPassword response representation

--- a/openstack_cli/src/compute/v2/server/server_password/get.rs
+++ b/openstack_cli/src/compute/v2/server/server_password/get.rs
@@ -75,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// ServerPassword response representation

--- a/openstack_cli/src/compute/v2/server/set_20.rs
+++ b/openstack_cli/src/compute/v2/server/set_20.rs
@@ -60,6 +60,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -88,17 +94,17 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -118,7 +124,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 }
 
@@ -726,6 +732,7 @@ impl ServerCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set_20::Request::builder();
         ep_builder.header("OpenStack-API-Version", "compute 2.0");
 

--- a/openstack_cli/src/compute/v2/server/set_21.rs
+++ b/openstack_cli/src/compute/v2/server/set_21.rs
@@ -60,6 +60,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -88,17 +94,17 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -118,7 +124,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 }
 
@@ -726,6 +732,7 @@ impl ServerCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set_21::Request::builder();
         ep_builder.header("OpenStack-API-Version", "compute 2.1");
 

--- a/openstack_cli/src/compute/v2/server/set_219.rs
+++ b/openstack_cli/src/compute/v2/server/set_219.rs
@@ -60,6 +60,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -88,12 +94,12 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -101,12 +107,12 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -126,7 +132,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 }
 
@@ -734,6 +740,7 @@ impl ServerCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set_219::Request::builder();
         ep_builder.header("OpenStack-API-Version", "compute 2.19");
 

--- a/openstack_cli/src/compute/v2/server/set_290.rs
+++ b/openstack_cli/src/compute/v2/server/set_290.rs
@@ -60,6 +60,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -88,12 +94,12 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -101,7 +107,7 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The hostname to configure for the instance in the metadata service.
@@ -117,12 +123,12 @@ struct Server {
     ///
     /// **New in version 2.90**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hostname: Option<String>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -142,7 +148,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 }
 
@@ -750,6 +756,7 @@ impl ServerCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set_290::Request::builder();
         ep_builder.header("OpenStack-API-Version", "compute 2.90");
 

--- a/openstack_cli/src/compute/v2/server/set_294.rs
+++ b/openstack_cli/src/compute/v2/server/set_294.rs
@@ -60,6 +60,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `server` object.
+    ///
     #[command(flatten)]
     server: Server,
 }
@@ -73,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -88,12 +94,12 @@ enum OsDcfDiskConfig {
 struct Server {
     /// IPv4 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv4: Option<String>,
 
     /// IPv6 address that should be used to access this server.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     access_ipv6: Option<String>,
 
     /// A free form description of the server. Limited to 255 characters in
@@ -101,7 +107,7 @@ struct Server {
     ///
     /// **New in version 2.19**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The hostname to configure for the instance in the metadata service.
@@ -117,12 +123,12 @@ struct Server {
     ///
     /// **New in version 2.90**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     hostname: Option<String>,
 
     /// The server name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// Controls how the API partitions the disk when you create, rebuild, or
@@ -142,7 +148,7 @@ struct Server {
     ///   scheme and file system is in the source image. If the target flavor
     ///   disk is larger, the API does not partition the remaining disk space.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     os_dcf_disk_config: Option<OsDcfDiskConfig>,
 }
 
@@ -750,6 +756,7 @@ impl ServerCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set_294::Request::builder();
         ep_builder.header("OpenStack-API-Version", "compute 2.94");
 

--- a/openstack_cli/src/compute/v2/server/shelve.rs
+++ b/openstack_cli/src/compute/v2/server/shelve.rs
@@ -101,7 +101,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/shelve_offload.rs
+++ b/openstack_cli/src/compute/v2/server/shelve_offload.rs
@@ -96,7 +96,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/show.rs
+++ b/openstack_cli/src/compute/v2/server/show.rs
@@ -82,7 +82,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/suspend.rs
+++ b/openstack_cli/src/compute/v2/server/suspend.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/tag/delete.rs
+++ b/openstack_cli/src/compute/v2/server/tag/delete.rs
@@ -66,12 +66,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/compute/v2/server/tag/delete_all.rs
+++ b/openstack_cli/src/compute/v2/server/tag/delete_all.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/compute/v2/server/tag/list.rs
+++ b/openstack_cli/src/compute/v2/server/tag/list.rs
@@ -63,7 +63,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Tags response representation

--- a/openstack_cli/src/compute/v2/server/tag/replace_226.rs
+++ b/openstack_cli/src/compute/v2/server/tag/replace_226.rs
@@ -54,7 +54,9 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    /// A list of tags. The maximum count of tags in this list is 50.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }
 
@@ -67,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/compute/v2/server/tag/set.rs
+++ b/openstack_cli/src/compute/v2/server/tag/set.rs
@@ -70,12 +70,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/compute/v2/server/tag/show.rs
+++ b/openstack_cli/src/compute/v2/server/tag/show.rs
@@ -67,12 +67,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/compute/v2/server/topology/list.rs
+++ b/openstack_cli/src/compute/v2/server/topology/list.rs
@@ -69,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// Topologies response representation

--- a/openstack_cli/src/compute/v2/server/trigger_crash_dump_217.rs
+++ b/openstack_cli/src/compute/v2/server/trigger_crash_dump_217.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/unlock.rs
+++ b/openstack_cli/src/compute/v2/server/unlock.rs
@@ -72,7 +72,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/unpause.rs
+++ b/openstack_cli/src/compute/v2/server/unpause.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/unrescue.rs
+++ b/openstack_cli/src/compute/v2/server/unrescue.rs
@@ -80,7 +80,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Server response representation

--- a/openstack_cli/src/compute/v2/server/unshelve_277.rs
+++ b/openstack_cli/src/compute/v2/server/unshelve_277.rs
@@ -52,6 +52,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     unshelve: Option<Unshelve>,
 }
@@ -65,13 +67,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Unshelve Body data
 #[derive(Args)]
 struct Unshelve {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/unshelve_291.rs
+++ b/openstack_cli/src/compute/v2/server/unshelve_291.rs
@@ -52,6 +52,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// The action.
+    ///
     #[command(flatten)]
     unshelve: Option<Unshelve>,
 }
@@ -65,16 +67,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.1/servers/{id}/action API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Unshelve Body data
 #[derive(Args)]
 struct Unshelve {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 }
 

--- a/openstack_cli/src/compute/v2/server/volume_attachment/create_20.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/create_20.rs
@@ -55,6 +55,9 @@ pub struct VolumeAttachmentCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A dictionary representation of a volume attachment containing the
+    /// fields `device` and `volumeId`.
+    ///
     #[command(flatten)]
     volume_attachment: VolumeAttachment,
 }
@@ -68,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// VolumeAttachment Body data
@@ -81,12 +88,12 @@ struct VolumeAttachment {
     /// a user-supplied device name. This is the same behavior as if the device
     /// name parameter is not supplied on the request.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
     /// The UUID of the volume to attach.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/volume_attachment/create_249.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/create_249.rs
@@ -55,6 +55,9 @@ pub struct VolumeAttachmentCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A dictionary representation of a volume attachment containing the
+    /// fields `device` and `volumeId`.
+    ///
     #[command(flatten)]
     volume_attachment: VolumeAttachment,
 }
@@ -68,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// VolumeAttachment Body data
@@ -81,7 +88,7 @@ struct VolumeAttachment {
     /// a user-supplied device name. This is the same behavior as if the device
     /// name parameter is not supplied on the request.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
     /// A device role tag that can be applied to a volume when attaching it to
@@ -96,12 +103,12 @@ struct VolumeAttachment {
     ///
     /// **New in version 2.49**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tag: Option<String>,
 
     /// The UUID of the volume to attach.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/volume_attachment/create_279.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/create_279.rs
@@ -55,6 +55,9 @@ pub struct VolumeAttachmentCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A dictionary representation of a volume attachment containing the
+    /// fields `device` and `volumeId`.
+    ///
     #[command(flatten)]
     volume_attachment: VolumeAttachment,
 }
@@ -68,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// VolumeAttachment Body data
@@ -79,7 +86,7 @@ struct VolumeAttachment {
     ///
     /// **New in version 2.79**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     delete_on_termination: Option<bool>,
 
     /// Name of the device such as, `/dev/vdb`. Omit or set this parameter to
@@ -89,7 +96,7 @@ struct VolumeAttachment {
     /// a user-supplied device name. This is the same behavior as if the device
     /// name parameter is not supplied on the request.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
     /// A device role tag that can be applied to a volume when attaching it to
@@ -104,12 +111,12 @@ struct VolumeAttachment {
     ///
     /// **New in version 2.49**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tag: Option<String>,
 
     /// The UUID of the volume to attach.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/volume_attachment/delete.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/delete.rs
@@ -67,13 +67,21 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/os-volume_attachments/{id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// VolumeAttachment response representation

--- a/openstack_cli/src/compute/v2/server/volume_attachment/list.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/list.rs
@@ -63,10 +63,10 @@ pub struct VolumeAttachmentsCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     offset: Option<i32>,
 }
 
@@ -75,7 +75,11 @@ struct QueryParameters {
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 }
 /// VolumeAttachments response representation

--- a/openstack_cli/src/compute/v2/server/volume_attachment/set_20.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/set_20.rs
@@ -65,6 +65,10 @@ pub struct VolumeAttachmentCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A dictionary representation of a volume attachment containing the field
+    /// `volumeId` which is the UUID of the replacement volume, and other
+    /// fields to update in the attachment.
+    ///
     #[command(flatten)]
     volume_attachment: VolumeAttachment,
 }
@@ -78,13 +82,21 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/os-volume_attachments/{id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// VolumeAttachment Body data
@@ -92,7 +104,7 @@ struct PathParameters {
 struct VolumeAttachment {
     /// The UUID of the volume to attach instead of the attached volume.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/volume_attachment/set_285.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/set_285.rs
@@ -65,6 +65,10 @@ pub struct VolumeAttachmentCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A dictionary representation of a volume attachment containing the field
+    /// `volumeId` which is the UUID of the replacement volume, and other
+    /// fields to update in the attachment.
+    ///
     #[command(flatten)]
     volume_attachment: VolumeAttachment,
 }
@@ -78,13 +82,21 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/os-volume_attachments/{id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// VolumeAttachment Body data
@@ -95,40 +107,40 @@ struct VolumeAttachment {
     ///
     /// **New in version 2.85**
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     delete_on_termination: Option<bool>,
 
     /// Name of the device in the attachment object, such as, `/dev/vdb`.
     ///
     /// **New in version 2.85**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
     /// The UUID of the attachment.
     ///
     /// **New in version 2.85**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The UUID of the server.
     ///
     /// **New in version 2.85**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     server_id: Option<String>,
 
     /// The device tag applied to the volume block device or `null`.
     ///
     /// **New in version 2.85**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tag: Option<String>,
 
     /// The UUID of the volume to attach instead of the attached volume.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
 }
 

--- a/openstack_cli/src/compute/v2/server/volume_attachment/show.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/show.rs
@@ -64,13 +64,21 @@ struct QueryParameters {}
 struct PathParameters {
     /// server_id parameter for /v2.1/servers/{server_id}/topology API
     ///
-    #[arg(id = "path_param_server_id", value_name = "SERVER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_server_id",
+        value_name = "SERVER_ID"
+    )]
     server_id: String,
 
     /// id parameter for /v2.1/servers/{server_id}/os-volume_attachments/{id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// VolumeAttachment response representation

--- a/openstack_cli/src/identity/v3/auth/catalog/list.rs
+++ b/openstack_cli/src/identity/v3/auth/catalog/list.rs
@@ -110,7 +110,7 @@ impl CatalogsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = list::Request::builder();
+        let ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/auth/domain/list.rs
+++ b/openstack_cli/src/identity/v3/auth/domain/list.rs
@@ -108,7 +108,7 @@ impl DomainsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = list::Request::builder();
+        let ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/create.rs
@@ -64,14 +64,22 @@ struct PathParameters {
     /// /v3/auth/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/websso
     /// API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/auth/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/websso
     /// API
     ///
-    #[arg(id = "path_param_protocol_id", value_name = "PROTOCOL_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_protocol_id",
+        value_name = "PROTOCOL_ID"
+    )]
     protocol_id: String,
 }
 /// Websso response representation

--- a/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/get.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/get.rs
@@ -64,14 +64,22 @@ struct PathParameters {
     /// /v3/auth/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/websso
     /// API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/auth/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/websso
     /// API
     ///
-    #[arg(id = "path_param_protocol_id", value_name = "PROTOCOL_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_protocol_id",
+        value_name = "PROTOCOL_ID"
+    )]
     protocol_id: String,
 }
 /// Websso response representation

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
@@ -55,6 +55,8 @@ pub struct Saml2Command {
     #[command(flatten)]
     path: PathParameters,
 
+    /// An `auth` object.
+    ///
     #[command(flatten)]
     auth: Auth,
 }
@@ -81,12 +83,12 @@ enum Methods {
 struct Domain {
     /// User Domain ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// User Domain Name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -101,19 +103,19 @@ struct User {
 
     /// The ID of the user. Required if you do not specify the user name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name. Required if you do not specify the ID of the user. If
     /// you specify the user name, you must also specify the domain, by ID or
     /// name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// User Password
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
 }
 
@@ -133,7 +135,7 @@ struct Password {
 struct Token {
     /// Authorization Token value
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     id: Option<String>,
 }
 
@@ -141,10 +143,10 @@ struct Token {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct UserDomainStructInput {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -157,17 +159,17 @@ struct TotpUser {
 
     /// The user ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// MFA passcode
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     passcode: Option<String>,
 }
 
@@ -188,12 +190,12 @@ struct ApplicationCredentialUser {
 
     /// The user ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -201,15 +203,15 @@ struct ApplicationCredentialUser {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ApplicationCredential {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The secret for authenticating the application credential.
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     secret: Option<String>,
 
     /// A user object, required if an application credential is identified by
@@ -231,7 +233,7 @@ struct Identity {
     /// The authentication method. For password authentication, specify
     /// `password`.
     ///
-    #[arg(action=clap::ArgAction::Append, long, required=false)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, required=false)]
     methods: Vec<Methods>,
 
     /// The `password` object, contains the authentication information.
@@ -256,12 +258,12 @@ struct Identity {
 struct ProjectDomain {
     /// Project domain Id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Project domain name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -274,12 +276,12 @@ struct Project {
 
     /// Project Id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Project Name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -289,12 +291,12 @@ struct Project {
 struct ScopeDomain {
     /// Domain id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Domain name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -302,7 +304,7 @@ struct ScopeDomain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct OsTrustTrust {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 }
 
@@ -310,7 +312,7 @@ struct OsTrustTrust {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct System {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     all: Option<bool>,
 }
 

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
@@ -55,6 +55,8 @@ pub struct EcpCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// An `auth` object.
+    ///
     #[command(flatten)]
     auth: Auth,
 }
@@ -81,12 +83,12 @@ enum Methods {
 struct Domain {
     /// User Domain ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// User Domain Name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -101,19 +103,19 @@ struct User {
 
     /// The ID of the user. Required if you do not specify the user name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name. Required if you do not specify the ID of the user. If
     /// you specify the user name, you must also specify the domain, by ID or
     /// name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// User Password
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
 }
 
@@ -133,7 +135,7 @@ struct Password {
 struct Token {
     /// Authorization Token value
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     id: Option<String>,
 }
 
@@ -141,10 +143,10 @@ struct Token {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct UserDomainStructInput {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -157,17 +159,17 @@ struct TotpUser {
 
     /// The user ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// MFA passcode
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     passcode: Option<String>,
 }
 
@@ -188,12 +190,12 @@ struct ApplicationCredentialUser {
 
     /// The user ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -201,15 +203,15 @@ struct ApplicationCredentialUser {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ApplicationCredential {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The secret for authenticating the application credential.
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     secret: Option<String>,
 
     /// A user object, required if an application credential is identified by
@@ -231,7 +233,7 @@ struct Identity {
     /// The authentication method. For password authentication, specify
     /// `password`.
     ///
-    #[arg(action=clap::ArgAction::Append, long, required=false)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, required=false)]
     methods: Vec<Methods>,
 
     /// The `password` object, contains the authentication information.
@@ -256,12 +258,12 @@ struct Identity {
 struct ProjectDomain {
     /// Project domain Id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Project domain name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -274,12 +276,12 @@ struct Project {
 
     /// Project Id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Project Name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -289,12 +291,12 @@ struct Project {
 struct ScopeDomain {
     /// Domain id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Domain name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -302,7 +304,7 @@ struct ScopeDomain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct OsTrustTrust {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 }
 
@@ -310,7 +312,7 @@ struct OsTrustTrust {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct System {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     all: Option<bool>,
 }
 

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/get.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/get.rs
@@ -75,7 +75,7 @@ impl EcpCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/get.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/get.rs
@@ -75,7 +75,7 @@ impl Saml2Command {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/auth/os_federation/websso/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/websso/create.rs
@@ -62,7 +62,11 @@ struct PathParameters {
     /// protocol_id parameter for /v3/auth/OS-FEDERATION/websso/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_protocol_id", value_name = "PROTOCOL_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_protocol_id",
+        value_name = "PROTOCOL_ID"
+    )]
     protocol_id: String,
 }
 /// Websso response representation

--- a/openstack_cli/src/identity/v3/auth/os_federation/websso/show.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/websso/show.rs
@@ -62,7 +62,11 @@ struct PathParameters {
     /// protocol_id parameter for /v3/auth/OS-FEDERATION/websso/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_protocol_id", value_name = "PROTOCOL_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_protocol_id",
+        value_name = "PROTOCOL_ID"
+    )]
     protocol_id: String,
 }
 /// Websso response representation

--- a/openstack_cli/src/identity/v3/auth/project/list.rs
+++ b/openstack_cli/src/identity/v3/auth/project/list.rs
@@ -109,7 +109,7 @@ impl ProjectsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = list::Request::builder();
+        let ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/auth/system/list.rs
+++ b/openstack_cli/src/identity/v3/auth/system/list.rs
@@ -82,7 +82,7 @@ impl SystemsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = list::Request::builder();
+        let ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/auth/token/create.rs
+++ b/openstack_cli/src/identity/v3/auth/token/create.rs
@@ -62,6 +62,8 @@ pub struct TokenCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// An `auth` object.
+    ///
     #[command(flatten)]
     auth: Auth,
 }
@@ -88,12 +90,12 @@ enum Methods {
 struct Domain {
     /// User Domain ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// User Domain Name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -108,19 +110,19 @@ struct User {
 
     /// The ID of the user. Required if you do not specify the user name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name. Required if you do not specify the ID of the user. If
     /// you specify the user name, you must also specify the domain, by ID or
     /// name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// User Password
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
 }
 
@@ -140,7 +142,7 @@ struct Password {
 struct Token {
     /// Authorization Token value
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     id: Option<String>,
 }
 
@@ -148,10 +150,10 @@ struct Token {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct UserDomainStructInput {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -164,17 +166,17 @@ struct TotpUser {
 
     /// The user ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// MFA passcode
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     passcode: Option<String>,
 }
 
@@ -195,12 +197,12 @@ struct ApplicationCredentialUser {
 
     /// The user ID
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// The user name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -208,15 +210,15 @@ struct ApplicationCredentialUser {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ApplicationCredential {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The secret for authenticating the application credential.
     ///
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     secret: Option<String>,
 
     /// A user object, required if an application credential is identified by
@@ -238,7 +240,7 @@ struct Identity {
     /// The authentication method. For password authentication, specify
     /// `password`.
     ///
-    #[arg(action=clap::ArgAction::Append, long, required=false)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, required=false)]
     methods: Vec<Methods>,
 
     /// The `password` object, contains the authentication information.
@@ -263,12 +265,12 @@ struct Identity {
 struct ProjectDomain {
     /// Project domain Id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Project domain name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -281,12 +283,12 @@ struct Project {
 
     /// Project Id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Project Name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -296,12 +298,12 @@ struct Project {
 struct ScopeDomain {
     /// Domain id
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
     /// Domain name
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -309,7 +311,7 @@ struct ScopeDomain {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct OsTrustTrust {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 }
 
@@ -317,7 +319,7 @@ struct OsTrustTrust {
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct System {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     all: Option<bool>,
 }
 

--- a/openstack_cli/src/identity/v3/auth/token/delete.rs
+++ b/openstack_cli/src/identity/v3/auth/token/delete.rs
@@ -83,7 +83,7 @@ impl TokenCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = delete::Request::builder();
+        let ep_builder = delete::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/auth/token/os_pki/revoked/get.rs
+++ b/openstack_cli/src/identity/v3/auth/token/os_pki/revoked/get.rs
@@ -79,7 +79,7 @@ impl RevokedCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/endpoint/create.rs
+++ b/openstack_cli/src/identity/v3/endpoint/create.rs
@@ -54,6 +54,8 @@ pub struct EndpointCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// An `endpoint` object.
+    ///
     #[command(flatten)]
     endpoint: Endpoint,
 }
@@ -80,7 +82,7 @@ struct Endpoint {
     /// `false`. The endpoint does not appear in the service catalog. - `true`.
     /// The endpoint appears in the service catalog.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
     /// The interface type, which describes the visibility of the endpoint.
@@ -89,27 +91,27 @@ struct Endpoint {
     /// internal network interface. - `admin`. Visible by administrative users
     /// on a secure network interface.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     interface: Option<Interface>,
 
     /// (Deprecated in v3.2) The geographic location of the service endpoint.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     region: Option<String>,
 
     /// (Since v3.2) The ID of the region that contains the service endpoint.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     region_id: Option<String>,
 
     /// The UUID of the service to which the endpoint belongs.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     service_id: Option<String>,
 
     /// The endpoint URL.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     url: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/endpoint/delete.rs
+++ b/openstack_cli/src/identity/v3/endpoint/delete.rs
@@ -66,7 +66,11 @@ struct PathParameters {
     /// endpoint_id parameter for
     /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Endpoint response representation

--- a/openstack_cli/src/identity/v3/endpoint/list.rs
+++ b/openstack_cli/src/identity/v3/endpoint/list.rs
@@ -59,17 +59,17 @@ pub struct EndpointsCommand {
 struct QueryParameters {
     /// Filters the response by an interface.
     ///
-    #[arg(long, value_parser = ["admin","internal","public"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["admin","internal","public"])]
     interface: Option<String>,
 
     /// Filters the response by a region ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     region: Option<String>,
 
     /// Filters the response by a service ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     service_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/endpoint/os_endpoint_policy/policy/get.rs
+++ b/openstack_cli/src/identity/v3/endpoint/os_endpoint_policy/policy/get.rs
@@ -62,7 +62,11 @@ struct PathParameters {
     /// endpoint_id parameter for
     /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
     ///
-    #[arg(id = "path_param_endpoint_id", value_name = "ENDPOINT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_endpoint_id",
+        value_name = "ENDPOINT_ID"
+    )]
     endpoint_id: String,
 }
 /// Policy response representation

--- a/openstack_cli/src/identity/v3/endpoint/set.rs
+++ b/openstack_cli/src/identity/v3/endpoint/set.rs
@@ -56,6 +56,7 @@ pub struct EndpointCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -69,7 +70,11 @@ struct PathParameters {
     /// endpoint_id parameter for
     /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Endpoint response representation

--- a/openstack_cli/src/identity/v3/endpoint/show.rs
+++ b/openstack_cli/src/identity/v3/endpoint/show.rs
@@ -64,7 +64,11 @@ struct PathParameters {
     /// endpoint_id parameter for
     /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Endpoint response representation

--- a/openstack_cli/src/identity/v3/group/create.rs
+++ b/openstack_cli/src/identity/v3/group/create.rs
@@ -53,6 +53,8 @@ pub struct GroupCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `group` object
+    ///
     #[command(flatten)]
     group: Group,
 }
@@ -69,17 +71,17 @@ struct PathParameters {}
 struct Group {
     /// The description of the group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
 
     /// The user name. Must be unique within the owning domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/group/delete.rs
+++ b/openstack_cli/src/identity/v3/group/delete.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Group response representation

--- a/openstack_cli/src/identity/v3/group/list.rs
+++ b/openstack_cli/src/identity/v3/group/list.rs
@@ -59,7 +59,7 @@ pub struct GroupsCommand {
 struct QueryParameters {
     /// Filters the response by a domain ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     domain_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/group/set.rs
+++ b/openstack_cli/src/identity/v3/group/set.rs
@@ -58,6 +58,8 @@ pub struct GroupCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `group` object
+    ///
     #[command(flatten)]
     group: Group,
 }
@@ -71,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Group Body data
@@ -79,17 +85,17 @@ struct PathParameters {
 struct Group {
     /// The description of the group.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
 
     /// The user name. Must be unique within the owning domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 }
 
@@ -140,6 +146,7 @@ impl GroupCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters

--- a/openstack_cli/src/identity/v3/group/show.rs
+++ b/openstack_cli/src/identity/v3/group/show.rs
@@ -64,7 +64,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Group response representation

--- a/openstack_cli/src/identity/v3/group/user/delete.rs
+++ b/openstack_cli/src/identity/v3/group/user/delete.rs
@@ -65,12 +65,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 
     /// user_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// User response representation

--- a/openstack_cli/src/identity/v3/group/user/list.rs
+++ b/openstack_cli/src/identity/v3/group/user/list.rs
@@ -65,7 +65,7 @@ struct QueryParameters {
     /// Valid operators are: `lt`, `lte`, `gt`, `gte`, `eq`, and `neq`. Valid
     /// timestamps are of the form: YYYY-MM-DDTHH:mm:ssZ.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     password_expires_at: Option<String>,
 }
 
@@ -74,7 +74,11 @@ struct QueryParameters {
 struct PathParameters {
     /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 }
 /// Users response representation

--- a/openstack_cli/src/identity/v3/group/user/set.rs
+++ b/openstack_cli/src/identity/v3/group/user/set.rs
@@ -65,12 +65,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 
     /// user_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// User response representation

--- a/openstack_cli/src/identity/v3/group/user/show.rs
+++ b/openstack_cli/src/identity/v3/group/user/show.rs
@@ -63,12 +63,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 
     /// user_id parameter for /v3/groups/{group_id}/users/{user_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// User response representation

--- a/openstack_cli/src/identity/v3/os_federation/domain/list.rs
+++ b/openstack_cli/src/identity/v3/os_federation/domain/list.rs
@@ -101,7 +101,7 @@ impl DomainsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = list::Request::builder();
+        let ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
@@ -66,28 +66,32 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 }
 /// IdentityProvider Body data
 #[derive(Args)]
 struct IdentityProvider {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     authorization_ttl: Option<Option<i32>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     remote_ids: Option<Vec<String>>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/delete.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/delete.rs
@@ -62,7 +62,11 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 }
 /// IdentityProvider response representation

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/list.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/list.rs
@@ -56,12 +56,12 @@ pub struct IdentityProvidersCommand {
 struct QueryParameters {
     /// Filter for Identity Providers’ enabled attribute
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     enabled: Option<bool>,
 
     /// Filter for Identity Providers’ ID attribute
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
@@ -57,6 +57,7 @@ pub struct AuthCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -70,14 +71,22 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_protocol_id", value_name = "PROTOCOL_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_protocol_id",
+        value_name = "PROTOCOL_ID"
+    )]
     protocol_id: String,
 }
 /// Auth response representation

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
@@ -65,14 +65,22 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_protocol_id", value_name = "PROTOCOL_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_protocol_id",
+        value_name = "PROTOCOL_ID"
+    )]
     protocol_id: String,
 }
 /// Auth response representation

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/create.rs
@@ -65,23 +65,31 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Protocol Body data
 #[derive(Args)]
 struct Protocol {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mapping_id: String,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     remote_id_attribute: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/delete.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/delete.rs
@@ -64,14 +64,22 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Protocol response representation

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/list.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/list.rs
@@ -62,7 +62,11 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 }
 /// Protocols response representation

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/set.rs
@@ -65,23 +65,31 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Protocol Body data
 #[derive(Args)]
 struct Protocol {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mapping_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     remote_id_attribute: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/show.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/show.rs
@@ -63,14 +63,22 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 
     /// protocol_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Protocol response representation

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
@@ -64,25 +64,29 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 }
 /// IdentityProvider Body data
 #[derive(Args)]
 struct IdentityProvider {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     authorization_ttl: Option<Option<i32>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     remote_ids: Option<Vec<String>>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/show.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/show.rs
@@ -61,7 +61,11 @@ struct PathParameters {
     /// idp_id parameter for
     /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
     ///
-    #[arg(id = "path_param_idp_id", value_name = "IDP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_idp_id",
+        value_name = "IDP_ID"
+    )]
     idp_id: String,
 }
 /// IdentityProvider response representation

--- a/openstack_cli/src/identity/v3/os_federation/mapping/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/mapping/create.rs
@@ -66,13 +66,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// mapping_id parameter for /v3/OS-FEDERATION/mappings/{mapping_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Mapping Body data
 #[derive(Args)]
 struct Mapping {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     rules: Vec<Value>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/mapping/delete.rs
+++ b/openstack_cli/src/identity/v3/os_federation/mapping/delete.rs
@@ -63,7 +63,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// mapping_id parameter for /v3/OS-FEDERATION/mappings/{mapping_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Mapping response representation

--- a/openstack_cli/src/identity/v3/os_federation/mapping/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/mapping/set.rs
@@ -66,13 +66,17 @@ struct QueryParameters {}
 struct PathParameters {
     /// mapping_id parameter for /v3/OS-FEDERATION/mappings/{mapping_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Mapping Body data
 #[derive(Args)]
 struct Mapping {
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     rules: Vec<Value>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/mapping/show.rs
+++ b/openstack_cli/src/identity/v3/os_federation/mapping/show.rs
@@ -60,7 +60,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// mapping_id parameter for /v3/OS-FEDERATION/mappings/{mapping_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Mapping response representation

--- a/openstack_cli/src/identity/v3/os_federation/project/list.rs
+++ b/openstack_cli/src/identity/v3/os_federation/project/list.rs
@@ -101,7 +101,7 @@ impl ProjectsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = list::Request::builder();
+        let ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/identity/v3/os_federation/service_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/service_provider/create.rs
@@ -64,28 +64,32 @@ struct QueryParameters {}
 struct PathParameters {
     /// sp_id parameter for /v3/OS-FEDERATION/service_providers/{sp_id} API
     ///
-    #[arg(id = "path_param_sp_id", value_name = "SP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_sp_id",
+        value_name = "SP_ID"
+    )]
     sp_id: String,
 }
 /// ServiceProvider Body data
 #[derive(Args)]
 struct ServiceProvider {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     auth_url: String,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     relay_state_prefix: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     sp_url: String,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/service_provider/delete.rs
+++ b/openstack_cli/src/identity/v3/os_federation/service_provider/delete.rs
@@ -63,7 +63,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// sp_id parameter for /v3/OS-FEDERATION/service_providers/{sp_id} API
     ///
-    #[arg(id = "path_param_sp_id", value_name = "SP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_sp_id",
+        value_name = "SP_ID"
+    )]
     sp_id: String,
 }
 /// ServiceProvider response representation

--- a/openstack_cli/src/identity/v3/os_federation/service_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/service_provider/set.rs
@@ -64,28 +64,32 @@ struct QueryParameters {}
 struct PathParameters {
     /// sp_id parameter for /v3/OS-FEDERATION/service_providers/{sp_id} API
     ///
-    #[arg(id = "path_param_sp_id", value_name = "SP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_sp_id",
+        value_name = "SP_ID"
+    )]
     sp_id: String,
 }
 /// ServiceProvider Body data
 #[derive(Args)]
 struct ServiceProvider {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     auth_url: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     relay_state_prefix: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     sp_url: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/os_federation/service_provider/show.rs
+++ b/openstack_cli/src/identity/v3/os_federation/service_provider/show.rs
@@ -59,7 +59,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// sp_id parameter for /v3/OS-FEDERATION/service_providers/{sp_id} API
     ///
-    #[arg(id = "path_param_sp_id", value_name = "SP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_sp_id",
+        value_name = "SP_ID"
+    )]
     sp_id: String,
 }
 /// ServiceProvider response representation

--- a/openstack_cli/src/identity/v3/project/create.rs
+++ b/openstack_cli/src/identity/v3/project/create.rs
@@ -55,6 +55,8 @@ pub struct ProjectCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `project` object
+    ///
     #[command(flatten)]
     project: Project,
 }
@@ -70,7 +72,7 @@ struct PathParameters {}
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Options {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     immutable: Option<bool>,
 }
 
@@ -79,29 +81,29 @@ struct Options {
 struct Project {
     /// The description of the project.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the domain for the project.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     is_domain: Option<bool>,
 
     /// The name of the project.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The resource options for the project. Available resource options are
@@ -114,12 +116,12 @@ struct Project {
     ///
     /// **New in version 3.4**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     parent_id: Option<String>,
 
     /// A list of simple strings assigned to a project.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 }
 

--- a/openstack_cli/src/identity/v3/project/delete.rs
+++ b/openstack_cli/src/identity/v3/project/delete.rs
@@ -66,7 +66,11 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Project response representation

--- a/openstack_cli/src/identity/v3/project/group/role/delete.rs
+++ b/openstack_cli/src/identity/v3/project/group/role/delete.rs
@@ -66,19 +66,31 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// group_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/project/group/role/list.rs
+++ b/openstack_cli/src/identity/v3/project/group/role/list.rs
@@ -66,13 +66,21 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// group_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 }
 /// Roles response representation

--- a/openstack_cli/src/identity/v3/project/group/role/set.rs
+++ b/openstack_cli/src/identity/v3/project/group/role/set.rs
@@ -66,19 +66,31 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// group_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/project/group/role/show.rs
+++ b/openstack_cli/src/identity/v3/project/group/role/show.rs
@@ -64,19 +64,31 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// group_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_group_id", value_name = "GROUP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_group_id",
+        value_name = "GROUP_ID"
+    )]
     group_id: String,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/project/list.rs
+++ b/openstack_cli/src/identity/v3/project/list.rs
@@ -61,30 +61,30 @@ pub struct ProjectsCommand {
 struct QueryParameters {
     /// Filters the response by a domain ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     domain_id: Option<String>,
 
     /// If set to true, then only enabled projects will be returned. Any value
     /// other than 0 (including no value) will be interpreted as true.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     enabled: Option<bool>,
 
     /// If this is specified as true, then only projects acting as a domain are
     /// included. Otherwise, only projects that are not acting as a domain are
     /// included.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     is_domain: Option<bool>,
 
     /// Filters the response by a resource name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// Filters the response by a parent ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     parent_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/project/set.rs
+++ b/openstack_cli/src/identity/v3/project/set.rs
@@ -57,6 +57,8 @@ pub struct ProjectCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `project` object
+    ///
     #[command(flatten)]
     project: Project,
 }
@@ -71,14 +73,18 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Options Body data
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Options {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     immutable: Option<bool>,
 }
 
@@ -87,29 +93,29 @@ struct Options {
 struct Project {
     /// The description of the project.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the domain for the project.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     is_domain: Option<bool>,
 
     /// The name of the project.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The resource options for the project. Available resource options are
@@ -122,12 +128,12 @@ struct Project {
     ///
     /// **New in version 3.4**
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     parent_id: Option<String>,
 
     /// A list of simple strings assigned to a project.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 }
 
@@ -230,6 +236,7 @@ impl ProjectCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters

--- a/openstack_cli/src/identity/v3/project/show.rs
+++ b/openstack_cli/src/identity/v3/project/show.rs
@@ -67,7 +67,11 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Project response representation

--- a/openstack_cli/src/identity/v3/project/tag/delete.rs
+++ b/openstack_cli/src/identity/v3/project/tag/delete.rs
@@ -66,12 +66,20 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// value parameter for /v3/projects/{project_id}/tags/{value} API
     ///
-    #[arg(id = "path_param_value", value_name = "VALUE")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_value",
+        value_name = "VALUE"
+    )]
     value: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/identity/v3/project/tag/delete_all.rs
+++ b/openstack_cli/src/identity/v3/project/tag/delete_all.rs
@@ -66,7 +66,11 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/identity/v3/project/tag/list.rs
+++ b/openstack_cli/src/identity/v3/project/tag/list.rs
@@ -63,7 +63,11 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 }
 /// Tags response representation

--- a/openstack_cli/src/identity/v3/project/tag/replace.rs
+++ b/openstack_cli/src/identity/v3/project/tag/replace.rs
@@ -64,7 +64,11 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/identity/v3/project/tag/set.rs
+++ b/openstack_cli/src/identity/v3/project/tag/set.rs
@@ -66,12 +66,20 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// value parameter for /v3/projects/{project_id}/tags/{value} API
     ///
-    #[arg(id = "path_param_value", value_name = "VALUE")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_value",
+        value_name = "VALUE"
+    )]
     value: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/identity/v3/project/tag/show.rs
+++ b/openstack_cli/src/identity/v3/project/tag/show.rs
@@ -66,12 +66,20 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// value parameter for /v3/projects/{project_id}/tags/{value} API
     ///
-    #[arg(id = "path_param_value", value_name = "VALUE")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_value",
+        value_name = "VALUE"
+    )]
     value: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/identity/v3/project/user/role/delete.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/delete.rs
@@ -66,19 +66,31 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/project/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/list.rs
@@ -66,13 +66,21 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// Roles response representation

--- a/openstack_cli/src/identity/v3/project/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/set.rs
@@ -66,19 +66,31 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/project/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/show.rs
@@ -64,19 +64,31 @@ struct PathParameters {
     /// project_id parameter for
     /// /v3/projects/{project_id}/groups/{group_id}/roles API
     ///
-    #[arg(id = "path_param_project_id", value_name = "PROJECT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_project_id",
+        value_name = "PROJECT_ID"
+    )]
     project_id: String,
 
     /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/region/create.rs
+++ b/openstack_cli/src/identity/v3/region/create.rs
@@ -59,6 +59,8 @@ pub struct RegionCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `region` object
+    ///
     #[command(flatten)]
     region: Region,
 }
@@ -75,13 +77,13 @@ struct PathParameters {}
 struct Region {
     /// The region description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// To make this region a child of another region, set this parameter to
     /// the ID of the parent region.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     parent_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/region/delete.rs
+++ b/openstack_cli/src/identity/v3/region/delete.rs
@@ -67,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// region_id parameter for /v3/regions/{region_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Region response representation

--- a/openstack_cli/src/identity/v3/region/list.rs
+++ b/openstack_cli/src/identity/v3/region/list.rs
@@ -59,7 +59,7 @@ pub struct RegionsCommand {
 struct QueryParameters {
     /// Filters the response by a parent region, by ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     parent_region_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/region/set.rs
+++ b/openstack_cli/src/identity/v3/region/set.rs
@@ -58,6 +58,8 @@ pub struct RegionCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `region` object
+    ///
     #[command(flatten)]
     region: Region,
 }
@@ -71,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// region_id parameter for /v3/regions/{region_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Region Body data
@@ -79,13 +85,13 @@ struct PathParameters {
 struct Region {
     /// The region description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// To make this region a child of another region, set this parameter to
     /// the ID of the parent region.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     parent_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/region/show.rs
+++ b/openstack_cli/src/identity/v3/region/show.rs
@@ -63,7 +63,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// region_id parameter for /v3/regions/{region_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Region response representation

--- a/openstack_cli/src/identity/v3/role/create.rs
+++ b/openstack_cli/src/identity/v3/role/create.rs
@@ -55,6 +55,8 @@ pub struct RoleCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `role` object
+    ///
     #[command(flatten)]
     role: Role,
 }
@@ -70,7 +72,7 @@ struct PathParameters {}
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Options {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     immutable: Option<bool>,
 }
 
@@ -79,12 +81,12 @@ struct Options {
 struct Role {
     /// The role description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The role name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The resource options for the role. Available resource options are

--- a/openstack_cli/src/identity/v3/role/delete.rs
+++ b/openstack_cli/src/identity/v3/role/delete.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// role_id parameter for /v3/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/role/imply/delete.rs
+++ b/openstack_cli/src/identity/v3/role/imply/delete.rs
@@ -66,13 +66,21 @@ struct PathParameters {
     /// prior_role_id parameter for
     /// /v3/roles/{prior_role_id}/implies/{implied_role_id} API
     ///
-    #[arg(id = "path_param_prior_role_id", value_name = "PRIOR_ROLE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_prior_role_id",
+        value_name = "PRIOR_ROLE_ID"
+    )]
     prior_role_id: String,
 
     /// implied_role_id parameter for
     /// /v3/roles/{prior_role_id}/implies/{implied_role_id} API
     ///
-    #[arg(id = "path_param_implied_role_id", value_name = "IMPLIED_ROLE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_implied_role_id",
+        value_name = "IMPLIED_ROLE_ID"
+    )]
     implied_role_id: String,
 }
 /// Imply response representation

--- a/openstack_cli/src/identity/v3/role/imply/list.rs
+++ b/openstack_cli/src/identity/v3/role/imply/list.rs
@@ -66,7 +66,11 @@ struct PathParameters {
     /// prior_role_id parameter for
     /// /v3/roles/{prior_role_id}/implies/{implied_role_id} API
     ///
-    #[arg(id = "path_param_prior_role_id", value_name = "PRIOR_ROLE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_prior_role_id",
+        value_name = "PRIOR_ROLE_ID"
+    )]
     prior_role_id: String,
 }
 /// Implies response representation

--- a/openstack_cli/src/identity/v3/role/imply/set.rs
+++ b/openstack_cli/src/identity/v3/role/imply/set.rs
@@ -58,6 +58,7 @@ pub struct ImplyCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -71,13 +72,21 @@ struct PathParameters {
     /// prior_role_id parameter for
     /// /v3/roles/{prior_role_id}/implies/{implied_role_id} API
     ///
-    #[arg(id = "path_param_prior_role_id", value_name = "PRIOR_ROLE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_prior_role_id",
+        value_name = "PRIOR_ROLE_ID"
+    )]
     prior_role_id: String,
 
     /// implied_role_id parameter for
     /// /v3/roles/{prior_role_id}/implies/{implied_role_id} API
     ///
-    #[arg(id = "path_param_implied_role_id", value_name = "IMPLIED_ROLE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_implied_role_id",
+        value_name = "IMPLIED_ROLE_ID"
+    )]
     implied_role_id: String,
 }
 /// Imply response representation

--- a/openstack_cli/src/identity/v3/role/imply/show.rs
+++ b/openstack_cli/src/identity/v3/role/imply/show.rs
@@ -66,13 +66,21 @@ struct PathParameters {
     /// prior_role_id parameter for
     /// /v3/roles/{prior_role_id}/implies/{implied_role_id} API
     ///
-    #[arg(id = "path_param_prior_role_id", value_name = "PRIOR_ROLE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_prior_role_id",
+        value_name = "PRIOR_ROLE_ID"
+    )]
     prior_role_id: String,
 
     /// implied_role_id parameter for
     /// /v3/roles/{prior_role_id}/implies/{implied_role_id} API
     ///
-    #[arg(id = "path_param_implied_role_id", value_name = "IMPLIED_ROLE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_implied_role_id",
+        value_name = "IMPLIED_ROLE_ID"
+    )]
     implied_role_id: String,
 }
 /// Imply response representation

--- a/openstack_cli/src/identity/v3/role/list.rs
+++ b/openstack_cli/src/identity/v3/role/list.rs
@@ -61,7 +61,7 @@ pub struct RolesCommand {
 struct QueryParameters {
     /// Filters the response by a domain ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     domain_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/role/set.rs
+++ b/openstack_cli/src/identity/v3/role/set.rs
@@ -57,6 +57,8 @@ pub struct RoleCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `role` object
+    ///
     #[command(flatten)]
     role: Role,
 }
@@ -70,14 +72,18 @@ struct QueryParameters {}
 struct PathParameters {
     /// role_id parameter for /v3/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Options Body data
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Options {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     immutable: Option<bool>,
 }
 
@@ -86,12 +92,12 @@ struct Options {
 struct Role {
     /// The role description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The role name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The resource options for the role. Available resource options are
@@ -172,6 +178,7 @@ impl RoleCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters

--- a/openstack_cli/src/identity/v3/role/show.rs
+++ b/openstack_cli/src/identity/v3/role/show.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// role_id parameter for /v3/roles/{role_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/role_assignment/list.rs
+++ b/openstack_cli/src/identity/v3/role_assignment/list.rs
@@ -129,19 +129,19 @@ struct QueryParameters {
     /// Returns the effective assignments, including any assignments gained by
     /// virtue of group membership.
     ///
-    #[arg(action=clap::ArgAction::SetTrue, long)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Query parameters", long)]
     effective: Option<bool>,
 
     /// Filters the response by a group ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     group_id: Option<String>,
 
     /// If set, then the names of any entities returned will be include as well
     /// as their IDs. Any value other than 0 (including no value) will be
     /// interpreted as true.
     ///
-    #[arg(action=clap::ArgAction::SetTrue, long)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Query parameters", long)]
     include_names: Option<bool>,
 
     /// If set, then relevant assignments in the project hierarchy below the
@@ -149,33 +149,33 @@ struct QueryParameters {
     /// included in the response. Any value other than 0 (including no value)
     /// for include_subtree will be interpreted as true.
     ///
-    #[arg(action=clap::ArgAction::SetTrue, long)]
+    #[arg(action=clap::ArgAction::SetTrue, help_heading = "Query parameters", long)]
     include_subtree: Option<bool>,
 
     /// Filters the response by a role ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     role_id: Option<String>,
 
     /// Filters the response by a domain ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     scope_domain_id: Option<String>,
 
     /// Filters based on role assignments that are inherited. The only value of
     /// inherited_to that is currently supported is projects.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     scope_os_inherit_inherited_to: Option<String>,
 
     /// Filters the response by a project ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     scope_project_id: Option<String>,
 
     /// Filters the response by a user ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     user_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/service/create.rs
+++ b/openstack_cli/src/identity/v3/service/create.rs
@@ -53,6 +53,8 @@ pub struct ServiceCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `service` object.
+    ///
     #[command(flatten)]
     service: Service,
 }
@@ -69,7 +71,7 @@ struct PathParameters {}
 struct Service {
     /// The service description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// Defines whether the service and its endpoints appear in the service
@@ -77,18 +79,18 @@ struct Service {
     /// service catalog. - `true`. The service and its endpoints appear in the
     /// service catalog. Default is `true`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
     /// The service name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The service type, which describes the API implemented by the service.
     /// Value is `compute`, `ec2`, `identity`, `image`, `network`, or `volume`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/service/delete.rs
+++ b/openstack_cli/src/identity/v3/service/delete.rs
@@ -69,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// service_id parameter for /v3/services/{service_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Service response representation

--- a/openstack_cli/src/identity/v3/service/list.rs
+++ b/openstack_cli/src/identity/v3/service/list.rs
@@ -59,7 +59,7 @@ pub struct ServicesCommand {
 struct QueryParameters {
     /// Filters the response by a domain ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     service: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/service/set.rs
+++ b/openstack_cli/src/identity/v3/service/set.rs
@@ -58,6 +58,8 @@ pub struct ServiceCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `service` object.
+    ///
     #[command(flatten)]
     service: Service,
 }
@@ -71,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// service_id parameter for /v3/services/{service_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Service Body data
@@ -79,7 +85,7 @@ struct PathParameters {
 struct Service {
     /// The service description.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// Defines whether the service and its endpoints appear in the service
@@ -87,18 +93,18 @@ struct Service {
     /// service catalog. - `true`. The service and its endpoints appear in the
     /// service catalog. Default is `true`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
     /// The service name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The service type, which describes the API implemented by the service.
     /// Value is `compute`, `ec2`, `identity`, `image`, `network`, or `volume`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     _type: Option<String>,
 }
 
@@ -159,6 +165,7 @@ impl ServiceCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters

--- a/openstack_cli/src/identity/v3/service/show.rs
+++ b/openstack_cli/src/identity/v3/service/show.rs
@@ -64,7 +64,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// service_id parameter for /v3/services/{service_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Service response representation

--- a/openstack_cli/src/identity/v3/user/access_rule/delete.rs
+++ b/openstack_cli/src/identity/v3/user/access_rule/delete.rs
@@ -67,13 +67,21 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// access_rule_id parameter for
     /// /v3/users/{user_id}/access_rules/{access_rule_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AccessRule response representation

--- a/openstack_cli/src/identity/v3/user/access_rule/list.rs
+++ b/openstack_cli/src/identity/v3/user/access_rule/list.rs
@@ -64,7 +64,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// AccessRules response representation

--- a/openstack_cli/src/identity/v3/user/access_rule/show.rs
+++ b/openstack_cli/src/identity/v3/user/access_rule/show.rs
@@ -64,13 +64,21 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// access_rule_id parameter for
     /// /v3/users/{user_id}/access_rules/{access_rule_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AccessRule response representation

--- a/openstack_cli/src/identity/v3/user/application_credential/create.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/create.rs
@@ -57,6 +57,8 @@ pub struct ApplicationCredentialCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// An application credential object.
+    ///
     #[command(flatten)]
     application_credential: ApplicationCredential,
 }
@@ -71,7 +73,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// ApplicationCredential Body data
@@ -79,23 +85,23 @@ struct PathParameters {
 struct ApplicationCredential {
     /// A list of `access_rules` objects
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     access_rules: Option<Vec<Value>>,
 
     /// A description of the application credential’s purpose.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// An optional expiry time for the application credential. If unset, the
     /// application credential does not expire.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     expires_at: Option<String>,
 
     /// The name of the application credential. Must be unique to a user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// An optional list of role objects, identified by ID or name. The list
@@ -103,20 +109,20 @@ struct ApplicationCredential {
     /// not provided, the roles assigned to the application credential will be
     /// the same as the roles in the current token.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     roles: Option<Vec<Value>>,
 
     /// The secret that the application credential will be created with. If not
     /// provided, one will be generated.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     secret: Option<String>,
 
     /// An optional flag to restrict whether the application credential may be
     /// used for the creation or destruction of other application credentials
     /// or trusts. Defaults to false.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     unrestricted: Option<bool>,
 }
 

--- a/openstack_cli/src/identity/v3/user/application_credential/delete.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/delete.rs
@@ -66,14 +66,22 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// application_credential_id parameter for
     /// /v3/users/{user_id}/application_credentials/{application_credential_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ApplicationCredential response representation

--- a/openstack_cli/src/identity/v3/user/application_credential/list.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/list.rs
@@ -60,7 +60,7 @@ pub struct ApplicationCredentialsCommand {
 struct QueryParameters {
     /// The name of the application credential. Must be unique to a user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 }
 
@@ -70,7 +70,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// ApplicationCredentials response representation

--- a/openstack_cli/src/identity/v3/user/application_credential/show.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/show.rs
@@ -66,14 +66,22 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// application_credential_id parameter for
     /// /v3/users/{user_id}/application_credentials/{application_credential_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ApplicationCredential response representation

--- a/openstack_cli/src/identity/v3/user/create.rs
+++ b/openstack_cli/src/identity/v3/user/create.rs
@@ -58,6 +58,8 @@ pub struct UserCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `user` object
+    ///
     #[command(flatten)]
     user: User,
 }
@@ -73,25 +75,25 @@ struct PathParameters {}
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Options {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_change_password_upon_first_use: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_lockout_failure_attempts: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_password_expiry: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_user_inactivity: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     lock_password: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multi_factor_auth_enabled: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     multi_factor_auth_rules: Option<Vec<String>>,
 }
 
@@ -100,21 +102,21 @@ struct Options {
 struct User {
     /// The ID of the default project for the user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     default_project_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
     /// List of federated objects associated with a user. Each object in the
@@ -134,12 +136,12 @@ struct User {
     ///
     /// ```
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     federated: Option<Vec<Value>>,
 
     /// The user name. Must be unique within the owning domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: String,
 
     /// The resource options for the user. Available resource options are
@@ -153,7 +155,7 @@ struct User {
 
     /// The new password for the user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/user/delete.rs
+++ b/openstack_cli/src/identity/v3/user/delete.rs
@@ -66,7 +66,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// User response representation

--- a/openstack_cli/src/identity/v3/user/group/list.rs
+++ b/openstack_cli/src/identity/v3/user/group/list.rs
@@ -64,7 +64,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// Groups response representation

--- a/openstack_cli/src/identity/v3/user/list.rs
+++ b/openstack_cli/src/identity/v3/user/list.rs
@@ -61,23 +61,23 @@ pub struct UsersCommand {
 struct QueryParameters {
     /// Filters the response by a domain ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     domain_id: Option<String>,
 
     /// If set to true, then only enabled projects will be returned. Any value
     /// other than 0 (including no value) will be interpreted as true.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     enabled: Option<bool>,
 
     /// Filter for Identity Providers’ ID attribute
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// Filters the response by a resource name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// Filter results based on which user passwords have expired. The query
@@ -86,17 +86,17 @@ struct QueryParameters {
     /// Valid operators are: `lt`, `lte`, `gt`, `gte`, `eq`, and `neq`. Valid
     /// timestamps are of the form: YYYY-MM-DDTHH:mm:ssZ.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     password_expires_at: Option<String>,
 
     /// Filters the response by a protocol ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     protocol_id: Option<String>,
 
     /// Filters the response by a unique ID.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     unique_id: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/delete.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/delete.rs
@@ -64,14 +64,22 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// access_token_id parameter for
     /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AccessToken response representation

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/list.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/list.rs
@@ -64,7 +64,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// AccessTokens response representation

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/list.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/list.rs
@@ -65,14 +65,22 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// access_token_id parameter for
     /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
-    #[arg(id = "path_param_access_token_id", value_name = "ACCESS_TOKEN_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_access_token_id",
+        value_name = "ACCESS_TOKEN_ID"
+    )]
     access_token_id: String,
 }
 /// Roles response representation

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/show.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/show.rs
@@ -65,21 +65,33 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// access_token_id parameter for
     /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
-    #[arg(id = "path_param_access_token_id", value_name = "ACCESS_TOKEN_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_access_token_id",
+        value_name = "ACCESS_TOKEN_ID"
+    )]
     access_token_id: String,
 
     /// role_id parameter for
     /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Role response representation

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/show.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/show.rs
@@ -64,14 +64,22 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 
     /// access_token_id parameter for
     /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// AccessToken response representation

--- a/openstack_cli/src/identity/v3/user/password/set.rs
+++ b/openstack_cli/src/identity/v3/user/password/set.rs
@@ -56,6 +56,8 @@ pub struct PasswordCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `user` object
+    ///
     #[command(flatten)]
     user: User,
 }
@@ -70,7 +72,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// User Body data
@@ -78,12 +84,12 @@ struct PathParameters {
 struct User {
     /// The original password for the user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     original_password: Option<String>,
 
     /// The new password for the user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
 }
 

--- a/openstack_cli/src/identity/v3/user/project/list.rs
+++ b/openstack_cli/src/identity/v3/user/project/list.rs
@@ -64,7 +64,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_user_id", value_name = "USER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_user_id",
+        value_name = "USER_ID"
+    )]
     user_id: String,
 }
 /// Projects response representation

--- a/openstack_cli/src/identity/v3/user/set.rs
+++ b/openstack_cli/src/identity/v3/user/set.rs
@@ -62,6 +62,8 @@ pub struct UserCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// A `user` object
+    ///
     #[command(flatten)]
     user: User,
 }
@@ -76,32 +78,36 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Options Body data
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct Options {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_change_password_upon_first_use: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_lockout_failure_attempts: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_password_expiry: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ignore_user_inactivity: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     lock_password: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multi_factor_auth_enabled: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     multi_factor_auth_rules: Option<Vec<String>>,
 }
 
@@ -110,21 +116,21 @@ struct Options {
 struct User {
     /// The ID of the default project for the user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     default_project_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
 
     /// If the user is enabled, this value is `true`. If the user is disabled,
     /// this value is `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
 
     /// List of federated objects associated with a user. Each object in the
@@ -144,12 +150,12 @@ struct User {
     ///
     /// ```
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     federated: Option<Vec<Value>>,
 
     /// The user name. Must be unique within the owning domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The resource options for the user. Available resource options are
@@ -163,7 +169,7 @@ struct User {
 
     /// The new password for the user.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
 }
 
@@ -324,6 +330,7 @@ impl UserCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
+
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters

--- a/openstack_cli/src/identity/v3/user/show.rs
+++ b/openstack_cli/src/identity/v3/user/show.rs
@@ -67,7 +67,11 @@ struct PathParameters {
     /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// User response representation

--- a/openstack_cli/src/image/v2/image/create.rs
+++ b/openstack_cli/src/image/v2/image/create.rs
@@ -73,32 +73,115 @@ pub struct ImageCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long)]
+    /// Format of the image container.
+    ///
+    /// Values may vary based on the configuration available in a particular
+    /// OpenStack cloud. See the [Image Schema](#image-schema) response from
+    /// the cloud itself for the valid values available.
+    ///
+    /// Example formats are: `ami`, `ari`, `aki`, `bare`, `ovf`, `ova`, or
+    /// `docker`.
+    ///
+    /// The value might be `null` (JSON null data type).
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     container_format: Option<ContainerFormat>,
-    #[arg(long)]
+
+    /// The format of the disk.
+    ///
+    /// Values may vary based on the configuration available in a particular
+    /// OpenStack cloud. See the [Image Schema](#image-schema) response from
+    /// the cloud itself for the valid values available.
+    ///
+    /// Example formats are: `ami`, `ari`, `aki`, `vhd`, `vhdx`, `vmdk`, `raw`,
+    /// `qcow2`, `vdi`, `ploop` or `iso`.
+    ///
+    /// The value might be `null` (JSON null data type).
+    ///
+    /// **Newton changes**: The `vhdx` disk format is a supported value.
+    ///
+    /// **Ocata changes**: The `ploop` disk format is a supported value.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     disk_format: Option<DiskFormat>,
-    #[arg(long)]
+
+    /// A unique, user-defined image UUID, in the format:
+    ///
+    /// ```text
+    /// nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn
+    ///
+    /// ```
+    ///
+    /// Where **n** is a hexadecimal digit from 0 to f, or F.
+    ///
+    /// For example:
+    ///
+    /// ```text
+    /// b2173dd3-7ad6-4362-baa6-a68bce3565cb
+    ///
+    /// ```
+    ///
+    /// If you omit this value, the API generates a UUID for the image. If you
+    /// specify a value that has already been assigned, the request fails with
+    /// a `409` response code.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+
+    /// A set of URLs to access the image file kept in external store
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     locations: Option<Vec<Value>>,
-    #[arg(long)]
+
+    /// Amount of disk space in GB that is required to boot the image.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     min_disk: Option<i32>,
-    #[arg(long)]
+
+    /// Amount of RAM in MB that is required to boot the image.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     min_ram: Option<i32>,
-    #[arg(long)]
+
+    /// The name of the image.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
-    #[arg(action=clap::ArgAction::Set, long)]
+
+    /// If true, image will not appear in default image list response.
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     os_hidden: Option<bool>,
-    #[arg(long)]
+
+    /// Owner of the image
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     owner: Option<String>,
-    #[arg(action=clap::ArgAction::Set, long)]
+
+    /// Image protection for deletion. Valid value is `true` or `false`.
+    /// Default is `false`.
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     protected: Option<bool>,
-    #[arg(action=clap::ArgAction::Append, long)]
+
+    /// List of tags for this image. Each tag is a string of at most 255 chars.
+    /// The maximum number of tags allowed on an image is set by the operator.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
-    #[arg(long)]
+
+    /// Visibility for this image. Valid value is one of: `public`, `private`,
+    /// `shared`, or `community`. At most sites, only an administrator can make
+    /// an image `public`. Some sites may restrict what users can make an image
+    /// `community`. Some sites may restrict what users can perform member
+    /// operations on a `shared` image. *Since the Image API v2.5, the default
+    /// value is `shared`.*
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     visibility: Option<Visibility>,
     /// Additional properties to be sent with the request
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, String)>>,
 }
 

--- a/openstack_cli/src/image/v2/image/deactivate.rs
+++ b/openstack_cli/src/image/v2/image/deactivate.rs
@@ -55,6 +55,7 @@ pub struct ImageCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -67,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Image response representation

--- a/openstack_cli/src/image/v2/image/delete.rs
+++ b/openstack_cli/src/image/v2/image/delete.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Image response representation

--- a/openstack_cli/src/image/v2/image/file/download.rs
+++ b/openstack_cli/src/image/v2/image/file/download.rs
@@ -85,7 +85,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 }
 /// File response representation

--- a/openstack_cli/src/image/v2/image/file/upload.rs
+++ b/openstack_cli/src/image/v2/image/file/upload.rs
@@ -94,7 +94,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 }
 /// File response representation

--- a/openstack_cli/src/image/v2/image/import/create.rs
+++ b/openstack_cli/src/image/v2/image/import/create.rs
@@ -119,13 +119,29 @@ pub struct ImportCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    /// When set to True the data will be imported to the set of stores you may
+    /// consume from this particular deployment of Glance (ie: the same set of
+    /// stores returned to a call to /v2/info/stores on the glance-api the
+    /// request hits). This can’t be used simultaneously with the `stores`
+    /// parameter.
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     all_stores: Option<bool>,
-    #[arg(action=clap::ArgAction::Set, long)]
+
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     all_stores_must_success: Option<bool>,
+
+    /// A JSON object indicating what import method you wish to use to import
+    /// your image. The content of this JSON object is another JSON object with
+    /// a `name` field whose value is the identifier for the import method.
+    ///
     #[command(flatten)]
     method: Option<Method>,
-    #[arg(action=clap::ArgAction::Append, long)]
+
+    /// If present contains the list of store id to import the image binary
+    /// data to.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     stores: Option<Vec<String>>,
 }
 
@@ -138,25 +154,29 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 }
 /// Method Body data
 #[derive(Args)]
 struct Method {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     glance_image_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     glance_region: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     glance_service_interface: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     uri: Option<String>,
 }
 

--- a/openstack_cli/src/image/v2/image/list.rs
+++ b/openstack_cli/src/image/v2/image/list.rs
@@ -158,12 +158,12 @@ struct QueryParameters {
     /// Specify a comparison filter based on the date and time when the
     /// resource was created.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     created_at: Option<String>,
 
     /// id filter parameter
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// Requests a page size of items. Returns a number of items up to a limit
@@ -171,56 +171,56 @@ struct QueryParameters {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 
     /// Filters the response by a member status. A valid value is accepted,
     /// pending, rejected, or all. Default is accepted.
     ///
-    #[arg(long, value_parser = ["accepted","all","pending","rejected"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["accepted","all","pending","rejected"])]
     member_status: Option<String>,
 
     /// Filters the response by a name, as a string. A valid value is the name
     /// of an image.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// When true, filters the response to display only "hidden" images. By
     /// default, "hidden" images are not included in the image-list response.
     /// (Since Image API v2.7)
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     os_hidden: Option<bool>,
 
     /// Filters the response by a project (also called a “tenant”) ID. Shows
     /// only images that are shared with you by the specified owner.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     owner: Option<String>,
 
     /// Filters the response by the ‘protected’ image property. A valid value
     /// is one of ‘true’, ‘false’ (must be all lowercase). Any other value will
     /// result in a 400 response.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     protected: Option<bool>,
 
     /// Filters the response by a maximum image size, in bytes.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     size_max: Option<String>,
 
     /// Filters the response by a minimum image size, in bytes.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     size_min: Option<String>,
 
     /// Sorts the response by one or more attribute and sort direction
@@ -228,7 +228,7 @@ struct QueryParameters {
     /// Default direction is desc. Use the comma (,) character to separate
     /// multiple values. For example: `sort=name:asc,status:desc`
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     sort: Option<String>,
 
     /// Sorts the response by a set of one or more sort direction and attribute
@@ -236,32 +236,32 @@ struct QueryParameters {
     /// (ascending) or desc (descending). If you omit the sort direction in a
     /// set, the default is desc.
     ///
-    #[arg(long, value_parser = ["asc","desc"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
     sort_dir: Option<String>,
 
     /// Sorts the response by an attribute, such as name, id, or updated_at.
     /// Default is created_at. The API uses the natural sorting direction of
     /// the sort_key image attribute.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     sort_key: Option<String>,
 
     /// Filters the response by an image status.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     status: Option<String>,
 
     /// Filters the response by the specified tag value. May be repeated, but
     /// keep in mind that you're making a conjunctive query, so only images
     /// containing all the tags specified will appear in the response.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tag: Option<Vec<String>>,
 
     /// Specify a comparison filter based on the date and time when the
     /// resource was most recently modified.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     updated_at: Option<String>,
 
     /// Filters the response by an image visibility value. A valid value is
@@ -272,7 +272,7 @@ struct QueryParameters {
     /// response shows public, private, and those shared images with a member
     /// status of accepted.
     ///
-    #[arg(long, value_parser = ["all","community","private","public","shared"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["all","community","private","public","shared"])]
     visibility: Option<String>,
 }
 

--- a/openstack_cli/src/image/v2/image/member/create.rs
+++ b/openstack_cli/src/image/v2/image/member/create.rs
@@ -66,6 +66,7 @@ pub struct MemberCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -78,7 +79,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 }
 /// Member response representation

--- a/openstack_cli/src/image/v2/image/member/delete.rs
+++ b/openstack_cli/src/image/v2/image/member/delete.rs
@@ -73,12 +73,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 
     /// member_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Member response representation

--- a/openstack_cli/src/image/v2/image/member/list.rs
+++ b/openstack_cli/src/image/v2/image/member/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 }
 /// Members response representation

--- a/openstack_cli/src/image/v2/image/member/set.rs
+++ b/openstack_cli/src/image/v2/image/member/set.rs
@@ -71,6 +71,7 @@ pub struct MemberCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -83,12 +84,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 
     /// member_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Member response representation

--- a/openstack_cli/src/image/v2/image/member/show.rs
+++ b/openstack_cli/src/image/v2/image/member/show.rs
@@ -68,12 +68,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 
     /// member_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Member response representation

--- a/openstack_cli/src/image/v2/image/patch.rs
+++ b/openstack_cli/src/image/v2/image/patch.rs
@@ -84,30 +84,102 @@ pub struct ImageCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long)]
+    /// Format of the image container.
+    ///
+    /// Values may vary based on the configuration available in a particular
+    /// OpenStack cloud. See the [Image Schema](#image-schema) response from
+    /// the cloud itself for the valid values available.
+    ///
+    /// Example formats are: `ami`, `ari`, `aki`, `bare`, `ovf`, `ova`, or
+    /// `docker`.
+    ///
+    /// The value might be `null` (JSON null data type).
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     container_format: Option<ContainerFormat>,
-    #[arg(long)]
+
+    /// The format of the disk.
+    ///
+    /// Values may vary based on the configuration available in a particular
+    /// OpenStack cloud. See the [Image Schema](#image-schema) response from
+    /// the cloud itself for the valid values available.
+    ///
+    /// Example formats are: `ami`, `ari`, `aki`, `vhd`, `vhdx`, `vmdk`, `raw`,
+    /// `qcow2`, `vdi`, `ploop` or `iso`.
+    ///
+    /// The value might be `null` (JSON null data type).
+    ///
+    /// **Newton changes**: The `vhdx` disk format is a supported value.
+    ///
+    /// **Ocata changes**: The `ploop` disk format is a supported value.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     disk_format: Option<DiskFormat>,
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+
+    /// A list of objects, each of which describes an image location. Each
+    /// object contains a `url` key, whose value is a URL specifying a
+    /// location, and a `metadata` key, whose value is a dict of key:value
+    /// pairs containing information appropriate to the use of whatever
+    /// external store is indicated by the URL. *This list appears only if the*
+    /// `show_multiple_locations` *option is set to* `true` *in the Image
+    /// service’s configuration file.* **Because it presents a security risk,
+    /// this option is disabled by default.**
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     locations: Option<Vec<Value>>,
-    #[arg(long)]
+
+    /// Amount of disk space in GB that is required to boot the image. The
+    /// value might be `null` (JSON null data type).
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     min_disk: Option<i32>,
-    #[arg(long)]
+
+    /// Amount of RAM in MB that is required to boot the image. The value might
+    /// be `null` (JSON null data type).
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     min_ram: Option<i32>,
-    #[arg(long)]
+
+    /// The name of the image. Value might be `null` (JSON null data type).
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
-    #[arg(action=clap::ArgAction::Set, long)]
+
+    /// This field controls whether an image is displayed in the default
+    /// image-list response. A “hidden” image is out of date somehow (for
+    /// example, it may not have the latest updates applied) and hence should
+    /// not be a user’s first choice, but it’s not deleted because it may be
+    /// needed for server rebuilds. By hiding it from the default image list,
+    /// it’s easier for end users to find and use a more up-to-date version of
+    /// this image. *(Since Image API v2.7)*
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     os_hidden: Option<bool>,
-    #[arg(long)]
+
+    /// An identifier for the owner of the image, usually the project (also
+    /// called the “tenant”) ID. The value might be `null` (JSON null data
+    /// type).
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     owner: Option<String>,
-    #[arg(action=clap::ArgAction::Set, long)]
+
+    /// A boolean value that must be `false` or the image cannot be deleted.
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     protected: Option<bool>,
-    #[arg(action=clap::ArgAction::Append, long)]
+
+    /// List of tags for this image, possibly an empty list.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
-    #[arg(long)]
+
+    /// Image visibility, that is, the access permission for the image.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
     visibility: Option<Visibility>,
     /// Additional properties to be sent with the request
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, String>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, String)>>,
 }
 
@@ -120,7 +192,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 

--- a/openstack_cli/src/image/v2/image/reactivate.rs
+++ b/openstack_cli/src/image/v2/image/reactivate.rs
@@ -55,6 +55,7 @@ pub struct ImageCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -67,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Image response representation

--- a/openstack_cli/src/image/v2/image/show.rs
+++ b/openstack_cli/src/image/v2/image/show.rs
@@ -70,7 +70,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Image response representation

--- a/openstack_cli/src/image/v2/image/stage/stage.rs
+++ b/openstack_cli/src/image/v2/image/stage/stage.rs
@@ -56,6 +56,7 @@ pub struct StageCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -68,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 }
 /// Stage response representation

--- a/openstack_cli/src/image/v2/image/tag/delete.rs
+++ b/openstack_cli/src/image/v2/image/tag/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 
     /// tag_value parameter for /v2/images/{image_id}/tags/{tag_value} API
     ///
-    #[arg(id = "path_param_tag_value", value_name = "TAG_VALUE")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_tag_value",
+        value_name = "TAG_VALUE"
+    )]
     tag_value: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/image/v2/image/tag/set.rs
+++ b/openstack_cli/src/image/v2/image/tag/set.rs
@@ -55,6 +55,7 @@ pub struct TagCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -67,12 +68,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 
     /// tag_value parameter for /v2/images/{image_id}/tags/{tag_value} API
     ///
-    #[arg(id = "path_param_tag_value", value_name = "TAG_VALUE")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_tag_value",
+        value_name = "TAG_VALUE"
+    )]
     tag_value: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/image/v2/image/task/list.rs
+++ b/openstack_cli/src/image/v2/image/task/list.rs
@@ -70,7 +70,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// image_id parameter for /v2/images/{image_id}/members/{member_id} API
     ///
-    #[arg(id = "path_param_image_id", value_name = "IMAGE_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_image_id",
+        value_name = "IMAGE_ID"
+    )]
     image_id: String,
 }
 /// Tasks response representation

--- a/openstack_cli/src/image/v2/schema/metadef/namespace/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/namespace/get.rs
@@ -75,7 +75,7 @@ impl NamespaceCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/namespaces/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/namespaces/get.rs
@@ -75,7 +75,7 @@ impl NamespacesCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/object/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/object/get.rs
@@ -75,7 +75,7 @@ impl ObjectCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/objects/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/objects/get.rs
@@ -75,7 +75,7 @@ impl ObjectsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/properties/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/properties/get.rs
@@ -75,7 +75,7 @@ impl PropertiesCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/property/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/property/get.rs
@@ -75,7 +75,7 @@ impl PropertyCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/resource_type/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/resource_type/get.rs
@@ -75,7 +75,7 @@ impl ResourceTypeCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/resource_types/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/resource_types/get.rs
@@ -75,7 +75,7 @@ impl ResourceTypesCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/tag/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/tag/get.rs
@@ -75,7 +75,7 @@ impl TagCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/metadef/tags/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/tags/get.rs
@@ -75,7 +75,7 @@ impl TagsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/task/get.rs
+++ b/openstack_cli/src/image/v2/schema/task/get.rs
@@ -85,7 +85,7 @@ impl TaskCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/image/v2/schema/tasks/get.rs
+++ b/openstack_cli/src/image/v2/schema/tasks/get.rs
@@ -88,7 +88,7 @@ impl TasksCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = get::Request::builder();
+        let ep_builder = get::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/network/v2/availability_zone/list.rs
+++ b/openstack_cli/src/network/v2/availability_zone/list.rs
@@ -60,17 +60,17 @@ pub struct AvailabilityZonesCommand {
 struct QueryParameters {
     /// name query parameter for /v2.0/availability_zones API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// resource query parameter for /v2.0/availability_zones API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     resource: Option<String>,
 
     /// state query parameter for /v2.0/availability_zones API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     state: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/extension/show.rs
+++ b/openstack_cli/src/network/v2/extension/show.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/extensions/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Extension response representation

--- a/openstack_cli/src/network/v2/floatingip/create.rs
+++ b/openstack_cli/src/network/v2/floatingip/create.rs
@@ -110,17 +110,17 @@ struct Floatingip {
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// A valid DNS domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_domain: Option<String>,
 
     /// A valid DNS name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_name: Option<String>,
 
     /// The fixed IP address that is associated with the floating IP. If an
@@ -128,39 +128,39 @@ struct Floatingip {
     /// the first IP address unless you explicitly define a fixed IP address in
     /// the `fixed_ip_address` parameter.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     fixed_ip_address: Option<String>,
 
     /// The floating IP address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     floating_ip_address: Option<String>,
 
     /// The ID of the network associated with the floating IP.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     floating_network_id: String,
 
     /// The ID of a port associated with the floating IP. To associate the
     /// floating IP with a fixed IP at creation time, you must specify the
     /// identifier of the internal port.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 
     /// The ID of the QoS policy associated with the floating IP.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
     /// The subnet ID on which you want to create the floating IP.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     subnet_id: Option<String>,
 
     /// The ID of the project.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/floatingip/delete.rs
+++ b/openstack_cli/src/network/v2/floatingip/delete.rs
@@ -68,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/floatingips/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Floatingip response representation

--- a/openstack_cli/src/network/v2/floatingip/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/list.rs
@@ -71,72 +71,72 @@ pub struct FloatingipsCommand {
 struct QueryParameters {
     /// description query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     description: Option<String>,
 
     /// fixed_ip_address query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     fixed_ip_address: Option<String>,
 
     /// floating_ip_address query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     floating_ip_address: Option<String>,
 
     /// floating_network_id query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     floating_network_id: Option<String>,
 
     /// id query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// not-tags query parameter for /v2.0/floatingips API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags: Option<Vec<String>>,
 
     /// not-tags-any query parameter for /v2.0/floatingips API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags_any: Option<Vec<String>>,
 
     /// port_id query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     port_id: Option<String>,
 
     /// revision_number query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     revision_number: Option<String>,
 
     /// router_id query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     router_id: Option<String>,
 
     /// status query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     status: Option<String>,
 
     /// tags query parameter for /v2.0/floatingips API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags: Option<Vec<String>>,
 
     /// tags-any query parameter for /v2.0/floatingips API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags_any: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/floatingips API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/create.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/create.rs
@@ -71,7 +71,11 @@ struct PathParameters {
     /// floatingip_id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 }
 
@@ -91,51 +95,51 @@ struct PortForwarding {
     /// A text describing the rule, which helps users to manage/find easily
     /// theirs rules.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The TCP/UDP/other protocol port number of the port forwarding’s
     /// floating IP address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     external_port: Option<Option<f32>>,
 
     /// The TCP/UDP/other protocol port range of the port forwarding’s floating
     /// IP address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     external_port_range: Option<f32>,
 
     /// The fixed IPv4 address of the Neutron port associated to the floating
     /// IP port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_ip_address: Option<String>,
 
     /// The TCP/UDP/other protocol port number of the Neutron port fixed IP
     /// address associated to the floating ip port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_port: Option<Option<f32>>,
 
     /// The ID of the Neutron port associated to the floating IP port
     /// forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_port_id: Option<String>,
 
     /// The TCP/UDP/other protocol port range of the Neutron port fixed IP
     /// address associated to the floating ip port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_port_range: Option<f32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     project_id: Option<String>,
 
     /// The IP protocol used in the floating IP port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     protocol: Option<Protocol>,
 }
 

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/delete.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/delete.rs
@@ -67,13 +67,21 @@ struct PathParameters {
     /// floatingip_id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 
     /// id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// PortForwarding response representation

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
@@ -70,37 +70,37 @@ struct QueryParameters {
     /// description query parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     description: Option<String>,
 
     /// external_port query parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     external_port: Option<f32>,
 
     /// external_port_range query parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     external_port_range: Option<f32>,
 
     /// id query parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// internal_port_id query parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     internal_port_id: Option<String>,
 
     /// protocol query parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings API
     ///
-    #[arg(long, value_parser = ["dccp","icmp","ipv6-icmp","sctp","tcp","udp"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["dccp","icmp","ipv6-icmp","sctp","tcp","udp"])]
     protocol: Option<String>,
 }
 
@@ -110,7 +110,11 @@ struct PathParameters {
     /// floatingip_id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 }
 /// PortForwardings response representation

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/set.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/set.rs
@@ -71,13 +71,21 @@ struct PathParameters {
     /// floatingip_id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 
     /// id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -94,48 +102,48 @@ enum Protocol {
 /// PortForwarding Body data
 #[derive(Args)]
 struct PortForwarding {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The TCP/UDP/other protocol port number of the port forwarding’s
     /// floating IP address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     external_port: Option<Option<f32>>,
 
     /// The TCP/UDP/other protocol port range of the port forwarding’s floating
     /// IP address.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     external_port_range: Option<f32>,
 
     /// The fixed IPv4 address of the Neutron port associated to the floating
     /// IP port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_ip_address: Option<String>,
 
     /// The TCP/UDP/other protocol port number of the Neutron port fixed IP
     /// address associated to the floating ip port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_port: Option<Option<f32>>,
 
     /// The ID of the Neutron port associated to the floating IP port
     /// forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_port_id: Option<String>,
 
     /// The TCP/UDP/other protocol port range of the Neutron port fixed IP
     /// address associated to the floating ip port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     internal_port_range: Option<f32>,
 
     /// The IP protocol used in the floating IP port forwarding.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     protocol: Option<Protocol>,
 }
 

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/show.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/show.rs
@@ -69,13 +69,21 @@ struct PathParameters {
     /// floatingip_id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 
     /// id parameter for
     /// /v2.0/floatingips/{floatingip_id}/port_forwardings/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// PortForwarding response representation

--- a/openstack_cli/src/network/v2/floatingip/set.rs
+++ b/openstack_cli/src/network/v2/floatingip/set.rs
@@ -84,7 +84,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/floatingips/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Floatingip Body data
@@ -93,7 +97,7 @@ struct Floatingip {
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The fixed IP address that is associated with the floating IP. If an
@@ -101,17 +105,17 @@ struct Floatingip {
     /// the first IP address unless you explicitly define a fixed IP address in
     /// the `fixed_ip_address` parameter.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     fixed_ip_address: Option<String>,
 
     /// The ID of a port associated with the floating IP. To associate the
     /// floating IP with a fixed IP, you must specify the ID of the internal
     /// port. To disassociate the floating IP, `null` should be specified.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/floatingip/show.rs
+++ b/openstack_cli/src/network/v2/floatingip/show.rs
@@ -73,7 +73,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/floatingips/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Floatingip response representation

--- a/openstack_cli/src/network/v2/floatingip/tag/delete.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/delete.rs
@@ -62,12 +62,20 @@ struct PathParameters {
     /// floatingip_id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id}
     /// API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 
     /// id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/floatingip/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/delete_all.rs
@@ -62,7 +62,11 @@ struct PathParameters {
     /// floatingip_id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id}
     /// API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/floatingip/tag/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/list.rs
@@ -59,7 +59,11 @@ struct PathParameters {
     /// floatingip_id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id}
     /// API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 }
 /// Tags response representation

--- a/openstack_cli/src/network/v2/floatingip/tag/replace.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/replace.rs
@@ -48,7 +48,7 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }
 
@@ -62,7 +62,11 @@ struct PathParameters {
     /// floatingip_id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id}
     /// API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/floatingip/tag/set.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/set.rs
@@ -62,12 +62,20 @@ struct PathParameters {
     /// floatingip_id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id}
     /// API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 
     /// id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/floatingip/tag/show.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/show.rs
@@ -62,12 +62,20 @@ struct PathParameters {
     /// floatingip_id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id}
     /// API
     ///
-    #[arg(id = "path_param_floatingip_id", value_name = "FLOATINGIP_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_floatingip_id",
+        value_name = "FLOATINGIP_ID"
+    )]
     floatingip_id: String,
 
     /// id parameter for /v2.0/floatingips/{floatingip_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/network/create.rs
+++ b/openstack_cli/src/network/v2/network/create.rs
@@ -81,87 +81,87 @@ struct Network {
     /// The administrative state of the network, which is up (`true`) or down
     /// (`false`).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     admin_state_up: Option<bool>,
 
     /// The availability zone candidate for the network.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     availability_zone_hints: Option<Vec<String>>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// A valid DNS domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_domain: Option<String>,
 
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ha: Option<bool>,
 
     /// The network is default or not.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     is_default: Option<bool>,
 
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mtu: Option<i32>,
 
     /// Human-readable name of the network.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The port security status of the network. Valid values are enabled
     /// (`true`) and disabled (`false`). This value is used as the default
     /// value of `port_security_enabled` field of a newly created port.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     port_security_enabled: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider_network_type: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider_physical_network: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider_segmentation_id: Option<String>,
 
     /// The ID of the QoS policy associated with the network.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
     /// Indicates whether the network has an external routing facility that’s
     /// not managed by the networking service.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     router_external: Option<bool>,
 
     /// A list of provider `segment` objects.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     segments: Option<Vec<Value>>,
 
     /// Indicates whether this resource is shared across all projects. By
     /// default, only administrative users can change this value.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     shared: Option<bool>,
 
     /// The ID of the project that owns the resource. Only administrative and
     /// users with advsvc role can specify a project ID other than their own.
     /// You cannot change this value through authorization policies.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/network/delete.rs
+++ b/openstack_cli/src/network/v2/network/delete.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Network response representation

--- a/openstack_cli/src/network/v2/network/dhcp_agent/create.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/create.rs
@@ -55,6 +55,7 @@ pub struct DhcpAgentCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -68,7 +69,11 @@ struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id}
     /// API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 }
 /// DhcpAgent response representation

--- a/openstack_cli/src/network/v2/network/dhcp_agent/delete.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/delete.rs
@@ -62,12 +62,20 @@ struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id}
     /// API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 
     /// id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// DhcpAgent response representation

--- a/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
@@ -67,7 +67,11 @@ struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id}
     /// API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 }
 /// DhcpAgents response representation

--- a/openstack_cli/src/network/v2/network/dhcp_agent/set.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/set.rs
@@ -55,6 +55,7 @@ pub struct DhcpAgentCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -68,12 +69,20 @@ struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id}
     /// API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 
     /// id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// DhcpAgent response representation

--- a/openstack_cli/src/network/v2/network/dhcp_agent/show.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/show.rs
@@ -62,12 +62,20 @@ struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id}
     /// API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 
     /// id parameter for /v2.0/networks/{network_id}/dhcp-agents/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// DhcpAgent response representation

--- a/openstack_cli/src/network/v2/network/list.rs
+++ b/openstack_cli/src/network/v2/network/list.rs
@@ -77,92 +77,92 @@ pub struct NetworksCommand {
 struct QueryParameters {
     /// admin_state_up query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     admin_state_up: Option<bool>,
 
     /// description query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     description: Option<String>,
 
     /// id query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// is_default query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     is_default: Option<bool>,
 
     /// mtu query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     mtu: Option<i32>,
 
     /// name query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// not-tags query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags: Option<Vec<String>>,
 
     /// not-tags-any query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags_any: Option<Vec<String>>,
 
     /// provider:network_type query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     provider_network_type: Option<String>,
 
     /// provider:physical_network query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     provider_physical_network: Option<String>,
 
     /// provider:segmentation_id query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     provider_segmentation_id: Option<i32>,
 
     /// revision_number query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     revision_number: Option<String>,
 
     /// router:external query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     router_external: Option<bool>,
 
     /// shared query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     shared: Option<bool>,
 
     /// status query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     status: Option<String>,
 
     /// tags query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags: Option<Vec<String>>,
 
     /// tags-any query parameter for /v2.0/networks API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags_any: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/networks API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/network/set.rs
+++ b/openstack_cli/src/network/v2/network/set.rs
@@ -75,7 +75,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Network Body data
@@ -84,72 +88,72 @@ struct Network {
     /// The administrative state of the network, which is up (`true`) or down
     /// (`false`).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     admin_state_up: Option<bool>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// A valid DNS domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_domain: Option<String>,
 
     /// The network is default or not.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     is_default: Option<bool>,
 
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mtu: Option<i32>,
 
     /// Human-readable name of the network.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The port security status of the network. Valid values are enabled
     /// (`true`) and disabled (`false`). This value is used as the default
     /// value of `port_security_enabled` field of a newly created port.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     port_security_enabled: Option<bool>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider_network_type: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider_physical_network: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     provider_segmentation_id: Option<String>,
 
     /// The ID of the QoS policy associated with the network.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
     /// Indicates whether the network has an external routing facility that’s
     /// not managed by the networking service.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     router_external: Option<bool>,
 
     /// A list of provider `segment` objects.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     segments: Option<Vec<Value>>,
 
     /// Indicates whether this resource is shared across all projects. By
     /// default, only administrative users can change this value.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     shared: Option<bool>,
 }
 

--- a/openstack_cli/src/network/v2/network/show.rs
+++ b/openstack_cli/src/network/v2/network/show.rs
@@ -72,7 +72,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Network response representation

--- a/openstack_cli/src/network/v2/network/tag/delete.rs
+++ b/openstack_cli/src/network/v2/network/tag/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 
     /// id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/network/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/network/tag/delete_all.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/network/tag/list.rs
+++ b/openstack_cli/src/network/v2/network/tag/list.rs
@@ -58,7 +58,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 }
 /// Tags response representation

--- a/openstack_cli/src/network/v2/network/tag/replace.rs
+++ b/openstack_cli/src/network/v2/network/tag/replace.rs
@@ -48,7 +48,7 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }
 
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/network/tag/set.rs
+++ b/openstack_cli/src/network/v2/network/tag/set.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 
     /// id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/network/tag/show.rs
+++ b/openstack_cli/src/network/v2/network/tag/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// network_id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_network_id", value_name = "NETWORK_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_network_id",
+        value_name = "NETWORK_ID"
+    )]
     network_id: String,
 
     /// id parameter for /v2.0/networks/{network_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/port/add_allowed_address_pairs.rs
+++ b/openstack_cli/src/network/v2/port/add_allowed_address_pairs.rs
@@ -56,6 +56,7 @@ pub struct PortCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -69,7 +70,11 @@ struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/add_allowed_address_pairs
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Port response representation

--- a/openstack_cli/src/network/v2/port/binding/activate/activate.rs
+++ b/openstack_cli/src/network/v2/port/binding/activate/activate.rs
@@ -56,6 +56,7 @@ pub struct ActivateCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -68,12 +69,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 
     /// id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Activate response representation

--- a/openstack_cli/src/network/v2/port/binding/create.rs
+++ b/openstack_cli/src/network/v2/port/binding/create.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 }
 
@@ -88,16 +92,16 @@ enum VnicType {
 /// Binding Body data
 #[derive(Args)]
 struct Binding {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     profile: Option<Vec<(String, Value)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     project_id: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     vnic_type: Option<VnicType>,
 }
 

--- a/openstack_cli/src/network/v2/port/binding/delete.rs
+++ b/openstack_cli/src/network/v2/port/binding/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 
     /// id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Binding response representation

--- a/openstack_cli/src/network/v2/port/binding/list.rs
+++ b/openstack_cli/src/network/v2/port/binding/list.rs
@@ -59,22 +59,22 @@ pub struct BindingsCommand {
 struct QueryParameters {
     /// host query parameter for /v2.0/ports/{port_id}/bindings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     host: Option<String>,
 
     /// status query parameter for /v2.0/ports/{port_id}/bindings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     status: Option<String>,
 
     /// vif_type query parameter for /v2.0/ports/{port_id}/bindings API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     vif_type: Option<String>,
 
     /// vnic_type query parameter for /v2.0/ports/{port_id}/bindings API
     ///
-    #[arg(long, value_parser = ["accelerator-direct","accelerator-direct-physical","baremetal","direct","direct-physical","macvtap","normal","remote-managed","smart-nic","vdpa","virtio-forwarder"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["accelerator-direct","accelerator-direct-physical","baremetal","direct","direct-physical","macvtap","normal","remote-managed","smart-nic","vdpa","virtio-forwarder"])]
     vnic_type: Option<String>,
 }
 
@@ -83,7 +83,11 @@ struct QueryParameters {
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 }
 /// Bindings response representation

--- a/openstack_cli/src/network/v2/port/binding/set.rs
+++ b/openstack_cli/src/network/v2/port/binding/set.rs
@@ -66,12 +66,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 
     /// id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -93,13 +101,13 @@ enum VnicType {
 /// Binding Body data
 #[derive(Args)]
 struct Binding {
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     profile: Option<Vec<(String, Value)>>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     vnic_type: Option<VnicType>,
 }
 

--- a/openstack_cli/src/network/v2/port/binding/show.rs
+++ b/openstack_cli/src/network/v2/port/binding/show.rs
@@ -60,12 +60,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 
     /// id parameter for /v2.0/ports/{port_id}/bindings/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Binding response representation

--- a/openstack_cli/src/network/v2/port/create.rs
+++ b/openstack_cli/src/network/v2/port/create.rs
@@ -104,7 +104,7 @@ struct Port {
     /// The administrative state of the resource, which is up (`true`) or down
     /// (`false`). Default is `true`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     admin_state_up: Option<bool>,
 
     /// A set of zero or more allowed address pair objects each where address
@@ -115,13 +115,13 @@ struct Port {
     /// connected to the port can send a packet with source address which
     /// matches one of the specified allowed address pairs.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allowed_address_pairs: Option<Vec<Value>>,
 
     /// The ID of the host where the port resides. The default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     binding_host_id: Option<String>,
 
     /// A dictionary that enables the application running on the specific host
@@ -141,7 +141,7 @@ struct Port {
     /// `mac_address` field of the port resource will be updated to the MAC
     /// from the active binding.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     binding_profile: Option<Vec<(String, Value)>>,
 
     /// The type of vNIC which this port should be attached to. This is used to
@@ -151,45 +151,45 @@ struct Port {
     /// `remote-managed`. What type of vNIC is actually available depends on
     /// deployments. The default is `normal`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     binding_vnic_type: Option<BindingVnicType>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the device that uses this port. For example, a server
     /// instance or a logical router.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device_id: Option<String>,
 
     /// The entity type that uses this port. For example, `compute:nova`
     /// (server instance), `network:dhcp` (DHCP agent) or
     /// `network:router_interface` (router interface).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device_owner: Option<String>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device_profile: Option<String>,
 
     /// A valid DNS domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_domain: Option<String>,
 
     /// A valid DNS name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_name: Option<String>,
 
     /// A set of zero or more extra DHCP option pairs. An option pair consists
     /// of an option value and name.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     extra_dhcp_opts: Option<Vec<Value>>,
 
     /// The IP addresses for the port. If you would like to assign multiple IP
@@ -206,7 +206,7 @@ struct Port {
     ///   allocate the IP address if the address is a valid IP for any of the
     ///   subnets on the specified network.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     fixed_ips: Option<Vec<Value>>,
 
     /// Admin-only. A dict, at the top level keyed by mechanism driver aliases
@@ -219,29 +219,29 @@ struct Port {
     /// If omitted the default is defined by Open vSwitch. The field cannot be
     /// longer than 4095 characters.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     hints: Option<Vec<(String, Value)>>,
 
     /// The MAC address of the port. If unspecified, a MAC address is
     /// automatically generated.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mac_address: Option<String>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The ID of the attached network.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     network_id: Option<String>,
 
     /// The port NUMA affinity policy requested during the virtual machine
     /// scheduling. Values: `None`, `required`, `preferred` or `legacy`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     numa_affinity_policy: Option<NumaAffinityPolicy>,
 
     /// The port security status. A valid value is enabled (`true`) or disabled
@@ -249,33 +249,33 @@ struct Port {
     /// rules and anti-spoofing rules are applied to the traffic on the port.
     /// If disabled, no such rules are applied.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     port_security_enabled: Option<bool>,
 
     /// The uplink status propagation of the port. Valid values are enabled
     /// (`true`) and disabled (`false`).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     propagate_uplink_status: Option<bool>,
 
     /// QoS policy associated with the port.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
     /// The IDs of security groups applied to the port.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
     /// The ID of the project that owns the resource. Only administrative and
     /// users with advsvc role can specify a project ID other than their own.
     /// You cannot change this value through authorization policies.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/port/delete.rs
+++ b/openstack_cli/src/network/v2/port/delete.rs
@@ -70,7 +70,11 @@ struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/add_allowed_address_pairs
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Port response representation

--- a/openstack_cli/src/network/v2/port/list.rs
+++ b/openstack_cli/src/network/v2/port/list.rs
@@ -77,97 +77,97 @@ pub struct PortsCommand {
 struct QueryParameters {
     /// admin_state_up query parameter for /v2.0/ports API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     admin_state_up: Option<bool>,
 
     /// binding:host_id query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     binding_host_id: Option<String>,
 
     /// description query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     description: Option<String>,
 
     /// device_id query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     device_id: Option<String>,
 
     /// device_owner query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     device_owner: Option<String>,
 
     /// fixed_ips query parameter for /v2.0/ports API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     fixed_ips: Option<Vec<String>>,
 
     /// id query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// ip_allocation query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     ip_allocation: Option<String>,
 
     /// mac_address query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     mac_address: Option<String>,
 
     /// name query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// network_id query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     network_id: Option<String>,
 
     /// not-tags query parameter for /v2.0/ports API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags: Option<Vec<String>>,
 
     /// not-tags-any query parameter for /v2.0/ports API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags_any: Option<Vec<String>>,
 
     /// revision_number query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     revision_number: Option<String>,
 
     /// security_groups query parameter for /v2.0/ports API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     security_groups: Option<Vec<String>>,
 
     /// status query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     status: Option<String>,
 
     /// tags query parameter for /v2.0/ports API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags: Option<Vec<String>>,
 
     /// tags-any query parameter for /v2.0/ports API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags_any: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/ports API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/port/set.rs
+++ b/openstack_cli/src/network/v2/port/set.rs
@@ -98,7 +98,11 @@ struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/add_allowed_address_pairs
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -136,7 +140,7 @@ struct Port {
     /// The administrative state of the resource, which is up (`true`) or down
     /// (`false`). Default is `true`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     admin_state_up: Option<bool>,
 
     /// A set of zero or more allowed address pair objects each where address
@@ -147,13 +151,13 @@ struct Port {
     /// connected to the port can send a packet with source address which
     /// matches one of the specified allowed address pairs.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allowed_address_pairs: Option<Vec<Value>>,
 
     /// The ID of the host where the port resides. The default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     binding_host_id: Option<String>,
 
     /// A dictionary that enables the application running on the specific host
@@ -173,7 +177,7 @@ struct Port {
     /// `mac_address` field of the port resource will be updated to the MAC
     /// from the active binding.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     binding_profile: Option<Vec<(String, Value)>>,
 
     /// The type of vNIC which this port should be attached to. This is used to
@@ -183,47 +187,47 @@ struct Port {
     /// `remote-managed`. What type of vNIC is actually available depends on
     /// deployments. The default is `normal`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     binding_vnic_type: Option<BindingVnicType>,
 
     /// Status of the underlying data plane of a port.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     data_plane_status: Option<DataPlaneStatus>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// The ID of the device that uses this port. For example, a server
     /// instance or a logical router.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device_id: Option<String>,
 
     /// The entity type that uses this port. For example, `compute:nova`
     /// (server instance), `network:dhcp` (DHCP agent) or
     /// `network:router_interface` (router interface).
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     device_owner: Option<String>,
 
     /// A valid DNS domain.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_domain: Option<String>,
 
     /// A valid DNS name.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     dns_name: Option<String>,
 
     /// A set of zero or more extra DHCP option pairs. An option pair consists
     /// of an option value and name.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     extra_dhcp_opts: Option<Vec<Value>>,
 
     /// The IP addresses for the port. If you would like to assign multiple IP
@@ -240,7 +244,7 @@ struct Port {
     ///   allocate the IP address if the address is a valid IP for any of the
     ///   subnets on the specified network.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     fixed_ips: Option<Vec<Value>>,
 
     /// Admin-only. A dict, at the top level keyed by mechanism driver aliases
@@ -253,24 +257,24 @@ struct Port {
     /// If omitted the default is defined by Open vSwitch. The field cannot be
     /// longer than 4095 characters.
     ///
-    #[arg(long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     hints: Option<Vec<(String, Value)>>,
 
     /// The MAC address of the port. By default, only administrative users and
     /// users with advsvc role can change this value.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     mac_address: Option<String>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The port NUMA affinity policy requested during the virtual machine
     /// scheduling. Values: `None`, `required`, `preferred` or `legacy`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     numa_affinity_policy: Option<NumaAffinityPolicy>,
 
     /// The port security status. A valid value is enabled (`true`) or disabled
@@ -278,17 +282,17 @@ struct Port {
     /// rules and anti-spoofing rules are applied to the traffic on the port.
     /// If disabled, no such rules are applied.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     port_security_enabled: Option<bool>,
 
     /// QoS policy associated with the port.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
     /// The IDs of security groups applied to the port.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 }
 

--- a/openstack_cli/src/network/v2/port/show.rs
+++ b/openstack_cli/src/network/v2/port/show.rs
@@ -72,7 +72,11 @@ struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/add_allowed_address_pairs
     /// API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Port response representation

--- a/openstack_cli/src/network/v2/port/tag/delete.rs
+++ b/openstack_cli/src/network/v2/port/tag/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 
     /// id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/port/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/port/tag/delete_all.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/port/tag/list.rs
+++ b/openstack_cli/src/network/v2/port/tag/list.rs
@@ -58,7 +58,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 }
 /// Tags response representation

--- a/openstack_cli/src/network/v2/port/tag/replace.rs
+++ b/openstack_cli/src/network/v2/port/tag/replace.rs
@@ -48,7 +48,7 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }
 
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/port/tag/set.rs
+++ b/openstack_cli/src/network/v2/port/tag/set.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 
     /// id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/port/tag/show.rs
+++ b/openstack_cli/src/network/v2/port/tag/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// port_id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_port_id", value_name = "PORT_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_port_id",
+        value_name = "PORT_ID"
+    )]
     port_id: String,
 
     /// id parameter for /v2.0/ports/{port_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/router/add_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/add_external_gateways.rs
@@ -67,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router Body data
@@ -75,7 +79,7 @@ struct PathParameters {
 struct Router {
     /// The list of external gateways of the router.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_gateways: Option<Vec<Value>>,
 }
 

--- a/openstack_cli/src/network/v2/router/add_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/add_extraroutes.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router Body data
@@ -75,7 +79,7 @@ struct Router {
     /// with `destination` and `nexthop` parameters. It is available when
     /// `extraroute` extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     routes: Option<Vec<Value>>,
 }
 

--- a/openstack_cli/src/network/v2/router/add_router_interface.rs
+++ b/openstack_cli/src/network/v2/router/add_router_interface.rs
@@ -53,12 +53,12 @@ pub struct RouterCommand {
 
     /// The ID of the port. One of subnet_id or port_id must be specified.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 
     /// The ID of the subnet. One of subnet_id or port_id must be specified.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     subnet_id: Option<String>,
 }
 
@@ -71,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router response representation

--- a/openstack_cli/src/network/v2/router/conntrack_helper/create.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/create.rs
@@ -71,7 +71,11 @@ struct PathParameters {
     /// router_id parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 }
 
@@ -90,20 +94,20 @@ enum Protocol {
 struct ConntrackHelper {
     /// The netfilter conntrack helper module.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     helper: Option<String>,
 
     /// The network port for the netfilter conntrack target rule.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port: Option<f32>,
 
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     project_id: Option<String>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     protocol: Option<Protocol>,
 }
 

--- a/openstack_cli/src/network/v2/router/conntrack_helper/delete.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/delete.rs
@@ -67,12 +67,20 @@ struct PathParameters {
     /// router_id parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ConntrackHelper response representation

--- a/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
@@ -66,24 +66,24 @@ struct QueryParameters {
     /// helper query parameter for /v2.0/routers/{router_id}/conntrack_helpers
     /// API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     helper: Option<String>,
 
     /// id query parameter for /v2.0/routers/{router_id}/conntrack_helpers API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// port query parameter for /v2.0/routers/{router_id}/conntrack_helpers
     /// API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     port: Option<f32>,
 
     /// protocol query parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers API
     ///
-    #[arg(long, value_parser = ["dccp","icmp","ipv6-icmp","sctp","tcp","udp"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["dccp","icmp","ipv6-icmp","sctp","tcp","udp"])]
     protocol: Option<String>,
 }
 
@@ -93,7 +93,11 @@ struct PathParameters {
     /// router_id parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 }
 /// ConntrackHelpers response representation

--- a/openstack_cli/src/network/v2/router/conntrack_helper/set.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/set.rs
@@ -69,12 +69,20 @@ struct PathParameters {
     /// router_id parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 
@@ -93,17 +101,17 @@ enum Protocol {
 struct ConntrackHelper {
     /// The netfilter conntrack helper module.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     helper: Option<String>,
 
     /// The network port for the netfilter conntrack target rule.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port: Option<f32>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     protocol: Option<Protocol>,
 }
 

--- a/openstack_cli/src/network/v2/router/conntrack_helper/show.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/show.rs
@@ -69,12 +69,20 @@ struct PathParameters {
     /// router_id parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/conntrack_helpers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ConntrackHelper response representation

--- a/openstack_cli/src/network/v2/router/create.rs
+++ b/openstack_cli/src/network/v2/router/create.rs
@@ -84,13 +84,13 @@ struct PathParameters {}
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ExternalGatewayInfo {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_snat: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_fixed_ips: Option<Vec<Value>>,
 
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     network_id: String,
 }
 
@@ -100,25 +100,25 @@ struct Router {
     /// The administrative state of the resource, which is up (`true`) or down
     /// (`false`). Default is `true`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     admin_state_up: Option<bool>,
 
     /// The availability zone candidates for the router. It is available when
     /// `router_availability_zone` extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     availability_zone_hints: Option<Vec<String>>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// `true` indicates a distributed router. It is available when `dvr`
     /// extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     distributed: Option<Option<bool>>,
 
     /// Enable NDP proxy attribute. Default is `false`, To persist this
@@ -126,7 +126,7 @@ struct Router {
     /// `neutron.conf` file. It is available when `router-extend-ndp-proxy`
     /// extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_ndp_proxy: Option<Option<bool>>,
 
     /// The external gateway information of the router. If the router has an
@@ -139,25 +139,25 @@ struct Router {
 
     /// The ID of the flavor associated with the router.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     flavor_id: Option<String>,
 
     /// `true` indicates a highly-available router. It is available when
     /// `l3-ha` extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ha: Option<Option<bool>>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The ID of the project that owns the resource. Only administrative and
     /// users with advsvc role can specify a project ID other than their own.
     /// You cannot change this value through authorization policies.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/router/delete.rs
+++ b/openstack_cli/src/network/v2/router/delete.rs
@@ -70,7 +70,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router response representation

--- a/openstack_cli/src/network/v2/router/l3_agent/create.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/create.rs
@@ -55,6 +55,7 @@ pub struct L3AgentCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -67,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 }
 /// L3Agent response representation

--- a/openstack_cli/src/network/v2/router/l3_agent/delete.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// L3Agent response representation

--- a/openstack_cli/src/network/v2/router/l3_agent/list.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/list.rs
@@ -66,7 +66,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 }
 /// L3Agents response representation

--- a/openstack_cli/src/network/v2/router/l3_agent/set.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/set.rs
@@ -55,6 +55,7 @@ pub struct L3AgentCommand {
     path: PathParameters,
 
     #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
+    #[arg(help_heading = "Body parameters")]
     properties: Option<Vec<(String, Value)>>,
 }
 
@@ -67,12 +68,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// L3Agent response representation

--- a/openstack_cli/src/network/v2/router/l3_agent/show.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/l3-agents/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// L3Agent response representation

--- a/openstack_cli/src/network/v2/router/list.rs
+++ b/openstack_cli/src/network/v2/router/list.rs
@@ -72,57 +72,57 @@ pub struct RoutersCommand {
 struct QueryParameters {
     /// admin_state_up query parameter for /v2.0/routers API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     admin_state_up: Option<bool>,
 
     /// description query parameter for /v2.0/routers API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     description: Option<String>,
 
     /// enable_ndp_proxy query parameter for /v2.0/routers API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     enable_ndp_proxy: Option<bool>,
 
     /// id query parameter for /v2.0/routers API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// name query parameter for /v2.0/routers API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// not-tags query parameter for /v2.0/routers API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags: Option<Vec<String>>,
 
     /// not-tags-any query parameter for /v2.0/routers API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags_any: Option<Vec<String>>,
 
     /// revision_number query parameter for /v2.0/routers API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     revision_number: Option<String>,
 
     /// tags query parameter for /v2.0/routers API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags: Option<Vec<String>>,
 
     /// tags-any query parameter for /v2.0/routers API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags_any: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/routers API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/router/remove_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/remove_external_gateways.rs
@@ -67,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router Body data
@@ -75,7 +79,7 @@ struct PathParameters {
 struct Router {
     /// The list of external gateways of the router.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_gateways: Option<Vec<Value>>,
 }
 

--- a/openstack_cli/src/network/v2/router/remove_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/remove_extraroutes.rs
@@ -65,7 +65,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router Body data
@@ -75,7 +79,7 @@ struct Router {
     /// with `destination` and `nexthop` parameters. It is available when
     /// `extraroute` extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     routes: Option<Vec<Value>>,
 }
 

--- a/openstack_cli/src/network/v2/router/remove_router_interface.rs
+++ b/openstack_cli/src/network/v2/router/remove_router_interface.rs
@@ -53,12 +53,12 @@ pub struct RouterCommand {
 
     /// The ID of the port. One of subnet_id or port_id must be specified.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 
     /// The ID of the subnet. One of subnet_id or port_id must be specified.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     subnet_id: Option<String>,
 }
 
@@ -71,7 +71,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router response representation

--- a/openstack_cli/src/network/v2/router/set.rs
+++ b/openstack_cli/src/network/v2/router/set.rs
@@ -79,20 +79,24 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// ExternalGatewayInfo Body data
 #[derive(Args)]
 #[group(required = false, multiple = true)]
 struct ExternalGatewayInfo {
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_snat: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_fixed_ips: Option<Vec<Value>>,
 
-    #[arg(long, required = false)]
+    #[arg(help_heading = "Body parameters", long, required = false)]
     network_id: String,
 }
 
@@ -102,19 +106,19 @@ struct Router {
     /// The administrative state of the resource, which is up (`true`) or down
     /// (`false`).
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     admin_state_up: Option<bool>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// `true` indicates a distributed router. It is available when `dvr`
     /// extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     distributed: Option<Option<bool>>,
 
     /// Enable NDP proxy attribute. Default is `false`, To persist this
@@ -122,7 +126,7 @@ struct Router {
     /// `neutron.conf` file. It is available when `router-extend-ndp-proxy`
     /// extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_ndp_proxy: Option<Option<bool>>,
 
     /// The external gateway information of the router. If the router has an
@@ -136,19 +140,19 @@ struct Router {
     /// `true` indicates a highly-available router. It is available when
     /// `l3-ha` extension is enabled.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     ha: Option<Option<bool>>,
 
     /// Human-readable name of the resource.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The extra routes configuration for L3 router. A list of dictionaries
     /// with `destination` and `nexthop` parameters. It is available when
     /// `extraroute` extension is enabled. Default is an empty list (`[]`).
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     routes: Option<Vec<Value>>,
 }
 

--- a/openstack_cli/src/network/v2/router/show.rs
+++ b/openstack_cli/src/network/v2/router/show.rs
@@ -72,7 +72,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router response representation

--- a/openstack_cli/src/network/v2/router/tag/delete.rs
+++ b/openstack_cli/src/network/v2/router/tag/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/router/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/router/tag/delete_all.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/router/tag/list.rs
+++ b/openstack_cli/src/network/v2/router/tag/list.rs
@@ -58,7 +58,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 }
 /// Tags response representation

--- a/openstack_cli/src/network/v2/router/tag/replace.rs
+++ b/openstack_cli/src/network/v2/router/tag/replace.rs
@@ -48,7 +48,7 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }
 
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/router/tag/set.rs
+++ b/openstack_cli/src/network/v2/router/tag/set.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/router/tag/show.rs
+++ b/openstack_cli/src/network/v2/router/tag/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// router_id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_router_id", value_name = "ROUTER_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_router_id",
+        value_name = "ROUTER_ID"
+    )]
     router_id: String,
 
     /// id parameter for /v2.0/routers/{router_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/router/update_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/update_external_gateways.rs
@@ -67,7 +67,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// id parameter for /v2.0/routers/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Router Body data
@@ -75,7 +79,7 @@ struct PathParameters {
 struct Router {
     /// The list of external gateways of the router.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_gateways: Option<Vec<Value>>,
 }
 

--- a/openstack_cli/src/network/v2/subnet/create.rs
+++ b/openstack_cli/src/network/v2/subnet/create.rs
@@ -126,36 +126,36 @@ struct Subnet {
     /// automatically allocates pools for covering all IP addresses in the
     /// CIDR, excluding the address reserved for the subnet gateway by default.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allocation_pools: Option<Vec<Value>>,
 
     /// The CIDR of the subnet.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// List of dns name servers associated with the subnet. Default is an
     /// empty list.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     dns_nameservers: Option<Vec<String>>,
 
     /// Whether to publish DNS records for IPs from this subnet. Default is
     /// `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     dns_publish_fixed_ip: Option<bool>,
 
     /// Indicates whether dhcp is enabled or disabled for the subnet. Default
     /// is `true`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_dhcp: Option<bool>,
 
     /// Gateway IP of this subnet. If the value is `null` that implies no
@@ -163,76 +163,76 @@ struct Subnet {
     /// specified, OpenStack Networking allocates an address from the CIDR for
     /// the gateway for the subnet by default.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     gateway_ip: Option<String>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     host_routes: Option<Vec<Value>>,
 
     /// The IP protocol version. Value is `4` or `6`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     ip_version: i32,
 
     /// The IPv6 address modes specifies mechanisms for assigning IP addresses.
     /// Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     ipv6_address_mode: Option<Ipv6AddressMode>,
 
     /// The IPv6 router advertisement specifies whether the networking service
     /// should transmit ICMPv6 packets, for a subnet. Value is `slaac`,
     /// `dhcpv6-stateful`, `dhcpv6-stateless`.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     ipv6_ra_mode: Option<Ipv6RaMode>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The ID of the network to which the subnet belongs.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     network_id: String,
 
     /// The prefix length to use for subnet allocation from a subnet pool. If
     /// not specified, the `default_prefixlen` value of the subnet pool will be
     /// used.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     prefixlen: Option<i32>,
 
     /// The ID of a network segment the subnet is associated with. It is
     /// available when `segment` extension is enabled.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     segment_id: Option<String>,
 
     /// The service types associated with the subnet.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     service_types: Option<Vec<String>>,
 
     /// The ID of the subnet pool associated with the subnet.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     subnetpool_id: Option<String>,
 
     /// The ID of the project that owns the resource. Only administrative and
     /// users with advsvc role can specify a project ID other than their own.
     /// You cannot change this value through authorization policies.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     tenant_id: Option<String>,
 
     /// Whether to allocate this subnet from the default subnet pool.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     use_default_subnetpool: Option<bool>,
 }
 

--- a/openstack_cli/src/network/v2/subnet/delete.rs
+++ b/openstack_cli/src/network/v2/subnet/delete.rs
@@ -68,7 +68,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Subnet response representation

--- a/openstack_cli/src/network/v2/subnet/list.rs
+++ b/openstack_cli/src/network/v2/subnet/list.rs
@@ -72,97 +72,97 @@ pub struct SubnetsCommand {
 struct QueryParameters {
     /// cidr query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     cidr: Option<String>,
 
     /// description query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     description: Option<String>,
 
     /// enable_dhcp query parameter for /v2.0/subnets API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     enable_dhcp: Option<bool>,
 
     /// gateway_ip query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     gateway_ip: Option<String>,
 
     /// id query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
     /// ip_version query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     ip_version: Option<i32>,
 
     /// ipv6_address_mode query parameter for /v2.0/subnets API
     ///
-    #[arg(long, value_parser = ["dhcpv6-stateful","dhcpv6-stateless","slaac"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["dhcpv6-stateful","dhcpv6-stateless","slaac"])]
     ipv6_address_mode: Option<String>,
 
     /// ipv6_ra_mode query parameter for /v2.0/subnets API
     ///
-    #[arg(long, value_parser = ["dhcpv6-stateful","dhcpv6-stateless","slaac"])]
+    #[arg(help_heading = "Query parameters", long, value_parser = ["dhcpv6-stateful","dhcpv6-stateless","slaac"])]
     ipv6_ra_mode: Option<String>,
 
     /// name query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     name: Option<String>,
 
     /// network_id query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     network_id: Option<String>,
 
     /// not-tags query parameter for /v2.0/subnets API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags: Option<Vec<String>>,
 
     /// not-tags-any query parameter for /v2.0/subnets API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     not_tags_any: Option<Vec<String>>,
 
     /// revision_number query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     revision_number: Option<String>,
 
     /// segment_id query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     segment_id: Option<String>,
 
     /// shared query parameter for /v2.0/subnets API
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     shared: Option<bool>,
 
     /// subnetpool_id query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     subnetpool_id: Option<String>,
 
     /// tags query parameter for /v2.0/subnets API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags: Option<Vec<String>>,
 
     /// tags-any query parameter for /v2.0/subnets API
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
     tags_any: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/subnets API
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Query parameters", long)]
     tenant_id: Option<String>,
 }
 

--- a/openstack_cli/src/network/v2/subnet/set.rs
+++ b/openstack_cli/src/network/v2/subnet/set.rs
@@ -76,7 +76,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Subnet Body data
@@ -87,31 +91,31 @@ struct Subnet {
     /// automatically allocates pools for covering all IP addresses in the
     /// CIDR, excluding the address reserved for the subnet gateway by default.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allocation_pools: Option<Vec<Value>>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
     /// List of dns name servers associated with the subnet. Default is an
     /// empty list.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     dns_nameservers: Option<Vec<String>>,
 
     /// Whether to publish DNS records for IPs from this subnet. Default is
     /// `false`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     dns_publish_fixed_ip: Option<bool>,
 
     /// Indicates whether dhcp is enabled or disabled for the subnet. Default
     /// is `true`.
     ///
-    #[arg(action=clap::ArgAction::Set, long)]
+    #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_dhcp: Option<bool>,
 
     /// Gateway IP of this subnet. If the value is `null` that implies no
@@ -119,29 +123,29 @@ struct Subnet {
     /// specified, OpenStack Networking allocates an address from the CIDR for
     /// the gateway for the subnet by default.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     gateway_ip: Option<String>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.
     ///
-    #[arg(action=clap::ArgAction::Append, long, value_name="JSON", value_parser=parse_json)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     host_routes: Option<Vec<Value>>,
 
     /// Human-readable name of the resource.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
     /// The ID of a network segment the subnet is associated with. It is
     /// available when `segment` extension is enabled.
     ///
-    #[arg(long)]
+    #[arg(help_heading = "Body parameters", long)]
     segment_id: Option<String>,
 
     /// The service types associated with the subnet.
     ///
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     service_types: Option<Vec<String>>,
 }
 

--- a/openstack_cli/src/network/v2/subnet/show.rs
+++ b/openstack_cli/src/network/v2/subnet/show.rs
@@ -69,7 +69,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Subnet response representation

--- a/openstack_cli/src/network/v2/subnet/tag/delete.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/delete.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_subnet_id", value_name = "SUBNET_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_subnet_id",
+        value_name = "SUBNET_ID"
+    )]
     subnet_id: String,
 
     /// id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/subnet/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/delete_all.rs
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_subnet_id", value_name = "SUBNET_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_subnet_id",
+        value_name = "SUBNET_ID"
+    )]
     subnet_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/subnet/tag/list.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/list.rs
@@ -58,7 +58,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_subnet_id", value_name = "SUBNET_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_subnet_id",
+        value_name = "SUBNET_ID"
+    )]
     subnet_id: String,
 }
 /// Tags response representation

--- a/openstack_cli/src/network/v2/subnet/tag/replace.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/replace.rs
@@ -48,7 +48,7 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(action=clap::ArgAction::Append, long)]
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }
 
@@ -61,7 +61,11 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_subnet_id", value_name = "SUBNET_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_subnet_id",
+        value_name = "SUBNET_ID"
+    )]
     subnet_id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/subnet/tag/set.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/set.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_subnet_id", value_name = "SUBNET_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_subnet_id",
+        value_name = "SUBNET_ID"
+    )]
     subnet_id: String,
 
     /// id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation

--- a/openstack_cli/src/network/v2/subnet/tag/show.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/show.rs
@@ -61,12 +61,20 @@ struct QueryParameters {}
 struct PathParameters {
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_subnet_id", value_name = "SUBNET_ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_subnet_id",
+        value_name = "SUBNET_ID"
+    )]
     subnet_id: String,
 
     /// id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
-    #[arg(id = "path_param_id", value_name = "ID")]
+    #[arg(
+        help_heading = "Path parameters",
+        id = "path_param_id",
+        value_name = "ID"
+    )]
     id: String,
 }
 /// Tag response representation


### PR DESCRIPTION
Add explicit grouping of path/query/body parameters in the `--help`
output.
