### PR TITLE
chore: Update compute.floatingip

### DIFF
--- a/openstack_cli/src/compute/v2/floating_ip/create.rs
+++ b/openstack_cli/src/compute/v2/floating_ip/create.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_json;
-use crate::common::parse_key_val;
 use openstack_sdk::api::compute::v2::floating_ip::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -63,10 +61,6 @@ pub struct FloatingIpCommand {
     /// Path parameters
     #[command(flatten)]
     path: PathParameters,
-
-    #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
-    #[arg(help_heading = "Body parameters")]
-    properties: Option<Vec<(String, Value)>>,
 }
 
 /// Query parameters
@@ -106,14 +100,11 @@ impl FloatingIpCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = create::Request::builder();
+        let ep_builder = create::Request::builder();
 
         // Set path parameters
         // Set query parameters
         // Set body parameters
-        if let Some(properties) = &self.properties {
-            ep_builder.properties(properties.iter().cloned());
-        }
 
         let ep = ep_builder
             .build()

--- a/openstack_cli/src/compute/v2/floating_ips_bulk/create.rs
+++ b/openstack_cli/src/compute/v2/floating_ips_bulk/create.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_json;
-use crate::common::parse_key_val;
 use openstack_sdk::api::compute::v2::floating_ips_bulk::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -55,10 +53,6 @@ pub struct FloatingIpsBulkCommand {
     /// Path parameters
     #[command(flatten)]
     path: PathParameters,
-
-    #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
-    #[arg(help_heading = "Body parameters")]
-    properties: Option<Vec<(String, Value)>>,
 }
 
 /// Query parameters
@@ -98,14 +92,11 @@ impl FloatingIpsBulkCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let mut ep_builder = create::Request::builder();
+        let ep_builder = create::Request::builder();
 
         // Set path parameters
         // Set query parameters
         // Set body parameters
-        if let Some(properties) = &self.properties {
-            ep_builder.properties(properties.iter().cloned());
-        }
 
         let ep = ep_builder
             .build()

--- a/openstack_cli/src/compute/v2/floating_ips_bulk/set.rs
+++ b/openstack_cli/src/compute/v2/floating_ips_bulk/set.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_json;
-use crate::common::parse_key_val;
 use openstack_sdk::api::compute::v2::floating_ips_bulk::set;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -49,10 +47,6 @@ pub struct FloatingIpsBulkCommand {
     /// Path parameters
     #[command(flatten)]
     path: PathParameters,
-
-    #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
-    #[arg(help_heading = "Body parameters")]
-    properties: Option<Vec<(String, Value)>>,
 }
 
 /// Query parameters
@@ -107,9 +101,6 @@ impl FloatingIpsBulkCommand {
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters
-        if let Some(properties) = &self.properties {
-            ep_builder.properties(properties.iter().cloned());
-        }
 
         let ep = ep_builder
             .build()

--- a/openstack_sdk/src/api/compute/v2/floating_ip/create.rs
+++ b/openstack_sdk/src/api/compute/v2/floating_ip/create.rs
@@ -35,26 +35,20 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
-use serde_json::Value;
-use std::collections::BTreeMap;
-
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request<'a> {
+pub struct Request {
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
-
-    #[builder(setter(name = "_properties"), default, private)]
-    _properties: BTreeMap<Cow<'a, str>, Value>,
 }
-impl<'a> Request<'a> {
+impl Request {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder<'a> {
+    pub fn builder() -> RequestBuilder {
         RequestBuilder::default()
     }
 }
 
-impl<'a> RequestBuilder<'a> {
+impl RequestBuilder {
     /// Add a single header to the Floating_Ip.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -77,21 +71,9 @@ where {
             .extend(iter.map(Into::into));
         self
     }
-
-    pub fn properties<I, K, V>(&mut self, iter: I) -> &mut Self
-    where
-        I: Iterator<Item = (K, V)>,
-        K: Into<Cow<'a, str>>,
-        V: Into<Value>,
-    {
-        self._properties
-            .get_or_insert_with(BTreeMap::new)
-            .extend(iter.map(|(k, v)| (k.into(), v.into())));
-        self
-    }
 }
 
-impl<'a> RestEndpoint for Request<'a> {
+impl RestEndpoint for Request {
     fn method(&self) -> http::Method {
         http::Method::POST
     }
@@ -102,16 +84,6 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         QueryParams::default()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-
-        for (key, val) in &self._properties {
-            params.push(key.clone(), val.clone());
-        }
-
-        params.into_body()
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/compute/v2/floating_ips_bulk/create.rs
+++ b/openstack_sdk/src/api/compute/v2/floating_ips_bulk/create.rs
@@ -27,26 +27,20 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
-use serde_json::Value;
-use std::collections::BTreeMap;
-
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request<'a> {
+pub struct Request {
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
-
-    #[builder(setter(name = "_properties"), default, private)]
-    _properties: BTreeMap<Cow<'a, str>, Value>,
 }
-impl<'a> Request<'a> {
+impl Request {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder<'a> {
+    pub fn builder() -> RequestBuilder {
         RequestBuilder::default()
     }
 }
 
-impl<'a> RequestBuilder<'a> {
+impl RequestBuilder {
     /// Add a single header to the Floating_Ips_Bulk.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -69,21 +63,9 @@ where {
             .extend(iter.map(Into::into));
         self
     }
-
-    pub fn properties<I, K, V>(&mut self, iter: I) -> &mut Self
-    where
-        I: Iterator<Item = (K, V)>,
-        K: Into<Cow<'a, str>>,
-        V: Into<Value>,
-    {
-        self._properties
-            .get_or_insert_with(BTreeMap::new)
-            .extend(iter.map(|(k, v)| (k.into(), v.into())));
-        self
-    }
 }
 
-impl<'a> RestEndpoint for Request<'a> {
+impl RestEndpoint for Request {
     fn method(&self) -> http::Method {
         http::Method::POST
     }
@@ -94,16 +76,6 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         QueryParams::default()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-
-        for (key, val) in &self._properties {
-            params.push(key.clone(), val.clone());
-        }
-
-        params.into_body()
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/compute/v2/floating_ips_bulk/set.rs
+++ b/openstack_sdk/src/api/compute/v2/floating_ips_bulk/set.rs
@@ -20,9 +20,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
-use serde_json::Value;
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
@@ -34,9 +32,6 @@ pub struct Request<'a> {
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
-
-    #[builder(setter(name = "_properties"), default, private)]
-    _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
@@ -68,18 +63,6 @@ where {
             .extend(iter.map(Into::into));
         self
     }
-
-    pub fn properties<I, K, V>(&mut self, iter: I) -> &mut Self
-    where
-        I: Iterator<Item = (K, V)>,
-        K: Into<Cow<'a, str>>,
-        V: Into<Value>,
-    {
-        self._properties
-            .get_or_insert_with(BTreeMap::new)
-            .extend(iter.map(|(k, v)| (k.into(), v.into())));
-        self
-    }
 }
 
 impl<'a> RestEndpoint for Request<'a> {
@@ -93,16 +76,6 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         QueryParams::default()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-
-        for (key, val) in &self._properties {
-            params.push(key.clone(), val.clone());
-        }
-
-        params.into_body()
     }
 
     fn service_type(&self) -> ServiceType {


### PR DESCRIPTION
Flip use of UNSET

in the previous change we added support for UNSET to have empty schema. It is more logical to use UNSET when the schema is not defined and not when it is empty. Fix that.

Change-Id: I6568ca826d119b42f74d3f2ee9a691ac1278bc26

Changes are triggered by https://review.opendev.org/926496