### PR TITLE
feat: Make sort_key and sort_dir in neutron array

### DIFF
--- a/openstack_cli/src/network/v2/address_group/list.rs
+++ b/openstack_cli/src/network/v2/address_group/list.rs
@@ -127,14 +127,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -216,10 +216,10 @@ impl AddressGroupsCommand {
             ep_builder.revision_number(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/address_scope/list.rs
+++ b/openstack_cli/src/network/v2/address_scope/list.rs
@@ -122,14 +122,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/address-scopes API
     ///
@@ -206,10 +206,10 @@ impl AddressScopesCommand {
             ep_builder.ip_version(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/agent/dhcp_network/list.rs
+++ b/openstack_cli/src/network/v2/agent/dhcp_network/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -155,10 +155,10 @@ impl DhcpNetworksCommand {
         ep_builder.agent_id(&self.path.agent_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/agent/l3_router/list.rs
+++ b/openstack_cli/src/network/v2/agent/l3_router/list.rs
@@ -98,14 +98,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -148,10 +148,10 @@ impl L3RoutersCommand {
         ep_builder.agent_id(&self.path.agent_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/agent/list.rs
+++ b/openstack_cli/src/network/v2/agent/list.rs
@@ -139,14 +139,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// topic query parameter for /v2.0/agents API
     ///
@@ -301,10 +301,10 @@ impl AgentsCommand {
             ep_builder.availability_zone(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/auto_allocated_topology/list.rs
+++ b/openstack_cli/src/network/v2/auto_allocated_topology/list.rs
@@ -79,14 +79,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -121,10 +121,10 @@ impl AutoAllocatedTopologiesCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/availability_zone/list.rs
+++ b/openstack_cli/src/network/v2/availability_zone/list.rs
@@ -107,14 +107,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// state query parameter for /v2.0/availability_zones API
     ///
@@ -175,10 +175,10 @@ impl AvailabilityZonesCommand {
             ep_builder.state(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/default_security_group_rule/create.rs
+++ b/openstack_cli/src/network/v2/default_security_group_rule/create.rs
@@ -125,9 +125,9 @@ struct DefaultSecurityGroupRule {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[arg(help_heading = "Body parameters", long)]
     protocol: Option<String>,
@@ -219,9 +219,9 @@ struct ResponseData {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/default_security_group_rule/list.rs
+++ b/openstack_cli/src/network/v2/default_security_group_rule/list.rs
@@ -159,14 +159,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// used_in_default_sg query parameter for
     /// /v2.0/default-security-group-rules API
@@ -239,9 +239,9 @@ struct ResponseData {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde()]
     #[structable(optional, wide)]
@@ -333,10 +333,10 @@ impl DefaultSecurityGroupRulesCommand {
             ep_builder.used_in_non_default_sg(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/default_security_group_rule/show.rs
+++ b/openstack_cli/src/network/v2/default_security_group_rule/show.rs
@@ -131,9 +131,9 @@ struct ResponseData {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/flavor/list.rs
+++ b/openstack_cli/src/network/v2/flavor/list.rs
@@ -126,14 +126,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -211,10 +211,10 @@ impl FlavorsCommand {
             ep_builder.enabled(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/flavor/next_provider/list.rs
+++ b/openstack_cli/src/network/v2/flavor/next_provider/list.rs
@@ -79,14 +79,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -136,10 +136,10 @@ impl NextProvidersCommand {
         ep_builder.flavor_id(&self.path.flavor_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/flavor/service_profile/list.rs
+++ b/openstack_cli/src/network/v2/flavor/service_profile/list.rs
@@ -79,14 +79,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -128,10 +128,10 @@ impl ServiceProfilesCommand {
         ep_builder.flavor_id(&self.path.flavor_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/floatingip/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/list.rs
@@ -153,14 +153,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// status query parameter for /v2.0/floatingips API
     ///
@@ -367,10 +367,10 @@ impl FloatingipsCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
@@ -137,14 +137,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -261,10 +261,10 @@ impl PortForwardingsCommand {
             ep_builder.external_port_range(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/floatingip/tag/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -143,10 +143,10 @@ impl TagsCommand {
         ep_builder.floatingip_id(&self.path.floatingip_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/floatingip_pool/list.rs
+++ b/openstack_cli/src/network/v2/floatingip_pool/list.rs
@@ -79,14 +79,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -133,10 +133,10 @@ impl FloatingipPoolsCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/local_ip/list.rs
+++ b/openstack_cli/src/network/v2/local_ip/list.rs
@@ -124,14 +124,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -229,10 +229,10 @@ impl LocalIpsCommand {
             ep_builder.revision_number(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/local_ip/port_association/list.rs
+++ b/openstack_cli/src/network/v2/local_ip/port_association/list.rs
@@ -121,14 +121,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -208,10 +208,10 @@ impl PortAssociationsCommand {
             ep_builder.host(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/log/log/list.rs
+++ b/openstack_cli/src/network/v2/log/log/list.rs
@@ -145,14 +145,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// target_id query parameter for /v2.0/log/logs API
     ///
@@ -286,10 +286,10 @@ impl LogsCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/log/loggable_resource/list.rs
+++ b/openstack_cli/src/network/v2/log/loggable_resource/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -137,10 +137,10 @@ impl LoggableResourcesCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/metering/metering_label/list.rs
+++ b/openstack_cli/src/network/v2/metering/metering_label/list.rs
@@ -120,14 +120,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/metering/metering-labels API
     ///
@@ -204,10 +204,10 @@ impl MeteringLabelsCommand {
             ep_builder.shared(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/metering/metering_label_rule/list.rs
+++ b/openstack_cli/src/network/v2/metering/metering_label_rule/list.rs
@@ -139,14 +139,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// The source IP prefix that the metering rule is associated with; in this
     /// context, source IP prefix represents the source IP of the network
@@ -252,10 +252,10 @@ impl MeteringLabelRulesCommand {
             ep_builder.destination_ip_prefix(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/ndp_proxy/list.rs
+++ b/openstack_cli/src/network/v2/ndp_proxy/list.rs
@@ -94,14 +94,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -177,10 +177,10 @@ impl NdpProxiesCommand {
             ep_builder.revision_number(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -156,10 +156,10 @@ impl DhcpAgentsCommand {
         ep_builder.network_id(&self.path.network_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/network/list.rs
+++ b/openstack_cli/src/network/v2/network/list.rs
@@ -179,14 +179,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// status query parameter for /v2.0/networks API
     ///
@@ -454,10 +454,10 @@ impl NetworksCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/network/tag/list.rs
+++ b/openstack_cli/src/network/v2/network/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -142,10 +142,10 @@ impl TagsCommand {
         ep_builder.network_id(&self.path.network_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/network_ip_availability/list.rs
+++ b/openstack_cli/src/network/v2/network_ip_availability/list.rs
@@ -115,14 +115,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/network-ip-availabilities API
     ///
@@ -203,10 +203,10 @@ impl NetworkIpAvailabilitiesCommand {
             ep_builder.ip_version(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/network_segment_range/list.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/list.rs
@@ -127,14 +127,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tags query parameter for /v2.0/network-segment-ranges API
     ///
@@ -268,10 +268,10 @@ impl NetworkSegmentRangesCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/network_segment_range/tag/list.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -143,10 +143,10 @@ impl TagsCommand {
         ep_builder.network_segment_range_id(&self.path.network_segment_range_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -104,14 +104,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -177,10 +177,10 @@ impl PacketRateLimitRulesCommand {
             ep_builder.direction(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/policy/tag/list.rs
+++ b/openstack_cli/src/network/v2/policy/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -142,10 +142,10 @@ impl TagsCommand {
         ep_builder.policy_id(&self.path.policy_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/port/binding/list.rs
+++ b/openstack_cli/src/network/v2/port/binding/list.rs
@@ -91,14 +91,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// status query parameter for /v2.0/ports/{port_id}/bindings API
     ///
@@ -221,10 +221,10 @@ impl BindingsCommand {
             ep_builder.status(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/port/list.rs
+++ b/openstack_cli/src/network/v2/port/list.rs
@@ -184,14 +184,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// status query parameter for /v2.0/ports API
     ///
@@ -569,10 +569,10 @@ impl PortsCommand {
             ep_builder.security_groups(val.iter());
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/port/tag/list.rs
+++ b/openstack_cli/src/network/v2/port/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -142,10 +142,10 @@ impl TagsCommand {
         ep_builder.port_id(&self.path.port_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -101,14 +101,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -167,10 +167,10 @@ impl AliasBandwidthLimitRulesCommand {
             ep_builder.max_burst_kbps(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/alias_dscp_marking_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_dscp_marking_rule/list.rs
@@ -89,14 +89,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -141,10 +141,10 @@ impl AliasDscpMarkingRulesCommand {
             ep_builder.dscp_mark(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -156,10 +156,10 @@ impl AliasMinimumBandwidthRulesCommand {
             ep_builder.direction(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -152,10 +152,10 @@ impl AliasMinimumPacketRateRulesCommand {
             ep_builder.direction(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -118,14 +118,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -199,10 +199,10 @@ impl BandwidthLimitRulesCommand {
             ep_builder.max_burst_kbps(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/policy/dscp_marking_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/dscp_marking_rule/list.rs
@@ -111,14 +111,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -174,10 +174,10 @@ impl DscpMarkingRulesCommand {
             ep_builder.dscp_mark(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/policy/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/list.rs
@@ -142,14 +142,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tags query parameter for /v2.0/qos/policies API
     ///
@@ -290,10 +290,10 @@ impl PoliciesCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -118,14 +118,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -193,10 +193,10 @@ impl MinimumBandwidthRulesCommand {
             ep_builder.direction(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -98,14 +98,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -164,10 +164,10 @@ impl MinimumPacketRateRulesCommand {
             ep_builder.direction(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/qos/rule_type/list.rs
+++ b/openstack_cli/src/network/v2/qos/rule_type/list.rs
@@ -107,14 +107,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -157,10 +157,10 @@ impl RuleTypesCommand {
             ep_builder.all_supported(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/quota/list.rs
+++ b/openstack_cli/src/network/v2/quota/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -200,10 +200,10 @@ impl QuotasCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/rbac_policy/list.rs
+++ b/openstack_cli/src/network/v2/rbac_policy/list.rs
@@ -117,14 +117,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// target_tenant query parameter for /v2.0/rbac-policies API
     ///
@@ -223,10 +223,10 @@ impl RbacPoliciesCommand {
             ep_builder.action(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
@@ -121,14 +121,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -202,10 +202,10 @@ impl ConntrackHelpersCommand {
             ep_builder.helper(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/router/l3_agent/list.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -155,10 +155,10 @@ impl L3AgentsCommand {
         ep_builder.router_id(&self.path.router_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/router/list.rs
+++ b/openstack_cli/src/network/v2/router/list.rs
@@ -143,14 +143,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tags query parameter for /v2.0/routers API
     ///
@@ -358,10 +358,10 @@ impl RoutersCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/router/tag/list.rs
+++ b/openstack_cli/src/network/v2/router/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -142,10 +142,10 @@ impl TagsCommand {
         ep_builder.router_id(&self.path.router_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/security_group/list.rs
+++ b/openstack_cli/src/network/v2/security_group/list.rs
@@ -137,14 +137,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tags query parameter for /v2.0/security-groups API
     ///
@@ -276,10 +276,10 @@ impl SecurityGroupsCommand {
             ep_builder.shared(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/security_group/tag/list.rs
+++ b/openstack_cli/src/network/v2/security_group/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -143,10 +143,10 @@ impl TagsCommand {
         ep_builder.security_group_id(&self.path.security_group_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/security_group_rule/create.rs
+++ b/openstack_cli/src/network/v2/security_group_rule/create.rs
@@ -125,9 +125,9 @@ struct SecurityGroupRule {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[arg(help_heading = "Body parameters", long)]
     protocol: Option<String>,
@@ -228,9 +228,9 @@ struct ResponseData {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/security_group_rule/list.rs
+++ b/openstack_cli/src/network/v2/security_group_rule/list.rs
@@ -173,14 +173,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tenant_id query parameter for /v2.0/security-group-rules API
     ///
@@ -263,9 +263,9 @@ struct ResponseData {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde()]
     #[structable(optional, wide)]
@@ -379,10 +379,10 @@ impl SecurityGroupRulesCommand {
             ep_builder.belongs_to_default_sg(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/security_group_rule/show.rs
+++ b/openstack_cli/src/network/v2/security_group_rule/show.rs
@@ -148,9 +148,9 @@ struct ResponseData {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde()]
     #[structable(optional)]

--- a/openstack_cli/src/network/v2/segment/list.rs
+++ b/openstack_cli/src/network/v2/segment/list.rs
@@ -133,14 +133,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -253,10 +253,10 @@ impl SegmentsCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/service_profile/list.rs
+++ b/openstack_cli/src/network/v2/service_profile/list.rs
@@ -120,14 +120,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -197,10 +197,10 @@ impl ServiceProfilesCommand {
             ep_builder.enabled(*val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/service_provider/list.rs
+++ b/openstack_cli/src/network/v2/service_provider/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -152,10 +152,10 @@ impl ServiceProvidersCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/subnet/list.rs
+++ b/openstack_cli/src/network/v2/subnet/list.rs
@@ -184,14 +184,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// subnetpool_id query parameter for /v2.0/subnets API
     ///
@@ -440,10 +440,10 @@ impl SubnetsCommand {
             ep_builder.segment_id(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/subnet/tag/list.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -142,10 +142,10 @@ impl TagsCommand {
         ep_builder.subnet_id(&self.path.subnet_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/subnetpool/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/list.rs
@@ -174,14 +174,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 
     /// tags query parameter for /v2.0/subnetpools API
     ///
@@ -390,10 +390,10 @@ impl SubnetpoolsCommand {
             ep_builder.description(val);
         }
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/subnetpool/tag/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -143,10 +143,10 @@ impl TagsCommand {
         ep_builder.subnetpool_id(&self.path.subnetpool_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/trunk/tag/list.rs
+++ b/openstack_cli/src/network/v2/trunk/tag/list.rs
@@ -78,14 +78,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -142,10 +142,10 @@ impl TagsCommand {
         ep_builder.trunk_id(&self.path.trunk_id);
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/vpn/endpoint_group/list.rs
+++ b/openstack_cli/src/network/v2/vpn/endpoint_group/list.rs
@@ -98,14 +98,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -172,10 +172,10 @@ impl EndpointGroupsCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/vpn/ikepolicy/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ikepolicy/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -200,10 +200,10 @@ impl IkepoliciesCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
@@ -147,13 +147,13 @@ struct IpsecSiteConnection {
     peer_address: Option<String>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     peer_cidrs: Option<Vec<String>>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.
@@ -278,14 +278,14 @@ struct ResponseData {
     peer_address: Option<String>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[serde()]
     #[structable(optional, pretty)]
     peer_cidrs: Option<Value>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
@@ -100,14 +100,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -207,14 +207,14 @@ struct ResponseData {
     peer_address: Option<String>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[serde()]
     #[structable(optional, pretty, wide)]
     peer_cidrs: Option<Value>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.
@@ -281,10 +281,10 @@ impl IpsecSiteConnectionsCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
@@ -148,13 +148,13 @@ struct IpsecSiteConnection {
     peer_address: Option<String>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     peer_cidrs: Option<Vec<String>>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.
@@ -269,14 +269,14 @@ struct ResponseData {
     peer_address: Option<String>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[serde()]
     #[structable(optional, pretty)]
     peer_cidrs: Option<Value>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/show.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/show.rs
@@ -170,14 +170,14 @@ struct ResponseData {
     peer_address: Option<String>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[serde()]
     #[structable(optional, pretty)]
     peer_cidrs: Option<Value>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.

--- a/openstack_cli/src/network/v2/vpn/ipsecpolicy/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsecpolicy/list.rs
@@ -97,14 +97,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -202,10 +202,10 @@ impl IpsecpoliciesCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_cli/src/network/v2/vpn/vpnservice/list.rs
+++ b/openstack_cli/src/network/v2/vpn/vpnservice/list.rs
@@ -100,14 +100,14 @@ struct QueryParameters {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[arg(help_heading = "Query parameters", long, value_parser = ["asc","desc"])]
-    sort_dir: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_dir: Option<Vec<String>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[arg(help_heading = "Query parameters", long)]
-    sort_key: Option<String>,
+    #[arg(action=clap::ArgAction::Append, help_heading = "Query parameters", long)]
+    sort_key: Option<Vec<String>>,
 }
 
 /// Path parameters
@@ -209,10 +209,10 @@ impl VpnservicesCommand {
         // Set path parameters
         // Set query parameters
         if let Some(val) = &self.query.sort_key {
-            ep_builder.sort_key(val);
+            ep_builder.sort_key(val.iter());
         }
         if let Some(val) = &self.query.sort_dir {
-            ep_builder.sort_dir(val);
+            ep_builder.sort_dir(val.iter());
         }
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);

--- a/openstack_sdk/src/api/network/v2/address_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/address_group/list.rs
@@ -44,6 +44,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -97,14 +98,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -117,6 +118,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Address_Group.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -157,8 +186,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("project_id", self.project_id.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/address_scope/list.rs
+++ b/openstack_sdk/src/api/network/v2/address_scope/list.rs
@@ -44,6 +44,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -92,14 +93,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tenant_id query parameter for /v2.0/address-scopes API
     ///
@@ -117,6 +118,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Address_Scope.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -157,8 +186,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("shared", self.shared);
         params.push_opt("ip_version", self.ip_version);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/agent/dhcp_network/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/dhcp_network/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -73,14 +74,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -93,6 +94,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Dhcp_Network.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -132,8 +161,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/agent/l3_router/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/l3_router/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -73,14 +74,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -93,6 +94,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the L3_Router.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -132,8 +161,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -108,14 +109,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// topic query parameter for /v2.0/agents API
     ///
@@ -133,6 +134,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Agent.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -177,8 +206,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("alive", self.alive.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("availability_zone", self.availability_zone.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/auto_allocated_topology/list.rs
+++ b/openstack_sdk/src/api/network/v2/auto_allocated_topology/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -49,14 +50,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -69,6 +70,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Auto_Allocated_Topology.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -104,8 +133,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/availability_zone/list.rs
+++ b/openstack_sdk/src/api/network/v2/availability_zone/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -78,14 +79,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// state query parameter for /v2.0/availability_zones API
     ///
@@ -103,6 +104,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Availability_Zone.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -141,8 +170,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("name", self.name.as_ref());
         params.push_opt("resource", self.resource.as_ref());
         params.push_opt("state", self.state.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/default_security_group_rule/create.rs
+++ b/openstack_sdk/src/api/network/v2/default_security_group_rule/create.rs
@@ -98,9 +98,9 @@ pub struct DefaultSecurityGroupRule<'a> {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/default_security_group_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/default_security_group_rule/list.rs
@@ -43,6 +43,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -129,14 +130,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// used_in_default_sg query parameter for
     /// /v2.0/default-security-group-rules API
@@ -161,6 +162,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Default_Security_Group_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -211,8 +240,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("remote_ip_prefix", self.remote_ip_prefix.as_ref());
         params.push_opt("used_in_default_sg", self.used_in_default_sg);
         params.push_opt("used_in_non_default_sg", self.used_in_non_default_sg);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/flavor/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -95,14 +96,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -115,6 +116,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Flavor.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -155,8 +184,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("service_type", self.service_type.as_ref());
         params.push_opt("enabled", self.enabled);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/flavor/next_provider/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/next_provider/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -55,14 +56,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -75,6 +76,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Next_Provider.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -114,8 +143,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/flavor/service_profile/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/service_profile/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -55,14 +56,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -75,6 +76,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Service_Profile.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -114,8 +143,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/list.rs
@@ -46,6 +46,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -124,14 +125,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// status query parameter for /v2.0/floatingips API
     ///
@@ -220,6 +221,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Floatingip.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -269,8 +298,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip/port_forwarding/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/port_forwarding/list.rs
@@ -44,6 +44,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -114,14 +115,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -134,6 +135,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Port_Forwarding.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -179,8 +208,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("internal_port_id", self.internal_port_id.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("external_port_range", self.external_port_range);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -55,14 +56,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -75,6 +76,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -114,8 +143,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip_pool/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip_pool/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -49,14 +50,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -69,6 +70,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Floatingip_Pool.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -104,8 +133,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/local_ip/list.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -94,14 +95,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -114,6 +115,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Local_Ip.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -158,8 +187,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("local_ip_address", self.local_ip_address.as_ref());
         params.push_opt("ip_mode", self.ip_mode.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/log/log/list.rs
+++ b/openstack_sdk/src/api/network/v2/log/log/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -115,14 +116,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// target_id query parameter for /v2.0/log/logs API
     ///
@@ -140,6 +141,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Log.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -185,8 +214,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("enabled", self.enabled);
         params.push_opt("revision_number", self.revision_number.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/log/loggable_resource/list.rs
+++ b/openstack_sdk/src/api/network/v2/log/loggable_resource/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,14 +69,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -88,6 +89,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Loggable_Resource.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -123,8 +152,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/metering/metering_label/list.rs
+++ b/openstack_sdk/src/api/network/v2/metering/metering_label/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -90,14 +91,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tenant_id query parameter for /v2.0/metering/metering-labels API
     ///
@@ -115,6 +116,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Metering_Label.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -155,8 +184,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("shared", self.shared);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/metering/metering_label_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/metering/metering_label_rule/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -109,14 +110,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// The source IP prefix that the metering rule is associated with; in this
     /// context, source IP prefix represents the source IP of the network
@@ -140,6 +141,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Metering_Label_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -182,8 +211,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("remote_ip_prefix", self.remote_ip_prefix.as_ref());
         params.push_opt("source_ip_prefix", self.source_ip_prefix.as_ref());
         params.push_opt("destination_ip_prefix", self.destination_ip_prefix.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/ndp_proxy/list.rs
+++ b/openstack_sdk/src/api/network/v2/ndp_proxy/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -64,14 +65,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -84,6 +85,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Ndp_Proxy.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -122,8 +151,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("name", self.name.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/dhcp_agent/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -74,14 +75,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -94,6 +95,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Dhcp_Agent.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -133,8 +162,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/list.rs
@@ -50,6 +50,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -148,14 +149,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// status query parameter for /v2.0/networks API
     ///
@@ -244,6 +245,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Network.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -300,8 +329,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("is_default", self.is_default);
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -54,14 +55,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -74,6 +75,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -113,8 +142,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network_ip_availability/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_ip_availability/list.rs
@@ -43,6 +43,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -86,14 +87,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tenant_id query parameter for /v2.0/network-ip-availabilities API
     ///
@@ -111,6 +112,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Network_Ip_Availability.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -150,8 +179,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("network_name", self.network_name.as_ref());
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("ip_version", self.ip_version.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network_segment_range/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/list.rs
@@ -22,6 +22,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -95,14 +96,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tags query parameter for /v2.0/network-segment-ranges API
     ///
@@ -181,6 +182,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Network_Segment_Range.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -227,8 +256,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network_segment_range/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -55,14 +56,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -75,6 +76,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -114,8 +143,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -79,14 +80,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -99,6 +100,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Packet_Rate_Limit_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -142,8 +171,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("max_kpps", self.max_kpps);
         params.push_opt("max_burst_kpps", self.max_burst_kpps);
         params.push_opt("direction", self.direction.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/policy/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/policy/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -54,14 +55,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -74,6 +75,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -113,8 +142,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/port/binding/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/binding/list.rs
@@ -28,6 +28,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -66,14 +67,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// status query parameter for /v2.0/ports/{port_id}/bindings API
     ///
@@ -101,6 +102,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Binding.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -140,8 +169,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("vif_type", self.vif_type.as_ref());
         params.push_opt("vnic_type", self.vnic_type.as_ref());
         params.push_opt("status", self.status.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/port/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/list.rs
@@ -155,14 +155,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// status query parameter for /v2.0/ports API
     ///
@@ -278,6 +278,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Port.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -336,8 +364,8 @@ impl<'a> RestEndpoint for Request<'a> {
                 .iter()
                 .map(|value| ("security_groups", value)),
         );
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/port/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -54,14 +55,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -74,6 +75,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -109,8 +138,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,14 +71,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -90,6 +91,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Alias_Bandwidth_Limit_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -129,8 +158,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("max_kbps", self.max_kbps);
         params.push_opt("direction", self.direction.as_ref());
         params.push_opt("max_burst_kbps", self.max_burst_kbps);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_dscp_marking_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_dscp_marking_rule/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -59,14 +60,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -79,6 +80,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Alias_Dscp_Marking_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -116,8 +145,8 @@ impl<'a> RestEndpoint for Request<'a> {
         let mut params = QueryParams::default();
         params.push_opt("id", self.id.as_ref());
         params.push_opt("dscp_mark", self.dscp_mark);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -66,14 +67,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -86,6 +87,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Alias_Minimum_Bandwidth_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -124,8 +153,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kbps", self.min_kbps);
         params.push_opt("direction", self.direction.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -66,14 +67,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -86,6 +87,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Alias_Minimum_Packet_Rate_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -124,8 +153,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kpps", self.min_kpps);
         params.push_opt("direction", self.direction.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -94,14 +95,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -114,6 +115,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Bandwidth_Limit_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -156,8 +185,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("max_kbps", self.max_kbps);
         params.push_opt("max_burst_kbps", self.max_burst_kbps);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/dscp_marking_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/dscp_marking_rule/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -88,14 +89,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -108,6 +109,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Dscp_Marking_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -149,8 +178,8 @@ impl<'a> RestEndpoint for Request<'a> {
         let mut params = QueryParams::default();
         params.push_opt("id", self.id.as_ref());
         params.push_opt("dscp_mark", self.dscp_mark);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/list.rs
@@ -44,6 +44,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -112,14 +113,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tags query parameter for /v2.0/qos/policies API
     ///
@@ -203,6 +204,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Policy.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -249,8 +278,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -94,14 +95,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -114,6 +115,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Minimum_Bandwidth_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -156,8 +185,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kbps", self.min_kbps);
         params.push_opt("direction", self.direction.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -73,14 +74,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -93,6 +94,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Minimum_Packet_Rate_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -135,8 +164,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kpps", self.min_kpps);
         params.push_opt("direction", self.direction.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/rule_type/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/rule_type/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -78,14 +79,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,6 +99,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Rule_Type.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -135,8 +164,8 @@ impl<'a> RestEndpoint for Request<'a> {
         let mut params = QueryParams::default();
         params.push_opt("all_rules", self.all_rules);
         params.push_opt("all_supported", self.all_supported);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/quota/list.rs
+++ b/openstack_sdk/src/api/network/v2/quota/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,14 +69,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -88,6 +89,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Quota.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -123,8 +152,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/rbac_policy/list.rs
+++ b/openstack_sdk/src/api/network/v2/rbac_policy/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -88,14 +89,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// target_tenant query parameter for /v2.0/rbac-policies API
     ///
@@ -118,6 +119,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Rbac_Policy.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -159,8 +188,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("target_tenant", self.target_tenant.as_ref());
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("action", self.action.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -97,14 +98,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -117,6 +118,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Conntrack_Helper.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -160,8 +189,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("protocol", self.protocol.as_ref());
         params.push_opt("port", self.port);
         params.push_opt("helper", self.helper.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/l3_agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/l3_agent/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -73,14 +74,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -93,6 +94,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the L3_Agent.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -132,8 +161,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/list.rs
@@ -45,6 +45,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -113,14 +114,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tags query parameter for /v2.0/routers API
     ///
@@ -204,6 +205,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Router.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -250,8 +279,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -54,14 +55,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -74,6 +75,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -113,8 +142,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/security_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group/list.rs
@@ -44,6 +44,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -107,14 +108,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tags query parameter for /v2.0/security-groups API
     ///
@@ -198,6 +199,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Security_Group.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -243,8 +272,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("shared", self.shared);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/security_group/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -55,14 +56,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -75,6 +76,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -114,8 +143,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/security_group_rule/create.rs
+++ b/openstack_sdk/src/api/network/v2/security_group_rule/create.rs
@@ -98,9 +98,9 @@ pub struct SecurityGroupRule<'a> {
     /// `ipv6-opts` or `60`, `ipv6-route` or `43`, `ospf` or `89`, `pgm` or
     /// `113`, `rsvp` or `46`, `sctp` or `132`, `tcp` or `6`, `udp` or `17`,
     /// `udplite` or `136`, `vrrp` or `112`. Additionally, any integer value
-    /// between \[0-255\] is also valid. The string `any` (or integer `0`)
-    /// means `all` IP protocols. See the constants in `neutron_lib.constants`
-    /// for the most up-to-date list of supported strings.
+    /// between [0-255] is also valid. The string `any` (or integer `0`) means
+    /// `all` IP protocols. See the constants in `neutron_lib.constants` for
+    /// the most up-to-date list of supported strings.
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/security_group_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group_rule/list.rs
@@ -43,6 +43,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -143,14 +144,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tenant_id query parameter for /v2.0/security-group-rules API
     ///
@@ -168,6 +169,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Security_Group_Rule.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -221,8 +250,8 @@ impl<'a> RestEndpoint for Request<'a> {
             self.remote_address_group_id.as_ref(),
         );
         params.push_opt("belongs_to_default_sg", self.belongs_to_default_sg);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/segment/list.rs
+++ b/openstack_sdk/src/api/network/v2/segment/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -103,14 +104,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -123,6 +124,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Segment.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -165,8 +194,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("name", self.name.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/service_profile/list.rs
+++ b/openstack_sdk/src/api/network/v2/service_profile/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -90,14 +91,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -110,6 +111,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Service_Profile.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -149,8 +178,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("driver", self.driver.as_ref());
         params.push_opt("enabled", self.enabled);
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/service_provider/list.rs
+++ b/openstack_sdk/src/api/network/v2/service_provider/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,14 +69,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -88,6 +89,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Service_Provider.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -123,8 +152,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/subnet/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/list.rs
@@ -46,6 +46,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -154,14 +155,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// subnetpool_id query parameter for /v2.0/subnets API
     ///
@@ -250,6 +251,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Subnet.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -305,8 +334,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("segment_id", self.segment_id.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/subnet/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -49,14 +50,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
@@ -74,6 +75,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -113,8 +142,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/subnetpool/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/list.rs
@@ -45,6 +45,7 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -143,14 +144,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// tags query parameter for /v2.0/subnetpools API
     ///
@@ -234,6 +235,34 @@ impl<'a> RequestBuilder<'a> {
         self
     }
 
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Subnetpool.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -286,8 +315,8 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/subnetpool/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -49,14 +50,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// subnetpool_id parameter for /v2.0/subnetpools/{subnetpool_id}/tags/{id}
     /// API
@@ -75,6 +76,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -114,8 +143,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/trunk/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/trunk/tag/list.rs
@@ -21,6 +21,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -49,14 +50,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     /// trunk_id parameter for /v2.0/trunks/{trunk_id}/tags/{id} API
     ///
@@ -74,6 +75,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Tag.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -109,8 +138,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/endpoint_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/endpoint_group/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,14 +69,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -88,6 +89,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Endpoint_Group.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -123,8 +152,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/ikepolicy/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ikepolicy/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,14 +69,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -88,6 +89,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Ikepolicy.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -123,8 +152,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/create.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/create.rs
@@ -122,14 +122,14 @@ pub struct IpsecSiteConnection<'a> {
     pub(crate) peer_address: Option<Cow<'a, str>>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) peer_cidrs: Option<Vec<Cow<'a, str>>>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,14 +69,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -88,6 +89,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Ipsec_Site_Connection.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -123,8 +152,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/set.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/set.rs
@@ -110,14 +110,14 @@ pub struct IpsecSiteConnection<'a> {
     pub(crate) peer_address: Option<Cow<'a, str>>,
 
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
-    /// net_address > / \< prefix > .
+    /// net_address > / < prefix > .
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) peer_cidrs: Option<Vec<Cow<'a, str>>>,
 
     /// The ID for the endpoint group that contains private CIDRs in the form
-    /// \< net_address > / \< prefix > for the peer side of the connection. You
+    /// \< net_address > / < prefix > for the peer side of the connection. You
     /// must specify this parameter with the `local_ep_group_id` parameter
     /// unless in backward-compatible mode where `peer_cidrs` is provided with
     /// a `subnet_id` for the VPN service.

--- a/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/list.rs
@@ -40,6 +40,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,14 +69,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -88,6 +89,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Ipsecpolicy.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -123,8 +152,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/vpnservice/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/vpnservice/list.rs
@@ -42,6 +42,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,14 +71,14 @@ pub struct Request<'a> {
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_dir: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_dir"))]
+    sort_dir: BTreeSet<Cow<'a, str>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
-    #[builder(default, setter(into))]
-    sort_key: Option<Cow<'a, str>>,
+    #[builder(default, private, setter(name = "_sort_key"))]
+    sort_key: BTreeSet<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -90,6 +91,34 @@ impl<'a> Request<'a> {
 }
 
 impl<'a> RequestBuilder<'a> {
+    /// Sort results by the attribute. This is an optional feature and may be
+    /// silently ignored by the server.
+    ///
+    pub fn sort_key<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_key
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
+    /// Sort direction. This is an optional feature and may be silently ignored
+    /// by the server.
+    ///
+    pub fn sort_dir<I, T>(&mut self, iter: I) -> &mut Self
+    where
+        I: Iterator<Item = T>,
+        T: Into<Cow<'a, str>>,
+    {
+        self.sort_dir
+            .get_or_insert_with(BTreeSet::new)
+            .extend(iter.map(Into::into));
+        self
+    }
+
     /// Add a single header to the Vpnservice.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -125,8 +154,8 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.push_opt("sort_key", self.sort_key.as_ref());
-        params.push_opt("sort_dir", self.sort_dir.as_ref());
+        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
+        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);


### PR DESCRIPTION
Neutron allows sort_key and sort_dir to be arrays. Unfortunately there
is no easy way how to also cover requirements that when they are their
count should pair, so leave it out for now.

Change-Id: Ie60f78ebfbf0ed615adc08ed4055f1ace7ca5b2e

Changes are triggered by https://review.opendev.org/935489
