### PR TITLE
feat(sdk): Add possibility to skip version discovery

### DIFF
--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -349,7 +349,7 @@ impl OpenStack {
             self.catalog
                 .get_service_endpoint(service_type.to_string(), None, None::<String>)
         {
-            if true {
+            if self.catalog.discovery_allowed(service_type.to_string()) {
                 info!("Performing `{}` endpoint version discovery", service_type);
 
                 let mut try_url = ep.url().clone();

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -430,7 +430,7 @@ where {
             self.catalog
                 .get_service_endpoint(service_type.to_string(), None, None::<String>)
         {
-            if true {
+            if self.catalog.discovery_allowed(service_type.to_string()) {
                 info!("Performing `{}` endpoint version discovery", service_type);
 
                 let mut try_url = ep.url().clone();


### PR DESCRIPTION
According to the formal service catalog consumption process it should be
possible to skip service discovery. Add default to skip discovery for
object-store service and process configuration options
(XXX_skip_discovery: bool).
