### PR TITLE
fix(auth): Deal with InvalidPort in discovery doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default-members = ["openstack_cli", "openstack_sdk"]
 license = "Apache-2.0"
 edition = "2021"
 authors = ["Artem Goncharov (gtema)"]
-rust-version = "1.75"  # MSRV
+rust-version = "1.76"  # MSRV
 homepage = "https://github.com/gtema/openstack"
 repository = "https://github.com/gtema/openstack"
 

--- a/openstack_sdk/src/auth/authtoken.rs
+++ b/openstack_sdk/src/auth/authtoken.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{error, trace};
+use tracing::{debug, error, trace};
 
 use crate::api::identity::v3::auth::token::create as token_v3;
 use crate::api::identity::v3::auth::token::get as token_v3_info;
@@ -394,6 +394,10 @@ pub(crate) fn build_auth_request_from_receipt<'a>(
     let auth = config.auth.clone().ok_or(AuthTokenError::MissingAuthData)?;
     // Check required_auth_methods rules
     // Note: Keystone returns list of lists (as set of different rules)
+    debug!(
+        "Server requests additional authentication with one of: {:?}",
+        &receipt_data.required_auth_methods
+    );
     for auth_rule in &receipt_data.required_auth_methods {
         for required_method in auth_rule {
             if !receipt_data

--- a/openstack_sdk/src/catalog.rs
+++ b/openstack_sdk/src/catalog.rs
@@ -269,7 +269,9 @@ impl Catalog {
         let catalog_types = self
             .service_authority
             .get_all_types_by_service_type(&service_type.to_string())?;
-        for ep in discovery::extract_discovery_endpoints(url, data)?.iter_mut() {
+        for ep in
+            discovery::extract_discovery_endpoints(url, data, service_type.to_string())?.iter_mut()
+        {
             ep.set_region(region.as_ref());
             // Rounded (to the major) version so that we respect catalog_endpoints and
             // endpoint_overrides for a higher minor versions

--- a/openstack_sdk/src/catalog/error.rs
+++ b/openstack_sdk/src/catalog/error.rs
@@ -28,6 +28,12 @@ pub enum CatalogError {
         source: ApiVersionError,
     },
 
+    #[error("Regex parse error: {}", source)]
+    Regex {
+        #[from]
+        source: regex::Error,
+    },
+
     /// Invalid URL
     #[error("Url `{0}` cannot be base")]
     UrlCannotBeBase(String),


### PR DESCRIPTION
It can happen that discovery document is screwed. In certain cases there
are ways how to deal with those issues (i.e. InvalidPort). In any way
use the catalog endpoint when unrecoverable errors occur.
