### PR TITLE
feat: New generated content

### DIFF
--- a/openstack_cli/src/block_storage/v3/quota_class_set/set.rs
+++ b/openstack_cli/src/block_storage/v3/quota_class_set/set.rs
@@ -49,8 +49,8 @@ pub struct QuotaClassSetCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
-    quota_class_set: Vec<(String, String)>,
+    #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, i32>)]
+    quota_class_set: Vec<(String, i32)>,
 }
 
 /// Query parameters

--- a/openstack_cli/src/compute/v2/flavor/create_20.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_20.rs
@@ -80,7 +80,7 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    disk: String,
+    disk: i32,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
@@ -104,12 +104,12 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    os_flv_ext_data_ephemeral: Option<String>,
+    os_flv_ext_data_ephemeral: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    ram: String,
+    ram: i32,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
@@ -122,12 +122,12 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    swap: Option<String>,
+    swap: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    vcpus: String,
+    vcpus: i32,
 }
 
 /// Flavor response representation
@@ -250,18 +250,18 @@ impl FlavorCommand {
             flavor_builder.id(Some(val.into()));
         }
 
-        flavor_builder.ram(&args.ram);
+        flavor_builder.ram(args.ram);
 
-        flavor_builder.vcpus(&args.vcpus);
+        flavor_builder.vcpus(args.vcpus);
 
-        flavor_builder.disk(&args.disk);
+        flavor_builder.disk(args.disk);
 
         if let Some(val) = &args.os_flv_ext_data_ephemeral {
-            flavor_builder.os_flv_ext_data_ephemeral(val);
+            flavor_builder.os_flv_ext_data_ephemeral(*val);
         }
 
         if let Some(val) = &args.swap {
-            flavor_builder.swap(val);
+            flavor_builder.swap(*val);
         }
 
         if let Some(val) = &args.rxtx_factor {

--- a/openstack_cli/src/compute/v2/flavor/create_21.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_21.rs
@@ -80,7 +80,7 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    disk: String,
+    disk: i32,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
@@ -104,12 +104,12 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    os_flv_ext_data_ephemeral: Option<String>,
+    os_flv_ext_data_ephemeral: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    ram: String,
+    ram: i32,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
@@ -122,12 +122,12 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    swap: Option<String>,
+    swap: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    vcpus: String,
+    vcpus: i32,
 }
 
 /// Flavor response representation
@@ -250,18 +250,18 @@ impl FlavorCommand {
             flavor_builder.id(Some(val.into()));
         }
 
-        flavor_builder.ram(&args.ram);
+        flavor_builder.ram(args.ram);
 
-        flavor_builder.vcpus(&args.vcpus);
+        flavor_builder.vcpus(args.vcpus);
 
