### PR TITLE
fix(cli): Fix network.port.dns_assignments schema

### DIFF
--- a/openstack_cli/src/network/v2/port/create.rs
+++ b/openstack_cli/src/network/v2/port/create.rs
@@ -401,8 +401,8 @@ struct ResponseData {
     /// `hostname`, `ip_address` and `fqdn`.
     ///
     #[serde()]
-    #[structable(optional)]
-    dns_assignment: Option<String>,
+    #[structable(optional, pretty)]
+    dns_assignment: Option<Value>,
 
     /// A valid DNS domain.
     ///

--- a/openstack_cli/src/network/v2/port/list.rs
+++ b/openstack_cli/src/network/v2/port/list.rs
@@ -296,8 +296,8 @@ struct ResponseData {
     /// `hostname`, `ip_address` and `fqdn`.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    dns_assignment: Option<String>,
+    #[structable(optional, pretty, wide)]
+    dns_assignment: Option<Value>,
 
     /// A valid DNS domain.
     ///

--- a/openstack_cli/src/network/v2/port/set.rs
+++ b/openstack_cli/src/network/v2/port/set.rs
@@ -416,8 +416,8 @@ struct ResponseData {
     /// `hostname`, `ip_address` and `fqdn`.
     ///
     #[serde()]
-    #[structable(optional)]
-    dns_assignment: Option<String>,
+    #[structable(optional, pretty)]
+    dns_assignment: Option<Value>,
 
     /// A valid DNS domain.
     ///

--- a/openstack_cli/src/network/v2/port/show.rs
+++ b/openstack_cli/src/network/v2/port/show.rs
@@ -192,8 +192,8 @@ struct ResponseData {
     /// `hostname`, `ip_address` and `fqdn`.
     ///
     #[serde()]
-    #[structable(optional)]
-    dns_assignment: Option<String>,
+    #[structable(optional, pretty)]
+    dns_assignment: Option<Value>,
 
     /// A valid DNS domain.
     ///


### PR DESCRIPTION
dns_assignments in Neutron are not having any schema information. This
leads to ser/deser issues when the fiels is populated (is usually not
the case in devstack, but often with real clouds). Add required
information to the schema so that cli knows it is a complex object
treating it as json value.
