### PR TITLE
chore: Change components map initialization

### DIFF
--- a/openstack_tui/.config/config.json5
+++ b/openstack_tui/.config/config.json5
@@ -51,5 +51,24 @@
     ":": { "action": "ResourceSelect", "description": "Select resource"},// Select the resource
     "<F4>": { "action": "SelectProject", "description": "Select project"},
     "<r>": {"action": "Refresh", "description": "Refresh data"}
+  },
+  "mode_aliases": {
+    "aggregates (compute)": "ComputeAggregates",
+    "application credentials (identity)": "IdentityApplicationCredentials",
+    "flavors": "ComputeFlavors",
+    "groups (identity)": "IdentityGroups",
+    "host-aggregates (compute)": "ComputeAggregates",
+    "hypervisors (compute)": "ComputeHypervisors",
+    "images": "ImageImages",
+    "nets": "NetworkNetworks",
+    "networks": "NetworkNetworks",
+    "projects": "IdentityProjects",
+    "security groups (network)": "NetworkSecurityGroups",
+    "security group rules (network)": "NetworkSecurityGroupRules",
+    "servers": "ComputeServers",
+    "sg": "NetworkSecurityGroups",
+    "sgr": "NetworkSecurityGroupRules",
+    "subnets (network)": "NetworkSubnets",
+    "users": "IdentityUsers"
   }
 }

