### PR TITLE
feat: Add support for --os-client-config-file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,6 +2025,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/openstack_cli/src/bin/osc.rs
+++ b/openstack_cli/src/bin/osc.rs
@@ -21,7 +21,7 @@ use color_eyre::eyre::{Report, Result};
 use color_eyre::owo_colors::OwoColorize;
 use color_eyre::section::PanicMessage;
 use std::env;
-use std::{fmt, panic::Location};
+use std::fmt;
 
 #[tokio::main]
 async fn main() -> Result<(), Report> {

--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -114,6 +114,24 @@ pub struct GlobalOpts {
     #[arg(long, env = "OS_PROJECT_NAME", global = true, display_order = 901)]
     pub os_project_name: Option<String>,
 
+    /// Custom path to the `clouds.yaml` config file
+    #[arg(
+        long,
+        env = "OS_CLIENT_CONFIG_FILE",
+        global = true,
+        display_order = 905
+    )]
+    pub os_client_config_file: Option<String>,
+
+    /// Custom path to the `secure.yaml` config file
+    #[arg(
+        long,
+        env = "OS_CLIENT_SECURE_FILE",
+        global = true,
+        display_order = 905
+    )]
+    pub os_client_secure_file: Option<String>,
+
     /// Output format
     #[arg(short, long, global = true, value_enum, display_order = 910)]
     pub output: Option<OutputFormat>,

--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -22,6 +22,7 @@
 // }
 #![allow(clippy::enum_variant_names)]
 use std::io::{self, IsTerminal};
+use std::path::Path;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
@@ -81,7 +82,15 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         })
         .init();
 
-    let cfg = openstack_sdk::config::ConfigFile::new().unwrap();
+    let mut custom_configs: Vec<&Path> = Vec::new();
+    if let Some(ref clouds) = cli.global_opts.os_client_config_file {
+        custom_configs.push(Path::new(clouds));
+    }
+    if let Some(ref secure) = cli.global_opts.os_client_secure_file {
+        custom_configs.push(Path::new(secure));
+    }
+    let cfg = openstack_sdk::config::ConfigFile::try_from(custom_configs)?;
+
     // Identify target cloud to connect to
     let cloud_name = match cli.global_opts.os_cloud {
         Some(ref cloud) => cloud.clone(),

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -69,6 +69,7 @@ url = { workspace = true }
 [dev-dependencies]
 httpmock = "^0.7"
 reserve-port = "^2.0"
+tempfile = "^3.13"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [[test]]


### PR DESCRIPTION
Similarly to openstacksdk/cli support `--os-client-config-file` and
`--os-client-secure-file` to specify alternative path to the
configuration files.
