### PR TITLE
chore(ci): Temporarily disable musl target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "openstack_cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ ci = ["github"]
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
+targets = ["x86_64-unknown-linux-gnu"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
 # Whether cargo-dist should create a Github Release or use an existing draft


### PR DESCRIPTION
it is impossible to build fuzz target on musl without adding more
packages and cargo-dist is not in favor of that. For now remove musl
target to make a release and in next steps replace cargo-dist with other
way of building artifacts.
