### PR TITLE
fix: Reset input when resource select popup closed

### DIFF
--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -212,6 +212,11 @@ impl App {
             // Normal global keybinding
             action_tx.send(action.action.clone())?;
         } else if key.code == KeyCode::Esc && self.active_popup.is_some() {
+            if let Some(popup_type) = &self.active_popup {
+                if let Some(popup) = self.popups.get_mut(popup_type) {
+                    popup.handle_key_events(key)?;
+                }
+            }
             // Close the popup
             self.active_popup = None;
             if !self.cloud_connected {

--- a/openstack_tui/src/components/fuzzy_select_list.rs
+++ b/openstack_tui/src/components/fuzzy_select_list.rs
@@ -157,6 +157,10 @@ impl Component for FuzzySelectList {
                 };
                 self.filter()?;
             }
+            KeyCode::Esc => {
+                self.input = None;
+                self.filter()?;
+            }
             KeyCode::Char(i) => {
                 self.input.get_or_insert(String::new()).push(*i);
                 self.filter()?;


### PR DESCRIPTION
When resource select popup is being closed reset the user input
