### PR TITLE
chore: replace deprecated chrono::Duration::days call

### DIFF
--- a/openstack_sdk/src/auth.rs
+++ b/openstack_sdk/src/auth.rs
@@ -130,7 +130,8 @@ mod tests {
             token: "".to_string(),
             auth_info: Some(AuthResponse {
                 token: AuthToken {
-                    expires_at: chrono::offset::Local::now() - chrono::Duration::days(1),
+                    expires_at: chrono::offset::Local::now()
+                        - chrono::Duration::try_days(1).unwrap(),
                     ..Default::default()
                 },
             }),
@@ -144,7 +145,8 @@ mod tests {
             token: "".to_string(),
             auth_info: Some(AuthResponse {
                 token: AuthToken {
-                    expires_at: chrono::offset::Local::now() + chrono::Duration::days(1),
+                    expires_at: chrono::offset::Local::now()
+                        + chrono::Duration::try_days(1).unwrap(),
                     ..Default::default()
                 },
             }),


### PR DESCRIPTION
new chrono release deprecated above call. Replace it with
`chrono::Duration::try_days()` call.
