### PR TITLE
fix: Set proper default column width

### DIFF
--- a/openstack_tui/.config/config.json5
+++ b/openstack_tui/.config/config.json5
@@ -44,14 +44,14 @@
     },
     "ImageImages": {
       "d": { "action": "DescribeResource", "description": "Describe"},
-      "0": { "action": {"SetImageFilters": {} }, "description": "default filtersall"},
+      "0": { "action": {"SetImageFilters": {} }, "description": "default filters"},
       "1": { "action": {"SetImageFilters": {"visibility": "public"} },"description": "public"},
       "2": { "action": {"SetImageFilters": {"visibility": "shared"} },"description": "shared"},
       "3": { "action": {"SetImageFilters": {"visibility": "private"} },"description": "private"},
     },
     "NetworkNetworks": {
       "d": { "action": "DescribeResource", "description": "Describe"},
-      "<enter>": { "action": "ShowNetworkSubnets", "description": "subnetworks"},
+      "<enter>": { "action": "ShowNetworkSubnets", "description": "Subnets"},
     },
     "NetworkSubnets": {
       "d": { "action": "DescribeResource", "description": "Describe"},

--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -326,8 +326,11 @@ where
     /// Synchronize table data from internal vector of typed entries
     pub fn sync_table_data(&mut self) -> Result<(), TuiError> {
         let (headers, rows) = self.items.build(&self.output_config);
-        self.column_widths.clear();
-        self.column_widths.resize(headers.len(), 1);
+        self.column_widths = headers
+            .clone()
+            .into_iter()
+            .map(|col| col.len() + 1)
+            .collect::<Vec<usize>>();
         self.table_headers = headers.clone().into_iter().map(Cell::from).collect::<Row>();
         self.table_rows = rows;
         for row in &self.table_rows {
@@ -500,7 +503,7 @@ where
 
         if self.describe_enabled {
             let content_layout =
-                Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]);
+                Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]);
             let [content, describe] = content_layout.areas(inner);
 
             self.render_table(frame, content);


### PR DESCRIPTION
When table has no data columns are sized at 1 char.
