### PR TITLE
chore(ci): Run functional tests only when necessary

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -4,6 +4,12 @@ name: Functional
 on:
   pull_request:
     branches: [ "main" ]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/functional.yml'
+      - 'openstack_cli/**'
+      - 'openstack_sdk/**'
 
 jobs:
   functional:
@@ -44,6 +50,11 @@ jobs:
           branch: ${{ matrix.openstack_version }}
           enabled_services: swift
           log_dir: /tmp/devstack-logs
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
 
       - name: Execute functional tests
         env:


### PR DESCRIPTION
Add files filter to functional test workflow to only run when
Cargo.{lock,toml} or anything und the sdk/cli code has been modified.
This allows to skip functests on doc-only or workflow optimization
changes.
