### PR TITLE
feat: Allow overriding project in cli

### DIFF
--- a/doc/src/osc.md
+++ b/doc/src/osc.md
@@ -778,6 +778,8 @@ OpenStack client rewritten in Rust
 ###### **Options:**
 
 * `--os-cloud <OS_CLOUD>` — Name reference to the clouds.yaml entry for the cloud configuration
+* `--os-project-id <OS_PROJECT_ID>` — Project ID to use instead of the one in connection profile
+* `--os-project-name <OS_PROJECT_NAME>` — Project Name to use instead of the one in the connection profile
 * `-o`, `--output <OUTPUT>` — Output format
 
   Possible values:

--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -64,6 +64,14 @@ pub struct GlobalOpts {
     #[arg(long, env = "OS_CLOUD", global = true, display_order = 900)]
     pub os_cloud: Option<String>,
 
+    /// Project ID to use instead of the one in connection profile
+    #[arg(long, env = "OS_PROJECT_ID", global = true, display_order = 901)]
+    pub os_project_id: Option<String>,
+
+    /// Project Name to use instead of the one in the connection profile
+    #[arg(long, env = "OS_PROJECT_NAME", global = true, display_order = 901)]
+    pub os_project_name: Option<String>,
+
     /// Output format
     #[arg(short, long, global = true, value_enum, display_order = 910)]
     pub output: Option<OutputFormat>,

--- a/openstack_sdk/src/config.rs
+++ b/openstack_sdk/src/config.rs
@@ -84,7 +84,7 @@ pub struct ConfigFile {
 
 /// Authentication data
 #[derive(Clone, Default, Deserialize)]
-pub(crate) struct Auth {
+pub struct Auth {
     /// Authentication URL
     pub(crate) auth_url: Option<String>,
     /// Authentication endpoint type (public/internal/admin)

--- a/openstack_sdk/src/lib.rs
+++ b/openstack_sdk/src/lib.rs
@@ -15,7 +15,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod api;
-mod auth;
+pub mod auth;
 pub mod catalog;
 pub mod config;
 mod error;

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -339,6 +339,8 @@ where {
                 trace!("Valid Auth is available for reauthz: {:?}", available_auth);
                 let auth_ep = authtoken::build_reauth_request(&available_auth, &requested_scope)?;
                 rsp = auth_ep.raw_query_async_ll(self, Some(false)).await?;
+                // Check whether re-auth was successful
+                api::check_response_error::<Self>(&rsp, None)?;
             } else {
                 // No auth/authz information available. Proceed with new auth
                 trace!("No Auth already available. Proceeding with new login");

--- a/openstack_sdk/src/state.rs
+++ b/openstack_sdk/src/state.rs
@@ -184,7 +184,7 @@ impl State {
                 AuthTokenScope::Project(project) => {
                     if let AuthTokenScope::Project(cached) = k {
                         // Scope type matches
-                        if project.id == cached.id {
+                        if project.id.is_some() && project.id == cached.id {
                             // Match by ID is definite
                             return Some((k.clone(), v.clone()));
                         } else if project.name == cached.name {


### PR DESCRIPTION
Add `--os-project-id`/`--os-project-name` cli parameters to authorize
against a different project (not the one in the clouds.yaml).
