### PR TITLE
feat: add the ability to specify the configs to load via a builder

### DIFF
--- a/openstack_cli/README.md
+++ b/openstack_cli/README.md
@@ -12,7 +12,7 @@ but also an enforced UX consistency.
 from one tool to another.
 
 Commands implementation code is being produced by
-(codegenerator)[https://opendev.org/openstack/codegenerator] what means there
+[codegenerator](https://opendev.org/openstack/codegenerator) what means there
 is no maintenance required for that code.
 
 ## Microversions

--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -22,7 +22,6 @@
 // }
 #![allow(clippy::enum_variant_names)]
 use std::io::{self, IsTerminal};
-use std::path::Path;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
@@ -83,14 +82,10 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         })
         .init();
 
-    let mut custom_configs: Vec<&Path> = Vec::new();
-    if let Some(ref clouds) = cli.global_opts.os_client_config_file {
-        custom_configs.push(Path::new(clouds));
-    }
-    if let Some(ref secure) = cli.global_opts.os_client_secure_file {
-        custom_configs.push(Path::new(secure));
-    }
-    let cfg = openstack_sdk::config::ConfigFile::try_from(custom_configs)?;
+    let cfg = openstack_sdk::config::ConfigFile::new_with_user_specified_configs(
+        cli.global_opts.os_client_config_file.as_deref(),
+        cli.global_opts.os_client_secure_file.as_deref(),
+    )?;
 
     // Identify target cloud to connect to
     let cloud_name = match cli.global_opts.os_cloud {

--- a/openstack_sdk/src/auth/authtoken_scope.rs
+++ b/openstack_sdk/src/auth/authtoken_scope.rs
@@ -123,7 +123,7 @@ pub enum AuthTokenScope {
     Unscoped,
 }
 
-/// Build [`AuthorizationScope`] data from [`CloudConfig`]
+/// Build [`AuthTokenScope`] data from [`CloudConfig`](config::CloudConfig)
 impl TryFrom<&config::CloudConfig> for AuthTokenScope {
     type Error = AuthTokenScopeError;
     fn try_from(config: &config::CloudConfig) -> Result<Self, Self::Error> {


### PR DESCRIPTION
After a bit back and forth on how to actually implement the proposed solution https://github.com/gtema/openstack/issues/608#issuecomment-2384546393, this is what should work and not break anything (since the last release), though the order of configurations has been changed to match what the python OpenStackSDK does.

I have removed the previous solution with `TryFrom`, but I can add it back if desired.