### PR TITLE
fix: Fix network.fip cli command

### DIFF
--- a/openstack_cli/src/network/v2/floatingip/create.rs
+++ b/openstack_cli/src/network/v2/floatingip/create.rs
@@ -173,8 +173,6 @@ struct ResponseData {
     #[structable(optional)]
     created_at: Option<String>,
 
-    /// A human-readable description for the resource.
-    ///
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
@@ -223,8 +221,8 @@ struct ResponseData {
     /// this field is `null`.
     ///
     #[serde()]
-    #[structable(optional)]
-    port_details: Option<String>,
+    #[structable(optional, pretty)]
+    port_details: Option<Value>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -236,8 +234,8 @@ struct ResponseData {
     /// or (`external_port_range`).
     ///
     #[serde()]
-    #[structable(optional)]
-    port_forwardings: Option<String>,
+    #[structable(optional, pretty)]
+    port_forwardings: Option<Value>,
 
     /// The ID of a port associated with the floating IP.
     ///

--- a/openstack_cli/src/network/v2/floatingip/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/list.rs
@@ -160,8 +160,6 @@ struct ResponseData {
     #[structable(optional)]
     created_at: Option<String>,
 
-    /// A human-readable description for the resource.
-    ///
     #[serde()]
     #[structable(optional, wide)]
     description: Option<String>,
@@ -210,8 +208,8 @@ struct ResponseData {
     /// this field is `null`.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    port_details: Option<String>,
+    #[structable(optional, pretty, wide)]
+    port_details: Option<Value>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -223,8 +221,8 @@ struct ResponseData {
     /// or (`external_port_range`).
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    port_forwardings: Option<String>,
+    #[structable(optional, pretty, wide)]
+    port_forwardings: Option<Value>,
 
     /// The ID of a port associated with the floating IP.
     ///

--- a/openstack_cli/src/network/v2/floatingip/set.rs
+++ b/openstack_cli/src/network/v2/floatingip/set.rs
@@ -128,8 +128,6 @@ struct ResponseData {
     #[structable(optional)]
     created_at: Option<String>,
 
-    /// A human-readable description for the resource.
-    ///
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
@@ -178,8 +176,8 @@ struct ResponseData {
     /// this field is `null`.
     ///
     #[serde()]
-    #[structable(optional)]
-    port_details: Option<String>,
+    #[structable(optional, pretty)]
+    port_details: Option<Value>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -191,8 +189,8 @@ struct ResponseData {
     /// or (`external_port_range`).
     ///
     #[serde()]
-    #[structable(optional)]
-    port_forwardings: Option<String>,
+    #[structable(optional, pretty)]
+    port_forwardings: Option<Value>,
 
     /// The ID of a port associated with the floating IP.
     ///

--- a/openstack_cli/src/network/v2/floatingip/show.rs
+++ b/openstack_cli/src/network/v2/floatingip/show.rs
@@ -88,8 +88,6 @@ struct ResponseData {
     #[structable(optional)]
     created_at: Option<String>,
 
-    /// A human-readable description for the resource.
-    ///
     #[serde()]
     #[structable(optional)]
     description: Option<String>,
@@ -138,8 +136,8 @@ struct ResponseData {
     /// this field is `null`.
     ///
     #[serde()]
-    #[structable(optional)]
-    port_details: Option<String>,
+    #[structable(optional, pretty)]
+    port_details: Option<Value>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -151,8 +149,8 @@ struct ResponseData {
     /// or (`external_port_range`).
     ///
     #[serde()]
-    #[structable(optional)]
-    port_forwardings: Option<String>,
+    #[structable(optional, pretty)]
+    port_forwardings: Option<Value>,
 
     /// The ID of a port associated with the floating IP.
     ///


### PR DESCRIPTION
In some clouds Neutron is deployed with extensions and port_details with
port_forwardings in reality are not strings, but complex objects.
Address this.
