### PR TITLE
feat: Add resource link in path parameters

### DIFF
--- a/doc/src/osc.md
+++ b/doc/src/osc.md
@@ -9615,13 +9615,17 @@ Unassigns a role from a user on a domain.
 
 Relationship: `https://docs.openstack.org/api/openstack-identity/3/rel/domain_user_role`
 
-**Usage:** `osc identity domain user role delete <DOMAIN_ID> <USER_ID> <ID>`
+**Usage:** `osc identity domain user role delete <--user-name <USER_NAME>|--user-id <USER_ID>> <DOMAIN_ID> <ID>`
 
 ###### **Arguments:**
 
 * `<DOMAIN_ID>` — domain_id parameter for /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-* `<USER_ID>` — user_id parameter for /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
 * `<ID>` — role_id parameter for /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -9631,12 +9635,16 @@ Lists role assignments for a user on a domain.
 
 Relationship: `https://docs.openstack.org/api/openstack-identity/3/rel/domain_user_roles`
 
-**Usage:** `osc identity domain user role list <DOMAIN_ID> <USER_ID>`
+**Usage:** `osc identity domain user role list <--user-name <USER_NAME>|--user-id <USER_ID>> <DOMAIN_ID>`
 
 ###### **Arguments:**
 
 * `<DOMAIN_ID>` — domain_id parameter for /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-* `<USER_ID>` — user_id parameter for /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -9646,13 +9654,17 @@ Assigns a role to a user on a domain.
 
 Relationship: `https://developer.openstack.org/api-ref/identity/v3/index.html#assign-role-to-user-on-domain`
 
-**Usage:** `osc identity domain user role set <DOMAIN_ID> <USER_ID> <ID>`
+**Usage:** `osc identity domain user role set <--user-name <USER_NAME>|--user-id <USER_ID>> <DOMAIN_ID> <ID>`
 
 ###### **Arguments:**
 
 * `<DOMAIN_ID>` — domain_id parameter for /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-* `<USER_ID>` — user_id parameter for /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
 * `<ID>` — role_id parameter for /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -9662,13 +9674,17 @@ Check if a user has a specific role on the domain.
 
 GET/HEAD /v3/domains/{domain_id}/users/{user_id}/roles/{role_id}
 
-**Usage:** `osc identity domain user role show <DOMAIN_ID> <USER_ID> <ID>`
+**Usage:** `osc identity domain user role show <--user-name <USER_NAME>|--user-id <USER_ID>> <DOMAIN_ID> <ID>`
 
 ###### **Arguments:**
 
 * `<DOMAIN_ID>` — domain_id parameter for /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-* `<USER_ID>` — user_id parameter for /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
 * `<ID>` — role_id parameter for /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -10600,13 +10616,17 @@ Unassigns a role from a user on a project.
 
 Relationship: `https://docs.openstack.org/api/openstack-identity/3/rel/project_user_role`
 
-**Usage:** `osc identity project user role delete <PROJECT_ID> <USER_ID> <ID>`
+**Usage:** `osc identity project user role delete <--user-name <USER_NAME>|--user-id <USER_ID>> <PROJECT_ID> <ID>`
 
 ###### **Arguments:**
 
 * `<PROJECT_ID>` — project_id parameter for /v3/projects/{project_id}/groups/{group_id}/roles API
-* `<USER_ID>` — user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles API
 * `<ID>` — role_id parameter for /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -10616,12 +10636,16 @@ Lists role assignments for a user on a project.
 
 Relationship: `https://docs.openstack.org/api/openstack-identity/3/rel/project_user_role`
 
-**Usage:** `osc identity project user role list <PROJECT_ID> <USER_ID>`
+**Usage:** `osc identity project user role list <--user-name <USER_NAME>|--user-id <USER_ID>> <PROJECT_ID>`
 
 ###### **Arguments:**
 
 * `<PROJECT_ID>` — project_id parameter for /v3/projects/{project_id}/groups/{group_id}/roles API
