### PR TITLE
chore: Beter modularize cloud worker services

### DIFF
--- a/openstack_tui/src/cloud_worker/compute/types.rs
+++ b/openstack_tui/src/cloud_worker/compute/types.rs
@@ -1,0 +1,107 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeFlavorFilters {}
+
+impl fmt::Display for ComputeFlavorFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeFlavorFilters>
+    for openstack_sdk::api::compute::v2::flavor::list_detailed::RequestBuilder<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(_value: &ComputeFlavorFilters) -> Result<Self, Self::Error> {
+        let mut ep_builder =
+            openstack_sdk::api::compute::v2::flavor::list_detailed::Request::builder();
+
+        ep_builder.sort_key("name");
+        Ok(ep_builder)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeServerFilters {
+    pub all_tenants: Option<bool>,
+}
+
+impl fmt::Display for ComputeServerFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeServerFilters>
+    for openstack_sdk::api::compute::v2::server::list_detailed::RequestBuilder<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(value: &ComputeServerFilters) -> Result<Self, Self::Error> {
+        let mut ep_builder =
+            openstack_sdk::api::compute::v2::server::list_detailed::Request::builder();
+
+        ep_builder.sort_key("display_name");
+        ep_builder.sort_dir("asc");
+
+        if let Some(true) = &value.all_tenants {
+            ep_builder.all_tenants("true");
+        }
+
+        Ok(ep_builder)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeHypervisorFilters {}
+
+impl fmt::Display for ComputeHypervisorFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+impl TryFrom<&ComputeHypervisorFilters>
+    for openstack_sdk::api::compute::v2::hypervisor::list_detailed::RequestBuilder<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(_value: &ComputeHypervisorFilters) -> Result<Self, Self::Error> {
+        Ok(openstack_sdk::api::compute::v2::hypervisor::list_detailed::Request::builder())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeAggregateFilters {}
+
+impl fmt::Display for ComputeAggregateFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+impl TryFrom<&ComputeAggregateFilters>
+    for openstack_sdk::api::compute::v2::aggregate::list::RequestBuilder
+{
+    type Error = eyre::Report;
+
+    fn try_from(_value: &ComputeAggregateFilters) -> Result<Self, Self::Error> {
+        Ok(openstack_sdk::api::compute::v2::aggregate::list::Request::builder())
+    }
+}

--- a/openstack_tui/src/cloud_worker/identity/types.rs
+++ b/openstack_tui/src/cloud_worker/identity/types.rs
@@ -1,0 +1,31 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityAuthProjectFilters {}
+impl fmt::Display for IdentityAuthProjectFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityProjectFilters {}
+impl fmt::Display for IdentityProjectFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}

--- a/openstack_tui/src/cloud_worker/image.rs
+++ b/openstack_tui/src/cloud_worker/image.rs
@@ -14,17 +14,46 @@
 
 use eyre::Result;
 use serde_json::Value;
+use tokio::sync::mpsc::UnboundedSender;
 
 use openstack_sdk::{api::Pagination, api::QueryAsync};
 
-use crate::cloud_worker::types::ImageFilters;
-use crate::cloud_worker::Cloud;
+use crate::action::Action;
+use crate::cloud_worker::{Cloud, Resource};
+
+pub mod types;
+use types::*;
 
 pub trait ImageExt {
+    async fn query_resource(
+        &mut self,
+        app_tx: &UnboundedSender<Action>,
+        resource: Resource,
+    ) -> Result<()>;
+
     async fn get_images(&mut self, filters: &ImageFilters) -> Result<Vec<Value>>;
 }
 
 impl ImageExt for Cloud {
+    async fn query_resource(
+        &mut self,
+        app_tx: &UnboundedSender<Action>,
+        resource: Resource,
+    ) -> Result<()> {
+        match resource {
+            Resource::ImageImages(ref filters) => match self.get_images(filters).await {
+                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+                Err(err) => {
+                    app_tx.send(Action::Error(format!("Failed to fetch images: {:?}", err)))?
+                }
+            },
+            _ => {
+                todo!()
+            }
+        }
+        Ok(())
+    }
+
     async fn get_images(&mut self, filters: &ImageFilters) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
             let mut ep_builder = openstack_sdk::api::image::v2::image::list::Request::builder();
@@ -38,7 +67,6 @@ impl ImageExt for Cloud {
             let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
                 .query_async(session)
                 .await?;
-            //let res: Vec<Value> = ep.query_async(session).await?;
             return Ok(res);
         }
         Ok(Vec::new())

--- a/openstack_tui/src/cloud_worker/image/types.rs
+++ b/openstack_tui/src/cloud_worker/image/types.rs
@@ -1,0 +1,29 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImageFilters {
+    pub visibility: Option<String>,
+}
+impl fmt::Display for ImageFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(val) = &self.visibility {
+            write!(f, "{}", val)?;
+        }
+        Ok(())
+    }
+}

--- a/openstack_tui/src/cloud_worker/network/types.rs
+++ b/openstack_tui/src/cloud_worker/network/types.rs
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkNetworkFilters {}
+impl fmt::Display for NetworkNetworkFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkSubnetFilters {
+    pub network_id: Option<String>,
+}
+impl fmt::Display for NetworkSubnetFilters {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(val) = &self.network_id {
+            write!(f, "network: {}", val)?;
+        }
+        Ok(())
+    }
+}

