### PR TITLE
feat: Enable bs.service.list command

### DIFF
--- a/openstack_cli/src/block_storage/v3.rs
+++ b/openstack_cli/src/block_storage/v3.rs
@@ -34,6 +34,7 @@ mod message;
 mod os_volume_transfer;
 mod qos_spec;
 mod resource_filter;
+mod service;
 mod snapshot;
 mod snapshot_manage;
 mod r#type;
@@ -67,6 +68,7 @@ pub enum BlockStorageCommands {
     Message(message::MessageCommand),
     OsVolumeTransfer(os_volume_transfer::VolumeTransferCommand),
     QosSpec(qos_spec::QosSpecCommand),
+    Service(service::ServiceCommand),
     Snapshot(snapshot::SnapshotCommand),
     SnapshotManage(snapshot_manage::SnapshotManageCommand),
     ResourceFilter(resource_filter::ResourceFilterCommand),
@@ -106,6 +108,7 @@ impl BlockStorageCommand {
                 cmd.take_action(parsed_args, session).await
             }
             BlockStorageCommands::QosSpec(cmd) => cmd.take_action(parsed_args, session).await,
+            BlockStorageCommands::Service(cmd) => cmd.take_action(parsed_args, session).await,
             BlockStorageCommands::Snapshot(cmd) => cmd.take_action(parsed_args, session).await,
             BlockStorageCommands::SnapshotManage(cmd) => {
                 cmd.take_action(parsed_args, session).await

--- a/openstack_cli/src/block_storage/v3/service.rs
+++ b/openstack_cli/src/block_storage/v3/service.rs
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Block storage Service commands
+//!
+
+use clap::{Parser, Subcommand};
+
+use crate::{Cli, OpenStackCliError};
+
+use openstack_sdk::AsyncOpenStack;
+
+mod list;
+
+/// Services (os-services)
+///
+/// Administrator only. Lists all Cinder services, enables or disables a Cinder service, freeze or
+/// thaw the specified cinder-volume host, failover a replicating cinder-volume host.
+#[derive(Parser)]
+pub struct ServiceCommand {
+    /// subcommand
+    #[command(subcommand)]
+    command: ServiceCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum ServiceCommands {
+    List(list::ServicesCommand),
+}
+
+impl ServiceCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            ServiceCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/tests/block_storage/v3/service/mod.rs
+++ b/openstack_cli/tests/block_storage/v3/service/mod.rs
@@ -12,25 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod attachment;
-mod backup;
-mod cluster;
-mod default_type;
-mod extension;
-mod group;
-mod group_snapshot;
-mod group_type;
-mod host;
-mod limit;
-mod message;
-mod qos_spec;
-mod resource_filter;
-mod service;
-mod snapshot;
-mod snapshot_manage;
-mod r#type;
-mod volume;
-mod volume_manage;
+mod list_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -39,7 +21,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("block-storage").arg("--help");
+    cmd.args(["block-storage", "service", "--help"]);
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
- enable `block-storage service list` command. The output will change once the OpenAPI schema is being fixed
- service actions will be covered separately once openapi is extended with those.