### PR TITLE
chore(ci): Disable CI tests jobs on other platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          # - target: x86_64-unknown-linux-musl
+          #   os: ubuntu-latest
+          # - target: x86_64-apple-darwin
+          #   os: macos-latest
+          # - target: x86_64-pc-windows-msvc
+          #   os: windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -55,6 +55,7 @@ jobs:
 
       - name: Run Doc tests
         run: cargo test --doc
+
   fuzz:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@
 # with the appropriate title/body, and will be undrafted for you.
 
 name: Release
+permissions:
+  contents: read
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.


### PR DESCRIPTION
Now that carg-dist is back and builds are prepared in every PR it makes
no sense to do explicit testing on all platforms (there are no platform
specific features in the code anyway). Disable some platforms from the
matrix.