-        flavor_builder.disk(&args.disk);
+        flavor_builder.disk(args.disk);
 
         if let Some(val) = &args.os_flv_ext_data_ephemeral {
-            flavor_builder.os_flv_ext_data_ephemeral(val);
+            flavor_builder.os_flv_ext_data_ephemeral(*val);
         }
 
         if let Some(val) = &args.swap {
-            flavor_builder.swap(val);
+            flavor_builder.swap(*val);
         }
 
         if let Some(val) = &args.rxtx_factor {

--- a/openstack_cli/src/compute/v2/flavor/create_255.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_255.rs
@@ -88,7 +88,7 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    disk: String,
+    disk: i32,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
@@ -112,12 +112,12 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    os_flv_ext_data_ephemeral: Option<String>,
+    os_flv_ext_data_ephemeral: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    ram: String,
+    ram: i32,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
@@ -130,12 +130,12 @@ struct Flavor {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    swap: Option<String>,
+    swap: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    vcpus: String,
+    vcpus: i32,
 }
 
 /// Flavor response representation
@@ -258,18 +258,18 @@ impl FlavorCommand {
             flavor_builder.id(Some(val.into()));
         }
 
-        flavor_builder.ram(&args.ram);
+        flavor_builder.ram(args.ram);
 
-        flavor_builder.vcpus(&args.vcpus);
+        flavor_builder.vcpus(args.vcpus);
 
-        flavor_builder.disk(&args.disk);
+        flavor_builder.disk(args.disk);
 
         if let Some(val) = &args.os_flv_ext_data_ephemeral {
-            flavor_builder.os_flv_ext_data_ephemeral(val);
+            flavor_builder.os_flv_ext_data_ephemeral(*val);
         }
 
         if let Some(val) = &args.swap {
-            flavor_builder.swap(val);
+            flavor_builder.swap(*val);
         }
 
         if let Some(val) = &args.rxtx_factor {

--- a/openstack_cli/src/compute/v2/quota_class_set/set_21.rs
+++ b/openstack_cli/src/compute/v2/quota_class_set/set_21.rs
@@ -87,105 +87,105 @@ struct QuotaClassSet {
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    cores: Option<String>,
+    cores: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    fixed_ips: Option<String>,
+    fixed_ips: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    floating_ips: Option<String>,
+    floating_ips: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    injected_file_content_bytes: Option<String>,
+    injected_file_content_bytes: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    injected_file_path_bytes: Option<String>,
+    injected_file_path_bytes: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    injected_files: Option<String>,
+    injected_files: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    instances: Option<String>,
+    instances: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    key_pairs: Option<String>,
+    key_pairs: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    metadata_items: Option<String>,
+    metadata_items: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    networks: Option<String>,
+    networks: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    ram: Option<String>,
+    ram: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    security_group_rules: Option<String>,
+    security_group_rules: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    security_groups: Option<String>,
+    security_groups: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    server_group_members: Option<String>,
+    server_group_members: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    server_groups: Option<String>,
+    server_groups: Option<i32>,
 }
 
 /// Response data as HashMap type
@@ -229,63 +229,63 @@ impl QuotaClassSetCommand {
         let args = &self.quota_class_set;
         let mut quota_class_set_builder = set_21::QuotaClassSetBuilder::default();
         if let Some(val) = &args.instances {
-            quota_class_set_builder.instances(val);
+            quota_class_set_builder.instances(*val);
         }
 
         if let Some(val) = &args.cores {
-            quota_class_set_builder.cores(val);
+            quota_class_set_builder.cores(*val);
         }
 
         if let Some(val) = &args.ram {
-            quota_class_set_builder.ram(val);
+            quota_class_set_builder.ram(*val);
         }
 
         if let Some(val) = &args.floating_ips {
-            quota_class_set_builder.floating_ips(val);
+            quota_class_set_builder.floating_ips(*val);
         }
 
         if let Some(val) = &args.fixed_ips {
-            quota_class_set_builder.fixed_ips(val);
+            quota_class_set_builder.fixed_ips(*val);
         }
 
         if let Some(val) = &args.metadata_items {
-            quota_class_set_builder.metadata_items(val);
+            quota_class_set_builder.metadata_items(*val);
         }
 
         if let Some(val) = &args.key_pairs {
-            quota_class_set_builder.key_pairs(val);
+            quota_class_set_builder.key_pairs(*val);
         }
 
         if let Some(val) = &args.security_groups {
-            quota_class_set_builder.security_groups(val);
+            quota_class_set_builder.security_groups(*val);
         }
 
         if let Some(val) = &args.security_group_rules {
-            quota_class_set_builder.security_group_rules(val);
+            quota_class_set_builder.security_group_rules(*val);
         }
 
         if let Some(val) = &args.injected_files {
-            quota_class_set_builder.injected_files(val);
+            quota_class_set_builder.injected_files(*val);
         }
 
         if let Some(val) = &args.injected_file_content_bytes {
-            quota_class_set_builder.injected_file_content_bytes(val);
+            quota_class_set_builder.injected_file_content_bytes(*val);
         }
 
         if let Some(val) = &args.injected_file_path_bytes {
-            quota_class_set_builder.injected_file_path_bytes(val);
+            quota_class_set_builder.injected_file_path_bytes(*val);
         }
 
         if let Some(val) = &args.server_groups {
-            quota_class_set_builder.server_groups(val);
+            quota_class_set_builder.server_groups(*val);
         }
 
         if let Some(val) = &args.server_group_members {
-            quota_class_set_builder.server_group_members(val);
+            quota_class_set_builder.server_group_members(*val);
         }
 
         if let Some(val) = &args.networks {
-            quota_class_set_builder.networks(val);
+            quota_class_set_builder.networks(*val);
         }
 
         ep_builder.quota_class_set(quota_class_set_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/quota_set/set_21.rs
+++ b/openstack_cli/src/compute/v2/quota_set/set_21.rs
@@ -93,21 +93,21 @@ struct QuotaSet {
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    cores: Option<String>,
+    cores: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    fixed_ips: Option<String>,
+    fixed_ips: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    floating_ips: Option<String>,
+    floating_ips: Option<i32>,
 
     /// You can force the update even if the quota has already been used and
     /// the reserved quota exceeds the new quota. To force the update, specify
@@ -121,84 +121,84 @@ struct QuotaSet {
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    injected_file_content_bytes: Option<String>,
+    injected_file_content_bytes: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    injected_file_path_bytes: Option<String>,
+    injected_file_path_bytes: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    injected_files: Option<String>,
+    injected_files: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    instances: Option<String>,
+    instances: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    key_pairs: Option<String>,
+    key_pairs: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    metadata_items: Option<String>,
+    metadata_items: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    networks: Option<String>,
+    networks: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    ram: Option<String>,
+    ram: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    security_group_rules: Option<String>,
+    security_group_rules: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    security_groups: Option<String>,
+    security_groups: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    server_group_members: Option<String>,
+    server_group_members: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[arg(help_heading = "Body parameters", long)]
-    server_groups: Option<String>,
+    server_groups: Option<i32>,
 }
 
 /// QuotaSet response representation
@@ -357,63 +357,63 @@ impl QuotaSetCommand {
         let args = &self.quota_set;
         let mut quota_set_builder = set_21::QuotaSetBuilder::default();
         if let Some(val) = &args.instances {
-            quota_set_builder.instances(val);
+            quota_set_builder.instances(*val);
         }
 
         if let Some(val) = &args.cores {
-            quota_set_builder.cores(val);
+            quota_set_builder.cores(*val);
         }
 
         if let Some(val) = &args.ram {
-            quota_set_builder.ram(val);
+            quota_set_builder.ram(*val);
         }
 
         if let Some(val) = &args.floating_ips {
-            quota_set_builder.floating_ips(val);
+            quota_set_builder.floating_ips(*val);
         }
 
         if let Some(val) = &args.fixed_ips {
-            quota_set_builder.fixed_ips(val);
+            quota_set_builder.fixed_ips(*val);
         }
 
         if let Some(val) = &args.metadata_items {
-            quota_set_builder.metadata_items(val);
+            quota_set_builder.metadata_items(*val);
         }
 
         if let Some(val) = &args.key_pairs {
-            quota_set_builder.key_pairs(val);
+            quota_set_builder.key_pairs(*val);
         }
 
         if let Some(val) = &args.security_groups {
-            quota_set_builder.security_groups(val);
+            quota_set_builder.security_groups(*val);
         }
 
         if let Some(val) = &args.security_group_rules {
-            quota_set_builder.security_group_rules(val);
+            quota_set_builder.security_group_rules(*val);
         }
 
         if let Some(val) = &args.injected_files {
-            quota_set_builder.injected_files(val);
+            quota_set_builder.injected_files(*val);
         }
 
         if let Some(val) = &args.injected_file_content_bytes {
-            quota_set_builder.injected_file_content_bytes(val);
+            quota_set_builder.injected_file_content_bytes(*val);
         }
 
         if let Some(val) = &args.injected_file_path_bytes {
-            quota_set_builder.injected_file_path_bytes(val);
+            quota_set_builder.injected_file_path_bytes(*val);
         }
 
         if let Some(val) = &args.server_groups {
-            quota_set_builder.server_groups(val);
+            quota_set_builder.server_groups(*val);
         }
 
         if let Some(val) = &args.server_group_members {
-            quota_set_builder.server_group_members(val);
+            quota_set_builder.server_group_members(*val);
         }
 
         if let Some(val) = &args.networks {
-            quota_set_builder.networks(val);
+            quota_set_builder.networks(*val);
         }
 
         if let Some(val) = &args.force {

--- a/openstack_cli/src/compute/v2/server/create_backup_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_20.rs
@@ -94,7 +94,7 @@ struct CreateBackup {
     /// when image count exceed the rotation count.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    rotation: String,
+    rotation: i32,
 }
 
 /// Server response representation
@@ -134,7 +134,7 @@ impl ServerCommand {
 
         create_backup_builder.backup_type(&args.backup_type);
 
-        create_backup_builder.rotation(&args.rotation);
+        create_backup_builder.rotation(args.rotation);
 
         if let Some(val) = &args.metadata {
             create_backup_builder.metadata(val.iter().cloned());

--- a/openstack_cli/src/compute/v2/server/create_backup_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_21.rs
@@ -94,7 +94,7 @@ struct CreateBackup {
     /// when image count exceed the rotation count.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    rotation: String,
+    rotation: i32,
 }
 
 /// Server response representation
@@ -134,7 +134,7 @@ impl ServerCommand {
 
         create_backup_builder.backup_type(&args.backup_type);
 
-        create_backup_builder.rotation(&args.rotation);
+        create_backup_builder.rotation(args.rotation);
 
         if let Some(val) = &args.metadata {
             create_backup_builder.metadata(val.iter().cloned());

--- a/openstack_cli/src/compute/v2/server/os_get_console_output.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_console_output.rs
@@ -94,7 +94,7 @@ struct OsGetConsoleOutput {
     /// ‘string’.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    length: Option<String>,
+    length: Option<Option<i32>>,
 }
 
 /// Server response representation
@@ -131,7 +131,7 @@ impl ServerCommand {
         let mut os_get_console_output_builder =
             os_get_console_output::OsGetConsoleOutputBuilder::default();
         if let Some(val) = &args.length {
-            os_get_console_output_builder.length(Some(val.into()));
+            os_get_console_output_builder.length(*val);
         }
 
         ep_builder.os_get_console_output(os_get_console_output_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server_group/create_264.rs
+++ b/openstack_cli/src/compute/v2/server_group/create_264.rs
@@ -82,7 +82,7 @@ enum Policy {
 #[group(required = false, multiple = true)]
 struct Rules {
     #[arg(help_heading = "Body parameters", long)]
-    max_server_per_host: Option<String>,
+    max_server_per_host: Option<i32>,
 }
 
 /// ServerGroup Body data
@@ -264,7 +264,7 @@ impl ServerGroupCommand {
         if let Some(val) = &args.rules {
             let mut rules_builder = create_264::RulesBuilder::default();
             if let Some(val) = &val.max_server_per_host {
-                rules_builder.max_server_per_host(val);
+                rules_builder.max_server_per_host(*val);
             }
             server_group_builder.rules(rules_builder.build().expect("A valid object"));
         }

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/create.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/create.rs
@@ -36,6 +36,7 @@ use clap::ValueEnum;
 use openstack_sdk::api::load_balancer::v2::loadbalancer::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 
 /// Creates a load balancer.
@@ -349,6 +350,18 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     vip_vnic_type: Option<String>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponsePools {
+    id: String,
+}
+
+impl fmt::Display for ResponsePools {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([format!("id={}", self.id)]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl LoadbalancerCommand {

--- a/openstack_cli/src/network/v2/network/create.rs
+++ b/openstack_cli/src/network/v2/network/create.rs
@@ -239,7 +239,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the network.
     ///

--- a/openstack_cli/src/network/v2/network/list.rs
+++ b/openstack_cli/src/network/v2/network/list.rs
@@ -251,7 +251,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the network.
     ///

--- a/openstack_cli/src/network/v2/network/set.rs
+++ b/openstack_cli/src/network/v2/network/set.rs
@@ -231,7 +231,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the network.
     ///

--- a/openstack_cli/src/network/v2/network/show.rs
+++ b/openstack_cli/src/network/v2/network/show.rs
@@ -152,7 +152,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the network.
     ///

--- a/openstack_cli/src/network/v2/network_segment_range/create.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/create.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::network_segment_range::create;
 use openstack_sdk::api::QueryAsync;
@@ -77,10 +78,10 @@ struct NetworkSegmentRange {
     description: Option<String>,
 
     #[arg(help_heading = "Body parameters", long)]
-    maximum: Option<f32>,
+    maximum: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    minimum: Option<f32>,
+    minimum: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
@@ -123,11 +124,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    maximum: Option<f32>,
+    maximum: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    minimum: Option<f32>,
+    minimum: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/network_segment_range/list.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/list.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::network_segment_range::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -137,11 +138,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional, wide)]
-    maximum: Option<f32>,
+    maximum: Option<IntString>,
 
     #[serde()]
     #[structable(optional, wide)]
-    minimum: Option<f32>,
+    minimum: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/network_segment_range/set.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/set.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::network_segment_range::find;
 use openstack_sdk::api::network::v2::network_segment_range::set;
@@ -78,10 +79,10 @@ struct NetworkSegmentRange {
     description: Option<String>,
 
     #[arg(help_heading = "Body parameters", long)]
-    maximum: Option<f32>,
+    maximum: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    minimum: Option<f32>,
+    minimum: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
@@ -112,11 +113,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    maximum: Option<f32>,
+    maximum: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    minimum: Option<f32>,
+    minimum: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/network_segment_range/show.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/show.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::network_segment_range::find;
 use openstack_sdk::api::QueryAsync;
@@ -92,11 +93,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    maximum: Option<f32>,
+    maximum: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    minimum: Option<f32>,
+    minimum: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/create.rs
+++ b/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/create.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::policy::packet_rate_limit_rule::create;
 use openstack_sdk::api::QueryAsync;
@@ -83,10 +84,10 @@ struct PacketRateLimitRule {
     direction: Option<Direction>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<i32>,
 }
 
 /// PacketRateLimitRule response representation
@@ -102,11 +103,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<IntString>,
 }
 
 impl PacketRateLimitRuleCommand {

--- a/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::policy::packet_rate_limit_rule::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -67,13 +68,13 @@ struct QueryParameters {
     /// /v2.0/policies/{policy_id}/packet_rate_limit_rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<i32>,
 
     /// max_kpps query parameter for
     /// /v2.0/policies/{policy_id}/packet_rate_limit_rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<i32>,
 }
 
 /// Path parameters
@@ -102,11 +103,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional, wide)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<IntString>,
 
     #[serde()]
     #[structable(optional, wide)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<IntString>,
 }
 
 impl PacketRateLimitRulesCommand {

--- a/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/set.rs
+++ b/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::policy::packet_rate_limit_rule::set;
 use openstack_sdk::api::QueryAsync;
@@ -93,10 +94,10 @@ struct PacketRateLimitRule {
     direction: Option<Direction>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<i32>,
 }
 
 /// PacketRateLimitRule response representation
@@ -112,11 +113,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<IntString>,
 }
 
 impl PacketRateLimitRuleCommand {

--- a/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/show.rs
+++ b/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::policy::packet_rate_limit_rule::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -88,11 +89,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<IntString>,
 }
 
 impl PacketRateLimitRuleCommand {

--- a/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/create.rs
+++ b/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/create.rs
@@ -33,6 +33,7 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_bandwidth_limit_rule::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -74,11 +75,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_bandwidth_limit_rule::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -65,12 +66,12 @@ struct QueryParameters {
     /// /v2.0/qos/alias-bandwidth-limit-rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<i32>,
 
     /// max_kbps query parameter for /v2.0/qos/alias-bandwidth-limit-rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<i32>,
 }
 
 /// Path parameters
@@ -89,11 +90,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional, wide)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional, wide)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional, wide)]

--- a/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/set.rs
+++ b/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::alias_bandwidth_limit_rule::set;
 use openstack_sdk::api::QueryAsync;
@@ -82,10 +83,10 @@ struct AliasBandwidthLimitRule {
     direction: Option<Direction>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<i32>,
 }
 
 /// AliasBandwidthLimitRule response representation
@@ -101,11 +102,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/show.rs
+++ b/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_bandwidth_limit_rule::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -77,11 +78,11 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/create.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/create.rs
@@ -33,6 +33,7 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_minimum_bandwidth_rule::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -74,7 +75,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_minimum_bandwidth_rule::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -66,7 +67,7 @@ struct QueryParameters {
     /// API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<i32>,
 }
 
 /// Path parameters
@@ -85,7 +86,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional, wide)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional, wide)]

--- a/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/set.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::alias_minimum_bandwidth_rule::set;
 use openstack_sdk::api::QueryAsync;
@@ -82,7 +83,7 @@ struct AliasMinimumBandwidthRule {
     direction: Option<Direction>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<i32>,
 }
 
 /// AliasMinimumBandwidthRule response representation
@@ -98,7 +99,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/show.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_minimum_bandwidth_rule::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -77,7 +78,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/create.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/create.rs
@@ -33,6 +33,7 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_minimum_packet_rate_rule::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -74,7 +75,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl AliasMinimumPacketRateRuleCommand {

--- a/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_minimum_packet_rate_rule::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -66,7 +67,7 @@ struct QueryParameters {
     /// API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<i32>,
 }
 
 /// Path parameters
@@ -85,7 +86,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional, wide)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl AliasMinimumPacketRateRulesCommand {

--- a/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/set.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::alias_minimum_packet_rate_rule::set;
 use openstack_sdk::api::QueryAsync;
@@ -83,7 +84,7 @@ struct AliasMinimumPacketRateRule {
     direction: Option<Direction>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<i32>,
 }
 
 /// AliasMinimumPacketRateRule response representation
@@ -99,7 +100,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl AliasMinimumPacketRateRuleCommand {

--- a/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/show.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::alias_minimum_packet_rate_rule::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -77,7 +78,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl AliasMinimumPacketRateRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/create.rs
+++ b/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/create.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::policy::bandwidth_limit_rule::create;
 use openstack_sdk::api::QueryAsync;
@@ -96,13 +97,13 @@ struct BandwidthLimitRule {
     /// The maximum burst size (in kilobits). Default is `0`.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<i32>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<i32>,
 }
 
 /// BandwidthLimitRule response representation
@@ -126,14 +127,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[serde()]
     #[structable(optional)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 }
 
 impl BandwidthLimitRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::policy::bandwidth_limit_rule::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -81,13 +82,13 @@ struct QueryParameters {
     /// /v2.0/qos/policies/{policy_id}/bandwidth_limit_rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<i32>,
 
     /// max_kbps query parameter for
     /// /v2.0/qos/policies/{policy_id}/bandwidth_limit_rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<i32>,
 }
 
 /// Path parameters
@@ -124,14 +125,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[serde()]
     #[structable(optional, wide)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 }
 
 impl BandwidthLimitRulesCommand {

--- a/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/set.rs
+++ b/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::policy::bandwidth_limit_rule::set;
 use openstack_sdk::api::QueryAsync;
@@ -106,13 +107,13 @@ struct BandwidthLimitRule {
     /// The maximum burst size (in kilobits). Default is `0`.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<i32>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<i32>,
 }
 
 /// BandwidthLimitRule response representation
@@ -136,14 +137,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[serde()]
     #[structable(optional)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 }
 
 impl BandwidthLimitRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/show.rs
+++ b/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::policy::bandwidth_limit_rule::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -101,14 +102,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<IntString>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[serde()]
     #[structable(optional)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<IntString>,
 }
 
 impl BandwidthLimitRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/create.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/create.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::policy::minimum_bandwidth_rule::create;
 use openstack_sdk::api::QueryAsync;
@@ -97,7 +98,7 @@ struct MinimumBandwidthRule {
     /// for port.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<i32>,
 }
 
 /// MinimumBandwidthRule response representation
@@ -122,7 +123,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 }
 
 impl MinimumBandwidthRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::policy::minimum_bandwidth_rule::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -87,7 +88,7 @@ struct QueryParameters {
     /// /v2.0/qos/policies/{policy_id}/minimum_bandwidth_rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<i32>,
 }
 
 /// Path parameters
@@ -125,7 +126,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 }
 
 impl MinimumBandwidthRulesCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/set.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::policy::minimum_bandwidth_rule::set;
 use openstack_sdk::api::QueryAsync;
@@ -111,7 +112,7 @@ struct MinimumBandwidthRule {
     /// for port.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<i32>,
 }
 
 /// MinimumBandwidthRule response representation
@@ -136,7 +137,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 }
 
 impl MinimumBandwidthRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/show.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::policy::minimum_bandwidth_rule::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -102,7 +103,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<IntString>,
 }
 
 impl MinimumBandwidthRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/create.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/create.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::policy::minimum_packet_rate_rule::create;
 use openstack_sdk::api::QueryAsync;
@@ -84,7 +85,7 @@ struct MinimumPacketRateRule {
     direction: Option<Direction>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<i32>,
 }
 
 /// MinimumPacketRateRule response representation
@@ -100,7 +101,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl MinimumPacketRateRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::policy::minimum_packet_rate_rule::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -67,7 +68,7 @@ struct QueryParameters {
     /// /v2.0/qos/policies/{policy_id}/minimum-packet-rate-rules API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<i32>,
 }
 
 /// Path parameters
@@ -96,7 +97,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional, wide)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl MinimumPacketRateRulesCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/set.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::qos::policy::minimum_packet_rate_rule::set;
 use openstack_sdk::api::QueryAsync;
@@ -94,7 +95,7 @@ struct MinimumPacketRateRule {
     direction: Option<Direction>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<i32>,
 }
 
 /// MinimumPacketRateRule response representation
@@ -110,7 +111,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl MinimumPacketRateRuleCommand {

--- a/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/show.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::qos::policy::minimum_packet_rate_rule::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -88,7 +89,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<IntString>,
 }
 
 impl MinimumPacketRateRuleCommand {

--- a/openstack_cli/src/network/v2/router/conntrack_helper/create.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/create.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::router::conntrack_helper::create;
 use openstack_sdk::api::QueryAsync;
@@ -98,7 +99,7 @@ struct ConntrackHelper {
     /// The network port for the netfilter conntrack target rule.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    port: Option<f32>,
+    port: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
     project_id: Option<String>,
@@ -128,7 +129,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    port: Option<f32>,
+    port: Option<IntString>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///

--- a/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::router::conntrack_helper::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -84,7 +85,7 @@ struct QueryParameters {
     /// API
     ///
     #[arg(help_heading = "Query parameters", long)]
-    port: Option<f32>,
+    port: Option<i32>,
 
     /// protocol query parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers API
@@ -125,7 +126,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    port: Option<f32>,
+    port: Option<IntString>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///

--- a/openstack_cli/src/network/v2/router/conntrack_helper/set.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::router::conntrack_helper::set;
 use openstack_sdk::api::QueryAsync;
@@ -105,7 +106,7 @@ struct ConntrackHelper {
     /// The network port for the netfilter conntrack target rule.
     ///
     #[arg(help_heading = "Body parameters", long)]
-    port: Option<f32>,
+    port: Option<i32>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///
@@ -132,7 +133,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    port: Option<f32>,
+    port: Option<IntString>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///

--- a/openstack_cli/src/network/v2/router/conntrack_helper/show.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::router::conntrack_helper::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
@@ -101,7 +102,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    port: Option<f32>,
+    port: Option<IntString>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///

--- a/openstack_cli/src/network/v2/subnetpool/create.rs
+++ b/openstack_cli/src/network/v2/subnetpool/create.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::subnetpool::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -162,7 +163,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<IntString>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -173,7 +174,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    default_quota: Option<i32>,
+    default_quota: Option<IntString>,
 
     /// A human-readable description for the resource.
     ///
@@ -205,14 +206,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<IntString>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     ///
     #[serde()]
     #[structable(optional)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<IntString>,
 
     /// Human-readable name of the resource.
     ///

--- a/openstack_cli/src/network/v2/subnetpool/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/list.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::subnetpool::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -185,7 +186,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<IntString>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -196,7 +197,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    default_quota: Option<i32>,
+    default_quota: Option<IntString>,
 
     /// A human-readable description for the resource.
     ///
@@ -228,14 +229,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<IntString>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     ///
     #[serde()]
     #[structable(optional, wide)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<IntString>,
 
     /// Human-readable name of the resource.
     ///

--- a/openstack_cli/src/network/v2/subnetpool/set.rs
+++ b/openstack_cli/src/network/v2/subnetpool/set.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::subnetpool::find;
 use openstack_sdk::api::network::v2::subnetpool::set;
@@ -162,7 +163,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<IntString>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -173,7 +174,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    default_quota: Option<i32>,
+    default_quota: Option<IntString>,
 
     /// A human-readable description for the resource.
     ///
@@ -205,14 +206,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<IntString>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     ///
     #[serde()]
     #[structable(optional)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<IntString>,
 
     /// Human-readable name of the resource.
     ///

--- a/openstack_cli/src/network/v2/subnetpool/show.rs
+++ b/openstack_cli/src/network/v2/subnetpool/show.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::subnetpool::find;
 use openstack_sdk::api::QueryAsync;
@@ -96,7 +97,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<IntString>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -107,7 +108,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    default_quota: Option<i32>,
+    default_quota: Option<IntString>,
 
     /// A human-readable description for the resource.
     ///
@@ -139,14 +140,14 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<IntString>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     ///
     #[serde()]
     #[structable(optional)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<IntString>,
 
     /// Human-readable name of the resource.
     ///

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::network::v2::vpn::ipsec_site_connection::create;
 use openstack_sdk::api::QueryAsync;
@@ -262,7 +263,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::network::v2::vpn::ipsec_site_connection::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -154,7 +155,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use clap::ValueEnum;
 use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::vpn::ipsec_site_connection::find;
@@ -253,7 +254,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/show.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/show.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::BoolString;
+use crate::common::IntString;
 use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::vpn::ipsec_site_connection::find;
 use openstack_sdk::api::QueryAsync;
@@ -154,7 +155,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    mtu: Option<i32>,
+    mtu: Option<IntString>,
 
     /// Human-readable name of the resource. Default is an empty string.
     ///

--- a/openstack_sdk/src/api/block_storage/v3/quota_class_set/set.rs
+++ b/openstack_sdk/src/api/block_storage/v3/quota_class_set/set.rs
@@ -27,7 +27,7 @@ use std::collections::BTreeMap;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     #[builder(private, setter(name = "_quota_class_set"))]
-    pub(crate) quota_class_set: BTreeMap<Cow<'a, str>, Cow<'a, str>>,
+    pub(crate) quota_class_set: BTreeMap<Cow<'a, str>, i32>,
 
     /// id parameter for /v3/os-quota-class-sets/{id} API
     ///
@@ -49,7 +49,7 @@ impl<'a> RequestBuilder<'a> {
     where
         I: Iterator<Item = (K, V)>,
         K: Into<Cow<'a, str>>,
-        V: Into<Cow<'a, str>>,
+        V: Into<i32>,
     {
         self.quota_class_set
             .get_or_insert_with(BTreeMap::new)
@@ -140,7 +140,7 @@ mod tests {
     fn test_service_type() {
         assert_eq!(
             Request::builder()
-                .quota_class_set(BTreeMap::<String, String>::new().into_iter())
+                .quota_class_set(BTreeMap::<String, i32>::new().into_iter())
                 .build()
                 .unwrap()
                 .service_type(),
@@ -151,7 +151,7 @@ mod tests {
     #[test]
     fn test_response_key() {
         assert!(Request::builder()
-            .quota_class_set(BTreeMap::<String, String>::new().into_iter())
+            .quota_class_set(BTreeMap::<String, i32>::new().into_iter())
             .build()
             .unwrap()
             .response_key()
@@ -173,7 +173,7 @@ mod tests {
 
         let endpoint = Request::builder()
             .id("id")
-            .quota_class_set(BTreeMap::<String, String>::new().into_iter())
+            .quota_class_set(BTreeMap::<String, i32>::new().into_iter())
             .build()
             .unwrap();
         let _: serde_json::Value = endpoint.query(&client).unwrap();
@@ -196,7 +196,7 @@ mod tests {
 
         let endpoint = Request::builder()
             .id("id")
-            .quota_class_set(BTreeMap::<String, String>::new().into_iter())
+            .quota_class_set(BTreeMap::<String, i32>::new().into_iter())
             .headers(
                 [(
                     Some(HeaderName::from_static("foo")),

--- a/openstack_sdk/src/api/compute/v2/flavor/create_20.rs
+++ b/openstack_sdk/src/api/compute/v2/flavor/create_20.rs
@@ -44,8 +44,8 @@ pub struct Flavor<'a> {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) disk: Cow<'a, str>,
+    #[builder()]
+    pub(crate) disk: i32,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
@@ -78,14 +78,14 @@ pub struct Flavor<'a> {
         rename = "OS-FLV-EXT-DATA:ephemeral",
         skip_serializing_if = "Option::is_none"
     )]
-    #[builder(default, setter(into))]
-    pub(crate) os_flv_ext_data_ephemeral: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) os_flv_ext_data_ephemeral: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) ram: Cow<'a, str>,
+    #[builder()]
+    pub(crate) ram: i32,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
@@ -99,14 +99,14 @@ pub struct Flavor<'a> {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) swap: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) swap: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) vcpus: Cow<'a, str>,
+    #[builder()]
+    pub(crate) vcpus: i32,
 }
 
 #[derive(Builder, Debug, Clone)]
@@ -211,10 +211,10 @@ mod tests {
             Request::builder()
                 .flavor(
                     FlavorBuilder::default()
-                        .disk("foo")
+                        .disk(123)
                         .name("foo")
-                        .ram("foo")
-                        .vcpus("foo")
+                        .ram(123)
+                        .vcpus(123)
                         .build()
                         .unwrap()
                 )
@@ -231,10 +231,10 @@ mod tests {
             Request::builder()
                 .flavor(
                     FlavorBuilder::default()
-                        .disk("foo")
+                        .disk(123)
                         .name("foo")
-                        .ram("foo")
-                        .vcpus("foo")
+                        .ram(123)
+                        .vcpus(123)
                         .build()
                         .unwrap()
                 )
@@ -262,10 +262,10 @@ mod tests {
         let endpoint = Request::builder()
             .flavor(
                 FlavorBuilder::default()
-                    .disk("foo")
+                    .disk(123)
                     .name("foo")
-                    .ram("foo")
-                    .vcpus("foo")
+                    .ram(123)
+                    .vcpus(123)
                     .build()
                     .unwrap(),
             )
@@ -292,10 +292,10 @@ mod tests {
         let endpoint = Request::builder()
             .flavor(
                 FlavorBuilder::default()
-                    .disk("foo")
+                    .disk(123)
                     .name("foo")
-                    .ram("foo")
-                    .vcpus("foo")
+                    .ram(123)
+                    .vcpus(123)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/flavor/create_21.rs
+++ b/openstack_sdk/src/api/compute/v2/flavor/create_21.rs
@@ -44,8 +44,8 @@ pub struct Flavor<'a> {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) disk: Cow<'a, str>,
+    #[builder()]
+    pub(crate) disk: i32,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
@@ -78,14 +78,14 @@ pub struct Flavor<'a> {
         rename = "OS-FLV-EXT-DATA:ephemeral",
         skip_serializing_if = "Option::is_none"
     )]
-    #[builder(default, setter(into))]
-    pub(crate) os_flv_ext_data_ephemeral: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) os_flv_ext_data_ephemeral: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) ram: Cow<'a, str>,
+    #[builder()]
+    pub(crate) ram: i32,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
@@ -99,14 +99,14 @@ pub struct Flavor<'a> {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) swap: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) swap: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) vcpus: Cow<'a, str>,
+    #[builder()]
+    pub(crate) vcpus: i32,
 }
 
 #[derive(Builder, Debug, Clone)]
@@ -211,10 +211,10 @@ mod tests {
             Request::builder()
                 .flavor(
                     FlavorBuilder::default()
-                        .disk("foo")
+                        .disk(123)
                         .name("foo")
-                        .ram("foo")
-                        .vcpus("foo")
+                        .ram(123)
+                        .vcpus(123)
                         .build()
                         .unwrap()
                 )
@@ -231,10 +231,10 @@ mod tests {
             Request::builder()
                 .flavor(
                     FlavorBuilder::default()
-                        .disk("foo")
+                        .disk(123)
                         .name("foo")
-                        .ram("foo")
-                        .vcpus("foo")
+                        .ram(123)
+                        .vcpus(123)
                         .build()
                         .unwrap()
                 )
@@ -262,10 +262,10 @@ mod tests {
         let endpoint = Request::builder()
             .flavor(
                 FlavorBuilder::default()
-                    .disk("foo")
+                    .disk(123)
                     .name("foo")
-                    .ram("foo")
-                    .vcpus("foo")
+                    .ram(123)
+                    .vcpus(123)
                     .build()
                     .unwrap(),
             )
@@ -292,10 +292,10 @@ mod tests {
         let endpoint = Request::builder()
             .flavor(
                 FlavorBuilder::default()
-                    .disk("foo")
+                    .disk(123)
                     .name("foo")
-                    .ram("foo")
-                    .vcpus("foo")
+                    .ram(123)
+                    .vcpus(123)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/flavor/create_255.rs
+++ b/openstack_sdk/src/api/compute/v2/flavor/create_255.rs
@@ -53,8 +53,8 @@ pub struct Flavor<'a> {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) disk: Cow<'a, str>,
+    #[builder()]
+    pub(crate) disk: i32,
 
     /// Only alphanumeric characters with hyphen ‘-’, underscore ‘\_’, spaces
     /// and dots ‘.’ are permitted. If an ID is not provided, then a default
@@ -87,14 +87,14 @@ pub struct Flavor<'a> {
         rename = "OS-FLV-EXT-DATA:ephemeral",
         skip_serializing_if = "Option::is_none"
     )]
-    #[builder(default, setter(into))]
-    pub(crate) os_flv_ext_data_ephemeral: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) os_flv_ext_data_ephemeral: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) ram: Cow<'a, str>,
+    #[builder()]
+    pub(crate) ram: i32,
 
     /// The receive / transmit factor (as a float) that will be set on ports if
     /// the network backend supports the QOS extension. Otherwise it will be
@@ -108,14 +108,14 @@ pub struct Flavor<'a> {
     /// (the default), no dedicated swap disk will be created.
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) swap: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) swap: Option<i32>,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) vcpus: Cow<'a, str>,
+    #[builder()]
+    pub(crate) vcpus: i32,
 }
 
 #[derive(Builder, Debug, Clone)]
@@ -220,10 +220,10 @@ mod tests {
             Request::builder()
                 .flavor(
                     FlavorBuilder::default()
-                        .disk("foo")
+                        .disk(123)
                         .name("foo")
-                        .ram("foo")
-                        .vcpus("foo")
+                        .ram(123)
+                        .vcpus(123)
                         .build()
                         .unwrap()
                 )
@@ -240,10 +240,10 @@ mod tests {
             Request::builder()
                 .flavor(
                     FlavorBuilder::default()
-                        .disk("foo")
+                        .disk(123)
                         .name("foo")
-                        .ram("foo")
-                        .vcpus("foo")
+                        .ram(123)
+                        .vcpus(123)
                         .build()
                         .unwrap()
                 )
@@ -271,10 +271,10 @@ mod tests {
         let endpoint = Request::builder()
             .flavor(
                 FlavorBuilder::default()
-                    .disk("foo")
+                    .disk(123)
                     .name("foo")
-                    .ram("foo")
-                    .vcpus("foo")
+                    .ram(123)
+                    .vcpus(123)
                     .build()
                     .unwrap(),
             )
@@ -301,10 +301,10 @@ mod tests {
         let endpoint = Request::builder()
             .flavor(
                 FlavorBuilder::default()
-                    .disk("foo")
+                    .disk(123)
                     .name("foo")
-                    .ram("foo")
-                    .vcpus("foo")
+                    .ram(123)
+                    .vcpus(123)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/quota_class_set/set_21.rs
+++ b/openstack_sdk/src/api/compute/v2/quota_class_set/set_21.rs
@@ -38,126 +38,126 @@ use std::borrow::Cow;
 ///
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
-pub struct QuotaClassSet<'a> {
+pub struct QuotaClassSet {
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) cores: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) cores: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) fixed_ips: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) fixed_ips: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) floating_ips: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) floating_ips: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) injected_file_content_bytes: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) injected_file_content_bytes: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) injected_file_path_bytes: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) injected_file_path_bytes: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) injected_files: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) injected_files: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) instances: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) instances: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) key_pairs: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) key_pairs: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) metadata_items: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) metadata_items: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) networks: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) networks: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) ram: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) ram: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) security_group_rules: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) security_group_rules: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) security_groups: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) security_groups: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) server_group_members: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) server_group_members: Option<i32>,
 
     /// The number of allowed injected files for the quota class.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) server_groups: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) server_groups: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]
