### PR TITLE
chore(ci): Undo release-plz per package

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,13 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    strategy:
-      matrix:
-        include:
-          - package: openstack_sdk
-          - package: openstack_cli
-          - package: openstack_tui
-          - package: structable_derive
 
     steps:
       - name: Harden Runner
@@ -53,5 +46,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          manifest_path: ${{ matrix.package }}/Cargo.toml

--- a/openstack_tui/Cargo.toml
+++ b/openstack_tui/Cargo.toml
@@ -32,7 +32,7 @@ itertools = { workspace = true }
 json5 = "^0.4"
 lazy_static = "^1.5"
 #log = "^0.4"
-openstack_sdk = { path = "../openstack_sdk", version = "^0.9" }
+openstack_sdk = { path = "../openstack_sdk", version = "^0.9", default-features = false, features = ["async", "identity"] }
 pretty_assertions = "^1.4"
 ratatui = { version = "^0.28", features = ["serde", "macros"] }
 serde = { workspace = true  }


### PR DESCRIPTION
Apparently release-plz does not really support one PR per package of a
workspace.
