### PR TITLE
feat: Use all resource names for path param naming

### DIFF
--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use crate::common::parse_json;
 use bytes::Bytes;
 use clap::ValueEnum;
+use dialoguer::Password;
 use http::Response;
 use openstack_sdk::api::identity::v3::auth::os_federation::saml2::create;
 use openstack_sdk::api::RawQueryAsync;

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use crate::common::parse_json;
 use bytes::Bytes;
 use clap::ValueEnum;
+use dialoguer::Password;
 use http::Response;
 use openstack_sdk::api::identity::v3::auth::os_federation::saml2::ecp::create;
 use openstack_sdk::api::RawQueryAsync;

--- a/openstack_cli/src/identity/v3/auth/token/create.rs
+++ b/openstack_cli/src/identity/v3/auth/token/create.rs
@@ -33,6 +33,7 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use clap::ValueEnum;
+use dialoguer::Password;
 use openstack_sdk::api::identity::v3::auth::token::create;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;

--- a/openstack_cli/src/identity/v3/domain/config/delete_all.rs
+++ b/openstack_cli/src/identity/v3/domain/config/delete_all.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::delete_all;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Deletes a domain configuration.
 ///
@@ -61,15 +65,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Config response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -90,7 +100,40 @@ impl ConfigCommand {
         let mut ep_builder = delete_all::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/domain/config/group/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::delete;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Deletes a domain group configuration.
 ///
@@ -63,17 +67,11 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -81,6 +79,18 @@ struct PathParameters {
         value_name = "GROUP"
     )]
     group: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Group response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -101,7 +111,40 @@ impl GroupCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group(&self.path.group);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/config/group/option/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/option/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::option::delete;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Deletes a domain group option configuration.
 ///
@@ -65,17 +69,11 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -84,7 +82,8 @@ struct PathParameters {
     )]
     group: String,
 
-    /// option parameter for /v3/domains/config/{group}/{option}/default API
+    /// option parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -92,6 +91,18 @@ struct PathParameters {
         value_name = "OPTION"
     )]
     option: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Option response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -112,7 +123,40 @@ impl OptionCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group(&self.path.group);
         ep_builder.option(&self.path.option);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/config/group/option/set.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/option/set.rs
@@ -32,10 +32,13 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::option::set;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Updates a domain group option configuration.
 ///
@@ -70,17 +73,11 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -89,7 +86,8 @@ struct PathParameters {
     )]
     group: String,
 
-    /// option parameter for /v3/domains/config/{group}/{option}/default API
+    /// option parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -97,6 +95,18 @@ struct PathParameters {
         value_name = "OPTION"
     )]
     option: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -131,7 +141,40 @@ impl OptionCommand {
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group(&self.path.group);
         ep_builder.option(&self.path.option);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/config/group/option/show.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/option/show.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::option::get;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Shows details for a domain group option configuration.
 ///
@@ -64,17 +67,11 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -83,7 +80,8 @@ struct PathParameters {
     )]
     group: String,
 
-    /// option parameter for /v3/domains/config/{group}/{option}/default API
+    /// option parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -91,6 +89,18 @@ struct PathParameters {
         value_name = "OPTION"
     )]
     option: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -125,7 +135,40 @@ impl OptionCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group(&self.path.group);
         ep_builder.option(&self.path.option);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/config/group/set.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/set.rs
@@ -33,11 +33,14 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use eyre::WrapErr;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::set;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Updates a domain group configuration.
 ///
@@ -72,17 +75,11 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -90,6 +87,18 @@ struct PathParameters {
         value_name = "GROUP"
     )]
     group: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -124,7 +133,40 @@ impl GroupCommand {
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group(&self.path.group);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/config/group/show.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/show.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::get;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Shows details for a domain group configuration.
 ///
@@ -62,17 +65,11 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -80,6 +77,18 @@ struct PathParameters {
         value_name = "GROUP"
     )]
     group: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -114,7 +123,40 @@ impl GroupCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group(&self.path.group);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/config/list.rs
+++ b/openstack_cli/src/identity/v3/domain/config/list.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::list;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Shows details for a domain configuration.
 ///
@@ -60,15 +63,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -103,7 +112,40 @@ impl ConfigsCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/domain/config/replace.rs
+++ b/openstack_cli/src/identity/v3/domain/config/replace.rs
@@ -33,11 +33,14 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use eyre::WrapErr;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::replace;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Creates a domain configuration.
 ///
@@ -68,15 +71,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -111,7 +120,40 @@ impl ConfigCommand {
         let mut ep_builder = replace::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
         // Set Request.config data

--- a/openstack_cli/src/identity/v3/domain/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/delete.rs
@@ -69,8 +69,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/domain/group/role/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::group::role::delete;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Unassigns a role from a group on a domain.
 ///
@@ -61,15 +65,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// group_id parameter for
     /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
@@ -91,6 +89,18 @@ struct PathParameters {
     )]
     id: String,
 }
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
+}
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {}
@@ -110,7 +120,40 @@ impl RoleCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.id(&self.path.id);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/group/role/list.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/list.rs
@@ -31,9 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::group::role::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists role assignments for a group on a domain.
 ///
@@ -59,15 +62,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// group_id parameter for
     /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
@@ -78,6 +75,18 @@ struct PathParameters {
         value_name = "GROUP_ID"
     )]
     group_id: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 /// Roles response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -116,7 +125,40 @@ impl RolesCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group_id(&self.path.group_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/group/role/set.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/set.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::group::role::set;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Assigns a role to a group on a domain.
 ///
