### PR TITLE
chore(ci): Enable unittest retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  NEXTEST_RETRIES: 3
 
 jobs:
   test:


### PR DESCRIPTION
Set NEXTEST_RETRIES env to allow retry of the unittests. This is
currently a workaround for flaky unittest of sdk with the webhook.
