### PR TITLE
refactor(sdk): Get rid of anyhow in openstack_sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,7 +1711,6 @@ dependencies = [
 name = "openstack_sdk"
 version = "0.5.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bincode",
  "bytes",

--- a/openstack_cli/src/bin/osc.rs
+++ b/openstack_cli/src/bin/osc.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), OpenStackCliError> {
     match openstack_cli::entry_point().await {
         Ok(()) => Ok(()),
         Err(e) => {
-            println!("{}", e);
+            eprintln!("{e:#}");
             return Err(e);
         }
     }

--- a/openstack_cli/src/error.rs
+++ b/openstack_cli/src/error.rs
@@ -29,14 +29,14 @@ pub enum OpenStackCliError {
         source: serde_json::Error,
     },
     /// SDK error
-    #[error("OpenStackSDK error: {}", source)]
+    #[error(transparent)]
     OpenStackSDK {
         /// The source of the error.
         #[from]
         source: openstack_sdk::OpenStackError,
     },
     /// OpenStack API error
-    #[error("OpenStackSDK error: {}", source)]
+    #[error(transparent)]
     OpenStackApi {
         /// The source of the error.
         #[from]
@@ -44,7 +44,7 @@ pub enum OpenStackCliError {
     },
 
     /// Configuration error
-    #[error("Config error: {}", source)]
+    #[error(transparent)]
     ConfigError {
         /// The source of the error.
         #[from]
@@ -52,7 +52,7 @@ pub enum OpenStackCliError {
     },
 
     /// OpenStack Service Catalog error
-    #[error("Service catalog error: {}", source)]
+    #[error(transparent)]
     OpenStackCatalog {
         /// The source of the error.
         #[from]
@@ -64,11 +64,11 @@ pub enum OpenStackCliError {
     NoSubcommands,
 
     /// Resource is not found
-    #[error("resource not found")]
+    #[error("Resource not found")]
     ResourceNotFound,
 
     /// Resource identifier is not unique
-    #[error("cannot uniqly findresource by identifier")]
+    #[error("Cannot uniqly findresource by identifier")]
     IdNotUnique,
 
     /// IO error

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -37,7 +37,6 @@ client_pem = []
 
 [dependencies]
 async-trait = {workspace = true}
-anyhow = {workspace = true}
 bincode = { version = "^1.3" }
 bytes = {workspace = true}
 chrono = { workspace= true }

--- a/openstack_sdk/src/api/find.rs
+++ b/openstack_sdk/src/api/find.rs
@@ -75,15 +75,28 @@ where
         let get_ep = self.findable.get_ep();
         let get_res = get_ep.query(client);
         let res: serde_json::Value = match get_res {
-            Err(x) => {
-                if let crate::api::ApiError::ResourceNotFound = x {
+            Err(x) => match x {
+                crate::api::ApiError::ResourceNotFound
+                | crate::api::ApiError::OpenStack {
+                    status: http::StatusCode::NOT_FOUND,
+                    ..
+                }
+                | crate::api::ApiError::OpenStackService {
+                    status: http::StatusCode::NOT_FOUND,
+                    ..
+                }
+                | crate::api::ApiError::OpenStackUnrecognized {
+                    status: http::StatusCode::NOT_FOUND,
+                    ..
+                } => {
                     let list_ep = self.findable.list_ep();
                     let data: Vec<serde_json::Value> = list_ep.query(client)?;
                     self.findable.locate_resource_in_list::<C>(data)?
-                } else {
+                }
+                _ => {
                     return Err(x);
                 }
-            }
+            },
             Ok(x) => x,
         };
 
@@ -108,15 +121,28 @@ where
         let get_ep = self.findable.get_ep();
         let get_res = get_ep.query_async(client).await;
         let res: serde_json::Value = match get_res {
-            Err(x) => {
-                if let crate::api::ApiError::ResourceNotFound = x {
+            Err(x) => match x {
+                crate::api::ApiError::ResourceNotFound
+                | crate::api::ApiError::OpenStack {
+                    status: http::StatusCode::NOT_FOUND,
+                    ..
+                }
+                | crate::api::ApiError::OpenStackService {
+                    status: http::StatusCode::NOT_FOUND,
+                    ..
+                }
+                | crate::api::ApiError::OpenStackUnrecognized {
+                    status: http::StatusCode::NOT_FOUND,
+                    ..
+                } => {
                     let list_ep = self.findable.list_ep();
                     let data: Vec<serde_json::Value> = list_ep.query_async(client).await?;
                     self.findable.locate_resource_in_list::<C>(data)?
-                } else {
+                }
+                _ => {
                     return Err(x);
                 }
-            }
+            },
             Ok(x) => x,
         };
 

--- a/openstack_sdk/src/api/paged/iter.rs
+++ b/openstack_sdk/src/api/paged/iter.rs
@@ -248,10 +248,18 @@ where
         let mut v = if let Ok(v) = serde_json::from_slice(rsp.body()) {
             v
         } else {
-            return Err(ApiError::server_error(status, rsp.body()));
+            return Err(ApiError::server_error(
+                Some(query::url_to_http_uri(base)),
+                status,
+                rsp.body(),
+            ));
         };
         if !status.is_success() {
-            return Err(ApiError::from_openstack(status, v));
+            return Err(ApiError::from_openstack(
+                Some(query::url_to_http_uri(base)),
+                status,
+                v,
+            ));
         }
 
         let next_url = if self.paged.endpoint.use_keyset_pagination() {

--- a/openstack_sdk/src/api/paged/pagination.rs
+++ b/openstack_sdk/src/api/paged/pagination.rs
@@ -14,7 +14,6 @@
 
 //! Results pagination
 
-use anyhow;
 use thiserror::Error;
 
 /// Errors which may occur with pagination.
@@ -31,9 +30,6 @@ pub enum PaginationError {
         #[source]
         source: url::ParseError,
     },
-
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
 }
 
 /// Pagination options

--- a/openstack_sdk/src/catalog.rs
+++ b/openstack_sdk/src/catalog.rs
@@ -22,12 +22,8 @@
 
 use bytes::Bytes;
 use std::collections::{HashMap, HashSet};
-
-use anyhow::Context;
-
-use url::Url;
-
 use tracing::{debug, error, trace};
+use url::Url;
 
 pub use crate::catalog::error::CatalogError;
 pub(crate) use crate::catalog::service_endpoint::ServiceEndpoint;
@@ -137,13 +133,7 @@ impl Catalog {
                         &ep.url,
                         Some(&ep.region),
                         Some(&ep.interface),
-                    )
-                    .with_context(|| {
-                        format!(
-                            "While processing service catalog response for service {}",
-                            srv.service_type
-                        )
-                    })?;
+                    )?;
                 }
             }
         }

--- a/openstack_sdk/src/config.rs
+++ b/openstack_sdk/src/config.rs
@@ -56,8 +56,6 @@ pub enum ConfigError {
         #[from]
         source: config::ConfigError,
     },
-    #[error(transparent)]
-    Other(#[from] anyhow::Error), // source and Display delegate to anyhow::Error
 }
 
 impl ConfigError {

--- a/openstack_sdk/src/error.rs
+++ b/openstack_sdk/src/error.rs
@@ -67,6 +67,10 @@ pub enum OpenStackError {
     },
 
     /// Authentication error
+    #[error("No authentication information available")]
+    NoAuth,
+
+    /// Authentication error
     #[error("error setting auth header: {}", source)]
     AuthError {
         /// The source of the error.
@@ -142,10 +146,6 @@ pub enum OpenStackError {
         #[from]
         source: serde_json::Error,
     },
-
-    /// Any other error
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
 }
 
 impl OpenStackError {

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -21,7 +21,6 @@ use std::fmt::{self, Debug};
 use std::time::SystemTime;
 use tracing::{debug, error, info, span, trace, Level};
 
-use anyhow::anyhow;
 use bytes::Bytes;
 use http::{Response as HttpResponse, StatusCode};
 
@@ -298,7 +297,7 @@ impl OpenStack {
                                 rsp = auth_endpoint.raw_query(self)?;
                             }
                         }
-                        api::check_response_error::<Self>(&rsp)?;
+                        api::check_response_error::<Self>(&rsp, None)?;
                     }
                     other => {
                         return Err(AuthTokenError::IdentityMethodSync {
@@ -334,7 +333,7 @@ impl OpenStack {
                         error!("No catalog information");
                     }
                 }
-                _ => return Err(anyhow!("No authentication information available").into()),
+                _ => return Err(OpenStackError::NoAuth),
             }
         }
         // TODO: without AuthToken authorization we may want to read catalog separately

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -19,7 +19,6 @@ use std::fmt::{self, Debug};
 use std::time::SystemTime;
 use tracing::{debug, error, info, span, trace, Level};
 
-use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::io::{Error as IoError, ErrorKind as IoErrorKind};
@@ -357,7 +356,7 @@ where {
                                 rsp = auth_endpoint.raw_query_async(self).await?;
                             }
                         }
-                        api::check_response_error::<Self>(&rsp)?;
+                        api::check_response_error::<Self>(&rsp, None)?;
                     }
                     AuthType::V3WebSso => {
                         let auth_url = auth::v3websso::get_auth_url(&self.config)?;
@@ -414,7 +413,7 @@ where {
                         error!("No catalog information");
                     }
                 }
-                _ => return Err(anyhow!("No authentication information available").into()),
+                _ => return Err(OpenStackError::NoAuth),
             }
         }
         // TODO: without AuthToken authorization we may want to read catalog separately