@@ -61,15 +65,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// group_id parameter for
     /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
@@ -91,6 +89,18 @@ struct PathParameters {
     )]
     id: String,
 }
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
+}
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {}
@@ -110,7 +120,40 @@ impl RoleCommand {
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.id(&self.path.id);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/group/role/show.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/show.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::group::role::get;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Check if a group has a specific role on a domain.
 ///
@@ -59,15 +63,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// group_id parameter for
     /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
@@ -89,6 +87,18 @@ struct PathParameters {
     )]
     id: String,
 }
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
+}
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {}
@@ -108,7 +118,40 @@ impl RoleCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.id(&self.path.id);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/set.rs
+++ b/openstack_cli/src/identity/v3/domain/set.rs
@@ -68,8 +68,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/domain/show.rs
+++ b/openstack_cli/src/identity/v3/domain/show.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/domain/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/list.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::user::role::list;
 use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
@@ -62,19 +63,25 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// User resource for which the operation should be performed.
     #[command(flatten)]
     user: UserInput,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 
 /// User input select group
@@ -125,7 +132,40 @@ impl RolesCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
 
         // Process path parameter `user_id`
         if let Some(id) = &self.path.user.user_id {
@@ -133,11 +173,11 @@ impl RolesCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/domain/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/set.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use bytes::Bytes;
 use http::Response;
 use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::user::role::set;
 use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
@@ -65,15 +66,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// User resource for which the operation should be performed.
     #[command(flatten)]
@@ -88,6 +83,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 
 /// User input select group
@@ -120,7 +127,40 @@ impl RoleCommand {
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
 
         // Process path parameter `user_id`
         if let Some(id) = &self.path.user.user_id {
@@ -128,11 +168,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/domain/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/show.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use bytes::Bytes;
 use http::Response;
 use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::user::role::get;
 use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
@@ -63,15 +64,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_domain_id",
-        value_name = "DOMAIN_ID"
-    )]
-    domain_id: String,
+    /// Domain resource for which the operation should be performed.
+    #[command(flatten)]
+    domain: DomainInput,
 
     /// User resource for which the operation should be performed.
     #[command(flatten)]
@@ -86,6 +81,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// Domain input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct DomainInput {
+    /// Domain Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_NAME")]
+    domain_name: Option<String>,
+    /// Domain ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
+    domain_id: Option<String>,
 }
 
 /// User input select group