-* `<USER_ID>` — user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -10631,13 +10655,17 @@ Assigns a role to a user on a project.
 
 Relationship: `https://docs.openstack.org/api/openstack-identity/3/rel/project_user_role`
 
-**Usage:** `osc identity project user role set <PROJECT_ID> <USER_ID> <ID>`
+**Usage:** `osc identity project user role set <--user-name <USER_NAME>|--user-id <USER_ID>> <PROJECT_ID> <ID>`
 
 ###### **Arguments:**
 
 * `<PROJECT_ID>` — project_id parameter for /v3/projects/{project_id}/groups/{group_id}/roles API
-* `<USER_ID>` — user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles API
 * `<ID>` — role_id parameter for /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -10647,13 +10675,17 @@ Check grant for project, user, role.
 
 GET/HEAD /v3/projects/{project_id/users/{user_id}/roles/{role_id}
 
-**Usage:** `osc identity project user role show <PROJECT_ID> <USER_ID> <ID>`
+**Usage:** `osc identity project user role show <--user-name <USER_NAME>|--user-id <USER_ID>> <PROJECT_ID> <ID>`
 
 ###### **Arguments:**
 
 * `<PROJECT_ID>` — project_id parameter for /v3/projects/{project_id}/groups/{group_id}/roles API
-* `<USER_ID>` — user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles API
 * `<ID>` — role_id parameter for /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
+
+###### **Options:**
+
+* `--user-name <USER_NAME>` — User Name
+* `--user-id <USER_ID>` — User ID
 
 
 
@@ -16292,10 +16324,6 @@ Error response codes: 400, 401, 403, 404
 * `--fixed-ips <JSON>` — The IP addresses for the port. If you would like to assign multiple IP addresses for the port, specify multiple entries in this field. Each entry consists of IP address (`ip_address`) and the subnet ID from which the IP address is assigned (`subnet_id`).
 
    - If you specify both a subnet ID and an IP address, OpenStack Networking tries to allocate the IP address on that subnet to the port. - If you specify only a subnet ID, OpenStack Networking allocates an available IP from that subnet to the port. - If you specify only an IP address, OpenStack Networking tries to allocate the IP address if the address is a valid IP for any of the subnets on the specified network.
-* `--hardware-offload-type <HARDWARE_OFFLOAD_TYPE>`
-
-  Possible values: `switchdev`
-
 * `--hints <key=value>` — Admin-only. A dict, at the top level keyed by mechanism driver aliases (as defined in setup.cfg). To following values can be used to control Open vSwitch’s Userspace Tx packet steering feature:
 
    - `{"openvswitch": {"other_config": {"tx-steering": "hash"}}}` - `{"openvswitch": {"other_config": {"tx-steering": "thread"}}}`

--- a/openstack_cli/src/identity/v3/domain/user/role/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::user::role::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Unassigns a role from a user on a domain.
 ///
@@ -71,15 +75,9 @@ struct PathParameters {
     )]
     domain_id: String,
 