--- a/openstack_sdk/src/state.rs
+++ b/openstack_sdk/src/state.rs
@@ -47,8 +47,6 @@ pub enum StateError {
         #[from]
         source: std::io::Error,
     },
-    #[error(transparent)]
-    Other(#[from] anyhow::Error), // source and Display delegate to anyhow::Error
 }
 
 /// A HashMap of Scope to Token

--- a/openstack_sdk/src/types/api_version.rs
+++ b/openstack_sdk/src/types/api_version.rs
@@ -16,7 +16,6 @@
 //!
 //! Endpoint api version handling
 
-use anyhow::anyhow;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::fmt;
@@ -45,8 +44,8 @@ pub enum ApiVersionError {
         #[from]
         source: std::num::ParseIntError,
     },
-    #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    #[error("Not a valid version string: {0}")]
+    Invalid(String),
 }
 
 /// ApiVersion
@@ -120,11 +119,7 @@ impl ApiVersion {
             }
             return Ok(res);
         }
-        Err(anyhow!(
-            "String {} does not look like a supported version.",
-            data.as_ref()
-        )
-        .into())
+        Err(ApiVersionError::Invalid(data.as_ref().to_string()))
     }
 
     /// Determine the api version from the [RestEndpoint](crate::api::RestEndpoint)


### PR DESCRIPTION
anyhow is great at adding context to the errors, but it is recommended
to use anyhow in client facing tools, while thiserror in libs. Using it
makes it quite ugly to get good errors in the cli. So get rid of it and
instead extend base errors to be self containing all required
information.
