### PR TITLE
chore(ci): Fix release-plz action

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -54,4 +54,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
-          package: ${{ matrix.package }}/Cargo.toml
+          manifest_path: ${{ matrix.package }}/Cargo.toml


### PR DESCRIPTION
Wrong action parameter has being used in the release-plz action (package
instead of manifest_path)
