### PR TITLE
fix: whitelist linter warning

### DIFF
--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -14,6 +14,13 @@
 
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
+// Allow Enum variant to end with enum's name
+// enum Type {
+//   ...
+//   FileType
+//   ...
+// }
+#![allow(clippy::enum_variant_names)]
 use std::io::{self, IsTerminal};
 
 use clap::Parser;


### PR DESCRIPTION
"variant name ends with the enum's name" linter warning make sense, but
we generate the code this way for now so allow it.
