### PR TITLE
fix: Process row only when selected

### DIFF
--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -105,7 +105,9 @@ impl<'a> Component for ComputeFlavors<'a> {
             _ => {}
         }
         if key.kind == KeyEventKind::Press && key.code == KeyCode::Enter {
-            return Ok(Some(Action::Describe(self.get_selected_raw().clone())));
+            if let Some(x) = self.get_selected_raw() {
+                return Ok(Some(Action::Describe(x.clone())));
+            }
         }
         Ok(None)
     }

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -93,19 +93,21 @@ impl<'a> Component for ComputeServers<'a> {
                 resource: Resource::ComputeServerConsoleOutput(id),
                 data,
             } => {
-                let server_id = self.get_selected_resource_id()?;
-                if server_id == id {
-                    return Ok(Some(Action::Describe(data)));
+                if let Some(server_id) = self.get_selected_resource_id()? {
+                    if server_id == id {
+                        return Ok(Some(Action::Describe(data)));
+                    }
                 }
             }
             Action::ServerConsoleOutput => {
-                let server_id = self.get_selected_resource_id()?;
-                if let Some(command_tx) = self.get_command_tx() {
-                    command_tx.send(Action::Mode(Mode::Describe))?;
+                if let Some(server_id) = self.get_selected_resource_id()? {
+                    if let Some(command_tx) = self.get_command_tx() {
+                        command_tx.send(Action::Mode(Mode::Describe))?;
+                    }
+                    return Ok(Some(Action::RequestCloudResource(
+                        Resource::ComputeServerConsoleOutput(server_id),
+                    )));
                 }
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::ComputeServerConsoleOutput(server_id),
-                )));
             }
             _ => {}
         };
@@ -126,7 +128,9 @@ impl<'a> Component for ComputeServers<'a> {
             _ => {}
         }
         if key.kind == KeyEventKind::Press && key.code == KeyCode::Enter {
-            return Ok(Some(Action::Describe(self.get_selected_raw().clone())));
+            if let Some(x) = self.get_selected_raw() {
+                return Ok(Some(Action::Describe(x.clone())));
+            }
         }
         Ok(None)
     }

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -108,15 +108,11 @@ impl<'a> Component for NetworkNetworks<'a> {
             KeyCode::Tab => self.key_tab()?,
             KeyCode::Enter => {
                 if let Some(command_tx) = self.get_command_tx() {
-                    command_tx.send(Action::NetworkSubnetFilter(NetworkSubnetFilters {
-                        network_id: self
-                            .get_selected_raw()
-                            .get("id")
-                            .unwrap()
-                            .as_str()
-                            .map(String::from)
-                            .clone(),
-                    }))?;
+                    if let Some(x) = self.get_selected_raw() {
+                        command_tx.send(Action::NetworkSubnetFilter(NetworkSubnetFilters {
+                            network_id: x.get("id").unwrap().as_str().map(String::from).clone(),
+                        }))?;
+                    }
                 }
                 return Ok(Some(Action::Mode(Mode::NetworkSubnets)));
             }

--- a/openstack_tui/src/components/network/subnets.rs
+++ b/openstack_tui/src/components/network/subnets.rs
@@ -114,7 +114,9 @@ impl<'a> Component for NetworkSubnets<'a> {
             _ => {}
         }
         if key.kind == KeyEventKind::Press && key.code == KeyCode::Enter {
-            return Ok(Some(Action::Describe(self.get_selected_raw().clone())));
+            if let Some(x) = self.get_selected_raw() {
+                return Ok(Some(Action::Describe(x.clone())));
+            }
         }
         Ok(None)
     }

--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -462,16 +462,20 @@ where
         Ok(())
     }
 
-    pub fn get_selected_raw(&self) -> &Value {
-        &self.raw_items[self.state.selected().unwrap()]
+    pub fn get_selected_raw(&self) -> Option<&Value> {
+        self.state.selected().and_then(|x| Some(&self.raw_items[x]))
     }
 
-    pub fn get_selected_resource_id(&self) -> Result<String, Report> {
+    pub fn get_selected_resource_id(&self) -> Result<Option<String>, Report> {
         self.get_selected_raw()
-            .get("id")
-            .ok_or_eyre("Resource ID must be known")?
-            .as_str()
-            .map(String::from)
-            .ok_or_eyre("Resource ID must be string")
+            .map(|entry| {
+                entry
+                    .get("id")
+                    .ok_or_eyre("Resource ID must be known")?
+                    .as_str()
+                    .map(String::from)
+                    .ok_or_eyre("Resource ID must be string")
+            })
+            .transpose()
     }
 }


### PR DESCRIPTION
Avoid crash when we try to call some actions on row which is not
selected (i.e. when no rows exist)
