### PR TITLE
fix: Repair subnetpool.ip_version field

### DIFF
--- a/openstack_cli/src/network/v2/subnetpool/create.rs
+++ b/openstack_cli/src/network/v2/subnetpool/create.rs
@@ -192,7 +192,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    ip_version: Option<String>,
+    ip_version: Option<i32>,
 
     /// The subnetpool is default pool or not.
     ///

--- a/openstack_cli/src/network/v2/subnetpool/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/list.rs
@@ -215,7 +215,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional, wide)]
-    ip_version: Option<String>,
+    ip_version: Option<i32>,
 
     /// The subnetpool is default pool or not.
     ///

--- a/openstack_cli/src/network/v2/subnetpool/set.rs
+++ b/openstack_cli/src/network/v2/subnetpool/set.rs
@@ -192,7 +192,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    ip_version: Option<String>,
+    ip_version: Option<i32>,
 
     /// The subnetpool is default pool or not.
     ///

--- a/openstack_cli/src/network/v2/subnetpool/show.rs
+++ b/openstack_cli/src/network/v2/subnetpool/show.rs
@@ -126,7 +126,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    ip_version: Option<String>,
+    ip_version: Option<i32>,
 
     /// The subnetpool is default pool or not.
     ///


### PR DESCRIPTION
Hardwire subnetpool.ip_version to be integer

Neutron treats ip_version as integer but the apidef does not tell anything about that. Implement hard overwrite.

Change-Id: I71a3416bb09325bbe8d8058d2d412023ea3a8c5f

Changes are triggered by https://review.opendev.org/926183