### PR TITLE
feat(sdk): Add find_by_name method

### DIFF
--- a/openstack_sdk/src/api.rs
+++ b/openstack_sdk/src/api.rs
@@ -75,7 +75,7 @@ pub use self::paged::Paged;
 pub use self::paged::Pagination;
 pub use self::paged::PaginationError;
 
-pub use self::find::find;
+pub use self::find::{find, find_by_name};
 
 pub use self::params::JsonBodyParams;
 pub use self::params::ParamValue;


### PR DESCRIPTION
It may be desired to find resource by name explicitly rather then guess
whether identifier is id or name in order to save API roundtrip known
not to return data. This is going to be used in the cli to allow
different handling of the path parameters allowing user to explicitly
specify whether the input is name or id.