--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -86,25 +86,6 @@ impl App {
     pub fn new(tick_rate: f64, frame_rate: f64, cloud_name: Option<String>) -> Result<Self> {
         let config = Config::new()?;
         let mode = Mode::Home;
-        let home_components: Box<dyn Component> = Box::new(Home::new());
-        let describe_component: Box<dyn Component> = Box::new(Describe::new());
-        let compute_servers_component: Box<dyn Component> = Box::new(ComputeServers::new());
-        let compute_flavors_component: Box<dyn Component> = Box::new(ComputeFlavors::new());
-        let compute_aggregates_component: Box<dyn Component> = Box::new(ComputeAggregates::new());
-        let compute_hypervisors_component: Box<dyn Component> = Box::new(ComputeHypervisors::new());
-        let identity_projects_component: Box<dyn Component> = Box::new(IdentityProjects::new());
-        let identity_appcred_component: Box<dyn Component> =
-            Box::new(IdentityApplicationCredentials::new());
-        let identity_groups_component: Box<dyn Component> = Box::new(IdentityGroups::new());
-        let identity_group_users_component: Box<dyn Component> =
-            Box::new(IdentityGroupUsers::new());
-        let identity_users_component: Box<dyn Component> = Box::new(IdentityUsers::new());
-        let image_images_component: Box<dyn Component> = Box::new(Images::new());
-        let network_component: Box<dyn Component> = Box::new(NetworkNetworks::new());
-        let sg_component: Box<dyn Component> = Box::new(NetworkSecurityGroups::new());
-        let sgr_component: Box<dyn Component> = Box::new(NetworkSecurityGroupRules::new());
-        let subnet_component: Box<dyn Component> = Box::new(NetworkSubnets::new());
-
         let (action_tx, action_rx) = mpsc::unbounded_channel();
 
         let (cloud_worker, mut cloud_worker_receiver) = mpsc::unbounded_channel();
@@ -117,30 +98,48 @@ impl App {
                 .unwrap();
         });
 
+        // Is there a way to initialize HashMap with Box<dyn Foo> as keys in one operation?
+        let mut components: HashMap<Mode, Box<dyn Component>> = HashMap::new();
+        components.insert(Mode::Home, Box::new(Home::new()));
+        components.insert(Mode::Describe, Box::new(Describe::new()));
+
+        components.insert(Mode::ComputeServers, Box::new(ComputeServers::new()));
+        components.insert(Mode::ComputeFlavors, Box::new(ComputeFlavors::new()));
+        components.insert(Mode::ComputeAggregates, Box::new(ComputeAggregates::new()));
+        components.insert(
+            Mode::ComputeHypervisors,
+            Box::new(ComputeHypervisors::new()),
+        );
+
+        components.insert(
+            Mode::IdentityApplicationCredentials,
+            Box::new(IdentityApplicationCredentials::new()),
+        );
+        components.insert(Mode::IdentityGroups, Box::new(IdentityGroups::new()));
+        components.insert(
+            Mode::IdentityGroupUsers,
+            Box::new(IdentityGroupUsers::new()),
+        );
+        components.insert(Mode::IdentityProjects, Box::new(IdentityProjects::new()));
+        components.insert(Mode::IdentityUsers, Box::new(IdentityUsers::new()));
+
+        components.insert(Mode::ImageImages, Box::new(Images::new()));
+
+        components.insert(Mode::NetworkNetworks, Box::new(NetworkNetworks::new()));
+        components.insert(
+            Mode::NetworkSecurityGroups,
+            Box::new(NetworkSecurityGroups::new()),
+        );
+        components.insert(
+            Mode::NetworkSecurityGroupRules,
+            Box::new(NetworkSecurityGroupRules::new()),
+        );
+        components.insert(Mode::NetworkSubnets, Box::new(NetworkSubnets::new()));
+
         Ok(Self {
             tick_rate,
             frame_rate,
-            components: HashMap::from([
-                (Mode::Home, home_components),
-                (Mode::Describe, describe_component),
-                (Mode::ComputeServers, compute_servers_component),
-                (Mode::ComputeFlavors, compute_flavors_component),
-                (Mode::ComputeAggregates, compute_aggregates_component),
-                (Mode::ComputeHypervisors, compute_hypervisors_component),
-                (
-                    Mode::IdentityApplicationCredentials,
-                    identity_appcred_component,
-                ),
-                (Mode::IdentityGroups, identity_groups_component),
-                (Mode::IdentityGroupUsers, identity_group_users_component),
-                (Mode::IdentityProjects, identity_projects_component),
-                (Mode::IdentityUsers, identity_users_component),
-                (Mode::ImageImages, image_images_component),
-                (Mode::NetworkNetworks, network_component),
-                (Mode::NetworkSubnets, subnet_component),
-                (Mode::NetworkSecurityGroups, sg_component),
-                (Mode::NetworkSecurityGroupRules, sgr_component),
-            ]),
+            components,
             header: Box::new(Header::new()),
             should_quit: false,
             should_suspend: false,

--- a/openstack_tui/src/components/fuzzy_select_list.rs
+++ b/openstack_tui/src/components/fuzzy_select_list.rs
@@ -52,8 +52,15 @@ impl FuzzySelectList {
         }
     }
 
-    pub fn set_items<S: AsRef<str>>(&mut self, items: Vec<S>) -> &mut Self {
-        self.all_items = items.iter().map(|x| x.as_ref().to_string()).collect();
+    pub fn set_items<I, S>(&mut self, items: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.all_items = items
+            .into_iter()
+            .map(|x| x.as_ref().to_string())
+            .collect::<Vec<_>>();
         self.filtered_items = self.all_items.clone();
         self.input = None;
         self

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -79,7 +79,7 @@ impl ProjectSelect {
 
         self.items = items;
         self.fuzzy_list
-            .set_items(self.items.iter().map(|x| x.name.clone()).collect());
+            .set_items(self.items.iter().map(|x| x.name.clone()));
         self.set_loading(false);
         Ok(())
     }

--- a/openstack_tui/src/config.rs
+++ b/openstack_tui/src/config.rs
@@ -12,7 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use derive_deref::{Deref, DerefMut};
@@ -40,6 +43,9 @@ pub struct Config {
     pub mode_keybindings: HashMap<Mode, KeyBindings>,
     #[serde(default)]
     pub global_keybindings: KeyBindings,
+    /// Aliases for the mode (for use in the mode selector)
+    #[serde(default)]
+    pub mode_aliases: BTreeMap<String, Mode>,
     #[serde(default)]
     pub styles: Styles,
 }
@@ -87,6 +93,10 @@ impl Config {
             cfg.global_keybindings
                 .entry(key.clone())
                 .or_insert_with(|| cmd.clone());
+        }
+
+        for (key, mode) in default_config.mode_aliases.iter() {
+            cfg.mode_aliases.entry(key.clone()).or_insert_with(|| *mode);
         }
         Ok(cfg)
     }
@@ -290,6 +300,18 @@ pub fn parse_key_sequence(raw: &str) -> Result<Vec<KeyEvent>, String> {
 
     sequences.into_iter().map(parse_key_event).collect()
 }
+
+//impl<'de> Deserialize<'de> for Mode {
+//    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+//    where
+//        D: Deserializer<'de>,
+//    {
+//        let parsed = String::deserialize(deserializer)?;
+//        let mode = Mode::try_from(parsed)?;
+//
+//        Ok(mode)
+//    }
+//}
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Styles {

--- a/openstack_tui/src/mode.rs
+++ b/openstack_tui/src/mode.rs
@@ -35,3 +35,15 @@ pub enum Mode {
     NetworkSecurityGroupRules,
     NetworkSubnets,
 }
+
+impl TryFrom<&str> for Mode {
+    type Error = &'static str;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "Home" => Ok(Self::Home),
+            "Describe" => Ok(Self::Describe),
+            _ => Err("Unknown Mode"),
+        }
+    }
+}


### PR DESCRIPTION
initializing hashmap with Box<dyn> objects is not trivial in Rust (at
least I do not see a nice way to do that now. In any way inserting
individual value with insert seems nicer then creating variable for
every component and then assigning them into the hashmap.
