### PR TITLE
feat(cli): Start switch to eyre for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -359,9 +359,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -566,6 +566,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -857,6 +884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "gloo-timers"
@@ -1312,6 +1349,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -1659,9 +1702,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1692,7 +1735,9 @@ dependencies = [
  "bytes",
  "clap",
  "cli-table",
+ "color-eyre",
  "dialoguer",
+ "eyre",
  "file_diff",
  "http 1.1.0",
  "indicatif",
@@ -1709,7 +1754,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.18",
  "url",
 ]
 
@@ -1769,6 +1814,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "parking"
@@ -2677,6 +2728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2745,17 @@ checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
  "tracing-core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "once_cell",
  "owo-colors",
  "tracing-error",
+ "url",
 ]
 
 [[package]]

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -45,7 +45,7 @@ anyhow = {workspace = true}
 bytes = {workspace = true}
 clap = { workspace = true, features = ["color", "derive", "env"] }
 cli-table = "^0.4"
-color-eyre = { version = "^0.5" }
+color-eyre = { version = "^0.5", features = ["default", "issue-url"] }
 dialoguer = {workspace = true}
 eyre = { version = "^0.6" }
 http = { workspace = true }

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -45,7 +45,9 @@ anyhow = {workspace = true}
 bytes = {workspace = true}
 clap = { workspace = true, features = ["color", "derive", "env"] }
 cli-table = "^0.4"
+color-eyre = { version = "^0.5" }
 dialoguer = {workspace = true}
+eyre = { version = "^0.6" }
 http = { workspace = true }
 json-patch = { workspace = true }
 openstack_sdk = { path="../openstack_sdk", version = "^0.6", default-features = false, features = ["async", "identity"] }

--- a/openstack_cli/src/auth/login.rs
+++ b/openstack_cli/src/auth/login.rs
@@ -13,8 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Perform cloud login
-use anyhow::anyhow;
 use clap::Parser;
+use eyre::eyre;
 use std::io::{self, Write};
 use tracing::info;
 
@@ -51,6 +51,6 @@ impl LoginCommand {
             stdout.write_all(&token.into_bytes())?;
             return Ok(());
         }
-        Err(anyhow!("Authorization information missing").into())
+        Err(eyre!("Authorization information missing").into())
     }
 }

--- a/openstack_cli/src/bin/osc.rs
+++ b/openstack_cli/src/bin/osc.rs
@@ -17,15 +17,11 @@
 //! The binary of the CLI
 #![deny(missing_docs)]
 
-use openstack_cli::error::OpenStackCliError;
+use color_eyre::eyre::{Report, Result};
 
 #[tokio::main]
-async fn main() -> Result<(), OpenStackCliError> {
-    match openstack_cli::entry_point().await {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            eprintln!("{e:#}");
-            return Err(e);
-        }
-    }
+async fn main() -> Result<(), Report> {
+    color_eyre::install()?;
+    openstack_cli::entry_point().await?;
+    Ok(())
 }

--- a/openstack_cli/src/error.rs
+++ b/openstack_cli/src/error.rs
@@ -123,7 +123,11 @@ pub enum OpenStackCliError {
         source: http::header::InvalidHeaderValue,
     },
 
+    /// Anyhow
+    #[error(transparent)]
+    Anyhow(#[from] anyhow::Error),
+
     /// Others
     #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    Other(#[from] eyre::Report),
 }

