### PR TITLE
feat: Add project selection

### DIFF
--- a/openstack_tui/.config/config.json5
+++ b/openstack_tui/.config/config.json5
@@ -22,6 +22,7 @@
     "F1": { "action": {"Mode": "Home"}, "description": "Home"},
     "F2": { "action": "CloudSelect", "description": "Select cloud"},// Switch cloud
     "F3": { "action": "ResourceSelect", "description": "Select resource"},// Select the resource
+    "F4": { "action": "SelectProject", "description": "Select project"},
     "r": {"action": "Refresh", "description": "Refresh data"}
   }
 }

--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -23,9 +23,10 @@ pub enum Resource {
     ComputeServers(ComputeServerFilters),
     ComputeServerConsoleOutput(String),
     ComputeQuota,
+    IdentityAuthProjects(IdentityAuthProjectFilters),
+    ImageImages(ImageFilters),
     NetworkNetworks(NetworkNetworkFilters),
     NetworkSubnets(NetworkSubnetFilters),
-    ImageImages(ImageFilters),
 }
 
 /// TUI action
@@ -43,6 +44,7 @@ pub enum Action {
     Error(String),
     Help,
     ConnectToCloud(String),
+    CloudChangeScope(openstack_sdk::auth::authtoken::AuthTokenScope),
     ConnectedToCloud(Box<openstack_sdk::types::identity::v3::AuthToken>),
     RequestCloudResource(Resource),
     ResourceData {
@@ -62,6 +64,7 @@ pub enum Action {
     PageDown,
     Describe(serde_json::Value),
     CloudSelect,
+    SelectProject,
     ListClouds,
     Clouds(Vec<String>),
     NetworkSubnetFilter(NetworkSubnetFilters),
@@ -103,6 +106,15 @@ impl fmt::Display for NetworkSubnetFilters {
         Ok(())
     }
 }
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityAuthProjectFilters {}
+impl fmt::Display for IdentityAuthProjectFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ImageFilters {
     pub visibility: Option<String>,

--- a/openstack_tui/src/cloud_services.rs
+++ b/openstack_tui/src/cloud_services.rs
@@ -15,9 +15,12 @@
 use eyre::Result;
 use serde_json::Value;
 
-use crate::action::{ImageFilters, NetworkNetworkFilters, NetworkSubnetFilters};
+use crate::action::{
+    IdentityAuthProjectFilters, ImageFilters, NetworkNetworkFilters, NetworkSubnetFilters,
+};
 
 mod compute;
+mod identity;
 mod image;
 mod network;
 
@@ -26,6 +29,13 @@ pub trait ComputeExt {
     async fn get_compute_servers(&mut self) -> Result<Vec<Value>>;
     async fn get_compute_server_console_output(&mut self, id: &String) -> Result<Value>;
     async fn get_compute_quota(&mut self) -> Result<Value>;
+}
+
+pub trait IdentityExt {
+    async fn get_identity_auth_projects(
+        &mut self,
+        filters: &IdentityAuthProjectFilters,
+    ) -> Result<Vec<Value>>;
 }
 
 pub trait ImageExt {

--- a/openstack_tui/src/cloud_services/identity.rs
+++ b/openstack_tui/src/cloud_services/identity.rs
@@ -1,0 +1,43 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use serde_json::Value;
+
+use openstack_sdk::api::QueryAsync;
+
+use crate::action::IdentityAuthProjectFilters;
+use crate::cloud_services::IdentityExt;
+use crate::cloud_worker::Cloud;
+
+impl IdentityExt for Cloud {
+    async fn get_identity_auth_projects(
+        &mut self,
+        _filters: &IdentityAuthProjectFilters,
+    ) -> Result<Vec<Value>> {
+        if let Some(session) = &self.cloud {
+            let ep_builder =
+                openstack_sdk::api::identity::v3::auth::project::list::Request::builder();
+
+            //if let Some(vis) = &filters.visibility {
+            //    ep_builder.visibility(vis);
+            //}
+            let ep = ep_builder.build()?;
+            let res: Vec<Value> = ep.query_async(session).await?;
+            //let res: Vec<Value> = ep.query_async(session).await?;
+            return Ok(res);
+        }
+        Ok(Vec::new())
+    }
+}

--- a/openstack_tui/src/components.rs
+++ b/openstack_tui/src/components.rs
@@ -30,6 +30,7 @@ pub mod header;
 pub mod home;
 pub mod image;
 pub mod network;
+pub mod project_select_popup;
 pub mod resource_select_popup;
 pub mod table_view;
 

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -53,7 +53,19 @@ impl<'a> Component for ComputeFlavors<'a> {
 
     fn update(&mut self, action: Action, current_mode: Mode) -> Result<Option<Action>> {
         match action {
-            Action::Mode(Mode::ComputeFlavors) | Action::Refresh | Action::ConnectToCloud(_) => {
+            Action::CloudChangeScope(_) => {
+                self.set_loading(true);
+            }
+            Action::ConnectedToCloud(_) => {
+                self.set_loading(true);
+                self.set_data(Vec::new())?;
+                if let Mode::ComputeFlavors = current_mode {
+                    return Ok(Some(Action::RequestCloudResource(
+                        Resource::ComputeFlavors(self.get_filters().clone()),
+                    )));
+                }
+            }
+            Action::Mode(Mode::ComputeFlavors) | Action::Refresh => {
                 self.set_loading(true);
                 return Ok(Some(Action::RequestCloudResource(
                     Resource::ComputeFlavors(self.get_filters().clone()),

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -56,7 +56,19 @@ impl<'a> Component for ComputeServers<'a> {
 
     fn update(&mut self, action: Action, current_mode: Mode) -> Result<Option<Action>> {
         match action {
-            Action::Mode(Mode::ComputeServers) | Action::Refresh | Action::ConnectToCloud(_) => {
+            Action::CloudChangeScope(_) => {
+                self.set_loading(true);
+            }
+            Action::ConnectedToCloud(_) => {
+                self.set_loading(true);
+                self.set_data(Vec::new())?;
+                if let Mode::ComputeServers = current_mode {
+                    return Ok(Some(Action::RequestCloudResource(
+                        Resource::ComputeServers(self.get_filters().clone()),
+                    )));
+                }
+            }
+            Action::Mode(Mode::ComputeServers) | Action::Refresh => {
                 self.set_loading(true);
                 return Ok(Some(Action::RequestCloudResource(
                     Resource::ComputeServers(self.get_filters().clone()),

--- a/openstack_tui/src/components/describe.rs
+++ b/openstack_tui/src/components/describe.rs
@@ -69,6 +69,8 @@ impl Describe {
                 .split("\n")
                 .map(String::from)
                 .collect::<Vec<_>>();
+        } else if data.is_null() {
+            self.text.clear();
         } else {
             let data: serde_yaml::Value = serde_json::from_value(data)?;
             self.text = serde_yaml::to_string(&data)?

--- a/openstack_tui/src/components/error_popup.rs
+++ b/openstack_tui/src/components/error_popup.rs
@@ -22,7 +22,9 @@ use ratatui::{
 use std::collections::HashMap;
 use tokio::sync::mpsc::UnboundedSender;
 
-use crate::{action::Action, components::Component, config::Config, utils::centered_rect};
+use crate::{
+    action::Action, components::Component, config::Config, mode::Mode, utils::centered_rect,
+};
 
 pub struct ErrorPopup {
     command_tx: Option<UnboundedSender<Action>>,
@@ -34,15 +36,12 @@ pub struct ErrorPopup {
 }
 
 impl ErrorPopup {
-    pub fn new(text: String) -> Self {
+    pub fn new() -> Self {
         Self {
             command_tx: None,
             config: Config::default(),
             keymap: HashMap::new(),
-            text: strip_ansi_escapes::strip_str(text)
-                .split("\n")
-                .map(String::from)
-                .collect::<Vec<_>>(),
+            text: Vec::new(),
             last_events: Vec::new(),
             scroll: (0, 0),
         }
@@ -67,6 +66,19 @@ impl Component for ErrorPopup {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.config = config;
         Ok(())
+    }
+
+    fn update(&mut self, action: Action, _current_mode: Mode) -> Result<Option<Action>> {
+        match action {
+            Action::Error(ref msg) => {
+                self.text = strip_ansi_escapes::strip_str(msg)
+                    .split("\n")
+                    .map(String::from)
+                    .collect::<Vec<_>>();
+            }
+            _ => {}
+        };
+        Ok(None)
     }
 
     fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<Action>> {

--- a/openstack_tui/src/components/header.rs
+++ b/openstack_tui/src/components/header.rs
@@ -137,6 +137,10 @@ impl Component for Header {
                 Span::styled("<F3>", Style::new().yellow()),
                 Span::from("Select resource"),
             ]),
+            Row::new(vec![
+                Span::styled("<F4>", Style::new().yellow()),
+                Span::from("Select project scope"),
+            ]),
         ];
         let global_shortcuts_table = Table::new(global_shortcuts_rows, widths)
             .column_spacing(1)

--- a/openstack_tui/src/components/image/images.rs
+++ b/openstack_tui/src/components/image/images.rs
@@ -57,9 +57,21 @@ impl<'a> Component for Images<'a> {
         Ok(())
     }
 
-    fn update(&mut self, action: Action, _current_mode: Mode) -> Result<Option<Action>> {
+    fn update(&mut self, action: Action, current_mode: Mode) -> Result<Option<Action>> {
         match action {
-            Action::Mode(Mode::ImageImages) | Action::Refresh | Action::ConnectToCloud(_) => {
+            Action::CloudChangeScope(_) => {
+                self.set_loading(true);
+            }
+            Action::ConnectedToCloud(_) => {
+                self.set_loading(true);
+                self.set_data(Vec::new())?;
+                if let Mode::ImageImages = current_mode {
+                    return Ok(Some(Action::RequestCloudResource(Resource::ImageImages(
+                        self.get_filters().clone(),
+                    ))));
+                }
+            }
+            Action::Mode(Mode::ImageImages) | Action::Refresh => {
                 self.set_loading(true);
                 return Ok(Some(Action::RequestCloudResource(Resource::ImageImages(
                     self.get_filters().clone(),

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -55,9 +55,21 @@ impl<'a> Component for NetworkNetworks<'a> {
         Ok(())
     }
 
-    fn update(&mut self, action: Action, _current_mode: Mode) -> Result<Option<Action>> {
+    fn update(&mut self, action: Action, current_mode: Mode) -> Result<Option<Action>> {
         match action {
-            Action::Mode(Mode::NetworkNetworks) | Action::Refresh | Action::ConnectToCloud(_) => {
+            Action::CloudChangeScope(_) => {
+                self.set_loading(true);
+            }
+            Action::ConnectedToCloud(_) => {
+                self.set_loading(true);
+                self.set_data(Vec::new())?;
+                if let Mode::NetworkNetworks = current_mode {
+                    return Ok(Some(Action::RequestCloudResource(
+                        Resource::NetworkNetworks(self.get_filters().clone()),
+                    )));
+                }
+            }
+            Action::Mode(Mode::NetworkNetworks) | Action::Refresh => {
                 self.set_loading(true);
                 return Ok(Some(Action::RequestCloudResource(
                     Resource::NetworkNetworks(self.get_filters().clone()),

--- a/openstack_tui/src/components/network/subnets.rs
+++ b/openstack_tui/src/components/network/subnets.rs
@@ -50,9 +50,21 @@ impl<'a> Component for NetworkSubnets<'a> {
         Ok(())
     }
 
-    fn update(&mut self, action: Action, _current_mode: Mode) -> Result<Option<Action>> {
+    fn update(&mut self, action: Action, current_mode: Mode) -> Result<Option<Action>> {
         match action {
-            Action::Mode(Mode::NetworkSubnets) | Action::Refresh | Action::ConnectToCloud(_) => {
+            Action::CloudChangeScope(_) => {
+                self.set_loading(true);
+            }
+            Action::ConnectedToCloud(_) => {
+                self.set_loading(true);
+                self.set_data(Vec::new())?;
+                if let Mode::NetworkSubnets = current_mode {
+                    return Ok(Some(Action::RequestCloudResource(
+                        Resource::NetworkSubnets(self.get_filters().clone()),
+                    )));
+                }
+            }
+            Action::Mode(Mode::NetworkSubnets) | Action::Refresh => {
                 self.set_loading(true);
                 return Ok(Some(Action::RequestCloudResource(
                     Resource::NetworkSubnets(self.get_filters().clone()),

--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -286,7 +286,11 @@ where
             if selected_idx < self.raw_items.len() {
                 self.describe
                     .set_data(self.raw_items[selected_idx].clone())?;
+            } else {
+                self.describe.set_data(Value::Null)?;
             }
+        } else {
+            self.describe.set_data(Value::Null)?;
         }
         Ok(())
     }

--- a/openstack_tui/src/config.rs
+++ b/openstack_tui/src/config.rs
@@ -303,6 +303,8 @@ pub struct Styles {
     pub popup_border_fg: Color,
     pub popup_border_error_fg: Color,
     pub item_selected_bg: Color,
+    pub item_highlight_fg: Color,
+    pub title_loading_fg: Color,
 }
 
 impl Default for Styles {
@@ -318,6 +320,8 @@ impl Default for Styles {
             popup_border_fg: tailwind::WHITE,
             popup_border_error_fg: tailwind::RED.c600,
             item_selected_bg: tailwind::BLUE.c400,
+            item_highlight_fg: tailwind::RED.c950,
+            title_loading_fg: tailwind::PINK.c400,
         }
     }
 }


### PR DESCRIPTION
In authenticated session it is possible to list available projects
(/auth/projects). Implement another selector popup to change the session
scope.

- add new popup
- make popup components long living components to better handle overall
  session data

Open:

- auth with ApplicationCredentials does not allow changing scope
- admin does not have list of available scopes at all