--- a/openstack_tui/src/cloud_worker/types.rs
+++ b/openstack_tui/src/cloud_worker/types.rs
@@ -13,10 +13,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use strum::Display;
 
-pub use crate::cloud_worker::compute::*;
+use openstack_sdk::types::ServiceType;
+
+pub use crate::cloud_worker::compute::types::*;
+pub use crate::cloud_worker::identity::types::*;
+pub use crate::cloud_worker::image::types::*;
+pub use crate::cloud_worker::network::types::*;
 
 /// OpenStack "resource"
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
@@ -35,50 +39,20 @@ pub enum Resource {
     NetworkQuota,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NetworkNetworkFilters {}
-impl fmt::Display for NetworkNetworkFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NetworkSubnetFilters {
-    pub network_id: Option<String>,
-}
-impl fmt::Display for NetworkSubnetFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(val) = &self.network_id {
-            write!(f, "network: {}", val)?;
+impl From<Resource> for ServiceType {
+    fn from(item: Resource) -> Self {
+        match item {
+            Resource::ComputeServers(_)
+            | Resource::ComputeServerConsoleOutput(_)
+            | Resource::ComputeFlavors(_)
+            | Resource::ComputeQuota
+            | Resource::ComputeAggregates(_)
+            | Resource::ComputeHypervisors(_) => Self::Compute,
+            Resource::IdentityAuthProjects(_) | Resource::IdentityProjects(_) => Self::Identity,
+            Resource::ImageImages(_) => Self::Image,
+            Resource::NetworkNetworks(_) | Resource::NetworkSubnets(_) | Resource::NetworkQuota => {
+                Self::Network
+            }
         }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityAuthProjectFilters {}
-impl fmt::Display for IdentityAuthProjectFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityProjectFilters {}
-impl fmt::Display for IdentityProjectFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ImageFilters {
-    pub visibility: Option<String>,
-}
-impl fmt::Display for ImageFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(val) = &self.visibility {
-            write!(f, "{}", val)?;
-        }
-        Ok(())
     }
 }

--- a/openstack_tui/src/components/compute/aggregates.rs
+++ b/openstack_tui/src/components/compute/aggregates.rs
@@ -44,7 +44,7 @@ pub struct AggregateData {
 
 pub type ComputeAggregates<'a> = TableViewComponentBase<'a, AggregateData, ComputeAggregateFilters>;
 
-impl<'a> Component for ComputeAggregates<'a> {
+impl Component for ComputeAggregates<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -46,7 +46,7 @@ pub struct FlavorData {
 
 pub type ComputeFlavors<'a> = TableViewComponentBase<'a, FlavorData, ComputeFlavorFilters>;
 
-impl<'a> Component for ComputeFlavors<'a> {
+impl Component for ComputeFlavors<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }

--- a/openstack_tui/src/components/compute/hypervisors.rs
+++ b/openstack_tui/src/components/compute/hypervisors.rs
@@ -45,7 +45,7 @@ pub struct HypervisorData {
 pub type ComputeHypervisors<'a> =
     TableViewComponentBase<'a, HypervisorData, ComputeHypervisorFilters>;
 
-impl<'a> Component for ComputeHypervisors<'a> {
+impl Component for ComputeHypervisors<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -44,7 +44,7 @@ pub struct ServerData {
 
 pub type ComputeServers<'a> = TableViewComponentBase<'a, ServerData, ComputeServerFilters>;
 
-impl<'a> Component for ComputeServers<'a> {
+impl Component for ComputeServers<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }

--- a/openstack_tui/src/components/identity/projects.rs
+++ b/openstack_tui/src/components/identity/projects.rs
@@ -46,7 +46,7 @@ pub struct ProjectData {
 
 pub type IdentityProjects<'a> = TableViewComponentBase<'a, ProjectData, IdentityProjectFilters>;
 
-impl<'a> Component for IdentityProjects<'a> {
+impl Component for IdentityProjects<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }

--- a/openstack_tui/src/components/image/images.rs
+++ b/openstack_tui/src/components/image/images.rs
@@ -49,7 +49,7 @@ pub struct ImageData {
 
 pub type Images<'a> = TableViewComponentBase<'a, ImageData, ImageFilters>;
 
-impl<'a> Component for Images<'a> {
+impl Component for Images<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -46,7 +46,7 @@ pub struct NetworkData {
 
 pub type NetworkNetworks<'a> = TableViewComponentBase<'a, NetworkData, NetworkNetworkFilters>;
 
-impl<'a> Component for NetworkNetworks<'a> {
+impl Component for NetworkNetworks<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }
@@ -90,18 +90,15 @@ impl<'a> Component for NetworkNetworks<'a> {
     }
 
     fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<Action>> {
-        match key.code {
-            KeyCode::Enter => {
-                if let Some(command_tx) = self.get_command_tx() {
-                    if let Some(x) = self.get_selected_raw() {
-                        command_tx.send(Action::NetworkSubnetFilter(NetworkSubnetFilters {
-                            network_id: x.get("id").unwrap().as_str().map(String::from).clone(),
-                        }))?;
-                    }
+        if key.code == KeyCode::Enter {
+            if let Some(command_tx) = self.get_command_tx() {
+                if let Some(x) = self.get_selected_raw() {
+                    command_tx.send(Action::NetworkSubnetFilter(NetworkSubnetFilters {
+                        network_id: x.get("id").unwrap().as_str().map(String::from).clone(),
+                    }))?;
                 }
-                return Ok(Some(Action::Mode(Mode::NetworkSubnets)));
             }
-            _ => {}
+            return Ok(Some(Action::Mode(Mode::NetworkSubnets)));
         }
         self.handle_key_events(key)
     }

--- a/openstack_tui/src/components/network/subnets.rs
+++ b/openstack_tui/src/components/network/subnets.rs
@@ -45,7 +45,7 @@ pub struct SubnetData {
 
 pub type NetworkSubnets<'a> = TableViewComponentBase<'a, SubnetData, NetworkSubnetFilters>;
 
-impl<'a> Component for NetworkSubnets<'a> {
+impl Component for NetworkSubnets<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<()> {
         self.set_config(config)
     }
@@ -88,13 +88,10 @@ impl<'a> Component for NetworkSubnets<'a> {
     }
 
     fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<Action>> {
-        match key.code {
-            KeyCode::Char('0') => {
-                return Ok(Some(Action::NetworkSubnetFilter(NetworkSubnetFilters {
-                    network_id: None,
-                })));
-            }
-            _ => {}
+        if let KeyCode::Char('0') = key.code {
+            return Ok(Some(Action::NetworkSubnetFilter(NetworkSubnetFilters {
+                network_id: None,
+            })));
         }
 
         self.handle_key_events(key)

--- a/openstack_tui/src/utils.rs
+++ b/openstack_tui/src/utils.rs
@@ -168,7 +168,7 @@ impl<'de> Deserialize<'de> for IntString {
     {
         struct MyVisitor;
 
-        impl<'de> Visitor<'de> for MyVisitor {
+        impl Visitor<'_> for MyVisitor {
             type Value = IntString;
 
             fn expecting(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Add a way for the service cloud_worker to cover resources it support to
heavily reduce cound of match branches in the main cloud_worker event
loop.

Add a test for trimming header cells addressing few potential panics.
