### PR TITLE
feat: Add support for placement microversion

### DIFF
--- a/openstack_sdk/src/api/rest_endpoint.rs
+++ b/openstack_sdk/src/api/rest_endpoint.rs
@@ -105,6 +105,7 @@ pub(crate) fn set_latest_microversion<E>(
     let mh_service_type = match endpoint.service_type() {
         ServiceType::BlockStorage => Some("volume"),
         ServiceType::Compute => Some("compute"),
+        ServiceType::Placement => Some("placement"),
         _ => None,
     };
     if let Some(st) = mh_service_type {

--- a/openstack_sdk/src/catalog/discovery.rs
+++ b/openstack_sdk/src/catalog/discovery.rs
@@ -129,6 +129,9 @@ impl EndpointVersion {
         if let Some(ver) = &self.version {
             return ApiVersion::from_apiver_str(ver, false);
         }
+        if let Some(ver) = &self.max_version {
+            return ApiVersion::from_apiver_str(ver, false);
+        }
         if let Some(ver) = &self.min_version {
             return ApiVersion::from_apiver_str(ver, false);
         }
@@ -185,7 +188,7 @@ mod tests {
         assert_eq!(None, ev.version);
         assert_eq!(None, ev.min_version);
         assert_eq!(Some("2.38".to_string()), ev.max_version);
-        assert_eq!(ApiVersion::new(2, 1), ev.get_api_version().unwrap());
+        assert_eq!(ApiVersion::new(2, 38), ev.get_api_version().unwrap());
 
         let ev: EndpointVersion = serde_json::from_value(json!({
               "status": "CURRENT",
@@ -436,5 +439,36 @@ mod tests {
         )
         .unwrap();
         assert_eq!(2, endpoints.len());
+    }
+
+    #[test]
+    fn test_discovery_placement() {
+        let endpoints = extract_discovery_endpoints(
+            &Url::parse("http://placement.example.com/").unwrap(),
+            &Bytes::from(
+                json!({
+                  "versions": {
+                    "values": [
+                      {
+                        "id": "v1.0",
+                        "links": [
+                          {
+                            "href": "",
+                            "rel": "self"
+                          }
+                        ],
+                        "status": "CURRENT",
+                        "min_version": "1.0",
+                        "max_version": "1.31",
+                      }
+                    ]
+                  }
+                })
+                .to_string(),
+            ),
+            "dummy",
+        )
+        .unwrap();
+        assert_eq!(&ApiVersion::new(1, 31), endpoints[1].version());
     }
 }

--- a/openstack_sdk/src/types.rs
+++ b/openstack_sdk/src/types.rs
@@ -39,6 +39,7 @@ pub enum ServiceType {
     LoadBalancer,
     Network,
     ObjectStore,
+    Placement,
     Other(String),
 }
 
@@ -52,6 +53,7 @@ impl fmt::Display for ServiceType {
             ServiceType::LoadBalancer => write!(f, "load-balancer"),
             ServiceType::Network => write!(f, "network"),
             ServiceType::ObjectStore => write!(f, "object-store"),
+            ServiceType::Placement => write!(f, "placement"),
             ServiceType::Other(x) => write!(f, "{x}"),
         }
     }


### PR DESCRIPTION
Extend microversion handling logic to also support placement service.

- add service type
- set mv for the service requests
- use max_version before the min_version as service version when version
  itself is not set
- get main service type before listing aliases of the service type (to
  work properly when requested service type is itself an alias).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
