### PR TITLE
chore: Remove fuzz from exclude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ members = [
   "xtask",
   "fuzz"
 ]
-exclude = ["fuzz"]
 default-members = ["openstack_cli", "openstack_sdk", "openstack_tui"]
 
 [workspace.package]


### PR DESCRIPTION
Listing fuzz in workspace exclude is not necessary