### PR TITLE
feat: Add user_id/project_id/domain_id reference

### DIFF
--- a/openstack_cli/src/compute/v2/keypair/delete.rs
+++ b/openstack_cli/src/compute/v2/keypair/delete.rs
@@ -32,10 +32,15 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::compute::v2::keypair::delete;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Deletes a keypair.
 ///
@@ -58,8 +63,24 @@ pub struct KeypairCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
 }
 
 /// Path parameters
@@ -95,8 +116,46 @@ impl KeypairCommand {
         // Set path parameters
         ep_builder.id(&self.path.id);
         // Set query parameters
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set body parameters
 

--- a/openstack_cli/src/compute/v2/keypair/list.rs
+++ b/openstack_cli/src/compute/v2/keypair/list.rs
@@ -31,10 +31,14 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::compute::v2::keypair::list;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists keypairs that are associated with the account.
 ///
@@ -67,8 +71,24 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
 }
 
 /// Path parameters
@@ -120,8 +140,46 @@ impl KeypairsCommand {
 
         // Set path parameters
         // Set query parameters
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/compute/v2/keypair/show.rs
+++ b/openstack_cli/src/compute/v2/keypair/show.rs
@@ -57,8 +57,24 @@ pub struct KeypairCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
 }
 
 /// Path parameters

--- a/openstack_cli/src/compute/v2/migration/get.rs
+++ b/openstack_cli/src/compute/v2/migration/get.rs
@@ -31,9 +31,14 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::compute::v2::migration::get;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists migrations.
 ///
@@ -87,8 +92,9 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     migration_type: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
-    project_id: Option<String>,
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
 
     #[arg(help_heading = "Query parameters", long)]
     source_compute: Option<String>,
@@ -96,8 +102,39 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     status: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
 }
 
 /// Path parameters
@@ -294,11 +331,87 @@ impl MigrationCommand {
         if let Some(val) = &self.query.changes_before {
             ep_builder.changes_before(val);
         }
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
-        if let Some(val) = &self.query.project_id {
-            ep_builder.project_id(val);
+        if let Some(id) = &self.query.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.query.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set body parameters
 

--- a/openstack_cli/src/compute/v2/quota_set/delete.rs
+++ b/openstack_cli/src/compute/v2/quota_set/delete.rs
@@ -32,10 +32,15 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::compute::v2::quota_set::delete;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Reverts the quotas to default values for a project or a project and a user.
 ///
@@ -61,10 +66,24 @@ pub struct QuotaSetCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    /// ID of user to set the quotas for.
-    ///
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
 }
 
 /// Path parameters
@@ -100,8 +119,46 @@ impl QuotaSetCommand {
         // Set path parameters
         ep_builder.id(&self.path.id);
         // Set query parameters
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set body parameters
 

--- a/openstack_cli/src/compute/v2/quota_set/details.rs
+++ b/openstack_cli/src/compute/v2/quota_set/details.rs
@@ -31,10 +31,14 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::compute::v2::quota_set::details;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Show the detail of quota for a project or a project and a user.
 ///
@@ -60,8 +64,24 @@ pub struct QuotaSetCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
 }
 
 /// Path parameters
@@ -225,8 +245,46 @@ impl QuotaSetCommand {
         // Set path parameters
         ep_builder.id(&self.path.id);
         // Set query parameters
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set body parameters
 

--- a/openstack_cli/src/compute/v2/quota_set/set_21.rs
+++ b/openstack_cli/src/compute/v2/quota_set/set_21.rs
@@ -32,9 +32,13 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::IntString;
+use eyre::OptionExt;
 use openstack_sdk::api::compute::v2::quota_set::set_21;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Update the quotas for a project or a project and a user.
 ///
@@ -67,10 +71,24 @@ pub struct QuotaSetCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    /// ID of user to set the quotas for.
-    ///
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
 }
 
 /// Path parameters
@@ -349,8 +367,46 @@ impl QuotaSetCommand {
         // Set path parameters
         ep_builder.id(&self.path.id);
         // Set query parameters
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set body parameters
         // Set Request.quota_set data

--- a/openstack_cli/src/compute/v2/quota_set/show.rs
+++ b/openstack_cli/src/compute/v2/quota_set/show.rs
@@ -32,9 +32,13 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::IntString;
+use eyre::OptionExt;
 use openstack_sdk::api::compute::v2::quota_set::get;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Show the quota for a project or a project and a user.
 ///
@@ -57,10 +61,24 @@ pub struct QuotaSetCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    /// ID of user to set the quotas for.
-    ///
-    #[arg(help_heading = "Query parameters", long)]
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
     user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
 }
 
 /// Path parameters
@@ -222,8 +240,46 @@ impl QuotaSetCommand {
         // Set path parameters
         ep_builder.id(&self.path.id);
         // Set query parameters
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set body parameters
 

--- a/openstack_cli/src/compute/v2/server/list.rs
+++ b/openstack_cli/src/compute/v2/server/list.rs
@@ -31,11 +31,16 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::compute::v2::server::list_detailed;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
+use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// For each server, shows server details including config drive, extended
 /// status, and server usage information.
@@ -185,8 +190,9 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     progress: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
-    project_id: Option<String>,
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
 
     #[arg(help_heading = "Query parameters", long)]
     ramdisk_id: Option<String>,
@@ -233,14 +239,45 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     terminated_at: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
-    user_id: Option<String>,
+    /// User resource for which the operation should be performed.
+    #[command(flatten)]
+    user: UserInput,
 
     #[arg(help_heading = "Query parameters", long)]
     uuid: Option<String>,
 
     #[arg(help_heading = "Query parameters", long)]
     vm_state: Option<String>,
+}
+
+/// User input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct UserInput {
+    /// User Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_NAME")]
+    user_name: Option<String>,
+    /// User ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "USER_ID")]
+    user_id: Option<String>,
+    /// Current authenticated user.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_user: bool,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
 }
 
 /// Path parameters
