### PR TITLE
fix: change condition in non-terminal data upload

### DIFF
--- a/openstack_cli/src/common.rs
+++ b/openstack_cli/src/common.rs
@@ -430,7 +430,7 @@ async fn build_upload_asyncread_from_file(
 pub(crate) async fn build_upload_asyncread(
     src_name: Option<String>,
 ) -> Result<BoxedAsyncRead, OpenStackCliError> {
-    if !std::io::stdin().is_terminal() || src_name.is_none() {
+    if !std::io::stdin().is_terminal() && src_name.is_none() {
         // Reading from stdin
         build_upload_asyncread_from_stdin().await
     } else {


### PR DESCRIPTION
Previously condition for the input data was wrongly evaluating to read
the data from stdin when it is not a terminal or file name was unset. It
makes no sense and stdin should be used when both conditions are true.
'else' branch is looking at the passed file name and still select stdin
when fname is '-'.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
