### PR TITLE
fix: Corrected volume query parameter name

### DIFF
--- a/openstack_cli/src/block_storage/v3/attachment/list.rs
+++ b/openstack_cli/src/block_storage/v3/attachment/list.rs
@@ -60,7 +60,7 @@ struct QueryParameters {
     /// Shows details for all project. Admin only.
     ///
     #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Requests a page size of items. Returns a number of items up to a limit
     /// value. Use the limit parameter to make an initial limited request and
@@ -178,8 +178,8 @@ impl AttachmentsCommand {
 
         // Set path parameters
         // Set query parameters
-        if let Some(val) = &self.query.all_tenans {
-            ep_builder.all_tenans(*val);
+        if let Some(val) = &self.query.all_tenants {
+            ep_builder.all_tenants(*val);
         }
         if let Some(val) = &self.query.sort {
             ep_builder.sort(val);

--- a/openstack_cli/src/block_storage/v3/snapshot/list.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/list.rs
@@ -60,7 +60,7 @@ struct QueryParameters {
     /// Shows details for all project. Admin only.
     ///
     #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Filters results by consumes_quota field. Resources that don’t use
     /// quotas are usually temporary internal resources created to perform an
@@ -264,8 +264,8 @@ impl SnapshotsCommand {
 
         // Set path parameters
         // Set query parameters
-        if let Some(val) = &self.query.all_tenans {
-            ep_builder.all_tenans(*val);
+        if let Some(val) = &self.query.all_tenants {
+            ep_builder.all_tenants(*val);
         }
         if let Some(val) = &self.query.sort {
             ep_builder.sort(val);

--- a/openstack_cli/src/block_storage/v3/volume/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/list.rs
@@ -60,7 +60,7 @@ struct QueryParameters {
     /// Shows details for all project. Admin only.
     ///
     #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Filters results by consumes_quota field. Resources that don’t use
     /// quotas are usually temporary internal resources created to perform an
@@ -386,8 +386,8 @@ impl VolumesCommand {
 
         // Set path parameters
         // Set query parameters
-        if let Some(val) = &self.query.all_tenans {
-            ep_builder.all_tenans(*val);
+        if let Some(val) = &self.query.all_tenants {
+            ep_builder.all_tenants(*val);
         }
         if let Some(val) = &self.query.sort {
             ep_builder.sort(val);

--- a/openstack_sdk/src/api/block_storage/v3/attachment/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/attachment/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// Shows details for all project. Admin only.
     ///
     #[builder(default)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Requests a page size of items. Returns a number of items up to a limit
     /// value. Use the limit parameter to make an initial limited request and
@@ -122,7 +122,7 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("all_tenans", self.all_tenans);
+        params.push_opt("all_tenants", self.all_tenants);
         params.push_opt("sort", self.sort.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());

--- a/openstack_sdk/src/api/block_storage/v3/attachment/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/attachment/list_detailed.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// Shows details for all project. Admin only.
     ///
     #[builder(default)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Requests a page size of items. Returns a number of items up to a limit
     /// value. Use the limit parameter to make an initial limited request and
@@ -122,7 +122,7 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("all_tenans", self.all_tenans);
+        params.push_opt("all_tenants", self.all_tenants);
         params.push_opt("sort", self.sort.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());

--- a/openstack_sdk/src/api/block_storage/v3/snapshot/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/snapshot/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// Shows details for all project. Admin only.
     ///
     #[builder(default)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Filters results by consumes_quota field. Resources that don’t use
     /// quotas are usually temporary internal resources created to perform an
@@ -136,7 +136,7 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("all_tenans", self.all_tenans);
+        params.push_opt("all_tenants", self.all_tenants);
         params.push_opt("sort", self.sort.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());

--- a/openstack_sdk/src/api/block_storage/v3/snapshot/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/snapshot/list_detailed.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// Shows details for all project. Admin only.
     ///
     #[builder(default)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Filters results by consumes_quota field. Resources that don’t use
     /// quotas are usually temporary internal resources created to perform an
@@ -136,7 +136,7 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("all_tenans", self.all_tenans);
+        params.push_opt("all_tenants", self.all_tenants);
         params.push_opt("sort", self.sort.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());

--- a/openstack_sdk/src/api/block_storage/v3/volume/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// Shows details for all project. Admin only.
     ///
     #[builder(default)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Filters results by consumes_quota field. Resources that don’t use
     /// quotas are usually temporary internal resources created to perform an
@@ -148,7 +148,7 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("all_tenans", self.all_tenans);
+        params.push_opt("all_tenants", self.all_tenants);
         params.push_opt("sort", self.sort.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());

--- a/openstack_sdk/src/api/block_storage/v3/volume/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/list_detailed.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// Shows details for all project. Admin only.
     ///
     #[builder(default)]
-    all_tenans: Option<bool>,
+    all_tenants: Option<bool>,
 
     /// Filters results by consumes_quota field. Resources that don’t use
     /// quotas are usually temporary internal resources created to perform an
@@ -148,7 +148,7 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("all_tenans", self.all_tenans);
+        params.push_opt("all_tenants", self.all_tenants);
         params.push_opt("sort", self.sort.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());


### PR DESCRIPTION
Fix QP name for listing volumes

There is a typo in a parameter name `all_tenans` where `all_tenants` should be.
Also set that limit can not be negative.

Change-Id: I11c53ad33911a9b95c419f94c5e406a3b6347226

Changes are triggered by https://review.opendev.org/926823