### PR TITLE
chore(ci): Improve `committed` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,10 @@ repos:
     rev: v1.21.0
     hooks:
       - id: typos
+  - repo: https://github.com/crate-ci/committed
+    rev: v1.0.20
+    hooks:
+      - id: committed
   - repo: local
     hooks:
       - id: cargo-fmt

--- a/committed.toml
+++ b/committed.toml
@@ -1,3 +1,3 @@
 style="conventional"
-ignore_author_re="(dependabot)"
+ignore_author_re="(dependabot|renovate)"
 merge_commit = false


### PR DESCRIPTION
- ignore renovate commites (since type may not be set)
- add committed check to pre-commit