@@ -166,7 +166,7 @@ pub struct Request<'a> {
     /// A `quota_class_set` object.
     ///
     #[builder(setter(into))]
-    pub(crate) quota_class_set: QuotaClassSet<'a>,
+    pub(crate) quota_class_set: QuotaClassSet,
 
     /// id parameter for /v2.1/os-quota-class-sets/{id} API
     ///

--- a/openstack_sdk/src/api/compute/v2/quota_set/set_21.rs
+++ b/openstack_sdk/src/api/compute/v2/quota_set/set_21.rs
@@ -39,30 +39,30 @@ use std::borrow::Cow;
 ///
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
-pub struct QuotaSet<'a> {
+pub struct QuotaSet {
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) cores: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) cores: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) fixed_ips: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) fixed_ips: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) floating_ips: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) floating_ips: Option<i32>,
 
     /// You can force the update even if the quota has already been used and
     /// the reserved quota exceeds the new quota. To force the update, specify
@@ -77,96 +77,96 @@ pub struct QuotaSet<'a> {
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) injected_file_content_bytes: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) injected_file_content_bytes: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) injected_file_path_bytes: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) injected_file_path_bytes: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) injected_files: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) injected_files: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) instances: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) instances: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) key_pairs: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) key_pairs: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) metadata_items: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) metadata_items: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) networks: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) networks: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) ram: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) ram: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) security_group_rules: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) security_group_rules: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) security_groups: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) security_groups: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) server_group_members: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) server_group_members: Option<i32>,
 
     /// The number of allowed injected files for each tenant.
     ///
     /// **Available until version 2.56**
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) server_groups: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) server_groups: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]
@@ -175,7 +175,7 @@ pub struct Request<'a> {
     /// A `quota_set` object.
     ///
     #[builder(setter(into))]