@@ -118,7 +125,40 @@ impl RoleCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.domain_id(&self.path.domain_id);
+
+        // Process path parameter `domain_id`
+        if let Some(id) = &self.path.domain.domain_id {
+            // domain_id is passed. No need to lookup
+            ep_builder.domain_id(id);
+        } else if let Some(name) = &self.path.domain.domain_name {
+            // domain_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_domain::Request::builder();
+            warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.domain_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
 
         // Process path parameter `user_id`
         if let Some(id) = &self.path.user.user_id {
@@ -126,11 +166,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/endpoint/delete.rs
+++ b/openstack_cli/src/identity/v3/endpoint/delete.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// endpoint_id parameter for
-    /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
+    /// endpoint_id parameter for /v3/endpoints/{endpoint_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/endpoint/set.rs
+++ b/openstack_cli/src/identity/v3/endpoint/set.rs
@@ -65,8 +65,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// endpoint_id parameter for
-    /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
+    /// endpoint_id parameter for /v3/endpoints/{endpoint_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/endpoint/show.rs
+++ b/openstack_cli/src/identity/v3/endpoint/show.rs
@@ -59,8 +59,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// endpoint_id parameter for
-    /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
+    /// endpoint_id parameter for /v3/endpoints/{endpoint_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/group/delete.rs
+++ b/openstack_cli/src/identity/v3/group/delete.rs
@@ -61,7 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
+    /// group_id parameter for /v3/groups/{group_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/group/set.rs
+++ b/openstack_cli/src/identity/v3/group/set.rs
@@ -69,7 +69,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
+    /// group_id parameter for /v3/groups/{group_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/group/show.rs
+++ b/openstack_cli/src/identity/v3/group/show.rs
@@ -60,7 +60,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
+    /// group_id parameter for /v3/groups/{group_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/group/user/delete.rs
+++ b/openstack_cli/src/identity/v3/group/user/delete.rs
@@ -117,11 +117,11 @@ impl UserCommand {
             ep_builder.id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/group/user/set.rs
+++ b/openstack_cli/src/identity/v3/group/user/set.rs
@@ -117,11 +117,11 @@ impl UserCommand {
             ep_builder.id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/group/user/show.rs
+++ b/openstack_cli/src/identity/v3/group/user/show.rs
@@ -115,11 +115,11 @@ impl UserCommand {
             ep_builder.id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/delete.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/delete.rs
@@ -58,8 +58,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/endpoint/get.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/endpoint/get.rs
@@ -58,8 +58,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/endpoints API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/set.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/set.rs
@@ -63,8 +63,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/show.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/show.rs
@@ -57,8 +57,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/delete.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/delete.rs
@@ -59,7 +59,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/list.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/list.rs
@@ -57,7 +57,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/set.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/set.rs
@@ -64,7 +64,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/show.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/show.rs
@@ -58,7 +58,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/delete.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/delete.rs
@@ -57,8 +57,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
@@ -66,7 +66,8 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
+    /// API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -76,7 +77,7 @@ struct PathParameters {
     idp_id: String,
 
     /// protocol_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
     /// API
     ///
     #[arg(

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
@@ -60,7 +60,8 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
+    /// API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -70,7 +71,7 @@ struct PathParameters {
     idp_id: String,
 
     /// protocol_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
     /// API
     ///
     #[arg(

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
@@ -59,8 +59,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/show.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/show.rs
@@ -56,8 +56,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
@@ -127,13 +127,13 @@ impl InheritedToProjectCommand {
         if let Some(id) = &self.path.domain.domain_id {
             // domain_id is passed. No need to lookup
             ep_builder.domain_id(id);
-        } else if let Some(name) = &self.path.user.user_name {
+        } else if let Some(name) = &self.path.domain.domain_name {
             // domain_name is passed. Need to lookup resource
-            let mut find_builder = find_domain::Request::builder();
+            let mut sub_find_builder = find_domain::Request::builder();
             warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
@@ -129,13 +129,13 @@ impl InheritedToProjectCommand {
         if let Some(id) = &self.path.domain.domain_id {
             // domain_id is passed. No need to lookup
             ep_builder.domain_id(id);
-        } else if let Some(name) = &self.path.user.user_name {
+        } else if let Some(name) = &self.path.domain.domain_name {
             // domain_name is passed. Need to lookup resource
-            let mut find_builder = find_domain::Request::builder();
+            let mut sub_find_builder = find_domain::Request::builder();
             warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
@@ -144,13 +144,13 @@ impl InheritedToProjectCommand {
         if let Some(id) = &self.path.domain.domain_id {
             // domain_id is passed. No need to lookup
             ep_builder.domain_id(id);
-        } else if let Some(name) = &self.path.user.user_name {
+        } else if let Some(name) = &self.path.domain.domain_name {
             // domain_name is passed. Need to lookup resource
-            let mut find_builder = find_domain::Request::builder();
+            let mut sub_find_builder = find_domain::Request::builder();
             warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
@@ -133,13 +133,13 @@ impl InheritedToProjectCommand {
         if let Some(id) = &self.path.domain.domain_id {
             // domain_id is passed. No need to lookup
             ep_builder.domain_id(id);
-        } else if let Some(name) = &self.path.user.user_name {
+        } else if let Some(name) = &self.path.domain.domain_name {
             // domain_name is passed. Need to lookup resource
-            let mut find_builder = find_domain::Request::builder();
+            let mut sub_find_builder = find_domain::Request::builder();
             warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
@@ -169,11 +169,11 @@ impl InheritedToProjectCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/get.rs
@@ -135,13 +135,13 @@ impl InheritedToProjectCommand {
         if let Some(id) = &self.path.domain.domain_id {
             // domain_id is passed. No need to lookup
             ep_builder.domain_id(id);
-        } else if let Some(name) = &self.path.user.user_name {
+        } else if let Some(name) = &self.path.domain.domain_name {
             // domain_name is passed. Need to lookup resource
-            let mut find_builder = find_domain::Request::builder();
+            let mut sub_find_builder = find_domain::Request::builder();
             warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
@@ -171,11 +171,11 @@ impl InheritedToProjectCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
@@ -150,13 +150,13 @@ impl InheritedToProjectCommand {
         if let Some(id) = &self.path.domain.domain_id {
             // domain_id is passed. No need to lookup
             ep_builder.domain_id(id);
-        } else if let Some(name) = &self.path.user.user_name {
+        } else if let Some(name) = &self.path.domain.domain_name {
             // domain_name is passed. Need to lookup resource
-            let mut find_builder = find_domain::Request::builder();
+            let mut sub_find_builder = find_domain::Request::builder();
             warn!("Querying domain by name (because of `--domain-name` parameter passed) may not be definite. This may fail in which case parameter `--domain-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
@@ -186,11 +186,11 @@ impl InheritedToProjectCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
@@ -64,7 +64,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
+    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
     /// API
     ///
     #[arg(
@@ -128,11 +128,11 @@ impl InheritedToProjectCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/get.rs
@@ -63,7 +63,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
+    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
     /// API
     ///
     #[arg(
@@ -141,11 +141,11 @@ impl InheritedToProjectCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
@@ -69,7 +69,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
+    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
     /// API
     ///
     #[arg(
@@ -147,11 +147,11 @@ impl InheritedToProjectCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/os_trust/trust/delete.rs
+++ b/openstack_cli/src/identity/v3/os_trust/trust/delete.rs
@@ -57,8 +57,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id}/roles/{role_id}
-    /// API
+    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/os_trust/trust/show.rs
+++ b/openstack_cli/src/identity/v3/os_trust/trust/show.rs
@@ -56,8 +56,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id}/roles/{role_id}
-    /// API
+    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/delete.rs
+++ b/openstack_cli/src/identity/v3/policy/delete.rs
@@ -61,9 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// policy_id parameter for /v3/policies/{policy_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/delete.rs
+++ b/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/delete.rs
@@ -59,8 +59,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/list.rs
+++ b/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/list.rs
@@ -57,8 +57,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/set.rs
+++ b/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/set.rs
@@ -64,8 +64,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/show.rs
+++ b/openstack_cli/src/identity/v3/policy/os_endpoint_policy/endpoint/show.rs
@@ -58,8 +58,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/os_endpoint_policy/service/delete.rs
+++ b/openstack_cli/src/identity/v3/policy/os_endpoint_policy/service/delete.rs
@@ -59,8 +59,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -70,8 +69,7 @@ struct PathParameters {
     policy_id: String,
 
     /// service_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/os_endpoint_policy/service/set.rs
+++ b/openstack_cli/src/identity/v3/policy/os_endpoint_policy/service/set.rs
@@ -64,8 +64,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -75,8 +74,7 @@ struct PathParameters {
     policy_id: String,
 
     /// service_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/os_endpoint_policy/service/show.rs
+++ b/openstack_cli/src/identity/v3/policy/os_endpoint_policy/service/show.rs
@@ -58,8 +58,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -69,8 +68,7 @@ struct PathParameters {
     policy_id: String,
 
     /// service_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/set.rs
+++ b/openstack_cli/src/identity/v3/policy/set.rs
@@ -66,9 +66,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// policy_id parameter for /v3/policies/{policy_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/policy/show.rs
+++ b/openstack_cli/src/identity/v3/policy/show.rs
@@ -60,9 +60,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// policy_id parameter for /v3/policies/{policy_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/delete.rs
+++ b/openstack_cli/src/identity/v3/project/delete.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/set.rs
+++ b/openstack_cli/src/identity/v3/project/set.rs
@@ -67,8 +67,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/show.rs
+++ b/openstack_cli/src/identity/v3/project/show.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/tag/delete.rs
+++ b/openstack_cli/src/identity/v3/project/tag/delete.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/tag/delete_all.rs
+++ b/openstack_cli/src/identity/v3/project/tag/delete_all.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/tag/list.rs
+++ b/openstack_cli/src/identity/v3/project/tag/list.rs
@@ -58,8 +58,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/tag/replace.rs
+++ b/openstack_cli/src/identity/v3/project/tag/replace.rs
@@ -59,8 +59,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/tag/set.rs
+++ b/openstack_cli/src/identity/v3/project/tag/set.rs
@@ -60,8 +60,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/tag/show.rs
+++ b/openstack_cli/src/identity/v3/project/tag/show.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/project/user/role/delete.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/delete.rs
@@ -66,7 +66,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -128,11 +128,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/project/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/list.rs
@@ -63,7 +63,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -133,11 +133,11 @@ impl RolesCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/project/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/set.rs
@@ -66,7 +66,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -128,11 +128,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/project/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/project/user/role/show.rs
@@ -64,7 +64,7 @@ struct QueryParameters {}
 #[derive(Args)]
 struct PathParameters {
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -126,11 +126,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/system/user/role/delete.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/delete.rs
@@ -116,11 +116,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/system/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/list.rs
@@ -119,11 +119,11 @@ impl RolesCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/system/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/set.rs
@@ -134,11 +134,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/system/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/show.rs
@@ -129,11 +129,11 @@ impl RoleCommand {
             ep_builder.user_id(id);
         } else if let Some(name) = &self.path.user.user_name {
             // user_name is passed. Need to lookup resource
-            let mut find_builder = find_user::Request::builder();
+            let mut sub_find_builder = find_user::Request::builder();
             warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
 
-            find_builder.id(name);
-            let find_ep = find_builder
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
                 .build()
                 .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
             let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;

--- a/openstack_cli/src/identity/v3/user/access_rule/delete.rs
+++ b/openstack_cli/src/identity/v3/user/access_rule/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::access_rule::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Delete an access rule. An access rule that is still in use by an
 /// application credential cannot be deleted.
@@ -62,15 +66,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// access_rule_id parameter for
     /// /v3/users/{user_id}/access_rules/{access_rule_id} API
@@ -81,6 +79,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// AccessRule response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -101,7 +111,40 @@ impl AccessRuleCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/access_rule/list.rs
+++ b/openstack_cli/src/identity/v3/user/access_rule/list.rs
@@ -31,9 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::access_rule::list;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// List all access rules for a user.
 ///
@@ -59,15 +62,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// AccessRules response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -104,7 +113,40 @@ impl AccessRulesCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/user/access_rule/show.rs
+++ b/openstack_cli/src/identity/v3/user/access_rule/show.rs
@@ -31,9 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::access_rule::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Show details of an access rule.
 ///
@@ -59,15 +62,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// access_rule_id parameter for
     /// /v3/users/{user_id}/access_rules/{access_rule_id} API
@@ -78,6 +75,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// AccessRule response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -114,7 +123,40 @@ impl AccessRuleCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/application_credential/delete.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::application_credential::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Delete an application credential.
 ///
@@ -61,15 +65,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// application_credential_id parameter for
     /// /v3/users/{user_id}/application_credentials/{application_credential_id}
@@ -81,6 +79,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// ApplicationCredential response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -101,7 +111,40 @@ impl ApplicationCredentialCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/application_credential/list.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/list.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::application_credential::list;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// List all application credentials for a user.
 ///
@@ -65,15 +68,21 @@ struct QueryParameters {
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// ApplicationCredentials response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -132,7 +141,40 @@ impl ApplicationCredentialsCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         if let Some(val) = &self.query.name {
             ep_builder.name(val);

--- a/openstack_cli/src/identity/v3/user/application_credential/show.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/show.rs
@@ -32,10 +32,13 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use openstack_sdk::api::find;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::application_credential::find;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Show details of an application credential.
 ///
@@ -61,15 +64,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// application_credential_id parameter for
     /// /v3/users/{user_id}/application_credentials/{application_credential_id}
@@ -81,6 +78,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// ApplicationCredential response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -138,7 +147,39 @@ impl ApplicationCredentialCommand {
 
         let mut find_builder = find::Request::builder();
 
-        find_builder.user_id(&self.path.user_id);
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            find_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        find_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         find_builder.id(&self.path.id);
         let find_ep = find_builder
             .build()

--- a/openstack_cli/src/identity/v3/user/credential/os_ec2/create.rs
+++ b/openstack_cli/src/identity/v3/user/credential/os_ec2/create.rs
@@ -33,10 +33,13 @@ use crate::StructTable;
 
 use crate::common::parse_json;
 use crate::common::parse_key_val;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::credential::os_ec2::create;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Create EC2 Credential for user.
 ///
@@ -64,15 +67,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -107,7 +116,40 @@ impl OsEc2Command {
         let mut ep_builder = create::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
         if let Some(properties) = &self.properties {

--- a/openstack_cli/src/identity/v3/user/credential/os_ec2/delete.rs
+++ b/openstack_cli/src/identity/v3/user/credential/os_ec2/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::credential::os_ec2::delete;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Delete a specific EC2 credential.
 ///
@@ -59,15 +63,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// credential_id parameter for
     /// /v3/users/{user_id}/credentials/OS-EC2/{credential_id} API
@@ -78,6 +76,18 @@ struct PathParameters {
         value_name = "CREDENTIAL_ID"
     )]
     credential_id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// OsEc2 response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -98,7 +108,40 @@ impl OsEc2Command {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.credential_id(&self.path.credential_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/credential/os_ec2/list.rs
+++ b/openstack_cli/src/identity/v3/user/credential/os_ec2/list.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::credential::os_ec2::list;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// List EC2 Credentials for user.
 ///
@@ -58,15 +61,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -101,7 +110,40 @@ impl OsEc2SCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/user/credential/os_ec2/show.rs
+++ b/openstack_cli/src/identity/v3/user/credential/os_ec2/show.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::credential::os_ec2::get;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Get a specific EC2 credential.
 ///
@@ -58,15 +61,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// credential_id parameter for
     /// /v3/users/{user_id}/credentials/OS-EC2/{credential_id} API
@@ -77,6 +74,18 @@ struct PathParameters {
         value_name = "CREDENTIAL_ID"
     )]
     credential_id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -111,7 +120,40 @@ impl OsEc2Command {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.credential_id(&self.path.credential_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/delete.rs
+++ b/openstack_cli/src/identity/v3/user/delete.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/user/group/list.rs
+++ b/openstack_cli/src/identity/v3/user/group/list.rs
@@ -31,9 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::group::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists groups to which a user belongs.
 ///
@@ -59,15 +62,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Groups response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -121,7 +130,40 @@ impl GroupsCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/delete.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/delete.rs
@@ -33,9 +33,13 @@ use crate::StructTable;
 
 use bytes::Bytes;
 use http::Response;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::delete;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Delete specific access token.
 ///
@@ -59,19 +63,12 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// access_token_id parameter for
-    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
-    /// API
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -79,6 +76,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// AccessToken response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -99,7 +108,40 @@ impl AccessTokenCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/list.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/list.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// List OAuth1 Access Tokens for user.
 ///
@@ -58,15 +61,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -101,7 +110,40 @@ impl AccessTokensCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/list.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/role/list.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::role::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// List roles for a user access token.
 ///
@@ -59,15 +62,9 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// access_token_id parameter for
     /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
@@ -79,6 +76,18 @@ struct PathParameters {
         value_name = "ACCESS_TOKEN_ID"
     )]
     access_token_id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -113,7 +122,40 @@ impl RolesCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.access_token_id(&self.path.access_token_id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/os_oauth1/access_token/show.rs
+++ b/openstack_cli/src/identity/v3/user/os_oauth1/access_token/show.rs
@@ -31,10 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
+use tracing::warn;
 
 /// Get specific access token.
 ///
@@ -58,19 +61,12 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     /// access_token_id parameter for
-    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
-    /// API
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[arg(
         help_heading = "Path parameters",
@@ -78,6 +74,18 @@ struct PathParameters {
         value_name = "ID"
     )]
     id: String,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -112,7 +120,40 @@ impl AccessTokenCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/user/password/set.rs
+++ b/openstack_cli/src/identity/v3/user/password/set.rs
@@ -34,9 +34,13 @@ use crate::StructTable;
 use bytes::Bytes;
 use dialoguer::Password;
 use http::Response;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::password::set;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Changes the password for a user.
 ///
@@ -67,15 +71,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// User Body data
 #[derive(Args, Clone)]
@@ -110,7 +120,40 @@ impl PasswordCommand {
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
         // Set Request.user data

--- a/openstack_cli/src/identity/v3/user/project/list.rs
+++ b/openstack_cli/src/identity/v3/user/project/list.rs
@@ -31,9 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::project::list;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// List projects to which the user has authorization to access.
 ///
@@ -59,15 +62,21 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_user_id",
-        value_name = "USER_ID"
-    )]
-    user_id: String,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
 }
 /// Projects response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -118,7 +127,40 @@ impl ProjectsCommand {
         let mut ep_builder = list::Request::builder();
 
         // Set path parameters
-        ep_builder.user_id(&self.path.user_id);
+
+        // Process path parameter `user_id`
+        if let Some(id) = &self.path.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.path.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/identity/v3/user/set.rs
+++ b/openstack_cli/src/identity/v3/user/set.rs
@@ -71,8 +71,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_cli/src/identity/v3/user/show.rs
+++ b/openstack_cli/src/identity/v3/user/show.rs
@@ -61,8 +61,7 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id} API
     ///
     #[arg(
         help_heading = "Path parameters",

--- a/openstack_sdk/src/api/identity/v3/domain/config/delete_all.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/delete_all.rs
@@ -30,8 +30,8 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/delete.rs
@@ -32,13 +32,13 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/get.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/get.rs
@@ -32,13 +32,13 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/head.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/head.rs
@@ -31,13 +31,13 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/option/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/option/delete.rs
@@ -34,18 +34,19 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,
 
-    /// option parameter for /v3/domains/config/{group}/{option}/default API
+    /// option parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     option: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/option/get.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/option/get.rs
@@ -34,18 +34,19 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,
 
-    /// option parameter for /v3/domains/config/{group}/{option}/default API
+    /// option parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     option: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/option/head.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/option/head.rs
@@ -31,18 +31,19 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,
 
-    /// option parameter for /v3/domains/config/{group}/{option}/default API
+    /// option parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     option: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/option/set.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/option/set.rs
@@ -41,18 +41,19 @@ pub struct Request<'a> {
     #[builder(private, setter(name = "_config"))]
     pub(crate) config: BTreeMap<Cow<'a, str>, Value>,
 
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,
 
-    /// option parameter for /v3/domains/config/{group}/{option}/default API
+    /// option parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     option: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/group/set.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/group/set.rs
@@ -41,13 +41,13 @@ pub struct Request<'a> {
     #[builder(private, setter(name = "_config"))]
     pub(crate) config: BTreeMap<Cow<'a, str>, BTreeMap<Cow<'a, str>, Value>>,
 
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,
 
-    /// group parameter for /v3/domains/config/{group}/{option}/default API
+    /// group parameter for /v3/domains/{domain_id}/config/{group}/{option} API
     ///
     #[builder(default, setter(into))]
     group: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/head.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/head.rs
@@ -31,8 +31,8 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/list.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/list.rs
@@ -30,8 +30,8 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/replace.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/replace.rs
@@ -37,8 +37,8 @@ pub struct Request<'a> {
     #[builder(private, setter(name = "_config"))]
     pub(crate) config: BTreeMap<Cow<'a, str>, BTreeMap<Cow<'a, str>, Value>>,
 
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/config/set.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/config/set.rs
@@ -37,8 +37,8 @@ pub struct Request<'a> {
     #[builder(private, setter(name = "_config"))]
     pub(crate) config: BTreeMap<Cow<'a, str>, BTreeMap<Cow<'a, str>, Value>>,
 
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id}/config/{group}/{option}
+    /// API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/delete.rs
@@ -38,8 +38,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/get.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/get.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/set.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/set.rs
@@ -93,8 +93,7 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) domain: Domain<'a>,
 
-    /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// domain_id parameter for /v3/domains/{domain_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/user/role/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/user/role/delete.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/user/role/get.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/user/role/get.rs
@@ -30,7 +30,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/user/role/head.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/user/role/head.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/user/role/list.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/user/role/list.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/domain/user/role/set.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/user/role/set.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/domains/{domain_id}/groups/{group_id}/roles/{role_id} API
+    /// /v3/domains/{domain_id}/users/{user_id}/roles/{role_id} API
     ///
     #[builder(default, setter(into))]
     domain_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/endpoint/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/endpoint/delete.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// endpoint_id parameter for
-    /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
+    /// endpoint_id parameter for /v3/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/endpoint/get.rs
+++ b/openstack_sdk/src/api/identity/v3/endpoint/get.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// endpoint_id parameter for
-    /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
+    /// endpoint_id parameter for /v3/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/endpoint/set.rs
+++ b/openstack_sdk/src/api/identity/v3/endpoint/set.rs
@@ -32,8 +32,7 @@ use std::collections::BTreeMap;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// endpoint_id parameter for
-    /// /v3/endpoints/{endpoint_id}/OS-ENDPOINT-POLICY/policy API
+    /// endpoint_id parameter for /v3/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/group/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/group/delete.rs
@@ -30,7 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
+    /// group_id parameter for /v3/groups/{group_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/group/get.rs
+++ b/openstack_sdk/src/api/identity/v3/group/get.rs
@@ -30,7 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
+    /// group_id parameter for /v3/groups/{group_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/group/set.rs
+++ b/openstack_sdk/src/api/identity/v3/group/set.rs
@@ -64,7 +64,7 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) group: Group<'a>,
 
-    /// group_id parameter for /v3/groups/{group_id}/users/{user_id} API
+    /// group_id parameter for /v3/groups/{group_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/delete.rs
@@ -28,8 +28,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/endpoint/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/endpoint/get.rs
@@ -29,8 +29,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/endpoints API
     ///
     #[builder(default, setter(into))]
     endpoint_group_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/endpoint/head.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/endpoint/head.rs
@@ -29,8 +29,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/endpoints API
     ///
     #[builder(default, setter(into))]
     endpoint_group_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/get.rs
@@ -28,8 +28,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/set.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/endpoint_group/set.rs
@@ -30,8 +30,7 @@ use std::collections::BTreeMap;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// endpoint_group_id parameter for
-    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id}/projects/{project_id}
-    /// API
+    /// /v3/OS-EP-FILTER/endpoint_groups/{endpoint_group_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/delete.rs
@@ -35,7 +35,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/get.rs
@@ -35,7 +35,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/head.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/head.rs
@@ -28,7 +28,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/list.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/list.rs
@@ -28,7 +28,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/set.rs
+++ b/openstack_sdk/src/api/identity/v3/os_ep_filter/project/endpoint/set.rs
@@ -37,7 +37,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// project_id parameter for
-    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoint_groups API
+    /// /v3/OS-EP-FILTER/projects/{project_id}/endpoints API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/create.rs
@@ -61,8 +61,7 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) identity_provider: IdentityProvider<'a>,
 
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[builder(default, setter(into))]
     idp_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/delete.rs
@@ -27,8 +27,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[builder(default, setter(into))]
     idp_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/get.rs
@@ -27,8 +27,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[builder(default, setter(into))]
     idp_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/protocol/auth/create.rs
@@ -33,13 +33,14 @@ use std::collections::BTreeMap;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
+    /// API
     ///
     #[builder(default, setter(into))]
     idp_id: Cow<'a, str>,
 
     /// protocol_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/protocol/auth/get.rs
@@ -31,13 +31,14 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
+    /// API
     ///
     #[builder(default, setter(into))]
     idp_id: Cow<'a, str>,
 
     /// protocol_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/protocol/auth/head.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/protocol/auth/head.rs
@@ -31,13 +31,14 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
+    /// API
     ///
     #[builder(default, setter(into))]
     idp_id: Cow<'a, str>,
 
     /// protocol_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}
+    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols/{protocol_id}/auth
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/set.rs
@@ -55,8 +55,7 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) identity_provider: IdentityProvider<'a>,
 
-    /// idp_id parameter for
-    /// /v3/OS-FEDERATION/identity_providers/{idp_id}/protocols API
+    /// idp_id parameter for /v3/OS-FEDERATION/identity_providers/{idp_id} API
     ///
     #[builder(default, setter(into))]
     idp_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
+    /// /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
@@ -32,7 +32,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
+    /// /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/head.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/head.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
+    /// /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
@@ -34,7 +34,7 @@ use std::collections::BTreeMap;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// domain_id parameter for
-    /// /v3/OS-INHERIT/domains/{domain_id}/users/{user_id}/roles/inherited_to_projects
+    /// /v3/OS-INHERIT/domains/{domain_id}/groups/{group_id}/roles/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
@@ -29,7 +29,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
+    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/get.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
+    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/head.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/head.rs
@@ -32,7 +32,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
+    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_sdk/src/api/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
@@ -34,7 +34,7 @@ use std::collections::BTreeMap;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/OS-INHERIT/projects/{project_id}/groups/{group_id}/roles/{role_id}/inherited_to_projects
+    /// /v3/OS-INHERIT/projects/{project_id}/users/{user_id}/roles/{role_id}/inherited_to_projects
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_trust/trust/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/os_trust/trust/delete.rs
@@ -27,8 +27,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id}/roles/{role_id}
-    /// API
+    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/os_trust/trust/get.rs
+++ b/openstack_sdk/src/api/identity/v3/os_trust/trust/get.rs
@@ -27,8 +27,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id}/roles/{role_id}
-    /// API
+    /// trust_id parameter for /v3/OS-TRUST/trusts/{trust_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/delete.rs
@@ -30,9 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// policy_id parameter for /v3/policies/{policy_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/get.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/get.rs
@@ -30,9 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// policy_id parameter for /v3/policies/{policy_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/delete.rs
@@ -35,8 +35,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/get.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/get.rs
@@ -35,8 +35,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/head.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/head.rs
@@ -35,8 +35,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/list.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/list.rs
@@ -28,8 +28,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/set.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/endpoint/set.rs
@@ -37,8 +37,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/delete.rs
@@ -29,15 +29,13 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// service_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/get.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/get.rs
@@ -29,15 +29,13 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// service_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/head.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/head.rs
@@ -29,15 +29,13 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// service_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/set.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/os_endpoint_policy/service/set.rs
@@ -31,15 +31,13 @@ use std::collections::BTreeMap;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// service_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
     /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id} API
     ///
     #[builder(default, setter(into))]
     policy_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/policy/set.rs
+++ b/openstack_sdk/src/api/identity/v3/policy/set.rs
@@ -32,9 +32,7 @@ use std::collections::BTreeMap;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// policy_id parameter for
-    /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}
-    /// API
+    /// policy_id parameter for /v3/policies/{policy_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/project/delete.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/get.rs
+++ b/openstack_sdk/src/api/identity/v3/project/get.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/set.rs
+++ b/openstack_sdk/src/api/identity/v3/project/set.rs
@@ -127,8 +127,7 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) project: Project<'a>,
 
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/tag/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/project/tag/delete.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/tag/delete_all.rs
+++ b/openstack_sdk/src/api/identity/v3/project/tag/delete_all.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/tag/get.rs
+++ b/openstack_sdk/src/api/identity/v3/project/tag/get.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/tag/head.rs
+++ b/openstack_sdk/src/api/identity/v3/project/tag/head.rs
@@ -29,8 +29,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/tag/list.rs
+++ b/openstack_sdk/src/api/identity/v3/project/tag/list.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/tag/replace.rs
+++ b/openstack_sdk/src/api/identity/v3/project/tag/replace.rs
@@ -31,8 +31,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/tag/set.rs
+++ b/openstack_sdk/src/api/identity/v3/project/tag/set.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// project_id parameter for /v3/projects/{project_id}/tags/{value} API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/user/role/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/project/user/role/delete.rs
@@ -37,7 +37,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/user/role/get.rs
+++ b/openstack_sdk/src/api/identity/v3/project/user/role/get.rs
@@ -36,7 +36,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/user/role/head.rs
+++ b/openstack_sdk/src/api/identity/v3/project/user/role/head.rs
@@ -30,7 +30,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/user/role/list.rs
+++ b/openstack_sdk/src/api/identity/v3/project/user/role/list.rs
@@ -31,7 +31,7 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/project/user/role/set.rs
+++ b/openstack_sdk/src/api/identity/v3/project/user/role/set.rs
@@ -37,7 +37,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     /// project_id parameter for
-    /// /v3/projects/{project_id}/groups/{group_id}/roles API
+    /// /v3/projects/{project_id}/users/{user_id}/roles API
     ///
     #[builder(default, setter(into))]
     project_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/application_credential/create.rs
+++ b/openstack_sdk/src/api/identity/v3/user/application_credential/create.rs
@@ -147,7 +147,8 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) application_credential: ApplicationCredential<'a>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/application_credentials/{application_credential_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/application_credential/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/user/application_credential/delete.rs
@@ -37,7 +37,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/application_credentials/{application_credential_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/application_credential/get.rs
+++ b/openstack_sdk/src/api/identity/v3/user/application_credential/get.rs
@@ -37,7 +37,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/application_credentials/{application_credential_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/application_credential/head.rs
+++ b/openstack_sdk/src/api/identity/v3/user/application_credential/head.rs
@@ -37,7 +37,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/application_credentials/{application_credential_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/application_credential/list.rs
+++ b/openstack_sdk/src/api/identity/v3/user/application_credential/list.rs
@@ -35,7 +35,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     name: Option<Cow<'a, str>>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/application_credentials/{application_credential_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/create.rs
+++ b/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/create.rs
@@ -31,8 +31,8 @@ use std::collections::BTreeMap;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/credentials/OS-EC2/{credential_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/delete.rs
@@ -35,8 +35,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     credential_id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/credentials/OS-EC2/{credential_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/get.rs
+++ b/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/get.rs
@@ -35,8 +35,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     credential_id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/credentials/OS-EC2/{credential_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/head.rs
+++ b/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/head.rs
@@ -35,8 +35,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     credential_id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/credentials/OS-EC2/{credential_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/list.rs
+++ b/openstack_sdk/src/api/identity/v3/user/credential/os_ec2/list.rs
@@ -29,8 +29,8 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/credentials/OS-EC2/{credential_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/user/delete.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/get.rs
+++ b/openstack_sdk/src/api/identity/v3/user/get.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/group/head.rs
+++ b/openstack_sdk/src/api/identity/v3/user/group/head.rs
@@ -29,8 +29,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id}/groups API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/group/list.rs
+++ b/openstack_sdk/src/api/identity/v3/user/group/list.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id}/groups API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/delete.rs
+++ b/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/delete.rs
@@ -30,14 +30,13 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// access_token_id parameter for
-    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
-    /// API
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/get.rs
+++ b/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/get.rs
@@ -30,14 +30,13 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// access_token_id parameter for
-    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
-    /// API
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/head.rs
+++ b/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/head.rs
@@ -30,14 +30,13 @@ use std::borrow::Cow;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     /// access_token_id parameter for
-    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
-    /// API
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/list.rs
+++ b/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/list.rs
@@ -29,8 +29,8 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id} API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/role/get.rs
+++ b/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/role/get.rs
@@ -44,7 +44,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/role/head.rs
+++ b/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/role/head.rs
@@ -44,7 +44,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/role/list.rs
+++ b/openstack_sdk/src/api/identity/v3/user/os_oauth1/access_token/role/list.rs
@@ -37,7 +37,8 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     access_token_id: Cow<'a, str>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
+    /// user_id parameter for
+    /// /v3/users/{user_id}/OS-OAUTH1/access_tokens/{access_token_id}/roles/{role_id}
     /// API
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/password/set.rs
+++ b/openstack_sdk/src/api/identity/v3/user/password/set.rs
@@ -55,8 +55,7 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) user: User<'a>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id}/password API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/project/head.rs
+++ b/openstack_sdk/src/api/identity/v3/user/project/head.rs
@@ -27,8 +27,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id}/projects API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/project/list.rs
+++ b/openstack_sdk/src/api/identity/v3/user/project/list.rs
@@ -30,8 +30,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id}/projects API
     ///
     #[builder(default, setter(into))]
     user_id: Cow<'a, str>,

--- a/openstack_sdk/src/api/identity/v3/user/set.rs
+++ b/openstack_sdk/src/api/identity/v3/user/set.rs
@@ -194,8 +194,7 @@ pub struct Request<'a> {
     #[builder(setter(into))]
     pub(crate) user: User<'a>,
 
-    /// user_id parameter for /v3/users/{user_id}/access_rules/{access_rule_id}
-    /// API
+    /// user_id parameter for /v3/users/{user_id} API
     ///
     #[builder(default, setter(into))]
     id: Cow<'a, str>,


### PR DESCRIPTION
for the url `/users/{user_id}/access_rules` and `/users/{user_id}/access_rules/{id}` param user_id should be named as
`users_access_rules_user_id` to better avoid name shadowing.

Change-Id: Ibe72515cad25009fe5e73afe1a98dc07ec1ac8d4

Changes are triggered by https://review.opendev.org/929614
