### PR TITLE
feat(cli): Add support for patch method in `api` call

### DIFF
--- a/doc/src/osc.md
+++ b/doc/src/osc.md
@@ -789,6 +789,8 @@ Example:
     HEAD
   - `get`:
     GET
+  - `patch`:
+    PATCH
   - `put`:
     PUT
   - `post`:

--- a/openstack_cli/src/api/mod.rs
+++ b/openstack_cli/src/api/mod.rs
@@ -47,6 +47,8 @@ enum Method {
     Head,
     /// GET
     Get,
+    /// PATCH
+    Patch,
     /// PUT
     Put,
     /// POST
@@ -60,6 +62,7 @@ impl From<Method> for http::Method {
         match item {
             Method::Head => http::Method::HEAD,
             Method::Get => http::Method::GET,
+            Method::Patch => http::Method::PATCH,
             Method::Put => http::Method::PUT,
             Method::Post => http::Method::POST,
             Method::Delete => http::Method::DELETE,


### PR DESCRIPTION
Keystone is using actively PATCH http method instead of post. Add it to
the `api` command.
