### PR TITLE
feat: Enable placement commands

### DIFF
--- a/openstack_cli/src/common.rs
+++ b/openstack_cli/src/common.rs
@@ -172,7 +172,7 @@ impl<'de> Deserialize<'de> for IntString {
     {
         struct MyVisitor;
 
-        impl<'de> Visitor<'de> for MyVisitor {
+        impl Visitor<'_> for MyVisitor {
             type Value = IntString;
 
             fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -217,7 +217,7 @@ impl<'de> Deserialize<'de> for NumString {
     {
         struct MyVisitor;
 
-        impl<'de> Visitor<'de> for MyVisitor {
+        impl Visitor<'_> for MyVisitor {
             type Value = NumString;
 
             fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -269,7 +269,7 @@ impl<'de> Deserialize<'de> for BoolString {
     {
         struct MyVisitor;
 
-        impl<'de> Visitor<'de> for MyVisitor {
+        impl Visitor<'_> for MyVisitor {
             type Value = BoolString;
 
             fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/openstack_cli/src/placement/v1.rs
+++ b/openstack_cli/src/placement/v1.rs
@@ -20,6 +20,14 @@ use openstack_sdk::{types::ServiceType, AsyncOpenStack};
 
 use crate::{Cli, OpenStackCliError};
 
+mod allocation;
+mod allocation_candidate;
+mod reshaper;
+mod resource_class;
+mod resource_provider;
+mod r#trait;
+mod usage;
+
 /// The placement API service was introduced in the 14.0.0 Newton release within the nova
 /// repository and extracted to the placement repository in the 19.0.0 Stein release. This is a
 /// REST API stack and data model used to track resource provider inventories and usages, along
@@ -48,19 +56,37 @@ pub struct PlacementCommand {
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum PlacementCommands {}
+pub enum PlacementCommands {
+    Allocation(Box<allocation::AllocationCommand>),
+    AllocationCandidate(Box<allocation_candidate::AllocationCandidateCommand>),
+    Reshaper(Box<reshaper::ReshaperCommand>),
+    ResourceClass(Box<resource_class::ResourceClassCommand>),
+    ResourceProvider(Box<resource_provider::ResourceProviderCommand>),
+    Trait(Box<r#trait::TraitCommand>),
+    Usage(Box<usage::UsageCommand>),
+}
 
 impl PlacementCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
-        _parsed_args: &Cli,
+        parsed_args: &Cli,
         session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         session
             .discover_service_endpoint(&ServiceType::Placement)
             .await?;
 
-        todo!()
+        match &self.command {
+            PlacementCommands::Allocation(cmd) => cmd.take_action(parsed_args, session).await,
+            PlacementCommands::AllocationCandidate(cmd) => {
+                cmd.take_action(parsed_args, session).await
+            }
+            PlacementCommands::Reshaper(cmd) => cmd.take_action(parsed_args, session).await,
+            PlacementCommands::ResourceClass(cmd) => cmd.take_action(parsed_args, session).await,
+            PlacementCommands::ResourceProvider(cmd) => cmd.take_action(parsed_args, session).await,
+            PlacementCommands::Trait(cmd) => cmd.take_action(parsed_args, session).await,
+            PlacementCommands::Usage(cmd) => cmd.take_action(parsed_args, session).await,
+        }
     }
 }

--- a/openstack_cli/src/placement/v1/allocation.rs
+++ b/openstack_cli/src/placement/v1/allocation.rs
@@ -1,0 +1,82 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Placement `allocation` command with subcommands
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+//mod create_113;
+//mod create_128;
+//mod create_134;
+//mod create_138;
+mod delete;
+mod set_10;
+//mod set_112;
+//mod set_128;
+//mod set_138;
+mod show;
+
+/// Allocations
+///
+/// Allocations are records representing resources that have been assigned and used by some
+/// consumer of that resource. They indicate the amount of a particular resource that has been
+/// allocated to a given consumer of that resource from a particular resource provider.
+#[derive(Parser)]
+pub struct AllocationCommand {
+    #[command(subcommand)]
+    command: AllocationCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum AllocationCommands {
+    //    #[command(visible_alias = "create")]
+    //    Create138(create_138::AllocationCommand),
+    //    Create134(create_134::AllocationCommand),
+    //    Create128(create_128::AllocationCommand),
+    //    Create113(create_113::AllocationCommand),
+    Delete(delete::AllocationCommand),
+    //    #[command(visible_alias = "set")]
+    //    Set138(set_138::AllocationCommand),
+    //    Set128(set_128::AllocationCommand),
+    //    Set112(set_112::AllocationCommand),
+    Set10(set_10::AllocationCommand),
+    Show(show::AllocationCommand),
+}
+
+impl AllocationCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            //            AllocationCommands::Create138(cmd) => cmd.take_action(parsed_args, session).await,
+            //            AllocationCommands::Create134(cmd) => cmd.take_action(parsed_args, session).await,
+            //            AllocationCommands::Create128(cmd) => cmd.take_action(parsed_args, session).await,
+            //            AllocationCommands::Create113(cmd) => cmd.take_action(parsed_args, session).await,
+            AllocationCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            //            AllocationCommands::Set138(cmd) => cmd.take_action(parsed_args, session).await,
+            //            AllocationCommands::Set128(cmd) => cmd.take_action(parsed_args, session).await,
+            //            AllocationCommands::Set112(cmd) => cmd.take_action(parsed_args, session).await,
+            AllocationCommands::Set10(cmd) => cmd.take_action(parsed_args, session).await,
+            AllocationCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/placement/v1/allocation/set_112.rs
+++ b/openstack_cli/src/placement/v1/allocation/set_112.rs
@@ -112,8 +112,8 @@ impl AllocationCommand {
         // Set Request.allocations data
 
         ep_builder.allocations(
-            &self
-                .allocations
+            self.allocations
+                .clone()
                 .into_iter()
                 .map(|(k, v)| {
                     serde_json::from_value(v.to_owned()).map(|v: set_112::Allocations| (k, v))

--- a/openstack_cli/src/placement/v1/allocation/set_128.rs
+++ b/openstack_cli/src/placement/v1/allocation/set_128.rs
@@ -115,8 +115,8 @@ impl AllocationCommand {
         // Set Request.allocations data
 
         ep_builder.allocations(
-            &self
-                .allocations
+            self.allocations
+                .clone()
                 .into_iter()
                 .map(|(k, v)| {
                     serde_json::from_value(v.to_owned()).map(|v: set_128::Allocations| (k, v))

--- a/openstack_cli/src/placement/v1/allocation/set_138.rs
+++ b/openstack_cli/src/placement/v1/allocation/set_138.rs
@@ -151,8 +151,8 @@ impl AllocationCommand {
         // Set Request.allocations data
 
         ep_builder.allocations(
-            &self
-                .allocations
+            self.allocations
+                .clone()
                 .into_iter()
                 .map(|(k, v)| {
                     serde_json::from_value(v.to_owned()).map(|v: set_138::Allocations| (k, v))

--- a/openstack_cli/src/placement/v1/allocation_candidate.rs
+++ b/openstack_cli/src/placement/v1/allocation_candidate.rs
@@ -12,8 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Identity Catalog commands
-
+//! Placement `allocation_candidate` command with subcommands
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
@@ -22,27 +21,21 @@ use crate::{Cli, OpenStackCliError};
 
 mod list;
 
-/// Identity Catalog commands
-///
-/// A service is an OpenStack web service that you can access through a URL, i.e. an endpoint.
-///
-/// A service catalog lists the services that are available to the caller based upon the current
-/// authorization.
+/// Allocation candidates
 #[derive(Parser)]
-pub struct CatalogCommand {
-    /// subcommand
+pub struct AllocationCandidateCommand {
     #[command(subcommand)]
-    command: CatalogCommands,
+    command: AllocationCandidateCommands,
 }
 
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum CatalogCommands {
-    List(list::CatalogsCommand),
+pub enum AllocationCandidateCommands {
+    List(list::AllocationCandidateCommand),
 }
 
-impl CatalogCommand {
+impl AllocationCandidateCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
@@ -50,7 +43,7 @@ impl CatalogCommand {
         session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         match &self.command {
-            CatalogCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            AllocationCandidateCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
         }
     }
 }

--- a/openstack_cli/src/placement/v1/reshaper.rs
+++ b/openstack_cli/src/placement/v1/reshaper.rs
@@ -12,45 +12,43 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Identity Catalog commands
-
+//! Placement `reshaper` command with subcommands
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
 
 use crate::{Cli, OpenStackCliError};
 
-mod list;
+//mod create_134;
+//mod create_138;
 
-/// Identity Catalog commands
-///
-/// A service is an OpenStack web service that you can access through a URL, i.e. an endpoint.
-///
-/// A service catalog lists the services that are available to the caller based upon the current
-/// authorization.
+/// Reshaper
 #[derive(Parser)]
-pub struct CatalogCommand {
-    /// subcommand
+pub struct ReshaperCommand {
     #[command(subcommand)]
-    command: CatalogCommands,
+    command: ReshaperCommands,
 }
 
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum CatalogCommands {
-    List(list::CatalogsCommand),
+pub enum ReshaperCommands {
+    //    #[command(visible_alias = "create")]
+    //    Create138(create_138::ReshaperCommand),
+    //    Create134(create_134::ReshaperCommand),
 }
 
-impl CatalogCommand {
+impl ReshaperCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
-        parsed_args: &Cli,
-        session: &mut AsyncOpenStack,
+        _parsed_args: &Cli,
+        _session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
-        match &self.command {
-            CatalogCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
-        }
+        todo!()
+        //match &self.command {
+        //    ReshaperCommands::Create138(cmd) => cmd.take_action(parsed_args, session).await,
+        //    ReshaperCommands::Create134(cmd) => cmd.take_action(parsed_args, session).await,
+        //}
     }
 }

--- a/openstack_cli/src/placement/v1/resource_class.rs
+++ b/openstack_cli/src/placement/v1/resource_class.rs
@@ -12,37 +12,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Identity Catalog commands
-
+//! Placement `resource_class` command with subcommands
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
 
 use crate::{Cli, OpenStackCliError};
 
+mod create;
+mod delete;
 mod list;
+mod show;
 
-/// Identity Catalog commands
+/// Resource Class
 ///
-/// A service is an OpenStack web service that you can access through a URL, i.e. an endpoint.
-///
-/// A service catalog lists the services that are available to the caller based upon the current
-/// authorization.
+/// Resource classes are entities that indicate standard or deployer-specific resources that can be
+/// provided by a resource provider. This group of API calls works with a single resource class
+/// identified by name. One resource class can be listed, updated and deleted.
 #[derive(Parser)]
-pub struct CatalogCommand {
-    /// subcommand
+pub struct ResourceClassCommand {
     #[command(subcommand)]
-    command: CatalogCommands,
+    command: ResourceClassCommands,
 }
 
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum CatalogCommands {
-    List(list::CatalogsCommand),
+pub enum ResourceClassCommands {
+    Create(create::ResourceClassCommand),
+    Delete(delete::ResourceClassCommand),
+    List(list::ResourceClassesCommand),
+    Show(show::ResourceClassCommand),
 }
 
-impl CatalogCommand {
+impl ResourceClassCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
@@ -50,7 +53,10 @@ impl CatalogCommand {
         session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         match &self.command {
-            CatalogCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceClassCommands::Create(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceClassCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceClassCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceClassCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
         }
     }
 }

--- a/openstack_cli/src/placement/v1/resource_class/list.rs
+++ b/openstack_cli/src/placement/v1/resource_class/list.rs
@@ -33,7 +33,6 @@ use crate::StructTable;
 
 use openstack_sdk::api::placement::v1::resource_class::list;
 use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Return a list of all resource classes.

--- a/openstack_cli/src/placement/v1/resource_provider.rs
+++ b/openstack_cli/src/placement/v1/resource_provider.rs
@@ -1,0 +1,90 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Placement `resource_provider` command with subcommands
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod aggregate;
+mod allocation;
+mod create_10;
+mod create_114;
+mod delete;
+mod inventory;
+mod list;
+mod set_10;
+mod set_114;
+mod show;
+mod r#trait;
+mod usage;
+
+/// Resource Providers
+///
+/// Resource providers are entities which provide consumable inventory of one or more classes of
+/// resource (such as disk or memory). They can be listed (with filters), created, updated and
+/// deleted.
+#[derive(Parser)]
+pub struct ResourceProviderCommand {
+    #[command(subcommand)]
+    command: ResourceProviderCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum ResourceProviderCommands {
+    Aggregate(aggregate::AggregateCommand),
+    Allocation(allocation::AllocationCommand),
+    #[command(visible_alias = "create")]
+    Create114(create_114::ResourceProviderCommand),
+    Create10(create_10::ResourceProviderCommand),
+    Delete(delete::ResourceProviderCommand),
+    Inventory(inventory::InventoryCommand),
+    List(list::ResourceProvidersCommand),
+    #[command(visible_alias = "set")]
+    Set114(set_114::ResourceProviderCommand),
+    Set10(set_10::ResourceProviderCommand),
+    Show(show::ResourceProviderCommand),
+    Trait(r#trait::TraitCommand),
+    Usage(usage::UsageCommand),
+}
+
+impl ResourceProviderCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            ResourceProviderCommands::Aggregate(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Allocation(cmd) => {
+                cmd.take_action(parsed_args, session).await
+            }
+            ResourceProviderCommands::Create114(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Create10(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Inventory(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Set114(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Set10(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Trait(cmd) => cmd.take_action(parsed_args, session).await,
+            ResourceProviderCommands::Usage(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/placement/v1/resource_provider/aggregate.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/aggregate.rs
@@ -1,0 +1,96 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Placement `ResourceProviderAggregate` command with subcommands
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod list;
+mod set_11;
+mod set_119;
+
+/// Resource provider aggregates
+///
+/// Each resource provider can be associated with one or more other resource providers in groups
+/// called aggregates. API calls in this section are used to list and update the aggregates that
+/// are associated with one resource provider.
+///
+/// Provider aggregates are used for modeling relationships among providers. Examples may include:
+///
+///   - A shared storage pool providing DISK_GB resources to compute node providers that provide
+///     VCPU and MEMORY_MB resources.
+///
+///   - Affinity/anti-affinity relationships such as physical location, power failure domains, or
+///     other reliability/availability constructs.
+///
+///   - Groupings of compute host providers corresponding to Nova host aggregates or availability
+///     zones.
+///
+/// Note: Placement aggregates are not the same as Nova host aggregates and should not be
+/// considered equivalent.
+///
+/// The primary differences between Nova’s host aggregates and placement aggregates are the
+/// following:
+///
+///   - In Nova, a host aggregate associates a nova-compute service with other nova-compute
+///     services. Placement aggregates are not specific to a nova-compute service and are, in fact,
+///     not compute-specific at all. A resource provider in the Placement API is generic, and
+///     placement aggregates are simply groups of generic resource providers. This is an important
+///     difference especially for Ironic, which when used with Nova, has many Ironic baremetal nodes
+///     attached to a single nova-compute service. In the Placement API, each Ironic baremetal node
+///     is its own resource provider and can therefore be associated to other Ironic baremetal nodes
+///     via a placement aggregate association.
+///
+///   - In Nova, a host aggregate may have metadata key/value pairs attached to it. All
+///     nova-compute services associated with a Nova host aggregate share the same metadata.
+///     Placement aggregates have no such metadata because placement aggregates only represent the
+///     grouping of resource providers. In the Placement API, resource providers are individually
+///     decorated with traits that provide qualitative information about the resource provider.
+///
+///   - In Nova, a host aggregate dictates the availability zone within which one or more
+///     nova-compute services reside. While placement aggregates may be used to model availability
+///     zones, they have no inherent concept thereof.
+#[derive(Parser)]
+pub struct AggregateCommand {
+    #[command(subcommand)]
+    command: AggregateCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum AggregateCommands {
+    List(list::AggregateCommand),
+    #[command(visible_alias = "set")]
+    Set119(set_119::AggregateCommand),
+    Set11(set_11::AggregateCommand),
+}
+
+impl AggregateCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            AggregateCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            AggregateCommands::Set119(cmd) => cmd.take_action(parsed_args, session).await,
+            AggregateCommands::Set11(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/placement/v1/resource_provider/aggregate/list.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/aggregate/list.rs
@@ -87,7 +87,7 @@ impl StructTable for Vec<ResponseData> {
     fn build(&self, _: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = Vec::from(["Values".to_string()]);
         let res: Vec<Vec<String>> = Vec::from([Vec::from([self
-            .into_iter()
+            .iter()
             .map(|v| v.0.to_string())
             .collect::<Vec<_>>()
             .join(", ")])]);

--- a/openstack_cli/src/placement/v1/resource_provider/aggregate/set_11.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/aggregate/set_11.rs
@@ -85,7 +85,7 @@ impl StructTable for Vec<ResponseData> {
     fn build(&self, _: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = Vec::from(["Values".to_string()]);
         let res: Vec<Vec<String>> = Vec::from([Vec::from([self
-            .into_iter()
+            .iter()
             .map(|v| v.0.to_string())
             .collect::<Vec<_>>()
             .join(", ")])]);

--- a/openstack_cli/src/placement/v1/resource_provider/aggregate/set_119.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/aggregate/set_119.rs
@@ -91,7 +91,7 @@ impl StructTable for Vec<ResponseData> {
     fn build(&self, _: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = Vec::from(["Values".to_string()]);
         let res: Vec<Vec<String>> = Vec::from([Vec::from([self
-            .into_iter()
+            .iter()
             .map(|v| v.0.to_string())
             .collect::<Vec<_>>()
             .join(", ")])]);

--- a/openstack_cli/src/placement/v1/resource_provider/allocation.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/allocation.rs
@@ -12,8 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Identity Catalog commands
-
+//! Placement `ResourceProviderAllocation` command with subcommands
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
@@ -22,27 +21,21 @@ use crate::{Cli, OpenStackCliError};
 
 mod list;
 
-/// Identity Catalog commands
-///
-/// A service is an OpenStack web service that you can access through a URL, i.e. an endpoint.
-///
-/// A service catalog lists the services that are available to the caller based upon the current
-/// authorization.
+/// Resource provider allocations
 #[derive(Parser)]
-pub struct CatalogCommand {
-    /// subcommand
+pub struct AllocationCommand {
     #[command(subcommand)]
-    command: CatalogCommands,
+    command: AllocationCommands,
 }
 
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum CatalogCommands {
-    List(list::CatalogsCommand),
+pub enum AllocationCommands {
+    List(list::AllocationCommand),
 }
 
-impl CatalogCommand {
+impl AllocationCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
@@ -50,7 +43,7 @@ impl CatalogCommand {
         session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         match &self.command {
-            CatalogCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            AllocationCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
         }
     }
 }

--- a/openstack_cli/src/placement/v1/resource_provider/inventory.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/inventory.rs
@@ -1,0 +1,71 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Placement `ResourceProviderInventory` command with subcommands
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+//mod create;
+mod delete;
+mod delete_all;
+mod list;
+//mod replace;
+mod set;
+mod show;
+
+/// Resource provider inventories
+///
+/// Each resource provider has inventory records for one or more classes of resources. An inventory
+/// record contains information about the total and reserved amounts of the resource and any
+/// consumption constraints for that resource against the provider.
+#[derive(Parser)]
+pub struct InventoryCommand {
+    #[command(subcommand)]
+    command: InventoryCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum InventoryCommands {
+    //    Create(create::InventoryCommand),
+    Delete(delete::InventoryCommand),
+    Purge(delete_all::InventoryCommand),
+    List(list::InventoriesCommand),
+    //    Replace(replace::InventoryCommand),
+    Set(set::InventoryCommand),
+    Show(show::InventoryCommand),
+}
+
+impl InventoryCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            //            InventoryCommands::Create(cmd) => cmd.take_action(parsed_args, session).await,
+            InventoryCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            InventoryCommands::Purge(cmd) => cmd.take_action(parsed_args, session).await,
+            InventoryCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            //            InventoryCommands::Replace(cmd) => cmd.take_action(parsed_args, session).await,
+            InventoryCommands::Set(cmd) => cmd.take_action(parsed_args, session).await,
+            InventoryCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/placement/v1/resource_provider/list.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/list.rs
@@ -33,7 +33,6 @@ use crate::StructTable;
 
 use openstack_sdk::api::placement::v1::resource_provider::list;
 use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
 use structable_derive::StructTable;
 
 /// List an optionally filtered collection of resource providers.

--- a/openstack_cli/src/placement/v1/resource_provider/trait.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/trait.rs
@@ -12,37 +12,36 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Identity Catalog commands
-
+//! Placement `ResourceProviderTrait` command with subcommands
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
 
 use crate::{Cli, OpenStackCliError};
 
+mod delete;
 mod list;
+mod set;
 
-/// Identity Catalog commands
+/// Resource provider traits
 ///
-/// A service is an OpenStack web service that you can access through a URL, i.e. an endpoint.
-///
-/// A service catalog lists the services that are available to the caller based upon the current
-/// authorization.
+/// This group of API requests queries/edits the association between traits and resource providers.
 #[derive(Parser)]
-pub struct CatalogCommand {
-    /// subcommand
+pub struct TraitCommand {
     #[command(subcommand)]
-    command: CatalogCommands,
+    command: TraitCommands,
 }
 
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum CatalogCommands {
-    List(list::CatalogsCommand),
+pub enum TraitCommands {
+    Delete(delete::TraitCommand),
+    List(list::TraitCommand),
+    Set(set::TraitCommand),
 }
 
-impl CatalogCommand {
+impl TraitCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
@@ -50,7 +49,9 @@ impl CatalogCommand {
         session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         match &self.command {
-            CatalogCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            TraitCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            TraitCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            TraitCommands::Set(cmd) => cmd.take_action(parsed_args, session).await,
         }
     }
 }

--- a/openstack_cli/src/placement/v1/resource_provider/trait/list.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/trait/list.rs
@@ -84,7 +84,7 @@ impl StructTable for Vec<ResponseData> {
     fn build(&self, _: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = Vec::from(["Values".to_string()]);
         let res: Vec<Vec<String>> = Vec::from([Vec::from([self
-            .into_iter()
+            .iter()
             .map(|v| v.0.to_string())
             .collect::<Vec<_>>()
             .join(", ")])]);

--- a/openstack_cli/src/placement/v1/resource_provider/trait/set.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/trait/set.rs
@@ -91,7 +91,7 @@ impl StructTable for Vec<ResponseData> {
     fn build(&self, _: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = Vec::from(["Values".to_string()]);
         let res: Vec<Vec<String>> = Vec::from([Vec::from([self
-            .into_iter()
+            .iter()
             .map(|v| v.0.to_string())
             .collect::<Vec<_>>()
             .join(", ")])]);

--- a/openstack_cli/src/placement/v1/resource_provider/usage.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/usage.rs
@@ -12,37 +12,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Identity Catalog commands
-
+//! Placement `ResourceProviderUsage` command with subcommands
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
 
 use crate::{Cli, OpenStackCliError};
 
-mod list;
+mod get;
 
-/// Identity Catalog commands
+/// Resource provider usages
 ///
-/// A service is an OpenStack web service that you can access through a URL, i.e. an endpoint.
-///
-/// A service catalog lists the services that are available to the caller based upon the current
-/// authorization.
+/// Show the consumption of resources for a resource provider in an aggregated form, i.e. without
+/// information for a particular consumer.
 #[derive(Parser)]
-pub struct CatalogCommand {
-    /// subcommand
+pub struct UsageCommand {
     #[command(subcommand)]
-    command: CatalogCommands,
+    command: UsageCommands,
 }
 
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum CatalogCommands {
-    List(list::CatalogsCommand),
+pub enum UsageCommands {
+    Get(get::UsageCommand),
 }
 
-impl CatalogCommand {
+impl UsageCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
@@ -50,7 +46,7 @@ impl CatalogCommand {
         session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         match &self.command {
-            CatalogCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            UsageCommands::Get(cmd) => cmd.take_action(parsed_args, session).await,
         }
     }
 }

--- a/openstack_cli/src/placement/v1/trait.rs
+++ b/openstack_cli/src/placement/v1/trait.rs
@@ -1,0 +1,64 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Placement `trait` command with subcommands
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod delete;
+mod list;
+mod set;
+mod show;
+
+/// Traits
+///
+/// Traits are qualitative characteristics of resource providers. The classic example for traits
+/// can be requesting disk from different providers: a user may request 80GiB of disk space for an
+/// instance (quantitative), but may also expect that the disk be SSD instead of spinning disk
+/// (qualitative). Traits provide a way to mark that a storage provider is SSD or spinning.
+#[derive(Parser)]
+pub struct TraitCommand {
+    #[command(subcommand)]
+    command: TraitCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum TraitCommands {
+    #[command(visible_alias = "set")]
+    Create(set::TraitCommand),
+    Delete(delete::TraitCommand),
+    List(list::TraitsCommand),
+    Show(show::TraitCommand),
+}
+
+impl TraitCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            TraitCommands::Create(cmd) => cmd.take_action(parsed_args, session).await,
+            TraitCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            TraitCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            TraitCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/placement/v1/trait/list.rs
+++ b/openstack_cli/src/placement/v1/trait/list.rs
@@ -85,7 +85,7 @@ impl StructTable for Vec<ResponseData> {
     fn build(&self, _: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
         let headers: Vec<String> = Vec::from(["Values".to_string()]);
         let res: Vec<Vec<String>> = Vec::from([Vec::from([self
-            .into_iter()
+            .iter()
             .map(|v| v.0.to_string())
             .collect::<Vec<_>>()
             .join(", ")])]);

--- a/openstack_cli/src/placement/v1/usage.rs
+++ b/openstack_cli/src/placement/v1/usage.rs
@@ -12,8 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Identity Catalog commands
-
+//! Placement `usage` command with subcommands
 use clap::{Parser, Subcommand};
 
 use openstack_sdk::AsyncOpenStack;
@@ -22,27 +21,23 @@ use crate::{Cli, OpenStackCliError};
 
 mod list;
 
-/// Identity Catalog commands
+/// Usages
 ///
-/// A service is an OpenStack web service that you can access through a URL, i.e. an endpoint.
-///
-/// A service catalog lists the services that are available to the caller based upon the current
-/// authorization.
+/// Represent the consumption of resources for a project and user.
 #[derive(Parser)]
-pub struct CatalogCommand {
-    /// subcommand
+pub struct UsageCommand {
     #[command(subcommand)]
-    command: CatalogCommands,
+    command: UsageCommands,
 }
 
 /// Supported subcommands
 #[allow(missing_docs)]
 #[derive(Subcommand)]
-pub enum CatalogCommands {
-    List(list::CatalogsCommand),
+pub enum UsageCommands {
+    List(list::UsagesCommand),
 }
 
-impl CatalogCommand {
+impl UsageCommand {
     /// Perform command action
     pub async fn take_action(
         &self,
@@ -50,7 +45,7 @@ impl CatalogCommand {
         session: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         match &self.command {
-            CatalogCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            UsageCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
         }
     }
 }

--- a/openstack_cli/tests/placement/v1/allocation/mod.rs
+++ b/openstack_cli/tests/placement/v1/allocation/mod.rs
@@ -12,12 +12,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+// mod create_113_autogen;
+// mod create_128_autogen;
+// mod create_134_autogen;
+// mod create_138_autogen;
+mod delete_autogen;
+// mod set_10_autogen;
+// mod set_112_autogen;
+// mod set_138_autogen;
+// mod set_18_autogen;
+mod show_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +30,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "allocation", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/allocation_candidate/mod.rs
+++ b/openstack_cli/tests/placement/v1/allocation_candidate/mod.rs
@@ -12,12 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod list_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +21,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "allocation-candidate", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/reshaper/mod.rs
+++ b/openstack_cli/tests/placement/v1/reshaper/mod.rs
@@ -12,12 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod create_134_autogen;
+mod create_138_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +22,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "reshaper", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/resource_class/mod.rs
+++ b/openstack_cli/tests/placement/v1/resource_class/mod.rs
@@ -12,12 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod create_autogen;
+mod delete_autogen;
+mod list_autogen;
+mod show_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +24,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "resource-class", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/resource_provider/aggregate/mod.rs
+++ b/openstack_cli/tests/placement/v1/resource_provider/aggregate/mod.rs
@@ -12,12 +12,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod list_autogen;
+mod set_119_autogen;
+mod set_11_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +23,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "resource-provider", "aggregate", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/resource_provider/allocation/mod.rs
+++ b/openstack_cli/tests/placement/v1/resource_provider/allocation/mod.rs
@@ -12,12 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod list_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +21,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "resource-provider", "allocation", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/resource_provider/inventory/mod.rs
+++ b/openstack_cli/tests/placement/v1/resource_provider/inventory/mod.rs
@@ -12,12 +12,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+// mod create_autogen;
+// mod delete_all_autogen;
+mod delete_autogen;
+mod list_autogen;
+// mod replace_autogen;
+mod set_autogen;
+mod show_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +27,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "resource-provider", "inventory", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/resource_provider/mod.rs
+++ b/openstack_cli/tests/placement/v1/resource_provider/mod.rs
@@ -12,10 +12,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+mod aggregate;
 mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
+mod create_10_autogen;
+mod create_114_autogen;
+mod delete_autogen;
+mod inventory;
+mod list_autogen;
+mod set_10_autogen;
+mod set_114_autogen;
+mod show_autogen;
 mod r#trait;
 mod usage;
 
@@ -26,7 +32,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "resource-provider", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/resource_provider/trait/mod.rs
+++ b/openstack_cli/tests/placement/v1/resource_provider/trait/mod.rs
@@ -12,12 +12,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod delete_autogen;
+mod list_autogen;
+mod set_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +23,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "resource-provider", "trait", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/resource_provider/usage/mod.rs
+++ b/openstack_cli/tests/placement/v1/resource_provider/usage/mod.rs
@@ -12,12 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod get_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +21,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "resource-provider", "usage", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/trait/mod.rs
+++ b/openstack_cli/tests/placement/v1/trait/mod.rs
@@ -12,12 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod delete_autogen;
+mod list_autogen;
+mod set_autogen;
+mod show_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +24,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "trait", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/placement/v1/usage/mod.rs
+++ b/openstack_cli/tests/placement/v1/usage/mod.rs
@@ -12,12 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod allocation;
-mod allocation_candidate;
-mod resource_class;
-mod resource_provider;
-mod r#trait;
-mod usage;
+mod list_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -26,7 +21,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["placement", "--help"]);
+    cmd.args(["placement", "usage", "--help"]);
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
Well, almost. Placement is so esoteric, that codegeneration doesn't
support yet some cornercases, therefore those commands are not yet
enabled.
