### PR TITLE
fix(ci): Undo merging of commited into linters workflow

### DIFF
--- a/.github/workflows/committed.yml
+++ b/.github/workflows/committed.yml
@@ -1,0 +1,23 @@
+# Not run as part of pre-commit checks because they don't handle sending the correct commit
+# range to `committed`
+name: Lint Commits
+on: [pull_request]
+
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+jobs:
+  committed:
+    name: Lint Commits
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Lint Commits
+      uses: crate-ci/committed@master

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -79,16 +79,3 @@ jobs:
       uses: crate-ci/typos@master
       with:
         config: _typos.toml
-
-  committed:
-    name: Lint Commits
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Checkout Actions Repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Lint Commits
-      uses: crate-ci/committed@master


### PR DESCRIPTION
committed must be working only on pull requests, but we want to keep
some other changes from the previous change. So undo only partial
changes.
