### PR TITLE
chore: Show full osc command in the doc

### DIFF
--- a/openstack_cli/src/identity/v3/user/access_rule.rs
+++ b/openstack_cli/src/identity/v3/user/access_rule.rs
@@ -24,50 +24,57 @@ mod delete;
 mod list;
 mod show;
 
-/// **Application Credentials - Access Rules**
+/// Application Credentials - Access Rules
 ///
-/// Users also have the option of delegating more
-/// fine-grained access control to their application
-/// credentials by using access rules. For example, to
-/// create an application credential that is constricted
-/// to creating servers in nova, the user can add the
-/// following access rules:
+/// Users have the option of delegating more fine-grained access control to their application
+/// credentials by using access rules. For example, to create an application credential that is
+/// constricted to creating servers in nova, the user can add the following access rules:
 ///
-/// ```json { "access_rules": [{ "path": "/v2.1/servers",
-/// "method": "POST", "service": "compute" }] } ```
+/// ```json
 ///
-/// The "path" attribute of application credential access
-/// rules uses a wildcard syntax to make it more flexible.
-/// For example, to create an application credential that
-/// is constricted to listing server IP addresses, you
-/// could use either of the following access rules:
+/// { "access_rules": [{ "path": "/v2.1/servers", "method": "POST", "service": "compute" }] }
 ///
-/// ```json { "access_rules": [ { "path":
-/// "/v2.1/servers/*/ips", "method": "GET", "service":
-/// "compute" } ] } ```
+/// ```
+///
+/// The "path" attribute of application credential access rules uses a wildcard syntax to make it
+/// more flexible. For example, to create an application credential that is constricted to listing
+/// server IP addresses, you could use either of the following access rules:
+///
+/// ```json
+///
+/// { "access_rules": [ { "path": "/v2.1/servers/*/ips", "method": "GET", "service": "compute" } ] }
+///
+/// ```
 ///
 /// or equivalently:
 ///
-/// ```json { "access_rules": [ { "path":
-/// "/v2.1/servers/{server_id}/ips", "method": "GET",
-/// "service": "compute" } ] } ```
+/// ```json
 ///
-/// In both cases, a request path containing any server ID
-/// will match the access rule. For even more flexibility,
-/// the recursive wildcard ** indicates that request paths
-/// containing any number of / will be matched. For
-/// example:
+/// { "access_rules": [ { "path": "/v2.1/servers/{server_id}/ips", "method": "GET", "service": "compute" } ] }
 ///
-/// ```json { "access_rules": [ { "path": "/v2.1/**",
-/// "method": "GET", "service": "compute" } ] } ```
+/// ```
+///
+/// In both cases, a request path containing any server ID will match the access rule. For even
+/// more flexibility, the recursive wildcard ** indicates that request paths containing any number
+/// of / will be matched. For example:
+///
+/// ```json
+///
+/// { "access_rules": [ { "path": "/v2.1/**", "method": "GET", "service": "compute" } ] }
+///
+/// ```
 ///
 /// will match any nova API for version 2.1.
 ///
-/// An access rule created for one application credential
-/// can be re-used by providing its ID to another
-/// application credential, for example:
+/// An access rule created for one application credential can be re-used by providing its ID to
+/// another application credential, for example:
 ///