-    pub(crate) quota_set: QuotaSet<'a>,
+    pub(crate) quota_set: QuotaSet,
 
     /// id parameter for /v2.1/os-quota-sets/{id} API
     ///

--- a/openstack_sdk/src/api/compute/v2/server/create_backup_20.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_backup_20.rs
@@ -53,8 +53,8 @@ pub struct CreateBackup<'a> {
     /// when image count exceed the rotation count.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) rotation: Cow<'a, str>,
+    #[builder()]
+    pub(crate) rotation: i32,
 }
 
 impl<'a> CreateBackupBuilder<'a> {
@@ -183,7 +183,7 @@ mod tests {
                     CreateBackupBuilder::default()
                         .backup_type("foo")
                         .name("foo")
-                        .rotation("foo")
+                        .rotation(123)
                         .build()
                         .unwrap()
                 )
@@ -201,7 +201,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation("foo")
+                    .rotation(123)
                     .build()
                     .unwrap()
             )
@@ -230,7 +230,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation("foo")
+                    .rotation(123)
                     .build()
                     .unwrap(),
             )
@@ -260,7 +260,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation("foo")
+                    .rotation(123)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/server/create_backup_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_backup_21.rs
@@ -53,8 +53,8 @@ pub struct CreateBackup<'a> {
     /// when image count exceed the rotation count.
     ///
     #[serde()]
