### PR TITLE
feat: Fix dns schema mapping names

### DIFF
--- a/openstack_cli/src/dns/v2/recordset/list.rs
+++ b/openstack_cli/src/dns/v2/recordset/list.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use openstack_sdk::api::dns::v2::recordset::list;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
+use serde_json::Value;
 use structable_derive::StructTable;
 
 /// This lists all recordsets owned by a project in Designate
@@ -170,6 +171,15 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     project_id: Option<String>,
+
+    /// A list of data for this recordset. Each item will be a separate record
+    /// in Designate These items should conform to the DNS spec for the record
+    /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
+    /// hostname.
+    ///
+    #[serde()]
+    #[structable(optional, pretty, wide)]
+    records: Option<Value>,
 
     /// The status of the resource.
     ///

--- a/openstack_cli/src/dns/v2/zone/recordset/create.rs
+++ b/openstack_cli/src/dns/v2/zone/recordset/create.rs
@@ -63,6 +63,14 @@ pub struct RecordsetCommand {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// A list of data for this recordset. Each item will be a separate record
+    /// in Designate These items should conform to the DNS spec for the record
+    /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
+    /// hostname.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
+    records: Option<Vec<String>>,
+
     /// TTL (Time to Live) for the recordset.
     ///
     #[arg(help_heading = "Body parameters", long)]
@@ -162,6 +170,15 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     project_id: Option<String>,
+
+    /// A list of data for this recordset. Each item will be a separate record
+    /// in Designate These items should conform to the DNS spec for the record
+    /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
+    /// hostname.
+    ///
+    #[serde()]
+    #[structable(optional, pretty)]
+    records: Option<Value>,
 
     /// The status of the resource.
     ///
@@ -265,6 +282,11 @@ impl RecordsetCommand {
         // Set Request.name data
         if let Some(arg) = &self.name {
             ep_builder.name(arg);
+        }
+
+        // Set Request.records data
+        if let Some(arg) = &self.records {
+            ep_builder.records(arg.iter().map(Into::into).collect::<Vec<_>>());
         }
 
         // Set Request.ttl data

--- a/openstack_cli/src/dns/v2/zone/recordset/list.rs
+++ b/openstack_cli/src/dns/v2/zone/recordset/list.rs
@@ -36,6 +36,7 @@ use openstack_sdk::api::dns::v2::zone::recordset::list;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
+use serde_json::Value;
 use structable_derive::StructTable;
 use tracing::warn;
 
@@ -184,6 +185,15 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, wide)]
     project_id: Option<String>,
+
+    /// A list of data for this recordset. Each item will be a separate record
+    /// in Designate These items should conform to the DNS spec for the record
+    /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
+    /// hostname.
+    ///
+    #[serde()]
+    #[structable(optional, pretty, wide)]
+    records: Option<Value>,
 
     /// The status of the resource.
     ///

--- a/openstack_cli/src/dns/v2/zone/recordset/show.rs
+++ b/openstack_cli/src/dns/v2/zone/recordset/show.rs
@@ -134,6 +134,15 @@ struct ResponseData {
     #[structable(optional)]
     project_id: Option<String>,
 
+    /// A list of data for this recordset. Each item will be a separate record
+    /// in Designate These items should conform to the DNS spec for the record
+    /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
+    /// hostname.
+    ///
+    #[serde()]
+    #[structable(optional, pretty)]
+    records: Option<Value>,
+
     /// The status of the resource.
     ///
     #[serde()]

--- a/openstack_cli/src/dns/v2/zone/set.rs
+++ b/openstack_cli/src/dns/v2/zone/set.rs
@@ -31,13 +31,12 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_key_val;
 use openstack_sdk::api::dns::v2::zone::find;
 use openstack_sdk::api::dns::v2::zone::set;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Update the attribute(s) for an existing zone.
 ///
@@ -52,9 +51,20 @@ pub struct ZoneCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
-    #[arg(help_heading = "Body parameters")]
-    properties: Option<Vec<(String, Value)>>,
+    /// Description for this zone
+    ///
+    #[arg(help_heading = "Body parameters", long)]
+    description: Option<String>,
+
+    /// e-mail for the zone. Used in SOA records for the zone
+    ///
+    #[arg(help_heading = "Body parameters", long)]
+    email: Option<String>,
+
+    /// TTL (Time to Live) for the zone.
+    ///
+    #[arg(help_heading = "Body parameters", long)]
+    ttl: Option<i32>,
 }
 
 /// Query parameters