@@ -671,11 +708,87 @@ impl ServersCommand {
 
         // Set path parameters
         // Set query parameters
-        if let Some(val) = &self.query.user_id {
-            ep_builder.user_id(val);
+        if let Some(id) = &self.query.user.user_id {
+            // user_id is passed. No need to lookup
+            ep_builder.user_id(id);
+        } else if let Some(name) = &self.query.user.user_name {
+            // user_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_user::Request::builder();
+            warn!("Querying user by name (because of `--user-name` parameter passed) may not be definite. This may fail in which case parameter `--user-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.user_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.user.current_user {
+            ep_builder.user_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
-        if let Some(val) = &self.query.project_id {
-            ep_builder.project_id(val);
+        if let Some(id) = &self.query.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.query.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         if let Some(val) = &self.query.tenant_id {
             ep_builder.tenant_id(val);

--- a/openstack_cli/src/identity/v3/domain/config/delete_all.rs
+++ b/openstack_cli/src/identity/v3/domain/config/delete_all.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::delete_all;
@@ -80,6 +81,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Config response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -133,6 +137,15 @@ impl ConfigCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/config/group/option/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/option/delete.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::option::delete;
@@ -103,6 +104,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Option response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -156,6 +160,15 @@ impl OptionCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group(&self.path.group);
         ep_builder.option(&self.path.option);

--- a/openstack_cli/src/identity/v3/domain/config/group/option/set.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/option/set.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_key_val;
+use eyre::OptionExt;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::option::set;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
@@ -107,6 +108,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -174,6 +178,15 @@ impl OptionCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group(&self.path.group);
         ep_builder.option(&self.path.option);

--- a/openstack_cli/src/identity/v3/domain/config/group/option/show.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/option/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::option::get;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
@@ -101,6 +102,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -168,6 +172,15 @@ impl OptionCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group(&self.path.group);
         ep_builder.option(&self.path.option);

--- a/openstack_cli/src/identity/v3/domain/config/group/set.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/set.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_json;
+use eyre::OptionExt;
 use eyre::WrapErr;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::set;
@@ -99,6 +100,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -166,6 +170,15 @@ impl GroupCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group(&self.path.group);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/config/group/show.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/show.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::group::get;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
@@ -89,6 +90,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -156,6 +160,15 @@ impl GroupCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group(&self.path.group);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/config/list.rs
+++ b/openstack_cli/src/identity/v3/domain/config/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::list;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
@@ -78,6 +79,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -145,6 +149,15 @@ impl ConfigsCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/config/replace.rs
+++ b/openstack_cli/src/identity/v3/domain/config/replace.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_json;
+use eyre::OptionExt;
 use eyre::WrapErr;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::replace;
@@ -86,6 +87,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -153,6 +157,15 @@ impl ConfigCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/config/set.rs
+++ b/openstack_cli/src/identity/v3/domain/config/set.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::parse_json;
+use eyre::OptionExt;
 use eyre::WrapErr;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::config::set;
@@ -86,6 +87,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -153,6 +157,15 @@ impl ConfigCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         // Set query parameters
         // Set body parameters

--- a/openstack_cli/src/identity/v3/domain/group/role/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/delete.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
@@ -100,6 +101,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -153,6 +157,15 @@ impl RoleCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.id(&self.path.id);

--- a/openstack_cli/src/identity/v3/domain/group/role/list.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/list.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::domain::group::role::list;
@@ -87,6 +88,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Roles response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -158,6 +162,15 @@ impl RolesCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group_id(&self.path.group_id);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/domain/group/role/set.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/set.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
@@ -100,6 +101,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -153,6 +157,15 @@ impl RoleCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.id(&self.path.id);

--- a/openstack_cli/src/identity/v3/domain/group/role/show.rs
+++ b/openstack_cli/src/identity/v3/domain/group/role/show.rs
@@ -32,6 +32,7 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
@@ -98,6 +99,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Role response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -151,6 +155,15 @@ impl RoleCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.id(&self.path.id);

--- a/openstack_cli/src/identity/v3/domain/user/role/delete.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/delete.rs
@@ -96,6 +96,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 
 /// User input select group
@@ -164,6 +167,15 @@ impl RoleCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
 
         // Process path parameter `user_id`

--- a/openstack_cli/src/identity/v3/domain/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/list.rs
@@ -83,6 +83,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 
 /// User input select group
@@ -169,6 +172,15 @@ impl RolesCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
 
         // Process path parameter `user_id`

--- a/openstack_cli/src/identity/v3/domain/user/role/set.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/set.rs
@@ -96,6 +96,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 
 /// User input select group
@@ -164,6 +167,15 @@ impl RoleCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
 
         // Process path parameter `user_id`

--- a/openstack_cli/src/identity/v3/domain/user/role/show.rs
+++ b/openstack_cli/src/identity/v3/domain/user/role/show.rs
@@ -94,6 +94,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 
 /// User input select group
@@ -162,6 +165,15 @@ impl RoleCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
 
         // Process path parameter `user_id`

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
@@ -103,6 +103,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// InheritedToProject response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -156,6 +159,15 @@ impl InheritedToProjectCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.role_id(&self.path.role_id);

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/get.rs
@@ -91,6 +91,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -158,6 +161,15 @@ impl InheritedToProjectCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group_id(&self.path.group_id);
         // Set query parameters

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
@@ -106,6 +106,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
@@ -173,6 +176,15 @@ impl InheritedToProjectCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
         ep_builder.group_id(&self.path.group_id);
         ep_builder.role_id(&self.path.role_id);

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
@@ -97,6 +97,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 
 /// User input select group
@@ -165,6 +168,15 @@ impl InheritedToProjectCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
 
         // Process path parameter `user_id`

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/get.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/get.rs
@@ -85,6 +85,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 
 /// User input select group
@@ -167,6 +170,15 @@ impl InheritedToProjectCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
 
         // Process path parameter `user_id`

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
@@ -100,6 +100,9 @@ struct DomainInput {
     /// Domain ID.
     #[arg(long, help_heading = "Path parameters", value_name = "DOMAIN_ID")]
     domain_id: Option<String>,
+    /// Current domain.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_domain: bool,
 }
 
 /// User input select group
@@ -182,6 +185,15 @@ impl InheritedToProjectCommand {
                     ))
                 }
             };
+        } else if self.path.domain.current_domain {
+            ep_builder.domain_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
         }
 
         // Process path parameter `user_id`

--- a/openstack_cli/src/load_balancer/v2/quota/delete.rs
+++ b/openstack_cli/src/load_balancer/v2/quota/delete.rs
@@ -32,10 +32,15 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
+use eyre::OptionExt;
 use http::Response;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::load_balancer::v2::quota::delete;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RawQueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Resets a project quota to use the deployment default quota.
 ///
@@ -58,14 +63,24 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for /v2/lbaas/quotas/{project_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_project_id",
-        value_name = "PROJECT_ID"
-    )]
-    project_id: String,
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
 }
 /// Quota response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -86,7 +101,49 @@ impl QuotaCommand {
         let mut ep_builder = delete::Request::builder();
 
         // Set path parameters
