### PR TITLE
feat(ssl): Add possibility to add custom root SSL ca

### DIFF
--- a/openstack_sdk/src/config.rs
+++ b/openstack_sdk/src/config.rs
@@ -177,6 +177,9 @@ pub struct CloudConfig {
     /// Region name
     pub region_name: Option<String>,
 
+    /// Custom CA Certificate
+    pub cacert: Option<String>,
+
     /// All other options
     #[serde(flatten)]
     pub options: HashMap<String, config::Value>,
@@ -306,6 +309,9 @@ impl CloudConfig {
         }
         if self.region_name.is_none() && update.region_name.is_some() {
             self.region_name.clone_from(&update.region_name);
+        }
+        if self.cacert.is_none() && update.cacert.is_some() {
+            self.cacert.clone_from(&update.cacert);
         }
         let current_keys: HashSet<String> = self.options.keys().cloned().collect();
         self.options.extend(

--- a/openstack_sdk/src/error.rs
+++ b/openstack_sdk/src/error.rs
@@ -155,6 +155,13 @@ pub enum OpenStackError {
         #[from]
         source: serde_json::Error,
     },
+    /// IO error.
+    #[error("IO error: {}\n\tPath: {}", source, path)]
+    IO {
+        /// The source of the error.
+        source: std::io::Error,
+        path: String,
+    },
 }
 
 impl OpenStackError {


### PR DESCRIPTION
Add support for `cacert` clouds.yaml option in a same way as python
tooling. This gives possibility to trust self-signed server
certificates.