--- a/openstack_cli/src/error.rs
+++ b/openstack_cli/src/error.rs
@@ -21,21 +21,37 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum OpenStackCliError {
-    /// Json serialization error
+    /// Json serialization error.
     #[error("failed to serialize data to json: {}", source)]
     SerializeJson {
         /// The source of the error.
         #[from]
         source: serde_json::Error,
     },
-    /// SDK error
+
+    /// OpenStack Auth error.
+    #[error("authentication error")]
+    Auth {
+        /// The source of the error.
+        source: openstack_sdk::OpenStackError,
+    },
+    /// Re-scope error.
+    #[error("error changing scope to {:?}", scope)]
+    ReScope {
+        /// Target scope.
+        scope: openstack_sdk::auth::authtoken::AuthTokenScope,
+        /// The source of the error.
+        source: openstack_sdk::OpenStackError,
+    },
+
+    /// SDK error.
     #[error(transparent)]
     OpenStackSDK {
         /// The source of the error.
         #[from]
         source: openstack_sdk::OpenStackError,
     },
-    /// OpenStack API error
+    /// OpenStack API error.
     #[error(transparent)]
     OpenStackApi {
         /// The source of the error.
@@ -43,7 +59,7 @@ pub enum OpenStackCliError {
         source: openstack_sdk::api::ApiError<openstack_sdk::RestError>,
     },
 
-    /// Configuration error
+    /// Configuration error.
     #[error(transparent)]
     ConfigError {
         /// The source of the error.
@@ -51,7 +67,7 @@ pub enum OpenStackCliError {
         source: openstack_sdk::config::ConfigError,
     },
 
-    /// OpenStack Service Catalog error
+    /// OpenStack Service Catalog error.
     #[error(transparent)]
     OpenStackCatalog {
         /// The source of the error.
@@ -59,75 +75,75 @@ pub enum OpenStackCliError {
         source: openstack_sdk::catalog::CatalogError,
     },
 
-    /// No subcommands
-    #[error("Command has no subcommands")]
+    /// No subcommands.
+    #[error("command has no subcommands")]
     NoSubcommands,
 
-    /// Resource is not found
-    #[error("Resource not found")]
+    /// Resource is not found.
+    #[error("resource not found")]
     ResourceNotFound,
 
-    /// Resource identifier is not unique
-    #[error("Cannot uniqly findresource by identifier")]
+    /// Resource identifier is not unique.
+    #[error("cannot find resource by identifier")]
     IdNotUnique,
 
-    /// IO error
+    /// IO error.
     #[error("IO error: {}", source)]
     IO {
         /// The source of the error.
         #[from]
         source: std::io::Error,
     },
-    /// Reqwest library error
-    #[error("Reqwest error: {}", source)]
+    /// Reqwest library error.
+    #[error("reqwest error: {}", source)]
     Reqwest {
         /// The source of the error.
         #[from]
         source: reqwest::Error,
     },
-    /// Clap library error
-    #[error("Argument parsing error: {}", source)]
+    /// Clap library error.
+    #[error("argument parsing error: {}", source)]
     Clap {
         /// The source of the error.
         #[from]
         source: clap::error::Error,
     },
-    /// Indicativ library error
-    #[error("Indicativ error: {}", source)]
+    /// Indicativ library error.
+    #[error("indicativ error: {}", source)]
     Idinticatif {
         /// The source of the error.
         #[from]
         source: indicatif::style::TemplateError,
     },
-    /// Endpoint builder error
+    /// Endpoint builder error.
     #[error("OpenStackSDK endpoint builder error: `{0}`")]
     EndpointBuild(String),
 
-    /// Connection error
-    #[error("Cloud connection for `{0:?}` cannot be found")]
+    /// Connection error.
+    #[error("cloud connection `{0:?}` cannot be found")]
     ConnectionNotFound(String),
 
-    /// Invalid header name
-    #[error("Invalid header name `{}`", source)]
+    /// Invalid header name.
+    #[error("invalid header name `{}`", source)]
     InvalidHeaderName {
         /// The source of the error.
         #[from]
         source: http::header::InvalidHeaderName,
     },
 
-    /// Invalid header value
-    #[error("Invalid header value `{}`", source)]
+    /// Invalid header value.
+    #[error("invalid header value `{}`", source)]
     InvalidHeaderValue {
         /// The source of the error.
         #[from]
         source: http::header::InvalidHeaderValue,
     },
 
-    /// Anyhow
+    /// Anyhow error.
     #[error(transparent)]
     Anyhow(#[from] anyhow::Error),
 
-    /// Others
+    /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),
 }

--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -24,7 +24,6 @@
 use std::io::{self, IsTerminal};
 
 use clap::Parser;
-use eyre::WrapErr;
 use tracing::Level;
 
 use openstack_sdk::{
@@ -79,8 +78,7 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         )?
         .ok_or(OpenStackCliError::ConnectionNotFound(
             cli.global_opts.os_cloud.clone().unwrap(),
-        ))
-        .wrap_err_with(|| "Error loading the connection configuration")?;
+        ))?;
     let mut renew_auth: bool = false;
 
     // Login command need to be analyzed before authorization
@@ -96,11 +94,11 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
     if std::io::stdin().is_terminal() {
         session = AsyncOpenStack::new_interactive(&profile, renew_auth)
             .await
-            .wrap_err_with(|| "Error during authenticating")?;
+            .map_err(|err| OpenStackCliError::Auth { source: err })?;
     } else {
         session = AsyncOpenStack::new(&profile)
             .await
-            .wrap_err_with(|| "Error during authenticating")?;
+            .map_err(|err| OpenStackCliError::Auth { source: err })?;
     }
     if cli.global_opts.os_project_id.is_some() || cli.global_opts.os_project_name.is_some() {
         let current_project = session
@@ -115,9 +113,16 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         };
         let scope = AuthTokenScope::Project(project.clone());
         session
-            .authorize(Some(scope), std::io::stdin().is_terminal(), renew_auth)
+            .authorize(
+                Some(scope.clone()),
+                std::io::stdin().is_terminal(),
+                renew_auth,
+            )
             .await
-            .wrap_err_with(|| format!("Error during changing scope to {:?}", project))?;
+            .map_err(|err| OpenStackCliError::ReScope {
+                scope: scope,
+                source: err,
+            })?;
     }
 
     // Invoke the command