-    #[builder(setter(into))]
-    pub(crate) rotation: Cow<'a, str>,
+    #[builder()]
+    pub(crate) rotation: i32,
 }
 
 impl<'a> CreateBackupBuilder<'a> {
@@ -183,7 +183,7 @@ mod tests {
                     CreateBackupBuilder::default()
                         .backup_type("foo")
                         .name("foo")
-                        .rotation("foo")
+                        .rotation(123)
                         .build()
                         .unwrap()
                 )
@@ -201,7 +201,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation("foo")
+                    .rotation(123)
                     .build()
                     .unwrap()
             )
@@ -230,7 +230,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation("foo")
+                    .rotation(123)
                     .build()
                     .unwrap(),
             )
@@ -260,7 +260,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation("foo")
+                    .rotation(123)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/server/os_get_console_output.rs
+++ b/openstack_sdk/src/api/compute/v2/server/os_get_console_output.rs
@@ -28,7 +28,7 @@ use std::borrow::Cow;
 ///
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
-pub struct OsGetConsoleOutput<'a> {
+pub struct OsGetConsoleOutput {
     /// The number of lines to fetch from the end of console log. All lines
     /// will be returned if this is not specified.
     ///
@@ -39,7 +39,7 @@ pub struct OsGetConsoleOutput<'a> {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) length: Option<Option<Cow<'a, str>>>,
+    pub(crate) length: Option<Option<i32>>,
 }
 
 #[derive(Builder, Debug, Clone)]
