### PR TITLE
fix(ci): Choose toolchain in the release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17 # stable
+        with:
+          toolchain: stable
 
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@7566221bba53f707d05e4149111ada2c3313ae28 # v0.5.61


### PR DESCRIPTION
Latest ruust-toolchain action requires toolchain to be set. Sadly this
was only detected in the failed release-plz run.
