### PR TITLE
chore: Add osc and tui into single version group

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,11 +11,13 @@ git_release_enable = true
 name = "openstack_cli"
 changelog_include = ["openstack_sdk"]
 git_release_enable = true
+version_group = "bins"
 
 [[package]]
 name = "openstack_tui"
 changelog_include = ["openstack_tui"]
 git_release_enable = true
+version_group = "bins"
 
 [[package]]
 name = "structable_derive"


### PR DESCRIPTION
It is desired to distribute binaries better enabling `cargo install` and
reasonably stable download url. This should be achievable (even not
perfect) when binary packages are all having same version so that in git
we have only one tag where artifacts will be stored.