-    /// user_id parameter for
-    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
@@ -90,6 +88,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -111,7 +121,40 @@ impl RoleCommand {
 
         // Set path parameters
         ep_builder.domain_id(&self.path.domain_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/list.rs
@@ -31,9 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::user::role::list;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists role assignments for a user on a domain.
 ///
@@ -69,15 +72,21 @@ struct PathParameters {
     )]
     domain_id: String,
 
-    /// user_id parameter for
-    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Roles response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -117,7 +126,40 @@ impl RolesCommand {
 
         // Set path parameters
         ep_builder.domain_id(&self.path.domain_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/domain/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/set.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::user::role::set;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Assigns a role to a user on a domain.
 ///
@@ -71,15 +75,9 @@ struct PathParameters {
     )]
     domain_id: String,
 
-    /// user_id parameter for
-    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
@@ -90,6 +88,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -111,7 +121,40 @@ impl RoleCommand {
 
         // Set path parameters
         ep_builder.domain_id(&self.path.domain_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/show.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::user::role::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Check if a user has a specific role on the domain.
 ///
@@ -69,15 +73,9 @@ struct PathParameters {
     )]
     domain_id: String,
 
-    /// user_id parameter for
-    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
@@ -88,6 +86,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -109,7 +119,40 @@ impl RoleCommand {
 
         // Set path parameters
         ep_builder.domain_id(&self.path.domain_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/group/user/delete.rs
+++ b/openstack_cli/src/identity/v3/group/user/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::group::user::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Removes a user from a group.
 ///
@@ -70,14 +74,21 @@ struct PathParameters {
     )]
     group_id: String,
 
-    /// user_id parameter for /v3/groups/{group_id}/users/{user_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_id",
-        value_name = "ID"
-    )]
-    id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// User response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -99,7 +110,40 @@ impl UserCommand {
 
         // Set path parameters
         ep_builder.group_id(&self.path.group_id);
-        ep_builder.id(&self.path.id);
+
+        // Process path parameter `id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/group/user/set.rs
+++ b/openstack_cli/src/identity/v3/group/user/set.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::group::user::set;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Adds a user to a group.
 ///
@@ -70,14 +74,21 @@ struct PathParameters {
     )]
     group_id: String,
 
-    /// user_id parameter for /v3/groups/{group_id}/users/{user_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_id",
-        value_name = "ID"
-    )]
-    id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// User response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -99,7 +110,40 @@ impl UserCommand {
 
         // Set path parameters
         ep_builder.group_id(&self.path.group_id);
-        ep_builder.id(&self.path.id);
+
+        // Process path parameter `id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/group/user/show.rs
+++ b/openstack_cli/src/identity/v3/group/user/show.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::group::user::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Check if a user is in a group.
 ///
@@ -68,14 +72,21 @@ struct PathParameters {
     )]
     group_id: String,
 
-    /// user_id parameter for /v3/groups/{group_id}/users/{user_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_id",
-        value_name = "ID"
-    )]
-    id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// User response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -97,7 +108,40 @@ impl UserCommand {
 
         // Set path parameters
         ep_builder.group_id(&self.path.group_id);
-        ep_builder.id(&self.path.id);
+
+        // Process path parameter `id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_inherit::domain::user::role::inherited_to_project::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Revokes an inherited project role from a user in a domain.
 ///
@@ -72,16 +76,9 @@ struct PathParameters {
     )]
     domain_id: String,
 
