### PR TITLE
fix: Fix network.agent property types

### DIFF
--- a/openstack_cli/src/network/v2/agent/create.rs
+++ b/openstack_cli/src/network/v2/agent/create.rs
@@ -74,7 +74,7 @@ struct ResponseData {
 
     #[serde()]
     #[structable(optional)]
-    alive: Option<String>,
+    alive: Option<bool>,
 
     #[serde()]
     #[structable(optional)]
@@ -85,8 +85,8 @@ struct ResponseData {
     binary: Option<String>,
 
     #[serde()]
-    #[structable(optional)]
-    configurations: Option<String>,
+    #[structable(optional, pretty)]
+    configurations: Option<Value>,
 
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/agent/list.rs
+++ b/openstack_cli/src/network/v2/agent/list.rs
@@ -35,6 +35,7 @@ use crate::common::BoolString;
 use openstack_sdk::api::network::v2::agent::list;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Lists all agents.
@@ -195,8 +196,8 @@ struct ResponseData {
     /// semantics of which are determined by the binary name and type.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    configurations: Option<serde_json::Value>,
+    #[structable(optional, pretty, wide)]
+    configurations: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///

--- a/openstack_cli/src/network/v2/agent/set.rs
+++ b/openstack_cli/src/network/v2/agent/set.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use crate::common::BoolString;
 use openstack_sdk::api::network::v2::agent::set;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Updates an agent.
@@ -109,7 +110,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    alive: Option<String>,
+    alive: Option<bool>,
 
     /// The availability zone of the agent.
     ///
@@ -128,8 +129,8 @@ struct ResponseData {
     /// semantics of which are determined by the binary name and type.
     ///
     #[serde()]
-    #[structable(optional)]
-    configurations: Option<String>,
+    #[structable(optional, pretty)]
+    configurations: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///

--- a/openstack_cli/src/network/v2/agent/show.rs
+++ b/openstack_cli/src/network/v2/agent/show.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use crate::common::BoolString;
 use openstack_sdk::api::network::v2::agent::get;
 use openstack_sdk::api::QueryAsync;
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Shows details for an agent.
@@ -93,7 +94,7 @@ struct ResponseData {
     ///
     #[serde()]
     #[structable(optional)]
-    alive: Option<String>,
+    alive: Option<bool>,
 
     /// The availability zone of the agent.
     ///
@@ -112,8 +113,8 @@ struct ResponseData {
     /// semantics of which are determined by the binary name and type.
     ///
     #[serde()]
-    #[structable(optional)]
-    configurations: Option<String>,
+    #[structable(optional, pretty)]
+    configurations: Option<Value>,
 
     /// Time at which the resource has been created (in UTC ISO8601 format).
     ///


### PR DESCRIPTION
- agent.alive is boolean
- agent.configurations is an object

None of them is having any type marker in neutron-lib -> hardcode.

Change-Id: Ib1d394baf9f6375d541b38b21b9b7a30898a1fb3

Changes are triggered by https://review.opendev.org/930561
