### PR TITLE
chore: drop serde_yaml dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml",
  "simple_logger",
  "thiserror",
  "tokio",
@@ -2265,19 +2264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0623d197252096520c6f2a5e1171ee436e5af99a5d7caa2891e55e61950e6d9"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,12 +2736,6 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ json-patch = { version = "^1.2" }
 reqwest = { version = "^0.12", features = ["blocking", "stream", "rustls-tls"], default-features = false }
 serde = { version="^1.0", features=["derive"] }
 serde_json = "^1.0"
-serde_yaml = "^0.9"
 serde_bytes = "^0.11"
 tokio = { version = "^1.37", features = ["fs", "macros", "net", "sync", "rt-multi-thread", "io-std", "signal"]}
 tokio-util = { version="^0.7", features = ["io", "compat"]}

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -34,7 +34,6 @@ open = { version = "^5.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = {workspace = true}
-serde_yaml = {workspace = true}
 serde_urlencoded = "^0.7"
 thiserror = { workspace = true }
 tokio = {workspace = true }


### PR DESCRIPTION
serde_yaml is deprecated, but also unused since cli doesn't support
direct yaml output anymore. SDK is relying on `config`. We can safely
drop serde_yaml dep.
