### PR TITLE
fix(pagination): Address new cornercase in pagination

### DIFF
--- a/openstack_sdk/src/api/ignore.rs
+++ b/openstack_sdk/src/api/ignore.rs
@@ -144,12 +144,6 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
-    struct DummyResult {
-        #[allow(dead_code)]
-        value: u8,
-    }
-
     #[cfg(feature = "sync")]
     #[test]
     fn test_openstack_non_json_response() {

--- a/openstack_sdk/src/api/object_store/v1/account/get.rs
+++ b/openstack_sdk/src/api/object_store/v1/account/get.rs
@@ -154,7 +154,11 @@ impl<'a> RestEndpoint for Request<'a> {
         self._headers.as_ref()
     }
 }
-impl<'a> Pageable for Request<'a> {}
+impl<'a> Pageable for Request<'a> {
+    fn use_keyset_pagination(&self) -> bool {
+        false
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/openstack_sdk/src/api/object_store/v1/container/get.rs
+++ b/openstack_sdk/src/api/object_store/v1/container/get.rs
@@ -174,7 +174,11 @@ impl<'a> RestEndpoint for Request<'a> {
         self._headers.as_ref()
     }
 }
-impl<'a> Pageable for Request<'a> {}
+impl<'a> Pageable for Request<'a> {
+    fn use_keyset_pagination(&self) -> bool {
+        false
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/openstack_sdk/src/api/paged.rs
+++ b/openstack_sdk/src/api/paged.rs
@@ -228,7 +228,7 @@ where
             }
 
             if use_keyset_pagination {
-                if next_url.is_none() && marker.is_none() {
+                if next_url.is_none() {
                     break;
                 }
             } else {

--- a/openstack_sdk/src/api/paged/next_page.rs
+++ b/openstack_sdk/src/api/paged/next_page.rs
@@ -12,21 +12,111 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Module to detect next page URL from the response
-
-use serde_json::Value;
-use std::borrow::Cow;
-
-use url::Url;
+//! Module to detect next page URL from the server response
 
 use http::HeaderMap;
+use serde_json::Value;
+use std::borrow::Cow;
+use thiserror::Error;
+use url::Url;
 
 use crate::api::PaginationError;
 
-pub(crate) fn next_page_from_headers(_headers: &HeaderMap) -> Result<Option<Url>, PaginationError> {
-    Err(PaginationError::Body {
-        msg: "error".into(),
-    })
+#[derive(Debug)]
+struct LinkHeader<'a> {
+    url: &'a str,
+    params: Vec<(&'a str, &'a str)>,
+}
+
+impl<'a> LinkHeader<'a> {
+    fn parse(s: &'a str) -> Result<Self, LinkHeaderParseError> {
+        let mut parts = s.split(';');
+
+        let url_part = parts.next().expect("a split always has at least one part");
+        let url = {
+            let part = url_part.trim();
+            if part.starts_with('<') && part.ends_with('>') {
+                &part[1..part.len() - 1]
+            } else {
+                return Err(LinkHeaderParseError::NoBrackets);
+            }
+        };
+
+        let params = parts
+            .map(|part| {
+                let part = part.trim();
+                let mut halves = part.splitn(2, '=');
+                let key = halves.next().expect("a split always has at least one part");
+                let value = if let Some(value) = halves.next() {
+                    if value.starts_with('"') && value.ends_with('"') {
+                        &value[1..value.len() - 1]
+                    } else {
+                        value
+                    }
+                } else {
+                    return Err(LinkHeaderParseError::MissingParamValue);
+                };
+
+                Ok((key, value))
+            })
+            .collect::<Result<Vec<_>, LinkHeaderParseError>>()?;
+
+        Ok(Self { url, params })
+    }
+}
+
+/// An error which can occur when parsing a link header.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum LinkHeaderParseError {
+    /// An invalid HTTP header found.
+    #[error("invalid header")]
+    InvalidHeader {
+        /// The source of the error.
+        #[from]
+        source: reqwest::header::ToStrError,
+    },
+    /// The `url` for a `Link` header missing `<>` brackets.
+    #[error("missing brackets around url")]
+    NoBrackets,
+    /// A parameter for a `Link` header missing a value.
+    #[error("missing parameter value")]
+    MissingParamValue,
+}
+
+impl LinkHeaderParseError {
+    fn invalid_header(source: reqwest::header::ToStrError) -> Self {
+        Self::InvalidHeader { source }
+    }
+}
+
+pub(crate) fn next_page_from_headers(headers: &HeaderMap) -> Result<Option<Url>, PaginationError> {
+    let link_headers = headers.get_all(reqwest::header::LINK).iter();
+    link_headers
+        .map(|link| {
+            let value = link
+                .to_str()
+                .map_err(LinkHeaderParseError::invalid_header)?;
+            Ok(LinkHeader::parse(value)?)
+        })
+        .collect::<Result<Vec<_>, PaginationError>>()?
+        .into_iter()
+        .find_map(|header| {
+            let is_next_link = header
+                .params
+                .into_iter()
+                .any(|(key, value)| key == "rel" && value == "next");
+
+            if is_next_link {
+                Some(header.url.parse().map_err(|x| PaginationError::InvalidUrl {
+                    url: header.url.to_string(),
+                    source: x,
+                }))
+            } else {
+                None
+            }
+        })
+        .transpose()
 }
 
 /// Detect link to the next page from the response body.
@@ -122,6 +212,8 @@ mod tests {
 
     use crate::api::paged::next_page::next_page_from_body;
 
+    use super::*;
+
     #[test]
     fn test_body_links() {
         let data = json!({"links": [{"rel": "next", "href": "http://foo.bar"}]});
@@ -160,5 +252,53 @@ mod tests {
         let res =
             next_page_from_body(&data, &None, Url::parse("http://dummy:15").unwrap()).unwrap();
         assert_eq!(res.unwrap(), Url::parse("http://dummy:15/foo/bar").unwrap());
+    }
+
+    #[test]
+    fn test_link_header_no_brackets() {
+        let err = LinkHeader::parse("url; param=value").unwrap_err();
+        if let LinkHeaderParseError::NoBrackets = err {
+            // expected error
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+    }
+
+    #[test]
+    fn test_link_header_no_param_value() {
+        let err = LinkHeader::parse("<url>; param").unwrap_err();
+        if let LinkHeaderParseError::MissingParamValue = err {
+            // expected error
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+    }
+
+    #[test]
+    fn test_link_header_no_params() {
+        let link = LinkHeader::parse("<url>").unwrap();
+        assert_eq!(link.url, "url");
+        assert_eq!(link.params.len(), 0);
+    }
+
+    #[test]
+    fn test_link_header_quoted_params() {
+        let link = LinkHeader::parse("<url>; param=\"value\"; param2=\"value\"").unwrap();
+        assert_eq!(link.url, "url");
+        assert_eq!(link.params.len(), 2);
+        assert_eq!(link.params[0].0, "param");
+        assert_eq!(link.params[0].1, "value");
+        assert_eq!(link.params[1].0, "param2");
+        assert_eq!(link.params[1].1, "value");
+    }
+    #[test]
+    fn test_link_header_bare_params() {
+        let link = LinkHeader::parse("<url>; param=value; param2=value").unwrap();
+        assert_eq!(link.url, "url");
+        assert_eq!(link.params.len(), 2);
+        assert_eq!(link.params[0].0, "param");
+        assert_eq!(link.params[0].1, "value");
+        assert_eq!(link.params[1].0, "param2");
+        assert_eq!(link.params[1].1, "value");
     }
 }

--- a/openstack_sdk/src/api/paged/pagination.rs
+++ b/openstack_sdk/src/api/paged/pagination.rs
@@ -16,19 +16,29 @@
 
 use thiserror::Error;
 
+use crate::api::paged::next_page::LinkHeaderParseError;
+
 /// Errors which may occur with pagination.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum PaginationError {
+    /// No pagination information available in the body.
     #[error("failed to find pagination in the response: {}", msg)]
     Body { msg: String },
-    /// An invalid URL can be returned.
+    /// An invalid URL.
     #[error("failed to parse a Link HTTP URL: {} {}", url, source)]
     InvalidUrl {
         url: String,
         /// The source of the error.
         #[source]
         source: url::ParseError,
+    },
+    /// A `Link` HTTP header cannot be parsed.
+    #[error("failed to parse a Link HTTP header: {}", source)]
+    LinkHeader {
+        /// The source of the error.
+        #[from]
+        source: LinkHeaderParseError,
     },
 }
 

--- a/openstack_sdk/src/test/client.rs
+++ b/openstack_sdk/src/test/client.rs
@@ -193,7 +193,7 @@ where
         assert_eq!(
             &body,
             &self.expected.body,
-            "\nbody is not the same:\nactual  : {}\nexpected: {}\n",
+            "\nbody is not the same:\nactual: {}\nexpected: {}\n",
             String::from_utf8_lossy(&body),
             String::from_utf8_lossy(&self.expected.body),
         );


### PR DESCRIPTION
Access to a new cloud uncovered one interesting case. There is a single
server in the cloud in the error state and Nova returns 404 for access
by name, while it finds it in the list. However, since this is the only
entry in the list pagination tries to get a next page with the marker
and get's back 400 (invalid marker). For the keyset pagination we should
really stop trying fetching next page when no information about the next
page is available. Swift is not using keyset pagination, and so set it
in the `RestEndpoint` properly while implementing reasonable pagination
using w3c `Link` header (thanks to GitLab SDK implementation).
