### PR TITLE
fix: Do not crash when connected with domain_scope

### DIFF
--- a/openstack_tui/src/cloud_worker/compute.rs
+++ b/openstack_tui/src/cloud_worker/compute.rs
@@ -181,20 +181,16 @@ impl ComputeExt for Cloud {
             let mut ep_builder =
                 openstack_sdk::api::compute::v2::quota_set::details::Request::builder();
 
-            ep_builder.id(self
-                .cloud
-                .as_ref()
-                .expect("Connected")
-                .get_auth_info()
-                .expect("Authorized")
-                .token
-                .project
-                .expect("Project scoped")
-                .id
-                .expect("ID is known"));
-            let ep = ep_builder.build()?;
-            let res: Value = ep.query_async(session).await?;
-            return Ok(res);
+            if let Some(auth) = session.get_auth_info() {
+                if let Some(project) = auth.token.project {
+                    if let Some(pid) = project.id {
+                        ep_builder.id(pid);
+                        let ep = ep_builder.build()?;
+                        let res: Value = ep.query_async(session).await?;
+                        return Ok(res);
+                    }
+                }
+            }
         }
         Ok(Value::Null)
     }

--- a/openstack_tui/src/cloud_worker/network.rs
+++ b/openstack_tui/src/cloud_worker/network.rs
@@ -115,20 +115,16 @@ impl NetworkExt for Cloud {
             let mut ep_builder =
                 openstack_sdk::api::network::v2::quota::details::Request::builder();
 
-            ep_builder.id(self
-                .cloud
-                .as_ref()
-                .expect("Connected")
-                .get_auth_info()
-                .expect("Authorized")
-                .token
-                .project
-                .expect("Project scoped")
-                .id
-                .expect("ID is known"));
-            let ep = ep_builder.build()?;
-            let res: Value = ep.query_async(session).await?;
-            return Ok(res);
+            if let Some(auth) = session.get_auth_info() {
+                if let Some(project) = auth.token.project {
+                    if let Some(pid) = project.id {
+                        ep_builder.id(pid);
+                        let ep = ep_builder.build()?;
+                        let res: Value = ep.query_async(session).await?;
+                        return Ok(res);
+                    }
+                }
+            }
         }
         Ok(Value::Null)
     }

--- a/openstack_tui/src/components/home.rs
+++ b/openstack_tui/src/components/home.rs
@@ -18,7 +18,7 @@ use itertools::Itertools;
 use ratatui::{
     layout::{
         Constraint::{Length, Min},
-        Layout, Rect,
+        Flex, Layout, Rect,
     },
     prelude::*,
     widgets::{block::*, *},
@@ -248,6 +248,14 @@ impl Component for Home {
             render_quota_gauge(network_quota.network.as_ref(), "Networks", f, areas[5]);
             render_quota_gauge(network_quota.subnet.as_ref(), "Subnets", f, areas[6]);
             render_quota_gauge(network_quota.port.as_ref(), "Ports", f, areas[7]);
+        }
+        if self.compute_quota.is_none() && self.network_quota.is_none() {
+            let layout = Layout::vertical([5]).flex(Flex::Center);
+            let [area] = layout.areas(inner);
+            let paragraph = Paragraph::new("Not available")
+                .style(Style::new().red().on_black())
+                .alignment(Alignment::Center);
+            f.render_widget(paragraph, area);
         }
 
         Ok(())


### PR DESCRIPTION
Home mode uses `expect` to access project_id of the current scope. This
causes unpleasant crash when initially connected with the domain scope.
Change it to be conditional and show "Not available" for quotas when
no data can be fetched.