-        ep_builder.project_id(&self.path.project_id);
+
+        // Process path parameter `project_id`
+        if let Some(id) = &self.path.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.path.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.path.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/load_balancer/v2/quota/set.rs
+++ b/openstack_cli/src/load_balancer/v2/quota/set.rs
@@ -31,9 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::load_balancer::v2::quota::set;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Updates a quota for a project.
 ///
@@ -74,14 +78,24 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for /v2/lbaas/quotas/{project_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_project_id",
-        value_name = "PROJECT_ID"
-    )]
-    project_id: String,
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
 }
 /// Quota Body data
 #[derive(Args, Clone)]
@@ -215,7 +229,49 @@ impl QuotaCommand {
         let mut ep_builder = set::Request::builder();
 
         // Set path parameters
-        ep_builder.project_id(&self.path.project_id);
+
+        // Process path parameter `project_id`
+        if let Some(id) = &self.path.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.path.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.path.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
+        }
         // Set query parameters
         // Set body parameters
         // Set Request.quota data

--- a/openstack_cli/src/load_balancer/v2/quota/show.rs
+++ b/openstack_cli/src/load_balancer/v2/quota/show.rs
@@ -31,9 +31,13 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::load_balancer::v2::quota::get;
 use openstack_sdk::api::QueryAsync;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Show the quota for the project.
 ///
