### PR TITLE
fix: Correct CI for openstack_tui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - '.github/workflows/ci.yml'
       - 'openstack_cli/**'
       - 'openstack_sdk/**'
+      - 'openstack_tui/**'
       - 'structable_derive/**'
       - 'fuzz/**'
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -15,6 +15,7 @@ on:
       - '.github/workflows/linters.yml'
       - 'openstack_cli/**'
       - 'openstack_sdk/**'
+      - 'openstack_tui/**'
       - 'structable_derive/**'
       - 'fuzz/**'
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
   "fuzz"
 ]
 exclude = ["fuzz"]
-default-members = ["openstack_cli", "openstack_sdk"]
+default-members = ["openstack_cli", "openstack_sdk", "openstack_tui"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY Cargo.toml Cargo.lock /usr/src/openstack/
 COPY openstack_sdk/Cargo.toml /usr/src/openstack/openstack_sdk/
 COPY openstack_cli/Cargo.toml /usr/src/openstack/openstack_cli/
 COPY openstack_tui/Cargo.toml /usr/src/openstack/openstack_tui/
+COPY openstack_tui/build.rs /usr/src/openstack/openstack_tui/
 COPY structable_derive/Cargo.toml /usr/src/openstack/structable_derive/
 COPY xtask/Cargo.toml /usr/src/openstack/xtask/
 COPY fuzz/Cargo.toml /usr/src/openstack/fuzz/
@@ -35,7 +36,7 @@ RUN rm -rf src
 RUN rustup target add x86_64-unknown-linux-musl
 
 ## This is a dummy build to get the dependencies cached.
-RUN cargo build --target x86_64-unknown-linux-musl --release
+RUN cargo build --target x86_64-unknown-linux-musl --release -p openstack_cli
 
 # Now copy in the rest of the sources
 COPY . /usr/src/openstack/
@@ -44,7 +45,7 @@ COPY . /usr/src/openstack/
 RUN touch openstack_sdk/src/lib.rs && touch openstack_cli/src/bin/osc.rs && touch openstack_cli/src/lib.rs && touch structable_derive/src/lib.rs
 
 # This is the actual application build.
-RUN cargo build --target x86_64-unknown-linux-musl --release
+RUN cargo build --target x86_64-unknown-linux-musl --release -p openstack_cli
 
 ################
 ##### Runtime

--- a/openstack_tui/Cargo.toml
+++ b/openstack_tui/Cargo.toml
@@ -32,7 +32,7 @@ itertools = { workspace = true }
 json5 = "^0.4"
 lazy_static = "^1.5"
 #log = "^0.4"
-openstack_sdk = { path = "../openstack_sdk", version = "^0.10", default-features = false, features = ["async", "identity"] }
+openstack_sdk = { path = "../openstack_sdk", version = "^0.10", default-features = false, features = ["async", "block_storage", "compute", "identity", "network"] }
 pretty_assertions = "^1.4"
 ratatui = { version = "^0.28", features = ["serde", "macros"] }
 serde = { workspace = true  }


### PR DESCRIPTION
- Code is using more features than declared in the Cargo.toml
- CI jobs are not triggered on openstack_tui project changes
- openstack_tui is not included in default workspace members resulting
  in being skipped in the tests
- fix docker build