### PR TITLE
chore: Re-enable sorting in network

### DIFF
--- a/openstack_tui/src/cloud_worker/network.rs
+++ b/openstack_tui/src/cloud_worker/network.rs
@@ -109,9 +109,9 @@ impl NetworkExt for Cloud {
 
     async fn get_networks(&mut self, _filters: &NetworkNetworkFilters) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
-            let ep_builder = openstack_sdk::api::network::v2::network::list::Request::builder();
-            //ep_builder.sort_key("name");
-            //ep_builder.sort_dir("asc");
+            let mut ep_builder = openstack_sdk::api::network::v2::network::list::Request::builder();
+            ep_builder.sort_key(["name"].into_iter());
+            ep_builder.sort_dir(["asc"].into_iter());
 
             let ep = ep_builder.build()?;
             let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
@@ -127,10 +127,10 @@ impl NetworkExt for Cloud {
         _filters: &NetworkSecurityGroupFilters,
     ) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
-            let ep_builder =
+            let mut ep_builder =
                 openstack_sdk::api::network::v2::security_group::list::Request::builder();
-            //ep_builder.sort_key("name");
-            //ep_builder.sort_dir("asc");
+            ep_builder.sort_key(["name"].into_iter());
+            ep_builder.sort_dir(["asc"].into_iter());
 
             let ep = ep_builder.build()?;
             let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
@@ -148,8 +148,8 @@ impl NetworkExt for Cloud {
         if let Some(session) = &self.cloud {
             let mut ep_builder =
                 openstack_sdk::api::network::v2::security_group_rule::list::Request::builder();
-            //ep_builder.sort_key("ethertype");
-            //ep_builder.sort_dir("asc");
+            ep_builder.sort_key(["ethertype"].into_iter());
+            ep_builder.sort_dir(["asc"].into_iter());
 
             if let Some(security_group_id) = &filters.security_group_id {
                 ep_builder.security_group_id(security_group_id.clone());
@@ -167,8 +167,8 @@ impl NetworkExt for Cloud {
     async fn get_subnets(&mut self, filters: &NetworkSubnetFilters) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
             let mut ep_builder = openstack_sdk::api::network::v2::subnet::list::Request::builder();
-            //ep_builder.sort_key("name");
-            //ep_builder.sort_dir("asc");
+            ep_builder.sort_key(["name"].into_iter());
+            ep_builder.sort_dir(["asc"].into_iter());
 
             if let Some(network_id) = &filters.network_id {
                 ep_builder.network_id(network_id.clone());

--- a/openstack_tui/src/components/network/security_group_rules.rs
+++ b/openstack_tui/src/components/network/security_group_rules.rs
@@ -39,11 +39,11 @@ pub struct NetworkData {
     #[structable(title = "Ethertype")]
     ethertype: String,
     #[serde(default, deserialize_with = "as_string")]
-    #[structable(title = "Protocol")]
-    protocol: String,
-    #[serde(default, deserialize_with = "as_string")]
     #[structable(title = "Direction")]
     direction: String,
+    #[serde(default, deserialize_with = "as_string")]
+    #[structable(title = "Protocol")]
+    protocol: String,
     #[serde(default, deserialize_with = "as_string")]
     #[structable(title = "Range Min")]
     port_range_min: String,


### PR DESCRIPTION
Well, almost. Apparently use of BTreeSet for array query parameters in
network is not appropriate since it is absolutely correct to request
`sort_key=f1&sort_key=f2&sort_key=f3&sort_dir=asc&sort_dir=asc&sort_dir=asc`
