### PR TITLE
chore: Drop better/human-panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,16 +388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "better-panic"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa9e1d11a268684cbd90ed36370d7577afb6c62d912ddff5c15fc34343e5036"
-dependencies = [
- "backtrace",
- "console",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,22 +1387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "human-panic"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5a08ed290eac04006e21e63d32e90086b6182c7cd0452d10f4264def1fec9a"
-dependencies = [
- "anstream",
- "anstyle",
- "backtrace",
- "os_info",
- "serde",
- "serde_derive",
- "toml 0.8.19",
- "uuid",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,7 +1827,7 @@ dependencies = [
  "serde_json",
  "shlex",
  "tempfile",
- "toml 0.5.11",
+ "toml",
  "topological-sort",
 ]
 
@@ -1993,7 +1967,6 @@ name = "openstack_cli"
 version = "0.7.3"
 dependencies = [
  "assert_cmd",
- "better-panic",
  "bytes",
  "clap",
  "clap_complete",
@@ -2003,7 +1976,6 @@ dependencies = [
  "eyre",
  "file_diff",
  "http 1.1.0",
- "human-panic",
  "indicatif",
  "json-patch",
  "openstack_sdk",
@@ -2072,7 +2044,6 @@ dependencies = [
 name = "openstack_tui"
 version = "0.1.3"
 dependencies = [
- "better-panic",
  "clap",
  "color-eyre",
  "config",
@@ -2081,7 +2052,6 @@ dependencies = [
  "dirs",
  "eyre",
  "futures",
- "human-panic",
  "itertools 0.13.0",
  "json5",
  "lazy_static",
@@ -2108,17 +2078,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "os_info"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
-dependencies = [
- "log",
- "serde",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "overload"
@@ -2763,15 +2722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,39 +3122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
-]
-
-[[package]]
 name = "topological-sort"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,15 +3310,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,11 @@ repository = "https://github.com/gtema/openstack"
 
 [workspace.dependencies]
 async-trait = { version = "^0.1" } #, optional = true }
-better-panic = { version = "^0.3" }
 bytes = "^1.7"
 chrono = { version = "^0.4", default-features = false, features = ["clock", "serde"] }
 clap = { version = "^4.5", features = ["cargo", "color", "derive", "env"] }
 clap_complete = { version = "^4.5" }
-color-eyre = { version = "^0.6", features = ["default", "issue-url"] }
+color-eyre = { version = "^0.6", features = ["default", "issue-url", "track-caller"] }
 config = { version = "^0.14", default-features = false }
 dialoguer = "^0.11"
 dirs = "^5.0"
@@ -33,7 +32,6 @@ eyre = { version = "^0.6" }
 futures = "^0.3"
 futures-util = { version = "^0.3", default-features = false}
 http = "^1.1"
-human-panic = { version = "^2.0" }
 itertools = { version = "^0.13" }
 json-patch = { version = "^2.0" }
 lazy_static = { version = "^1.5" }

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -50,7 +50,6 @@ _test_net_network-segment-range = []
 _test_net_vpn = []
 
 [dependencies]
-better-panic = { workspace = true }
 bytes = {workspace = true}
 clap = { workspace = true, features = ["color", "derive", "env"] }
 clap_complete = { workspace = true }
@@ -59,7 +58,6 @@ color-eyre = { workspace = true }
 dialoguer = { workspace = true, features=["fuzzy-select"] }
 eyre = { workspace = true }
 http = { workspace = true }
-human-panic = { workspace = true }
 json-patch = { workspace = true }
 openstack_sdk = { path="../openstack_sdk", version = "^0.11", default-features = false, features = ["async", "identity"] }
 indicatif = "^0.17"

--- a/openstack_cli/src/bin/osc.rs
+++ b/openstack_cli/src/bin/osc.rs
@@ -18,6 +18,10 @@
 #![deny(missing_docs)]
 
 use color_eyre::eyre::{Report, Result};
+use color_eyre::owo_colors::OwoColorize;
+use color_eyre::section::PanicMessage;
+use std::env;
+use std::{fmt, panic::Location};
 
 #[tokio::main]
 async fn main() -> Result<(), Report> {
@@ -26,47 +30,81 @@ async fn main() -> Result<(), Report> {
     Ok(())
 }
 
+struct MyPanicMessage;
+
+impl PanicMessage for MyPanicMessage {
+    fn display(&self, pi: &std::panic::PanicInfo<'_>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "{}", "The application panicked (crashed).".red())?;
+        writeln!(
+            f,
+            "{}",
+            "This is very sad, but you can help with the issue diagnose by reporting the issue."
+                .red()
+        )?;
+
+        // Print panic message.
+        writeln!(f, "\n{}", "What is known:".red())?;
+        writeln!(f, "\n{}", "Crash information:".yellow())?;
+        let payload = pi
+            .payload()
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| pi.payload().downcast_ref::<&str>().cloned())
+            .unwrap_or("<non string panic payload>");
+
+        // Print command
+        write!(f, "{}", "Command:  ".yellow())?;
+        writeln!(f, "{}", env::args().collect::<Vec<_>>().join(" ").purple())?;
+
+        // Error message
+        write!(f, "{}", "Message:  ".yellow())?;
+        writeln!(f, "{}", payload.cyan())?;
+
+        // If known, print panic location.
+        write!(f, "{}", "Location: ".yellow())?;
+        if let Some(loc) = pi.location() {
+            write!(f, "{}", loc.file().purple())?;
+            write!(f, ":")?;
+            writeln!(f, "{}", loc.line().purple())?;
+        } else {
+            writeln!(f, "<unknown>")?;
+        }
+        // Error message
+        write!(f, "{}", "Version:  ".yellow())?;
+        writeln!(f, "{}", env!("CARGO_PKG_VERSION").purple())?;
+
+        Ok(())
+    }
+}
+
 /// Initialize panic handling
 fn initialize_panic_handler() -> Result<()> {
+    let command = env::args().collect::<Vec<_>>().join("+");
     let (panic_hook, eyre_hook) = color_eyre::config::HookBuilder::default()
-        .panic_section(format!(
-            "This is a bug. Consider reporting it at {}/issues",
-            env!("CARGO_PKG_REPOSITORY")
-        ))
-        .capture_span_trace_by_default(false)
-        .display_location_section(false)
+        .issue_url(concat!(env!("CARGO_PKG_REPOSITORY"), "/issues/new"))
+        .issue_filter(|kind| match kind {
+            color_eyre::ErrorKind::NonRecoverable(_) => true,
+            color_eyre::ErrorKind::Recoverable(error) => !error.is::<std::fmt::Error>(),
+        })
+        .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
+        .add_issue_metadata("command", command)
+        .panic_message(MyPanicMessage)
+        .capture_span_trace_by_default(true)
+        .display_location_section(true)
         .display_env_section(false)
         .into_hooks();
     eyre_hook.install()?;
     std::panic::set_hook(Box::new(move |panic_info| {
         #[cfg(not(debug_assertions))]
         {
-            use human_panic::{handle_dump, print_msg, Metadata};
-            let meta = Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
-                .authors(env!("CARGO_PKG_AUTHORS"))
-                .homepage(env!("CARGO_PKG_HOMEPAGE"))
-                .support(format!(
-                    "Report issue at {}/issues",
-                    env!("CARGO_PKG_HOMEPAGE")
-                ));
-
-            let file_path = handle_dump(&meta, panic_info);
-            // prints human-panic message
-            print_msg(file_path, &meta)
-                .expect("human-panic: printing error message to console failed");
-            eprintln!("{}", panic_hook.panic_report(panic_info)); // prints color-eyre stack trace to stderr
+            eprintln!("\n{}", panic_hook.panic_report(panic_info)); // prints color-eyre stack trace to stderr
         }
         let msg = format!("{}", panic_hook.panic_report(panic_info));
         tracing::error!("Error: {}", strip_ansi_escapes::strip_str(msg));
 
         #[cfg(debug_assertions)]
         {
-            // Better Panic stacktrace that is only enabled when debugging.
-            better_panic::Settings::auto()
-                .most_recent_first(false)
-                .lineno_suffix(true)
-                .verbosity(better_panic::Verbosity::Full)
-                .create_panic_handler()(panic_info);
+            eprintln!("\n{}", panic_hook.panic_report(panic_info)); // prints color-eyre stack trace to stderr
         }
 
         std::process::exit(1);

--- a/openstack_tui/Cargo.toml
+++ b/openstack_tui/Cargo.toml
@@ -16,7 +16,6 @@ name = "ostui"
 path = "src/main.rs"
 
 [dependencies]
-better-panic = { workspace = true }
 clap = { workspace = true, features = ["cargo", "derive", "env", "wrap_help", "unicode", "string", "unstable-styles"] }
 color-eyre = { workspace = true }
 config = { workspace = true, features = ["json", "json5", "yaml"] }
@@ -25,7 +24,6 @@ derive_deref = "^1.1"
 dirs = { workspace = true }
 eyre = { workspace = true }
 futures = { workspace = true }
-human-panic = { workspace = true }
 itertools = { workspace = true }
 json5 = "^0.4"
 lazy_static = "^1.5"


### PR DESCRIPTION
Practice showed that neither better-panic gives any benefit, nor
human-panic (it is not possible to upload generated toml file to GitHub
easily). Get rid of them restoring eyre reporting functionality with
some styling.
