### PR TITLE
chore(compliance): Allow "unicode-3.0" license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -96,8 +96,8 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "MPL-2.0",
-    "OpenSSL",
     "LicenseRef-ring",
+    "Unicode-3.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
url lib pulls new dependencies which are of unicode-3 license. Since it
is OSI approved allow it.
