### PR TITLE
fix(pagination): Fix pagination when using iter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1695,6 +1695,7 @@ dependencies = [
  "cli-table",
  "dialoguer",
  "file_diff",
+ "futures",
  "http 1.1.0",
  "indicatif",
  "json-patch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { version = "^0.4", default-features = false, features = ["clock", "ser
 clap = { version = "^4.5", features = ["derive", "env"] }
 dialoguer = "^0.11"
 futures = "^0.3"
+futures-util = { version = "^0.3", default-features = false}
 http = "^1.1"
 json-patch = { version = "^2.0" }
 reqwest = { version = "^0.12", features = ["blocking", "stream", "rustls-tls"], default-features = false }

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -46,7 +46,7 @@ dialoguer = {workspace = true}
 dirs = "^5.0"
 form_urlencoded = "^1.2"
 futures = {workspace = true}
-futures-util = { version = "^0.3", default-features = false} #, optional = true }
+futures-util = { workspace = true }
 http = { workspace = true }
 http-body-util = "^0.1"
 hyper = { version = "^1.3", features = ["full"] }

--- a/openstack_sdk/src/api/paged/iter.rs
+++ b/openstack_sdk/src/api/paged/iter.rs
@@ -74,9 +74,13 @@ enum KeysetPage {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum Page {
-    // whether necessary
+    /// Pagination using page number.
     Number(u64),
+    /// Pagination using KeySet data.
     Keyset(KeysetPage),
+    /// Next page by the `marker` pointing to the last `id` of the previous page.
+    Marker(Option<String>),
+    /// Finished.
     Done,
 }
 
@@ -89,9 +93,9 @@ impl Page {
         }
     }
 
-    fn next_page(&mut self, next_url: Option<Url>) {
+    fn next_page(&mut self, next_url: Option<Url>, last_marker: Option<String>) {
         let next_page = match *self {
-            // whether necessary
+            Self::Marker(_) => Self::Marker(last_marker),
             Self::Number(page) => Self::Number(page + 1),
             Self::Keyset(_) => {
                 if let Some(next_url) = next_url {
@@ -108,7 +112,11 @@ impl Page {
 
     fn apply_to(&self, pairs: &mut url::form_urlencoded::Serializer<url::UrlQuery>) {
         match self {
-            // whether necessary
+            Self::Marker(marker) => {
+                if let Some(marker) = &marker {
+                    pairs.append_pair("marker", marker);
+                }
+            }
             Self::Number(page) => {
                 let page_str = page.to_string();
                 pairs.append_pair("page", &page_str);
@@ -139,7 +147,7 @@ where
         let next_page = if paged.endpoint.use_keyset_pagination() {
             Page::Keyset(KeysetPage::First)
         } else {
-            Page::Number(1)
+            Page::Marker(None)
         };
 
         let page_state = PageState {
@@ -155,7 +163,7 @@ where
 }
 
 impl<'a, E> PagedState<'a, E> {
-    fn next_page(&self, last_page_size: usize, next_url: Option<Url>) {
+    fn next_page(&self, last_page_size: usize, next_url: Option<Url>, marker: Option<String>) {
         let mut page_state = self.page_state.write().expect("poisoned next_page");
         page_state.total_results += last_page_size;
 
@@ -166,7 +174,7 @@ impl<'a, E> PagedState<'a, E> {
         {
             page_state.next_page = Page::Done;
         } else {
-            page_state.next_page.next_page(next_url);
+            page_state.next_page.next_page(next_url, marker);
         }
     }
 }
@@ -190,15 +198,12 @@ where
             self.paged.endpoint.parameters().add_to_url(&mut url);
 
             let per_page = self.paged.pagination.page_limit();
-            if per_page < usize::MAX {
-                let per_page_str = per_page.to_string();
-
-                {
-                    let mut pairs = url.query_pairs_mut();
-                    pairs.append_pair("limit", &per_page_str);
-
-                    next_page.apply_to(&mut pairs);
+            {
+                let mut pairs = url.query_pairs_mut();
+                if per_page < usize::MAX {
+                    pairs.append_pair("limit", &per_page.to_string());
                 }
+                next_page.apply_to(&mut pairs);
             }
 
             url
@@ -265,11 +270,33 @@ where
         let next_url = if self.paged.endpoint.use_keyset_pagination() {
             next_page::next_page_from_body(&v, &self.paged.endpoint.response_key(), base)?
         } else {
-            None
+            next_page::next_page_from_headers(rsp.headers())?
         };
 
         if let Some(root_key) = self.paged.endpoint.response_key() {
             v = v[root_key.to_string()].take();
+        }
+
+        let mut marker: Option<String> = None;
+
+        if next_url.is_none() {
+            // In swift we do not have next_page coming from anywhere.
+            // There is a header with total amount of records, but before
+            // even checking that we should also calculate the marker for
+            // the next page
+            if let Some(data) = v.as_array() {
+                if let Some(last_page_element) = data.last() {
+                    if let Some(id) = last_page_element.get("id") {
+                        if let Some(val) = id.as_str() {
+                            marker = Some(String::from(val));
+                        }
+                    } else if let Some(id) = last_page_element.get("name") {
+                        if let Some(val) = id.as_str() {
+                            marker = Some(String::from(val));
+                        }
+                    }
+                }
+            }
         }
 
         // List of items and every item is in additional container
@@ -297,7 +324,7 @@ where
                 page.truncate(limit - total_read_till_now);
             }
         }
-        self.next_page(page.len(), next_url);
+        self.next_page(page.len(), next_url, marker);
 
         Ok(page)
     }
@@ -323,7 +350,6 @@ where
             url
         } else {
             // Just return empty data.
-            // XXX: Return a new kind of PaginationError here?
             return Ok(Vec::new());
         };
         let (mut req, data) = self.build_request::<C>(url.clone())?;
@@ -352,7 +378,6 @@ where
             url
         } else {
             // Just return empty data.
-            // XXX: Return a new kind of PaginationError here?
             return Ok(Vec::new());
         };
         let (mut req, data) = self.build_request::<C>(url.clone())?;
@@ -434,5 +459,273 @@ where
         }
 
         self.current_page.pop().map(Ok)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use futures_util::TryStreamExt;
+    use http::StatusCode;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    use crate::api::rest_endpoint_prelude::*;
+    use crate::api::{self, ApiError, Pagination};
+    #[cfg(feature = "async")]
+    use crate::test::client::MockAsyncServerClient;
+    #[cfg(feature = "sync")]
+    use crate::test::client::MockServerClient;
+    use crate::test::client::{ExpectedUrl, PagedTestClient};
+
+    #[derive(Debug, Default)]
+    struct Dummy {
+        with_keyset: bool,
+    }
+
+    impl RestEndpoint for Dummy {
+        fn method(&self) -> http::Method {
+            http::Method::GET
+        }
+
+        fn endpoint(&self) -> Cow<'static, str> {
+            "paged_dummy".into()
+        }
+        fn service_type(&self) -> ServiceType {
+            ServiceType::Compute
+        }
+        fn response_key(&self) -> Option<Cow<'static, str>> {
+            Some("resources".into())
+        }
+    }
+
+    impl Pageable for Dummy {}
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct DummyResult {
+        value: u8,
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_non_json_response() {
+        let client = MockServerClient::new();
+        let mock = client.server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/paged_dummy");
+            then.status(StatusCode::OK.into()).body("not json");
+        });
+
+        let res: Result<Vec<DummyResult>, _> = api::paged(Dummy::default(), Pagination::All)
+            .iter(&client)
+            .collect();
+        let err = res.unwrap_err();
+        if let ApiError::OpenStackService { status, .. } = err {
+            assert_eq!(status, http::StatusCode::OK);
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+        mock.assert();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_non_json_response_async() {
+        let client = MockAsyncServerClient::new().await;
+        let mock = client.server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/paged_dummy");
+            then.status(StatusCode::OK.into()).body("not json");
+        });
+
+        let res: Result<Vec<DummyResult>, _> = api::paged(Dummy::default(), Pagination::All)
+            .iter_async(&client)
+            .try_collect()
+            .await;
+        let err = res.unwrap_err();
+        if let ApiError::OpenStackService { status, .. } = err {
+            assert_eq!(status, http::StatusCode::OK);
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+        mock.assert();
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_error_bad_json() {
+        let client = MockServerClient::new();
+        let mock = client.server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/paged_dummy");
+            then.status(StatusCode::CONFLICT.into());
+        });
+
+        let res: Result<Vec<DummyResult>, _> = api::paged(Dummy::default(), Pagination::All)
+            .iter(&client)
+            .collect();
+        let err = res.unwrap_err();
+        if let ApiError::OpenStackService { status, .. } = err {
+            assert_eq!(status, http::StatusCode::CONFLICT);
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+        mock.assert();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_error_bad_json_async() {
+        let client = MockAsyncServerClient::new().await;
+        let mock = client.server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/paged_dummy");
+            then.status(StatusCode::CONFLICT.into());
+        });
+
+        let res: Result<Vec<DummyResult>, _> = api::paged(Dummy::default(), Pagination::All)
+            .iter_async(&client)
+            .try_collect()
+            .await;
+        let err = res.unwrap_err();
+        if let ApiError::OpenStackService { status, .. } = err {
+            assert_eq!(status, http::StatusCode::CONFLICT);
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+        mock.assert();
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_error_detection() {
+        let client = MockServerClient::new();
+        let mock = client.server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/paged_dummy");
+            then.status(StatusCode::CONFLICT.into())
+                .json_body(json!({"message": "dummy error message"}));
+        });
+        let endpoint = Dummy::default();
+
+        let res: Result<Vec<DummyResult>, _> = api::paged(endpoint, Pagination::All)
+            .iter(&client)
+            .collect();
+        let err = res.unwrap_err();
+        if let ApiError::OpenStack { msg, .. } = err {
+            assert_eq!(msg, "dummy error message");
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+        mock.assert();
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_error_detection_async() {
+        let client = MockAsyncServerClient::new().await;
+        let mock = client.server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/paged_dummy");
+            then.status(StatusCode::CONFLICT.into())
+                .json_body(json!({"message": "dummy error message"}));
+        });
+        let endpoint = Dummy::default();
+
+        let res: Result<Vec<DummyResult>, _> = api::paged(endpoint, Pagination::All)
+            .iter_async(&client)
+            .try_collect()
+            .await;
+        let err = res.unwrap_err();
+        if let ApiError::OpenStack { msg, .. } = err {
+            assert_eq!(msg, "dummy error message");
+        } else {
+            panic!("unexpected error: {}", err);
+        }
+        mock.assert();
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_pagination_limit() {
+        let endpoint = ExpectedUrl::builder()
+            .endpoint("paged_dummy")
+            .paginated(true)
+            .build()
+            .unwrap();
+        let client =
+            PagedTestClient::new_raw(endpoint, (0..=255).map(|value| DummyResult { value }));
+        let query = Dummy { with_keyset: false };
+
+        let res: Vec<DummyResult> = api::paged(query, Pagination::Limit(25))
+            .iter(&client)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(res.len(), 25);
+        for (i, value) in res.iter().enumerate() {
+            assert_eq!(value.value, i as u8);
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_pagination_limit_async() {
+        let endpoint = ExpectedUrl::builder()
+            .endpoint("paged_dummy")
+            .paginated(true)
+            .build()
+            .unwrap();
+        let client =
+            PagedTestClient::new_raw(endpoint, (0..=255).map(|value| DummyResult { value }));
+        let query = Dummy { with_keyset: false };
+
+        let res: Vec<DummyResult> = api::paged(query, Pagination::Limit(25))
+            .iter_async(&client)
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(res.len(), 25);
+        for (i, value) in res.iter().enumerate() {
+            assert_eq!(value.value, i as u8);
+        }
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_pagination_all() {
+        let endpoint = ExpectedUrl::builder()
+            .endpoint("paged_dummy")
+            .paginated(true)
+            .build()
+            .unwrap();
+        let client =
+            PagedTestClient::new_raw(endpoint, (0..=255).map(|value| DummyResult { value }));
+        let query = Dummy::default();
+
+        let res: Vec<DummyResult> = api::paged(query, Pagination::All)
+            .iter(&client)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(res.len(), 256);
+        for (i, value) in res.iter().enumerate() {
+            assert_eq!(value.value, i as u8);
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_pagination_all_async() {
+        let endpoint = ExpectedUrl::builder()
+            .endpoint("paged_dummy")
+            .paginated(true)
+            .build()
+            .unwrap();
+        let client =
+            PagedTestClient::new_raw(endpoint, (0..=255).map(|value| DummyResult { value }));
+        let query = Dummy::default();
+
+        let res: Vec<DummyResult> = api::paged(query, Pagination::All)
+            .iter_async(&client)
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(res.len(), 256);
+        for (i, value) in res.iter().enumerate() {
+            assert_eq!(value.value, i as u8);
+        }
     }
 }


### PR DESCRIPTION
Using an iter approach to consume paginated data was not tested
properly. This results in a swift requests ending in an endless loop.
Add basic tests and add support for `marker` based pagination that works
for swift.
