### PR TITLE
feat: Allow skipping SSL verification

### DIFF
--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -60,7 +60,7 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
     tracing_subscriber::fmt()
         .with_writer(io::stderr)
         .with_max_level(match cli.global_opts.verbose {
-            0 => Level::ERROR,
+            0 => Level::WARN,
             1 => Level::INFO,
             2 => Level::DEBUG,
             _ => Level::TRACE,

--- a/openstack_sdk/src/config.rs
+++ b/openstack_sdk/src/config.rs
@@ -179,6 +179,8 @@ pub struct CloudConfig {
 
     /// Custom CA Certificate
     pub cacert: Option<String>,
+    /// Verify SSL Certificates
+    pub verify: Option<bool>,
 
     /// All other options
     #[serde(flatten)]
@@ -312,6 +314,9 @@ impl CloudConfig {
         }
         if self.cacert.is_none() && update.cacert.is_some() {
             self.cacert.clone_from(&update.cacert);
+        }
+        if self.verify.is_none() && update.verify.is_some() {
+            self.verify.clone_from(&update.verify);
         }
         let current_keys: HashSet<String> = self.options.keys().cloned().collect();
         self.options.extend(

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -20,7 +20,7 @@ use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::time::SystemTime;
 use std::{fs::File, io::Read};
-use tracing::{debug, error, info, span, trace, Level};
+use tracing::{debug, error, info, span, trace, warn, Level};
 
 use bytes::Bytes;
 use http::{Response as HttpResponse, StatusCode};
@@ -154,6 +154,11 @@ impl OpenStack {
                 client_builder = client_builder.add_root_certificate(cert);
             }
         }
+        if let Some(false) = &config.verify {
+            warn!("SSL Verification is disabled! Please consider using `cacert` instead for adding custom certificate.");
+            client_builder = client_builder.danger_accept_invalid_certs(true);
+        }
+
         let mut session = OpenStack {
             client: client_builder.build()?,
             config: config.clone(),

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -18,7 +18,7 @@ use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::time::SystemTime;
 use std::{fs::File, io::Read};
-use tracing::{debug, error, info, span, trace, Level};
+use tracing::{debug, error, info, span, trace, warn, Level};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -191,6 +191,10 @@ impl AsyncOpenStack {
             for cert in Certificate::from_pem_bundle(&buf)? {
                 client_builder = client_builder.add_root_certificate(cert);
             }
+        }
+        if let Some(false) = &config.verify {
+            warn!("SSL Verification is disabled! Please consider using `cacert` instead for adding custom certificate.");
+            client_builder = client_builder.danger_accept_invalid_certs(true);
         }
 
         let mut session = AsyncOpenStack {


### PR DESCRIPTION
A next step after adding support for `cacert` is adding `verify: false`
option allowing to skip certificate validation as such. Since this is
not a recommended thing add a warning recommending to configure cacert
instead.
