### PR TITLE
fix(ci): Fix broken cargo-dist releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,11 @@ jobs:
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(needs.host.outputs.val).announcement_is_prerelease && '--prerelease' || '' }}"
+          ANNOUNCEMENT_TITLE: "${{ fromJson(needs.host.outputs.val).announcement_title }}"
+          ANNOUNCEMENT_BODY: "${{ fromJson(needs.host.outputs.val).announcement_github_body }}"
         run: |
+          # Write and read notes from a file to avoid quoting breaking things
+          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
-          gh release edit "${{ needs.plan.outputs.tag }}" --draft=false $PRERELEASE_FLAG
+          gh release create "${{ needs.plan.outputs.tag }}" --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" $PRERELEASE_FLAG
           gh release upload "${{ needs.plan.outputs.tag }}" artifacts/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-
 # Publish jobs to run in CI
 pr-run-mode = "upload"
 # Whether cargo-dist should create a Github Release or use an existing draft
-create-release = false
+create-release = true
 # Whether to install an updater program
 install-updater = true
 # Whether to enable GitHub Attestations


### PR DESCRIPTION
Last step of cargo-dist was not updated properly and it is not able to create GH release as required in order to upload artifacts.