### PR TITLE
feat: Switch from cli-table to comfy-table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,29 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "cli-table"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53f9241f288a7b12c56565f04aaeaeeab6b8923d42d99255d4ca428b4d97f89"
-dependencies = [
- "cli-table-derive",
- "csv",
- "termcolor",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "cli-table-derive"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e83a93253aaae7c74eb7428ce4faa6e219ba94886908048888701819f82fb94"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "color-eyre"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +607,18 @@ name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
+name = "comfy-table"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
+dependencies = [
+ "crossterm 0.27.0",
+ "strum",
+ "strum_macros",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "compact_str"
@@ -706,6 +695,19 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
@@ -745,27 +747,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1970,8 +1951,8 @@ dependencies = [
  "bytes",
  "clap",
  "clap_complete",
- "cli-table",
  "color-eyre",
+ "comfy-table",
  "dialoguer",
  "eyre",
  "file_diff",
@@ -2048,7 +2029,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "config",
- "crossterm",
+ "crossterm 0.28.1",
  "derive_deref",
  "dirs",
  "eyre",
@@ -2434,7 +2415,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "instability",
  "itertools 0.13.0",
  "lru",
@@ -2979,15 +2960,6 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -55,8 +55,8 @@ _test_net_vpn = []
 bytes = {workspace = true}
 clap = { workspace = true, features = ["color", "derive", "env"] }
 clap_complete = { workspace = true }
-cli-table = "^0.4"
 color-eyre = { workspace = true }
+comfy-table = { version = "^7.1" }
 dialoguer = { workspace = true, features=["fuzzy-select"] }
 eyre = { workspace = true }
 http = { workspace = true }

--- a/openstack_cli/src/output.rs
+++ b/openstack_cli/src/output.rs
@@ -14,7 +14,7 @@
 
 //! Output processing module
 
-use cli_table::{print_stdout, Table};
+use comfy_table::{presets::UTF8_FULL_CONDENSED, ContentArrangement, Table};
 use eyre::WrapErr;
 use serde::de::DeserializeOwned;
 use std::collections::BTreeSet;
@@ -115,15 +115,14 @@ impl OutputProcessor {
     /// Produce output for humans (table)
     pub(crate) fn output_human<T: StructTable>(&self, data: &T) -> Result<(), OpenStackCliError> {
         let (headers, table_data) = data.build(&self.config);
-        print_stdout(
-            table_data.table().title(headers).separator(
-                cli_table::format::Separator::builder()
-                    .column(Some(cli_table::format::VerticalLine::default()))
-                    .title(Some(cli_table::format::HorizontalLine::default()))
-                    .build(),
-            ),
-        )
-        .map_err(OpenStackCliError::from)
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL_CONDENSED)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(headers)
+            .add_rows(table_data);
+        println!("{table}");
+        Ok(())
     }
 
     /// Produce output for machine


### PR DESCRIPTION
comfy-table provides more styling options including dynamic content
wrapping and UTF8 borders (it would be possible for the user to
customize output as desired). Project introduces few additional
dependencies (which are mostly anyway three) but is having more stars on
GitHub and activity.