@@ -66,14 +70,24 @@ struct QueryParameters {}
 /// Path parameters
 #[derive(Args)]
 struct PathParameters {
-    /// project_id parameter for /v2/lbaas/quotas/{project_id} API
-    ///
-    #[arg(
-        help_heading = "Path parameters",
-        id = "path_param_project_id",
-        value_name = "PROJECT_ID"
-    )]
-    project_id: String,
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
 }
 /// Quota response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
@@ -153,7 +167,49 @@ impl QuotaCommand {
         let mut ep_builder = get::Request::builder();
 
         // Set path parameters
-        ep_builder.project_id(&self.path.project_id);
+
+        // Process path parameter `project_id`
+        if let Some(id) = &self.path.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.path.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.path.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
+        }
         // Set query parameters
         // Set body parameters
 

--- a/openstack_cli/src/network/v2/local_ip/port_association/set.rs
+++ b/openstack_cli/src/network/v2/local_ip/port_association/set.rs
@@ -31,6 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use crate::common::parse_json;
 use crate::common::parse_key_val;
 use openstack_sdk::api::network::v2::local_ip::port_association::set;
 use openstack_sdk::api::QueryAsync;


### PR DESCRIPTION
user_id/project_id/domain_id path parameters passing through the base
openapi class will get reference to the identity resource what enables
id/name/current selector in the cli.

Ensure that codegenerator supports linked resources also for query
parameters.

Change-Id: I1412eedf3b80e5dcd5be122b600ffeaab57b1e2b

Changes are triggered by https://review.opendev.org/930986
