### PR TITLE
fix: Fix "down" button on last entry

### DIFF
--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -166,7 +166,7 @@ where
             Focus::Table => {
                 let i = match self.state.selected() {
                     Some(i) => {
-                        if i < self.items.len() {
+                        if i < self.items.len() - 1 {
                             i + 1
                         } else {
                             i


### PR DESCRIPTION
Fix condition determining end of the list to prevent showing
non-existing entry.
