### PR TITLE
fix: Fill domain name in the domain scope

### DIFF
--- a/openstack_tui/src/components/header.rs
+++ b/openstack_tui/src/components/header.rs
@@ -105,7 +105,11 @@ impl Component for Header {
                             self.domain_name = name.clone();
                         }
                     }
-                };
+                } else if let Some(domain) = &auth_token.domain {
+                    if let Some(name) = &domain.name {
+                        self.domain_name = name.clone();
+                    }
+                }
             }
             _ => {}
         };


### PR DESCRIPTION
Till now domain_name would have been set in the header in project scope
only. Change it to optionally extract current domain info from domain
scope.