@@ -73,22 +83,131 @@ struct PathParameters {
     )]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
+/// Zone response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {
+    /// current action in progress on the resource
+    ///
+    #[serde()]
+    #[structable(optional)]
+    action: Option<String>,
 
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
+    /// Key:Value pairs of information about this zone, and the pool the user
+    /// would like to place the zone in. This information can be used by the
+    /// scheduler to place zones on the correct pool.
+    ///
+    #[serde()]
+    #[structable(optional, pretty)]
+    attributes: Option<Value>,
+
+    /// Date / Time when resource was created.
+    ///
+    #[serde()]
+    #[structable(optional)]
+    created_at: Option<String>,
+
+    /// Description for this zone
+    ///
+    #[serde()]
+    #[structable(optional)]
+    description: Option<String>,
+
+    /// e-mail for the zone. Used in SOA records for the zone
+    ///
+    #[serde()]
+    #[structable(optional)]
+    email: Option<String>,
+
+    /// ID for the resource
+    ///
+    #[serde()]
+    #[structable(optional)]
+    id: Option<String>,
+
+    /// Links to the resource, and other related resources. When a response has
+    /// been broken into pages, we will include a `next` link that should be
+    /// followed to retrieve all results
+    ///
+    #[serde()]
+    #[structable(optional, pretty)]
+    links: Option<Value>,
+
+    /// Mandatory for secondary zones. The servers to slave from to get DNS
+    /// information
+    ///
+    #[serde()]
+    #[structable(optional, pretty)]
+    masters: Option<Value>,
+
+    /// DNS Name for the zone
+    ///
+    #[serde()]
+    #[structable(optional)]
+    name: Option<String>,
+
+    /// ID for the pool hosting this zone
+    ///
+    #[serde()]
+    #[structable(optional)]
+    pool_id: Option<String>,
+
+    /// ID for the project that owns the resource
+    ///
+    #[serde()]
+    #[structable(optional)]
+    project_id: Option<String>,
+
+    /// current serial number for the zone
+    ///
+    #[serde()]
+    #[structable(optional)]
+    serial: Option<i32>,
+
+    /// True if the zone is shared with another project.
+    ///
+    /// **New in version 2.1**
+    ///
+    #[serde()]
+    #[structable(optional)]
+    shared: Option<bool>,
+
+    /// The status of the resource.
+    ///
+    #[serde()]
+    #[structable(optional)]
+    status: Option<String>,
+
+    /// For secondary zones. The last time an update was retrieved from the
+    /// master servers
+    ///
+    #[serde()]
+    #[structable(optional)]
+    transferred_at: Option<String>,
+
+    /// TTL (Time to Live) for the zone.
+    ///
+    #[serde()]
+    #[structable(optional)]
+    ttl: Option<i32>,
+
+    /// Type of zone. PRIMARY is controlled by Designate, SECONDARY zones are
+    /// slaved from another DNS Server. Defaults to PRIMARY
+    ///
+    #[serde(rename = "type")]
+    #[structable(optional, title = "type")]
+    _type: Option<String>,
+
+    /// Date / Time when resource last updated.
+    ///
+    #[serde()]
+    #[structable(optional)]
+    updated_at: Option<String>,
+
+    /// Version of the resource
+    ///
+    #[serde()]
+    #[structable(optional)]
+    version: Option<i32>,
 }
 
 impl ZoneCommand {
@@ -121,8 +240,19 @@ impl ZoneCommand {
         ep_builder.id(resource_id.clone());
         // Set query parameters
         // Set body parameters
-        if let Some(properties) = &self.properties {
-            ep_builder.properties(properties.iter().cloned());
+        // Set Request.description data
+        if let Some(arg) = &self.description {
+            ep_builder.description(arg);
+        }
+
+        // Set Request.email data
+        if let Some(arg) = &self.email {
+            ep_builder.email(arg);
+        }
+
+        // Set Request.ttl data
+        if let Some(arg) = &self.ttl {
+            ep_builder.ttl(*arg);
         }
 
         let ep = ep_builder

--- a/openstack_sdk/src/api/dns/v2/zone/recordset/create.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/recordset/create.rs
@@ -71,6 +71,14 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     pub(crate) name: Option<Cow<'a, str>>,
 
+    /// A list of data for this recordset. Each item will be a separate record
+    /// in Designate These items should conform to the DNS spec for the record
+    /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
+    /// hostname.
+    ///
+    #[builder(default, setter(into))]
+    pub(crate) records: Option<Vec<Cow<'a, str>>>,
+
     /// TTL (Time to Live) for the recordset.
     ///
     #[builder(default)]
@@ -152,6 +160,9 @@ impl<'a> RestEndpoint for Request<'a> {
         }
         if let Some(val) = &self._type {
             params.push("type", serde_json::to_value(val)?);
+        }
+        if let Some(val) = &self.records {
+            params.push("records", serde_json::to_value(val)?);
         }
 
         params.into_body()

--- a/openstack_sdk/src/api/dns/v2/zone/recordset/set.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/recordset/set.rs
@@ -22,13 +22,29 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
-use serde_json::Value;
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// Description for this recordset
+    ///
+    #[builder(default, setter(into))]
+    pub(crate) description: Option<Cow<'a, str>>,
+
+    /// A list of data for this recordset. Each item will be a separate record
+    /// in Designate These items should conform to the DNS spec for the record
+    /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
+    /// hostname.
+    ///
+    #[builder(default, setter(into))]
+    pub(crate) records: Option<Vec<Cow<'a, str>>>,
+
+    /// TTL (Time to Live) for the recordset.
+    ///
+    #[builder(default)]
+    pub(crate) ttl: Option<i32>,
+
     /// recordset_id parameter for
     /// /v2/zones/{zone_id}/recordsets/{recordset_id} API
     ///
@@ -42,9 +58,6 @@ pub struct Request<'a> {
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
-
-    #[builder(setter(name = "_properties"), default, private)]
-    _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
@@ -76,18 +89,6 @@ where {
             .extend(iter.map(Into::into));
         self
     }
-
-    pub fn properties<I, K, V>(&mut self, iter: I) -> &mut Self
-    where
-        I: Iterator<Item = (K, V)>,
-        K: Into<Cow<'a, str>>,
-        V: Into<Value>,
-    {
-        self._properties
-            .get_or_insert_with(BTreeMap::new)
-            .extend(iter.map(|(k, v)| (k.into(), v.into())));
-        self
-    }
 }
 
 impl<'a> RestEndpoint for Request<'a> {
@@ -111,8 +112,14 @@ impl<'a> RestEndpoint for Request<'a> {
     fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
         let mut params = JsonBodyParams::default();
 
-        for (key, val) in &self._properties {
-            params.push(key.clone(), val.clone());
+        if let Some(val) = &self.ttl {
+            params.push("ttl", serde_json::to_value(val)?);
+        }
+        if let Some(val) = &self.description {
+            params.push("description", serde_json::to_value(val)?);
+        }
+        if let Some(val) = &self.records {
+            params.push("records", serde_json::to_value(val)?);
         }
 
         params.into_body()


### PR DESCRIPTION
some schemas were accidentially plural causing mismatch. In addition to
that recordset was missing records attribute (missed in the current
api-ref) and zone/recordset supports only limited set of updatable
attributes.

Change-Id: I51b3a93caa1fc8804e40493636bde537a58950a3

Changes are triggered by https://review.opendev.org/931872