-    /// user_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
@@ -93,6 +90,18 @@ struct PathParameters {
         value_name = "ROLE_ID"
     )]
     role_id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// InheritedToProject response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -114,7 +123,40 @@ impl InheritedToProjectCommand {
 
         // Set path parameters
         ep_builder.domain_id(&self.path.domain_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.role_id(&self.path.role_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/get.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_inherit::domain::user::role::inherited_to_project::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// The list only contains those role assignments to the domain that were
 /// specified as being inherited to projects within that domain.
@@ -72,16 +75,21 @@ struct PathParameters {
     )]
     domain_id: String,
 
-    /// user_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -117,7 +125,40 @@ impl InheritedToProjectCommand {
 
         // Set path parameters
         ep_builder.domain_id(&self.path.domain_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_inherit::project::user::role::inherited_to_project::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Relationship:
 /// `https://docs.openstack.org/api/openstack-identity/3/ext/OS-INHERIT/1.0/rel/project_user_role_inherited_to_projects`
@@ -70,16 +74,9 @@ struct PathParameters {
     )]
     project_id: String,
 
-    /// user_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
@@ -91,6 +88,18 @@ struct PathParameters {
         value_name = "ROLE_ID"
     )]
     role_id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// InheritedToProject response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -112,7 +121,40 @@ impl InheritedToProjectCommand {
 
         // Set path parameters
         ep_builder.project_id(&self.path.project_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.role_id(&self.path.role_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/get.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_inherit::project::user::role::inherited_to_project::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Check for an inherited grant for a user on a project.
 ///
@@ -70,16 +73,9 @@ struct PathParameters {
     )]
     project_id: String,
 
-    /// user_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
@@ -91,6 +87,18 @@ struct PathParameters {
         value_name = "ROLE_ID"
     )]
     role_id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -126,7 +134,40 @@ impl InheritedToProjectCommand {
 
         // Set path parameters
         ep_builder.project_id(&self.path.project_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.role_id(&self.path.role_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
@@ -33,10 +33,13 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_inherit::project::user::role::inherited_to_project::inherited_to_projects;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Request of the
 /// OS-INHERIT/projects/project_id/users/user_id/roles/role_id/inherited_to_projects:put
@@ -76,16 +79,9 @@ struct PathParameters {
     )]
     project_id: String,
 
-    /// user_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
@@ -97,6 +93,18 @@ struct PathParameters {
         value_name = "ROLE_ID"
     )]
     role_id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -132,7 +140,40 @@ impl InheritedToProjectCommand {
 
         // Set path parameters
         ep_builder.project_id(&self.path.project_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.role_id(&self.path.role_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/project/user/role/delete.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::user::role::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Unassigns a role from a user on a project.
 ///
@@ -71,15 +75,9 @@ struct PathParameters {
     )]
     project_id: String,
 
-    /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
@@ -90,6 +88,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -111,7 +121,40 @@ impl RoleCommand {
 
         // Set path parameters
         ep_builder.project_id(&self.path.project_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/project/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/list.rs
@@ -31,9 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::user::role::list;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists role assignments for a user on a project.
 ///
@@ -69,15 +72,21 @@ struct PathParameters {
     )]
     project_id: String,
 
-    /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Roles response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -117,7 +126,40 @@ impl RolesCommand {
 
         // Set path parameters
         ep_builder.project_id(&self.path.project_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/project/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/set.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::user::role::set;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Assigns a role to a user on a project.
 ///
@@ -71,15 +75,9 @@ struct PathParameters {
     )]
     project_id: String,
 
-    /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
@@ -90,6 +88,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -111,7 +121,40 @@ impl RoleCommand {
 
         // Set path parameters
         ep_builder.project_id(&self.path.project_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/project/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/show.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::user::role::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Check grant for project, user, role.
 ///
@@ -69,15 +73,9 @@ struct PathParameters {
     )]
     project_id: String,
 
-    /// user_id parameter for /v3/projects/{project_id}/users/{user_id}/roles
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for
     /// /v3/projects/{project_id}/users/{user_id}/roles/{role_id} API
@@ -88,6 +86,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -109,7 +119,40 @@ impl RoleCommand {
 
         // Set path parameters
         ep_builder.project_id(&self.path.project_id);
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/system/user/role/delete.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::system::user::role::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Remove a system role assignment from a user.
 ///
@@ -61,14 +65,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/system/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for /v3/system/users/{user_id}/roles/{role_id} API
     ///
@@ -78,6 +77,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -98,7 +109,40 @@ impl RoleCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/system/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/list.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::system::user::role::list;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Lists all system role assignment a user has.
 ///
@@ -60,14 +63,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/system/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -102,7 +112,40 @@ impl RolesCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/system/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/set.rs
@@ -33,10 +33,13 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::system::user::role::set;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Grant a user a role on the system.
 ///
@@ -66,14 +69,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/system/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for /v3/system/users/{user_id}/roles/{role_id} API
     ///
@@ -83,6 +81,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -117,7 +127,40 @@ impl RoleCommand {
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/system/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/show.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::system::user::role::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Get a specific system role assignment for a user. This is the same API as
 /// `HEAD /v3/system/users/{user_id}/roles/{role_id}`.
@@ -61,14 +64,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/system/users/{user_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// role_id parameter for /v3/system/users/{user_id}/roles/{role_id} API
     ///
@@ -78,6 +76,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -112,7 +122,40 @@ impl RoleCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/network/v2/port/create.rs
+++ b/openstack_cli/src/network/v2/port/create.rs
@@ -75,11 +75,6 @@ struct QueryParameters {}
 struct PathParameters {}
 
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
-enum HardwareOffloadType {
-    Switchdev,
-}
-
-#[derive(Clone, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
 enum NumaAffinityPolicy {
     Legacy,
     Preferred,
@@ -212,9 +207,6 @@ struct Port {
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     fixed_ips: Option<Vec<Value>>,
-
-    #[arg(help_heading = "Body parameters", long)]
-    hardware_offload_type: Option<HardwareOffloadType>,
 
     /// Admin-only. A dict, at the top level keyed by mechanism driver aliases
     /// (as defined in setup.cfg). To following values can be used to control
@@ -431,10 +423,6 @@ struct ResponseData {
     #[structable(optional, pretty)]
     fixed_ips: Option<Value>,
 
-    #[serde()]
-    #[structable(optional)]
-    hardware_offload_type: Option<String>,
-
     /// Admin-only. The following values control Open vSwitch’s Userspace Tx
     /// packet steering feature:
     ///
@@ -649,13 +637,6 @@ impl PortCommand {
 
         if let Some(val) = &args.device_profile {
             port_builder.device_profile(Some(val.into()));
-        }
-
-        if let Some(val) = &args.hardware_offload_type {
-            let tmp = match val {
-                HardwareOffloadType::Switchdev => create::HardwareOffloadType::Switchdev,
-            };
-            port_builder.hardware_offload_type(tmp);
         }
 
         if let Some(val) = &args.hints {

--- a/openstack_cli/src/network/v2/port/list.rs
+++ b/openstack_cli/src/network/v2/port/list.rs
@@ -362,10 +362,6 @@ struct ResponseData {
     #[structable(optional, pretty, wide)]
     fixed_ips: Option<Value>,
 
-    #[serde()]
-    #[structable(optional, wide)]
-    hardware_offload_type: Option<String>,
-
     /// Admin-only. The following values control Open vSwitch’s Userspace Tx
     /// packet steering feature:
     ///

--- a/openstack_cli/src/network/v2/port/set.rs
+++ b/openstack_cli/src/network/v2/port/set.rs
@@ -446,10 +446,6 @@ struct ResponseData {
     #[structable(optional, pretty)]
     fixed_ips: Option<Value>,
 
-    #[serde()]
-    #[structable(optional)]
-    hardware_offload_type: Option<String>,
-
     /// Admin-only. The following values control Open vSwitch’s Userspace Tx
     /// packet steering feature:
     ///

--- a/openstack_cli/src/network/v2/port/show.rs
+++ b/openstack_cli/src/network/v2/port/show.rs
@@ -221,10 +221,6 @@ struct ResponseData {
     #[structable(optional, pretty)]
     fixed_ips: Option<Value>,
 
-    #[serde()]
-    #[structable(optional)]
-    hardware_offload_type: Option<String>,
-
     /// Admin-only. The following values control Open vSwitch’s Userspace Tx
     /// packet steering feature:
     ///

--- a/openstack_sdk/src/api/network/v2/port/create.rs
+++ b/openstack_sdk/src/api/network/v2/port/create.rs
@@ -64,12 +64,6 @@ pub struct AllowedAddressPairs<'a> {
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
-pub enum HardwareOffloadType {
-    #[serde(rename = "switchdev")]
-    Switchdev,
-}
-
-#[derive(Debug, Deserialize, Clone, Serialize)]
 pub enum NumaAffinityPolicy {
     #[serde(rename = "legacy")]
     Legacy,
@@ -232,10 +226,6 @@ pub struct Port<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) fixed_ips: Option<Vec<FixedIps<'a>>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default)]
-    pub(crate) hardware_offload_type: Option<HardwareOffloadType>,
 
     /// Admin-only. A dict, at the top level keyed by mechanism driver aliases
     /// (as defined in setup.cfg). To following values can be used to control


### PR DESCRIPTION
When path_parameter contain something like `user_id` it is more
efficient (and provides a UX with more control) to accept
`user-id|user-name` from the user. This is achieved by introducing
resource links in the path parameters. When link is present parameter is
being processed differently.

Modify Keystone schema generation to insert link to the user everywhere
where `user_id` path parameter is present.

Change-Id: I8bf3d14dc751bdb97111a63dddfd0b604cf06abc

Changes are triggered by https://review.opendev.org/927746