@@ -48,7 +48,7 @@ pub struct Request<'a> {
     /// The action to get console output of the server.
     ///
     #[builder(setter(into))]
-    pub(crate) os_get_console_output: OsGetConsoleOutput<'a>,
+    pub(crate) os_get_console_output: OsGetConsoleOutput,
 
     /// id parameter for /v2.1/servers/{id}/action API
     ///

--- a/openstack_sdk/src/api/compute/v2/server_group/create_264.rs
+++ b/openstack_sdk/src/api/compute/v2/server_group/create_264.rs
@@ -55,10 +55,10 @@ pub enum Policy {
 ///
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
-pub struct Rules<'a> {
+pub struct Rules {
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
-    pub(crate) max_server_per_host: Option<Cow<'a, str>>,
+    #[builder(default)]
+    pub(crate) max_server_per_host: Option<i32>,
 }
 
 /// The server group object.
@@ -104,7 +104,7 @@ pub struct ServerGroup<'a> {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) rules: Option<Rules<'a>>,
+    pub(crate) rules: Option<Rules>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/network_segment_range/create.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/create.rs
@@ -45,11 +45,11 @@ pub struct NetworkSegmentRange<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) maximum: Option<f32>,
+    pub(crate) maximum: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) minimum: Option<f32>,
+    pub(crate) minimum: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/network_segment_range/set.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/set.rs
@@ -33,11 +33,11 @@ pub struct NetworkSegmentRange<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) maximum: Option<f32>,
+    pub(crate) maximum: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) minimum: Option<f32>,
+    pub(crate) minimum: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/create.rs
+++ b/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/create.rs
@@ -41,11 +41,11 @@ pub struct PacketRateLimitRule {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_burst_kpps: Option<f32>,
+    pub(crate) max_burst_kpps: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_kpps: Option<f32>,
+    pub(crate) max_kpps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -41,13 +41,13 @@ pub struct Request<'a> {
     /// /v2.0/policies/{policy_id}/packet_rate_limit_rules API
     ///
     #[builder(default)]
-    max_burst_kpps: Option<f32>,
+    max_burst_kpps: Option<i32>,
 
     /// max_kpps query parameter for
     /// /v2.0/policies/{policy_id}/packet_rate_limit_rules API
     ///
     #[builder(default)]
-    max_kpps: Option<f32>,
+    max_kpps: Option<i32>,
 
     /// policy_id parameter for
     /// /v2.0/policies/{policy_id}/packet_rate_limit_rules/{id} API

--- a/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/set.rs
+++ b/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/set.rs
@@ -41,11 +41,11 @@ pub struct PacketRateLimitRule {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_burst_kpps: Option<f32>,
+    pub(crate) max_burst_kpps: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_kpps: Option<f32>,
+    pub(crate) max_kpps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -39,12 +39,12 @@ pub struct Request<'a> {
     /// /v2.0/qos/alias-bandwidth-limit-rules API
     ///
     #[builder(default)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<i32>,
 
     /// max_kbps query parameter for /v2.0/qos/alias-bandwidth-limit-rules API
     ///
     #[builder(default)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<i32>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,

--- a/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/set.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/set.rs
@@ -41,11 +41,11 @@ pub struct AliasBandwidthLimitRule {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_burst_kbps: Option<f32>,
+    pub(crate) max_burst_kbps: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_kbps: Option<f32>,
+    pub(crate) max_kbps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     /// API
     ///
     #[builder(default)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<i32>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/set.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/set.rs
@@ -41,7 +41,7 @@ pub struct AliasMinimumBandwidthRule {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) min_kbps: Option<f32>,
+    pub(crate) min_kbps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     /// API
     ///
     #[builder(default)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<i32>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/set.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/set.rs
@@ -43,7 +43,7 @@ pub struct AliasMinimumPacketRateRule {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) min_kpps: Option<f32>,
+    pub(crate) min_kpps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/create.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/create.rs
@@ -55,14 +55,14 @@ pub struct BandwidthLimitRule {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_burst_kbps: Option<f32>,
+    pub(crate) max_burst_kbps: Option<i32>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_kbps: Option<f32>,
+    pub(crate) max_kbps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -56,13 +56,13 @@ pub struct Request<'a> {
     /// /v2.0/qos/policies/{policy_id}/bandwidth_limit_rules API
     ///
     #[builder(default)]
-    max_burst_kbps: Option<f32>,
+    max_burst_kbps: Option<i32>,
 
     /// max_kbps query parameter for
     /// /v2.0/qos/policies/{policy_id}/bandwidth_limit_rules API
     ///
     #[builder(default)]
-    max_kbps: Option<f32>,
+    max_kbps: Option<i32>,
 
     /// policy_id parameter for
     /// /v2.0/qos/policies/{policy_id}/bandwidth_limit_rules/{id} API

--- a/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/set.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/set.rs
@@ -55,14 +55,14 @@ pub struct BandwidthLimitRule {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_burst_kbps: Option<f32>,
+    pub(crate) max_burst_kbps: Option<i32>,
 
     /// The maximum KBPS (kilobits per second) value. If you specify this
     /// value, must be greater than 0 otherwise max_kbps will have no value.
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) max_kbps: Option<f32>,
+    pub(crate) max_kbps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/create.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/create.rs
@@ -56,7 +56,7 @@ pub struct MinimumBandwidthRule {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) min_kbps: Option<f32>,
+    pub(crate) min_kbps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -62,7 +62,7 @@ pub struct Request<'a> {
     /// /v2.0/qos/policies/{policy_id}/minimum_bandwidth_rules API
     ///
     #[builder(default)]
-    min_kbps: Option<f32>,
+    min_kbps: Option<i32>,
 
     /// policy_id parameter for
     /// /v2.0/qos/policies/{policy_id}/minimum_bandwidth_rules/{id} API

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/set.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/set.rs
@@ -60,7 +60,7 @@ pub struct MinimumBandwidthRule {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) min_kbps: Option<f32>,
+    pub(crate) min_kbps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/create.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/create.rs
@@ -43,7 +43,7 @@ pub struct MinimumPacketRateRule {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) min_kpps: Option<f32>,
+    pub(crate) min_kpps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -41,7 +41,7 @@ pub struct Request<'a> {
     /// /v2.0/qos/policies/{policy_id}/minimum-packet-rate-rules API
     ///
     #[builder(default)]
-    min_kpps: Option<f32>,
+    min_kpps: Option<i32>,
 
     /// policy_id parameter for
     /// /v2.0/qos/policies/{policy_id}/minimum-packet-rate-rules/{id} API

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/set.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/set.rs
@@ -43,7 +43,7 @@ pub struct MinimumPacketRateRule {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) min_kpps: Option<f32>,
+    pub(crate) min_kpps: Option<i32>,
 }
 
 #[derive(Builder, Debug, Clone)]

--- a/openstack_sdk/src/api/network/v2/router/conntrack_helper/create.rs
+++ b/openstack_sdk/src/api/network/v2/router/conntrack_helper/create.rs
@@ -61,7 +61,7 @@ pub struct ConntrackHelper<'a> {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) port: Option<f32>,
+    pub(crate) port: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
@@ -59,7 +59,7 @@ pub struct Request<'a> {
     /// API
     ///
     #[builder(default)]
-    port: Option<f32>,
+    port: Option<i32>,
 
     /// protocol query parameter for
     /// /v2.0/routers/{router_id}/conntrack_helpers API

--- a/openstack_sdk/src/api/network/v2/router/conntrack_helper/set.rs
+++ b/openstack_sdk/src/api/network/v2/router/conntrack_helper/set.rs
@@ -59,7 +59,7 @@ pub struct ConntrackHelper<'a> {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
-    pub(crate) port: Option<f32>,
+    pub(crate) port: Option<i32>,
 
     /// The network protocol for the netfilter conntrack target rule.
     ///


### PR DESCRIPTION
Update neutron schema resolution

Neutron treats subnetpool.XXX_prefixlen everywhere as integers including the database (it is even described like that in neutron api-ref itself). For some unknown reason it returns it as a string though. Maybe because in the apidef it is defined like `validate: "type:non_negative", convert_to: convert_to_int`. Modify api_def processing not to look at validate OR convert_to, but use convert_to results in update of the schema.

Change-Id: I52d1d207be54967a0a1b9a3443c661b1fabd69f4

Changes are triggered by https://review.opendev.org/925868