### PR TITLE
feat(cli): Interactive cloud connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
+ "fuzzy-matcher",
  "shell-words",
  "tempfile",
  "thiserror",
@@ -1158,6 +1159,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -47,7 +47,7 @@ clap = { workspace = true, features = ["color", "derive", "env"] }
 clap_complete = { workspace = true }
 cli-table = "^0.4"
 color-eyre = { workspace = true }
-dialoguer = {workspace = true}
+dialoguer = { workspace = true, features=["fuzzy-select"] }
 eyre = { version = "^0.6" }
 http = { workspace = true }
 human-panic = { workspace = true }

--- a/openstack_cli/src/error.rs
+++ b/openstack_cli/src/error.rs
@@ -147,6 +147,14 @@ pub enum OpenStackCliError {
         source: http::header::InvalidHeaderValue,
     },
 
+    /// User interaction using dialoguer crate failed
+    #[error("dialoguer error `{}`", source)]
+    DialoguerError {
+        /// The source of the error.
+        #[from]
+        source: dialoguer::Error,
+    },
+
     /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),

--- a/openstack_sdk/src/config.rs
+++ b/openstack_sdk/src/config.rs
@@ -385,9 +385,12 @@ impl ConfigFile {
     ///
     /// This method does not raise the exception when the cloud is
     /// not found.
-    pub fn get_cloud_config(&self, cloud_name: String) -> Result<Option<CloudConfig>, ConfigError> {
+    pub fn get_cloud_config<S: AsRef<str>>(
+        &self,
+        cloud_name: S,
+    ) -> Result<Option<CloudConfig>, ConfigError> {
         if let Some(clouds) = &self.clouds {
-            if let Some(cfg) = clouds.get(&cloud_name) {
+            if let Some(cfg) = clouds.get(cloud_name.as_ref()) {
                 let mut config = cfg.clone();
                 if let Some(ref profile_name) = config.profile {
                     let mut profile_definition: Option<&CloudConfig> = None;


### PR DESCRIPTION
When user has not specified `--os-cloud` param but the cli is running in
an interactive mode we can invoke dialoguer to offer user configured
clouds to select (similarly how it is done in the tui).
