### PR TITLE
fix: Disable pagination limits

### DIFF
--- a/openstack_tui/src/cloud_worker/compute.rs
+++ b/openstack_tui/src/cloud_worker/compute.rs
@@ -108,7 +108,7 @@ impl ComputeExt for Cloud {
                 )?
                 .build()?;
 
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::Limit(100))
+            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
                 .query_async(session)
                 .await?;
             return Ok(res);

--- a/openstack_tui/src/cloud_worker/image.rs
+++ b/openstack_tui/src/cloud_worker/image.rs
@@ -35,7 +35,7 @@ impl ImageExt for Cloud {
                 ep_builder.visibility(vis);
             }
             let ep = ep_builder.build()?;
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::Limit(100))
+            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
                 .query_async(session)
                 .await?;
             //let res: Vec<Value> = ep.query_async(session).await?;

--- a/openstack_tui/src/cloud_worker/network.rs
+++ b/openstack_tui/src/cloud_worker/network.rs
@@ -34,7 +34,7 @@ impl NetworkExt for Cloud {
             ep_builder.sort_dir("asc");
 
             let ep = ep_builder.build()?;
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::Limit(100))
+            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
                 .query_async(session)
                 .await?;
             return Ok(res);
@@ -52,7 +52,7 @@ impl NetworkExt for Cloud {
                 ep_builder.network_id(network_id.clone());
             }
             let ep = ep_builder.build()?;
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::Limit(100))
+            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
                 .query_async(session)
                 .await?;
             return Ok(res);

--- a/openstack_tui/src/components/identity/projects.rs
+++ b/openstack_tui/src/components/identity/projects.rs
@@ -79,11 +79,6 @@ impl<'a> Component for IdentityProjects<'a> {
             }
             Action::Tick => {
                 self.app_tick()?;
-                if let Mode::IdentityProjects = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::IdentityProjects(self.get_filters().clone()),
-                    )));
-                }
             }
             Action::Render => self.render_tick()?,
             Action::ResourcesData {


### PR DESCRIPTION
Safety measure to limit amount of resources fetched from the server side
is having a quite negative effect. Show all until pagination (or dynamic
fetch) is going to be added.

Disable auto-refresh on projects view.
