### PR TITLE
feat(tui): Add scrolling in the resource describe

### DIFF
--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -87,6 +87,7 @@ impl<'a> Component for ComputeFlavors<'a> {
             KeyCode::End => self.cursor_last()?,
             KeyCode::PageUp => self.cursor_page_up()?,
             KeyCode::PageDown => self.cursor_page_down()?,
+            KeyCode::Tab => self.key_tab()?,
             _ => {}
         }
         if key.kind == KeyEventKind::Press && key.code == KeyCode::Enter {

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -84,6 +84,7 @@ impl<'a> Component for ComputeServers<'a> {
             KeyCode::End => self.cursor_last()?,
             KeyCode::PageUp => self.cursor_page_up()?,
             KeyCode::PageDown => self.cursor_page_down()?,
+            KeyCode::Tab => self.key_tab()?,
             _ => {}
         }
         if key.kind == KeyEventKind::Press && key.code == KeyCode::Enter {

--- a/openstack_tui/src/components/image/images.rs
+++ b/openstack_tui/src/components/image/images.rs
@@ -100,6 +100,7 @@ impl<'a> Component for Images<'a> {
             KeyCode::End => self.cursor_last()?,
             KeyCode::PageUp => self.cursor_page_up()?,
             KeyCode::PageDown => self.cursor_page_down()?,
+            KeyCode::Tab => self.key_tab()?,
             _ => {}
         }
         Ok(None)

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -90,6 +90,7 @@ impl<'a> Component for NetworkNetworks<'a> {
             KeyCode::End => self.cursor_last()?,
             KeyCode::PageUp => self.cursor_page_up()?,
             KeyCode::PageDown => self.cursor_page_down()?,
+            KeyCode::Tab => self.key_tab()?,
             KeyCode::Enter => {
                 if let Some(command_tx) = self.get_command_tx() {
                     command_tx.send(Action::NetworkSubnetFilter(NetworkSubnetFilters {

--- a/openstack_tui/src/components/network/subnets.rs
+++ b/openstack_tui/src/components/network/subnets.rs
@@ -91,6 +91,7 @@ impl<'a> Component for NetworkSubnets<'a> {
             KeyCode::End => self.cursor_last()?,
             KeyCode::PageUp => self.cursor_page_up()?,
             KeyCode::PageDown => self.cursor_page_down()?,
+            KeyCode::Tab => self.key_tab()?,
             KeyCode::Char('0') => {
                 return Ok(Some(Action::NetworkSubnetFilter(NetworkSubnetFilters {
                     network_id: None,


### PR DESCRIPTION
Some resources have lot of content in the describe view and native
desire is to scoll it as well.
- Add <TAB> key to jump between table and the describe
- Use gray color for describe when not "active"
- Add vertical scrolling in the describe