--- a/openstack_cli/src/output.rs
+++ b/openstack_cli/src/output.rs
@@ -14,13 +14,11 @@
 
 //! Output processing module
 
-use anyhow::Context;
+use cli_table::{print_stdout, Table};
+use eyre::WrapErr;
+use serde::de::DeserializeOwned;
 use std::collections::BTreeSet;
 use std::io::{self, Write};
-
-use serde::de::DeserializeOwned;
-
-use cli_table::{print_stdout, Table};
 
 use crate::cli::{Cli, OutputFormat};
 use crate::OpenStackCliError;
@@ -91,7 +89,7 @@ impl OutputProcessor {
         match self.target {
             OutputFor::Human => {
                 let table: Vec<T> = serde_json::from_value(serde_json::Value::Array(data.clone()))
-                    .with_context(|| "Serializing Json data list into the table failed. Try using `-o json` to still see the raw data.".to_string())?;
+                    .wrap_err_with(|| "Serializing Json data list into the table failed. Try using `-o json` to still see the raw data.".to_string())?;
                 self.output_human(&table)
             }
             _ => self.output_machine(serde_json::from_value(serde_json::Value::Array(data))?),
@@ -107,7 +105,7 @@ impl OutputProcessor {
         match self.target {
             OutputFor::Human => {
                 let table: T = serde_json::from_value(data.clone())
-                    .with_context(|| "Serializing Json data list into the table failed. Try using `-o json` to still see the raw data.".to_string())?;
+                    .wrap_err_with(|| "Serializing Json data list into the table failed. Try using `-o json` to still see the raw data.".to_string())?;
                 self.output_human(&table)
             }
             _ => self.output_machine(serde_json::from_value(data)?),


### PR DESCRIPTION
Start switch from anyhow to eyre/color-eyre for error handling in the
cli due to a much more user friendly reporting.
