### PR TITLE
fix: Fix dns recordset schema

### DIFF
--- a/openstack_cli/src/dns/v2/zone/share/list.rs
+++ b/openstack_cli/src/dns/v2/zone/share/list.rs
@@ -38,6 +38,7 @@ use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 use tracing::warn;
 
@@ -111,6 +112,28 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, pretty)]
     shared_zones: Option<Value>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseLinks {
+    _self: Option<String>,
+    zone: Option<String>,
+}
+
+impl fmt::Display for ResponseLinks {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([
+            format!(
+                "_self={}",
+                self._self.clone().map_or(String::new(), |v| v.to_string())
+            ),
+            format!(
+                "zone={}",
+                self.zone.clone().map_or(String::new(), |v| v.to_string())
+            ),
+        ]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl SharesCommand {

--- a/openstack_sdk/src/api/dns/v2/zone/recordset/create.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/recordset/create.rs
@@ -81,11 +81,6 @@ pub struct Request<'a> {
     #[builder(default)]
     pub(crate) _type: Option<Type>,
 
-    /// The name of the zone that contains this recordset
-    ///
-    #[builder(default, setter(into))]
-    pub(crate) zone_name: Option<Cow<'a, str>>,
-
     /// zone_id parameter for /v2/zones/{zone_id}/recordsets/{recordset_id} API
     ///
     #[builder(default, setter(into))]
@@ -154,9 +149,6 @@ impl<'a> RestEndpoint for Request<'a> {
         }
         if let Some(val) = &self.description {
             params.push("description", serde_json::to_value(val)?);
-        }
-        if let Some(val) = &self.zone_name {
-            params.push("zone_name", serde_json::to_value(val)?);
         }
         if let Some(val) = &self._type {
             params.push("type", serde_json::to_value(val)?);


### PR DESCRIPTION
zone_name is a readOnly param and is not a uuid

Change-Id: If9a21d32ce431754a683c10e3e059def4bb3d9ba

Changes are triggered by https://review.opendev.org/931656
