### PR TITLE
chore(ci): Switch to released version of typos

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -94,6 +94,6 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
     - name: Check spelling of file.txt
-      uses: crate-ci/typos@c16dc8f5b4a7ad6211464ecf136c69c851e8e83c # master
+      uses: crate-ci/typos@81a34f1ca2d0bfdcc3470c0f279a20333cb94878 # v1.23.1
       with:
         config: typos.toml


### PR DESCRIPTION
Move from the master branch of typos to the released version to reduce
amount of updates and improve stability.
