### PR TITLE
feat: Add resource link to domain_id path parameter

### DIFF
--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::os_inherit::domain::group::role::inherited_to_project::delete;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Revokes an inherited project role from a group in a domain.
 ///
@@ -61,16 +65,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// group_id parameter for
     /// /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
@@ -94,6 +91,18 @@ struct PathParameters {
     )]
     role_id: String,
 }
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
+}
 /// InheritedToProject response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {}
@@ -113,7 +122,40 @@ impl InheritedToProjectCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // domain_name is passed. Need to lookup resource
+            let mut find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.role_id(&self.path.role_id);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::os_inherit::domain::group::role::inherited_to_project::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// The list only contains those role assignments to the domain that were
 /// specified as being inherited to projects within that domain.
@@ -61,16 +64,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// group_id parameter for
     /// /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
@@ -82,6 +78,18 @@ struct PathParameters {
         value_name = "GROUP_ID"
     )]
     group_id: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -116,7 +124,40 @@ impl InheritedToProjectCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // domain_name is passed. Need to lookup resource
+            let mut find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group_id(&self.path.group_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
@@ -33,10 +33,13 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::os_inherit::domain::group::role::inherited_to_project::inherited_to_projects;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Request of the
 /// OS-INHERIT/domains/domain_id/groups/group_id/roles/role_id/inherited_to_projects:put
@@ -65,16 +68,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// group_id parameter for
     /// /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
@@ -97,6 +93,18 @@ struct PathParameters {
         value_name = "ROLE_ID"
     )]
     role_id: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -131,7 +139,40 @@ impl InheritedToProjectCommand {
         let mut ep_builder = inherited_to_projects::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // domain_name is passed. Need to lookup resource
+            let mut find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.role_id(&self.path.role_id);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use bytes::Bytes;
 use http::Response;
 use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::os_inherit::domain::user::role::inherited_to_project::delete;
 use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
@@ -65,16 +66,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// User resource for which the operation should be performed.
     #[command(flatten)]
@@ -90,6 +84,18 @@ struct PathParameters {
         value_name = "ROLE_ID"
     )]
     role_id: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 
 /// User input select group
@@ -122,7 +128,40 @@ impl InheritedToProjectCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // domain_name is passed. Need to lookup resource
+            let mut find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
 
         // Process path parameter `user_id`
         if let Some(id) = &self.path.user.user_id {

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use crate::common::parse_json;
 use crate::common::parse_key_val;
 use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::os_inherit::domain::user::role::inherited_to_project::inherited_to_projects;
 use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
@@ -68,16 +69,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// User resource for which the operation should be performed.
     #[command(flatten)]
@@ -93,6 +87,18 @@ struct PathParameters {
         value_name = "ROLE_ID"
     )]
     role_id: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 
 /// User input select group
@@ -139,7 +145,40 @@ impl InheritedToProjectCommand {
         let mut ep_builder = inherited_to_projects::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // domain_name is passed. Need to lookup resource
+            let mut find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            find_builder.id(name);
+            let find_ep = find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
 
         // Process path parameter `user_id`
         if let Some(id) = &self.path.user.user_id {


### PR DESCRIPTION
Same way as for user we add resource link to the domain_id path
parameter allowing cli user to use `--domain-id|--domain-name`.

Change-Id: Ibf220ff2b3cd11d639b6b1c5fdff66da6fa80972

Changes are triggered by https://review.opendev.org/927860