-/// ```json { "access_rules": [ { "id": "abcdef" } ] } ```
+/// ```json
+///
+/// { "access_rules": [ { "id": "abcdef" } ] }
+///
+///
+/// ```
 #[derive(Parser)]
 pub struct AccessRuleCommand {
     /// subcommand

--- a/openstack_cli/src/identity/v3/user/application_credential.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential.rs
@@ -25,70 +25,84 @@ mod delete;
 mod list;
 mod show;
 
-/// **Application Credentials**
+/// Application Credentials
 ///
-/// Application credentials provide a way to delegate a user’s authorization
-/// to an application without sharing the user’s password authentication.
-/// This is a useful security measure, especially for situations where the
-/// user’s identification is provided by an external source, such as LDAP or
-/// a single-sign-on service. Instead of storing user passwords in config
-/// files, a user creates an application credential for a specific project,
-/// with all or a subset of the role assignments they have on that project,
-/// and then stores the application credential identifier and secret in the
-/// config file.
+/// Application credentials provide a way to delegate a user’s authorization to an application
+/// without sharing the user’s password authentication. This is a useful security measure,
+/// especially for situations where the user’s identification is provided by an external source,
+/// such as LDAP or a single-sign-on service. Instead of storing user passwords in config files, a
+/// user creates an application credential for a specific project, with all or a subset of the role
+/// assignments they have on that project, and then stores the application credential identifier
+/// and secret in the config file.
 ///
-/// Multiple application credentials may be active at once, so you can easily
-/// rotate application credentials by creating a second one, converting your
-/// applications to use it one by one, and finally deleting the first one.
+/// Multiple application credentials may be active at once, so you can easily rotate application
+/// credentials by creating a second one, converting your applications to use it one by one, and
+/// finally deleting the first one.
 ///
-/// Application credentials are limited by the lifespan of the user that
-/// created them. If the user is deleted, disabled, or loses a role
-/// assignment on a project, the application credential is deleted.
+/// Application credentials are limited by the lifespan of the user that created them. If the user
+/// is deleted, disabled, or loses a role assignment on a project, the application credential is
+/// deleted.
 ///
-/// Application credentials can have their privileges limited in two ways.
-/// First, the owner may specify a subset of their own roles that the
-/// application credential may assume when getting a token for a project. For
-/// example, if a user has the member role on a project, they also have the
-/// implied role reader and can grant the application credential only the
-/// reader role for the project:
+/// Application credentials can have their privileges limited in two ways. First, the owner may
+/// specify a subset of their own roles that the application credential may assume when getting a
+/// token for a project. For example, if a user has the member role on a project, they also have
+/// the implied role reader and can grant the application credential only the reader role for the
+/// project:
+///
+/// ```json
 ///
 /// "roles": [ {"name": "reader"} ]
 ///
-/// Users also have the option of delegating more fine-grained access control
-/// to their application credentials by using access rules. For example, to
-/// create an application credential that is constricted to creating servers
-/// in nova, the user can add the following access rules:
+/// ```
 ///
-/// "access_rules": [ { "path": "/v2.1/servers", "method": "POST", "service":
-/// "compute" } ]
+/// Users also have the option of delegating more fine-grained access control to their application
+/// credentials by using access rules. For example, to create an application credential that is
+/// constricted to creating servers in nova, the user can add the following access rules:
 ///
-/// The "path" attribute of application credential access rules uses a
-/// wildcard syntax to make it more flexible. For example, to create an
-/// application credential that is constricted to listing server IP
-/// addresses, you could use either of the following access rules:
+/// ```json
 ///
-/// "access_rules": [ { "path": "/v2.1/servers/*/ips", "method": "GET",
-/// "service": "compute" } ]
+/// "access_rules": [ { "path": "/v2.1/servers", "method": "POST", "service": "compute" } ]
+///
+/// ```
+///
+/// The "path" attribute of application credential access rules uses a wildcard syntax to make it
+/// more flexible. For example, to create an application credential that is constricted to listing
+/// server IP addresses, you could use either of the following access rules:
+///
+/// ```json
+///
+/// "access_rules": [ { "path": "/v2.1/servers/*/ips", "method": "GET", "service": "compute" } ]
+///
+/// ```
 ///
 /// or equivalently:
 ///
-/// "access_rules": [ { "path": "/v2.1/servers/{server_id}/ips", "method":
-/// "GET", "service": "compute" } ]
+/// ```json
 ///
-/// In both cases, a request path containing any server ID will match the
-/// access rule. For even more flexibility, the recursive wildcard **
-/// indicates that request paths containing any number of / will be matched.
-/// For example:
+/// "access_rules": [ { "path": "/v2.1/servers/{server_id}/ips", "method": "GET", "service": "compute" } ]
 ///
-/// "access_rules": [ { "path": "/v2.1/**", "method": "GET", "service":
-/// "compute" } ]
+/// ```
+///
+/// In both cases, a request path containing any server ID will match the access rule. For even
+/// more flexibility, the recursive wildcard ** indicates that request paths containing any number
+/// of / will be matched. For example:
+///
+/// ```json
+///
+/// "access_rules": [ { "path": "/v2.1/**", "method": "GET", "service": "compute" } ]
+///
+/// ```
 ///
 /// will match any nova API for version 2.1.
 ///
-/// An access rule created for one application credential can be re-used by
-/// providing its ID to another application credential, for example:
+/// An access rule created for one application credential can be re-used by providing its ID to
+/// another application credential, for example:
+///
+/// ```json
 ///
 /// "access_rules": [ { "id": "abcdef" } ]
+///
+/// ```
 #[derive(Parser)]
 pub struct ApplicationCredentialCommand {
     /// subcommand

--- a/xtask/src/bin/osc-cli-md.rs
+++ b/xtask/src/bin/osc-cli-md.rs
@@ -169,7 +169,7 @@ mod osc_cli_md_lib {
         //----------------------------------
 
         if command.get_subcommands().next().is_some() {
-            writeln!(buffer, "### **Subcommands:**\n")?;
+            writeln!(buffer, "### **Available subcommands:**\n")?;
 
             for subcommand in command.get_subcommands() {
                 if subcommand.is_hide_set() {
@@ -185,8 +185,9 @@ mod osc_cli_md_lib {
 
                 writeln!(
                     buffer,
-                    "* [`{subcommand_title_name}`]({}/{}.html) — {about}",
-                    title_name, subcommand_title_name
+                    "* [`{} {subcommand_title_name}`]({}/{subcommand_title_name}.html) — {about}",
+                    command_path.join(" "),
+                    title_name
                 )?;
             }
 


### PR DESCRIPTION
- render complete command under the subcommands instead of only the
  subcommand name
- address few issues in the identity docstrings
