### PR TITLE
feat: Use Array for serialized param instead of Set

### DIFF
--- a/openstack_cli/src/block_storage/v3/attachment/list.rs
+++ b/openstack_cli/src/block_storage/v3/attachment/list.rs
@@ -84,7 +84,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/backup/list.rs
+++ b/openstack_cli/src/block_storage/v3/backup/list.rs
@@ -84,7 +84,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/group/list.rs
+++ b/openstack_cli/src/block_storage/v3/group/list.rs
@@ -84,7 +84,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/group_snapshot/list.rs
+++ b/openstack_cli/src/block_storage/v3/group_snapshot/list.rs
@@ -83,7 +83,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/group_type/list.rs
+++ b/openstack_cli/src/block_storage/v3/group_type/list.rs
@@ -84,7 +84,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/manageable_snapshot/get.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_snapshot/get.rs
@@ -74,7 +74,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/manageable_snapshot/list.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_snapshot/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/manageable_volume/get.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_volume/get.rs
@@ -74,7 +74,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/manageable_volume/list.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_volume/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/message/list.rs
+++ b/openstack_cli/src/block_storage/v3/message/list.rs
@@ -78,7 +78,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/qos_spec/list.rs
+++ b/openstack_cli/src/block_storage/v3/qos_spec/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/snapshot/list.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/list.rs
@@ -93,7 +93,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/volume/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/list.rs
@@ -99,7 +99,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/block_storage/v3/volume_transfer/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume_transfer/list.rs
@@ -88,7 +88,7 @@ struct QueryParameters {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/placement/v1/allocation_candidate/list.rs
+++ b/openstack_cli/src/placement/v1/allocation_candidate/list.rs
@@ -178,7 +178,7 @@ struct QueryParameters {
     /// A comma-separated list of request group suffix strings ($S). Each must
     /// exactly match a suffix on a granular group somewhere else in the
     /// request. Importantly, the identified request groups need not have a
-    /// resources\[$S\]. If this is provided, at least one of the resource
+    /// resources[$S]. If this is provided, at least one of the resource
     /// providers satisfying a specified request group must be an ancestor of
     /// the rest. The same_subtree query parameter can be repeated and each
     /// repeat group is treated independently.

--- a/openstack_sdk/src/api/block_storage/v3/attachment/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/attachment/list.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/attachment/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/attachment/list_detailed.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/backup/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/backup/list.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/backup/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/backup/list_detailed.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/group/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group/list.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/group/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group/list_detailed.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/group_snapshot/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group_snapshot/list.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/group_snapshot/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group_snapshot/list_detailed.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/group_type/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group_type/list.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/manageable_snapshot/get.rs
+++ b/openstack_sdk/src/api/block_storage/v3/manageable_snapshot/get.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/manageable_snapshot/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/manageable_snapshot/list_detailed.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/manageable_volume/get.rs
+++ b/openstack_sdk/src/api/block_storage/v3/manageable_volume/get.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/manageable_volume/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/manageable_volume/list_detailed.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/message/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/message/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/qos_spec/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/qos_spec/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/snapshot/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/snapshot/list.rs
@@ -64,7 +64,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/snapshot/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/snapshot/list_detailed.rs
@@ -64,7 +64,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/volume/list.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/list.rs
@@ -70,7 +70,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/volume/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/list_detailed.rs
@@ -70,7 +70,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/block_storage/v3/volume_transfer/list_detailed.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume_transfer/list_detailed.rs
@@ -60,7 +60,7 @@ pub struct Request<'a> {
     offset: Option<i32>,
 
     /// Comma-separated list of sort keys and optional sort directions in the
-    /// form of \< key > \[: \< direction > \]. A valid direction is asc
+    /// form of < key > [: < direction > ]. A valid direction is asc
     /// (ascending) or desc (descending).
     ///
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/image/v2/image/list.rs
+++ b/openstack_sdk/src/api/image/v2/image/list.rs
@@ -118,7 +118,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -225,7 +224,7 @@ pub struct Request<'a> {
     /// containing all the tags specified will appear in the response.
     ///
     #[builder(default, private, setter(name = "_tag"))]
-    tag: BTreeSet<Cow<'a, str>>,
+    tag: Option<Vec<Cow<'a, str>>>,
 
     /// Specify a comparison filter based on the date and time when the
     /// resource was most recently modified.
@@ -265,7 +264,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.tag
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -312,7 +312,9 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("owner", self.owner.as_ref());
         params.push_opt("protected", self.protected);
         params.push_opt("status", self.status.as_ref());
-        params.extend(self.tag.iter().map(|value| ("tag", value)));
+        if let Some(val) = &self.tag {
+            params.extend(val.iter().map(|value| ("tag", value)));
+        }
         params.push_opt("visibility", self.visibility.as_ref());
         params.push_opt("os_hidden", self.os_hidden);
         params.push_opt("member_status", self.member_status.as_ref());

--- a/openstack_sdk/src/api/network/v2/address_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/address_group/list.rs
@@ -44,7 +44,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -99,13 +98,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -127,7 +126,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -141,7 +141,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -186,8 +187,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("project_id", self.project_id.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/address_scope/list.rs
+++ b/openstack_sdk/src/api/network/v2/address_scope/list.rs
@@ -44,7 +44,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -94,13 +93,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tenant_id query parameter for /v2.0/address-scopes API
     ///
@@ -127,7 +126,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -141,7 +141,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -186,8 +187,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("shared", self.shared);
         params.push_opt("ip_version", self.ip_version);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/agent/dhcp_network/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/dhcp_network/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -75,13 +74,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -103,7 +102,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -117,7 +117,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -161,8 +162,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/agent/l3_router/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/l3_router/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -75,13 +74,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -103,7 +102,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -117,7 +117,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -161,8 +162,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -110,13 +109,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// topic query parameter for /v2.0/agents API
     ///
@@ -143,7 +142,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -157,7 +157,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -206,8 +207,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("alive", self.alive.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("availability_zone", self.availability_zone.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/auto_allocated_topology/list.rs
+++ b/openstack_sdk/src/api/network/v2/auto_allocated_topology/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -51,13 +50,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -79,7 +78,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -93,7 +93,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -133,8 +134,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/availability_zone/list.rs
+++ b/openstack_sdk/src/api/network/v2/availability_zone/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -80,13 +79,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// state query parameter for /v2.0/availability_zones API
     ///
@@ -113,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -127,7 +127,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -170,8 +171,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("name", self.name.as_ref());
         params.push_opt("resource", self.resource.as_ref());
         params.push_opt("state", self.state.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/flavor/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -97,13 +96,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -125,7 +124,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -139,7 +139,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -184,8 +185,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("service_type", self.service_type.as_ref());
         params.push_opt("enabled", self.enabled);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/flavor/next_provider/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/next_provider/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -57,13 +56,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -85,7 +84,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -99,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -143,8 +144,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/flavor/service_profile/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/service_profile/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -57,13 +56,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -85,7 +84,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -99,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -143,8 +144,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/list.rs
@@ -46,7 +46,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -126,13 +125,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// status query parameter for /v2.0/floatingips API
     ///
@@ -230,7 +229,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -244,7 +244,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -298,8 +299,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip/port_forwarding/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/port_forwarding/list.rs
@@ -44,7 +44,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -116,13 +115,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -144,7 +143,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -158,7 +158,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -208,8 +209,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("internal_port_id", self.internal_port_id.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("external_port_range", self.external_port_range);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -57,13 +56,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -85,7 +84,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -99,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -143,8 +144,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/floatingip_pool/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip_pool/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -51,13 +50,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -79,7 +78,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -93,7 +93,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -133,8 +134,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/local_ip/list.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -96,13 +95,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -124,7 +123,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -138,7 +138,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -187,8 +188,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("local_ip_address", self.local_ip_address.as_ref());
         params.push_opt("ip_mode", self.ip_mode.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/local_ip/port_association/list.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/port_association/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -100,13 +99,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -128,7 +127,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -142,7 +142,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -190,8 +191,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("fixed_port_id", self.fixed_port_id.as_ref());
         params.push_opt("fixed_ip", self.fixed_ip.as_ref());
         params.push_opt("host", self.host.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/log/log/list.rs
+++ b/openstack_sdk/src/api/network/v2/log/log/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -117,13 +116,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// target_id query parameter for /v2.0/log/logs API
     ///
@@ -150,7 +149,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -164,7 +164,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -214,8 +215,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("enabled", self.enabled);
         params.push_opt("revision_number", self.revision_number.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/log/loggable_resource/list.rs
+++ b/openstack_sdk/src/api/network/v2/log/loggable_resource/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,13 +69,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,7 +97,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -112,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -152,8 +153,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/metering/metering_label/list.rs
+++ b/openstack_sdk/src/api/network/v2/metering/metering_label/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -92,13 +91,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tenant_id query parameter for /v2.0/metering/metering-labels API
     ///
@@ -125,7 +124,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -139,7 +139,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -184,8 +185,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("shared", self.shared);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/metering/metering_label_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/metering/metering_label_rule/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -111,13 +110,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// The source IP prefix that the metering rule is associated with; in this
     /// context, source IP prefix represents the source IP of the network
@@ -150,7 +149,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -164,7 +164,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -211,8 +212,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("remote_ip_prefix", self.remote_ip_prefix.as_ref());
         params.push_opt("source_ip_prefix", self.source_ip_prefix.as_ref());
         params.push_opt("destination_ip_prefix", self.destination_ip_prefix.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/ndp_proxy/list.rs
+++ b/openstack_sdk/src/api/network/v2/ndp_proxy/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -66,13 +65,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -94,7 +93,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -108,7 +108,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -151,8 +152,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("name", self.name.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/dhcp_agent/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -76,13 +75,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -104,7 +103,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -118,7 +118,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -162,8 +163,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/list.rs
@@ -50,7 +50,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -150,13 +149,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// status query parameter for /v2.0/networks API
     ///
@@ -254,7 +253,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -268,7 +268,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -329,8 +330,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("is_default", self.is_default);
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -56,13 +55,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -84,7 +83,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -98,7 +98,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -142,8 +143,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network_ip_availability/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_ip_availability/list.rs
@@ -43,7 +43,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -88,13 +87,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tenant_id query parameter for /v2.0/network-ip-availabilities API
     ///
@@ -121,7 +120,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -135,7 +135,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -179,8 +180,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("network_name", self.network_name.as_ref());
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("ip_version", self.ip_version.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network_segment_range/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/list.rs
@@ -22,7 +22,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -97,13 +96,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tags query parameter for /v2.0/network-segment-ranges API
     ///
@@ -191,7 +190,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -205,7 +205,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -256,8 +257,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/network_segment_range/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -57,13 +56,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -85,7 +84,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -99,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -143,8 +144,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -81,13 +80,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -109,7 +108,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -123,7 +123,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -171,8 +172,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("max_kpps", self.max_kpps);
         params.push_opt("max_burst_kpps", self.max_burst_kpps);
         params.push_opt("direction", self.direction.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/policy/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/policy/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -56,13 +55,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -84,7 +83,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -98,7 +98,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -142,8 +143,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/port/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/list.rs
@@ -51,7 +51,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -150,19 +149,19 @@ pub struct Request<'a> {
     /// security_groups query parameter for /v2.0/ports API
     ///
     #[builder(default, private, setter(name = "_security_groups"))]
-    security_groups: BTreeSet<Cow<'a, str>>,
+    security_groups: Option<Vec<Cow<'a, str>>>,
 
     /// Sort direction. This is an optional feature and may be silently ignored
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// status query parameter for /v2.0/ports API
     ///
@@ -273,7 +272,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.security_groups
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -287,7 +287,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -301,7 +302,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -359,13 +361,15 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(
-            self.security_groups
-                .iter()
-                .map(|value| ("security_groups", value)),
-        );
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.security_groups {
+            params.extend(val.iter().map(|value| ("security_groups", value)));
+        }
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/port/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -56,13 +55,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -84,7 +83,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -98,7 +98,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -138,8 +139,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -72,13 +71,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -100,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -114,7 +114,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -158,8 +159,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("max_kbps", self.max_kbps);
         params.push_opt("direction", self.direction.as_ref());
         params.push_opt("max_burst_kbps", self.max_burst_kbps);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_dscp_marking_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_dscp_marking_rule/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -61,13 +60,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -89,7 +88,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -103,7 +103,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -145,8 +146,12 @@ impl<'a> RestEndpoint for Request<'a> {
         let mut params = QueryParams::default();
         params.push_opt("id", self.id.as_ref());
         params.push_opt("dscp_mark", self.dscp_mark);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,13 +67,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -96,7 +95,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -110,7 +110,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -153,8 +154,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kbps", self.min_kbps);
         params.push_opt("direction", self.direction.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -68,13 +67,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -96,7 +95,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -110,7 +110,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -153,8 +154,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kpps", self.min_kpps);
         params.push_opt("direction", self.direction.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -96,13 +95,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -124,7 +123,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -138,7 +138,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -185,8 +186,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("max_kbps", self.max_kbps);
         params.push_opt("max_burst_kbps", self.max_burst_kbps);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/dscp_marking_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/dscp_marking_rule/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -90,13 +89,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -118,7 +117,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -132,7 +132,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -178,8 +179,12 @@ impl<'a> RestEndpoint for Request<'a> {
         let mut params = QueryParams::default();
         params.push_opt("id", self.id.as_ref());
         params.push_opt("dscp_mark", self.dscp_mark);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/list.rs
@@ -44,7 +44,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -114,13 +113,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tags query parameter for /v2.0/qos/policies API
     ///
@@ -213,7 +212,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -227,7 +227,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -278,8 +279,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -96,13 +95,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -124,7 +123,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -138,7 +138,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -185,8 +186,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kbps", self.min_kbps);
         params.push_opt("direction", self.direction.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -75,13 +74,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -103,7 +102,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -117,7 +117,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -164,8 +165,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("id", self.id.as_ref());
         params.push_opt("min_kpps", self.min_kpps);
         params.push_opt("direction", self.direction.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/qos/rule_type/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/rule_type/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -80,13 +79,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -108,7 +107,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -122,7 +122,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -164,8 +165,12 @@ impl<'a> RestEndpoint for Request<'a> {
         let mut params = QueryParams::default();
         params.push_opt("all_rules", self.all_rules);
         params.push_opt("all_supported", self.all_supported);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/quota/list.rs
+++ b/openstack_sdk/src/api/network/v2/quota/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,13 +69,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,7 +97,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -112,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -152,8 +153,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/rbac_policy/list.rs
+++ b/openstack_sdk/src/api/network/v2/rbac_policy/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -90,13 +89,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// target_tenant query parameter for /v2.0/rbac-policies API
     ///
@@ -128,7 +127,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -142,7 +142,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -188,8 +189,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("target_tenant", self.target_tenant.as_ref());
         params.push_opt("tenant_id", self.tenant_id.as_ref());
         params.push_opt("action", self.action.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -99,13 +98,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -127,7 +126,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -141,7 +141,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -189,8 +190,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("protocol", self.protocol.as_ref());
         params.push_opt("port", self.port);
         params.push_opt("helper", self.helper.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/l3_agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/l3_agent/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -75,13 +74,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -103,7 +102,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -117,7 +117,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -161,8 +162,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/list.rs
@@ -45,7 +45,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -115,13 +114,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tags query parameter for /v2.0/routers API
     ///
@@ -214,7 +213,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -228,7 +228,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -279,8 +280,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/router/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -56,13 +55,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -84,7 +83,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -98,7 +98,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -142,8 +143,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/security_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group/list.rs
@@ -44,7 +44,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -109,13 +108,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tags query parameter for /v2.0/security-groups API
     ///
@@ -208,7 +207,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -222,7 +222,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -272,8 +273,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("shared", self.shared);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/security_group/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -57,13 +56,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -85,7 +84,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -99,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -143,8 +144,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/security_group_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group_rule/list.rs
@@ -43,7 +43,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -145,13 +144,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tenant_id query parameter for /v2.0/security-group-rules API
     ///
@@ -178,7 +177,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -192,7 +192,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -250,8 +251,12 @@ impl<'a> RestEndpoint for Request<'a> {
             self.remote_address_group_id.as_ref(),
         );
         params.push_opt("belongs_to_default_sg", self.belongs_to_default_sg);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/segment/list.rs
+++ b/openstack_sdk/src/api/network/v2/segment/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -105,13 +104,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -133,7 +132,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -147,7 +147,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -194,8 +195,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("name", self.name.as_ref());
         params.push_opt("revision_number", self.revision_number.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/service_profile/list.rs
+++ b/openstack_sdk/src/api/network/v2/service_profile/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -92,13 +91,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -120,7 +119,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -134,7 +134,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -178,8 +179,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("driver", self.driver.as_ref());
         params.push_opt("enabled", self.enabled);
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/service_provider/list.rs
+++ b/openstack_sdk/src/api/network/v2/service_provider/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,13 +69,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,7 +97,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -112,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -152,8 +153,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/subnet/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -51,13 +50,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// subnet_id parameter for /v2.0/subnets/{subnet_id}/tags/{id} API
     ///
@@ -84,7 +83,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -98,7 +98,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -142,8 +143,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/subnetpool/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/list.rs
@@ -45,7 +45,6 @@ use crate::api::rest_endpoint_prelude::*;
 
 use crate::api::common::CommaSeparatedList;
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -145,13 +144,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// tags query parameter for /v2.0/subnetpools API
     ///
@@ -244,7 +243,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -258,7 +258,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -315,8 +316,12 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("not-tags", self.not_tags.as_ref());
         params.push_opt("not-tags-any", self.not_tags_any.as_ref());
         params.push_opt("description", self.description.as_ref());
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/subnetpool/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -51,13 +50,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// subnetpool_id parameter for /v2.0/subnetpools/{subnetpool_id}/tags/{id}
     /// API
@@ -85,7 +84,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -99,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -143,8 +144,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/trunk/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/trunk/tag/list.rs
@@ -21,7 +21,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -51,13 +50,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     /// trunk_id parameter for /v2.0/trunks/{trunk_id}/tags/{id} API
     ///
@@ -84,7 +83,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -98,7 +98,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -138,8 +139,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/endpoint_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/endpoint_group/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,13 +69,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,7 +97,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -112,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -152,8 +153,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/ikepolicy/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ikepolicy/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,13 +69,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,7 +97,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -112,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -152,8 +153,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,13 +69,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,7 +97,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -112,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -152,8 +153,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/list.rs
@@ -40,7 +40,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -70,13 +69,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -98,7 +97,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -112,7 +112,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -152,8 +153,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/network/v2/vpn/vpnservice/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/vpnservice/list.rs
@@ -42,7 +42,6 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 use crate::api::rest_endpoint_prelude::*;
 
 use std::borrow::Cow;
-use std::collections::BTreeSet;
 
 use crate::api::Pageable;
 #[derive(Builder, Debug, Clone)]
@@ -72,13 +71,13 @@ pub struct Request<'a> {
     /// by the server.
     ///
     #[builder(default, private, setter(name = "_sort_dir"))]
-    sort_dir: BTreeSet<Cow<'a, str>>,
+    sort_dir: Option<Vec<Cow<'a, str>>>,
 
     /// Sort results by the attribute. This is an optional feature and may be
     /// silently ignored by the server.
     ///
     #[builder(default, private, setter(name = "_sort_key"))]
-    sort_key: BTreeSet<Cow<'a, str>>,
+    sort_key: Option<Vec<Cow<'a, str>>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -100,7 +99,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_key
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -114,7 +114,8 @@ impl<'a> RequestBuilder<'a> {
         T: Into<Cow<'a, str>>,
     {
         self.sort_dir
-            .get_or_insert_with(BTreeSet::new)
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
             .extend(iter.map(Into::into));
         self
     }
@@ -154,8 +155,12 @@ impl<'a> RestEndpoint for Request<'a> {
 
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
-        params.extend(self.sort_key.iter().map(|value| ("sort_key", value)));
-        params.extend(self.sort_dir.iter().map(|value| ("sort_dir", value)));
+        if let Some(val) = &self.sort_key {
+            params.extend(val.iter().map(|value| ("sort_key", value)));
+        }
+        if let Some(val) = &self.sort_dir {
+            params.extend(val.iter().map(|value| ("sort_dir", value)));
+        }
         params.push_opt("limit", self.limit);
         params.push_opt("marker", self.marker.as_ref());
         params.push_opt("page_reverse", self.page_reverse);

--- a/openstack_sdk/src/api/placement/v1/reshaper/create_134.rs
+++ b/openstack_sdk/src/api/placement/v1/reshaper/create_134.rs
@@ -149,7 +149,7 @@ pub struct AllocationsItemStruct<'a> {
 
     /// A dictionary associating request group suffixes with a list of uuids
     /// identifying the resource providers that satisfied each group. The empty
-    /// string and \[a-zA-Z0-9\_-\]+ are valid suffixes. This field may be sent
+    /// string and [a-zA-Z0-9\_-]+ are valid suffixes. This field may be sent
     /// when writing allocations back to the server but will be ignored; this
     /// preserves symmetry between read and write representations.
     ///
@@ -189,7 +189,7 @@ impl<'a> AllocationsItemStructBuilder<'a> {
 
     /// A dictionary associating request group suffixes with a list of uuids
     /// identifying the resource providers that satisfied each group. The empty
-    /// string and \[a-zA-Z0-9\_-\]+ are valid suffixes. This field may be sent
+    /// string and [a-zA-Z0-9\_-]+ are valid suffixes. This field may be sent
     /// when writing allocations back to the server but will be ignored; this
     /// preserves symmetry between read and write representations.
     ///

--- a/openstack_sdk/src/api/placement/v1/reshaper/create_138.rs
+++ b/openstack_sdk/src/api/placement/v1/reshaper/create_138.rs
@@ -160,7 +160,7 @@ pub struct AllocationsItemStruct<'a> {
 
     /// A dictionary associating request group suffixes with a list of uuids
     /// identifying the resource providers that satisfied each group. The empty
-    /// string and \[a-zA-Z0-9\_-\]+ are valid suffixes. This field may be sent
+    /// string and [a-zA-Z0-9\_-]+ are valid suffixes. This field may be sent
     /// when writing allocations back to the server but will be ignored; this
     /// preserves symmetry between read and write representations.
     ///
@@ -200,7 +200,7 @@ impl<'a> AllocationsItemStructBuilder<'a> {
 
     /// A dictionary associating request group suffixes with a list of uuids
     /// identifying the resource providers that satisfied each group. The empty
-    /// string and \[a-zA-Z0-9\_-\]+ are valid suffixes. This field may be sent
+    /// string and [a-zA-Z0-9\_-]+ are valid suffixes. This field may be sent
     /// when writing allocations back to the server but will be ignored; this
     /// preserves symmetry between read and write representations.
     ///


### PR DESCRIPTION
A serializable query parameter of Array type should be mapped to Array
instead of Set (use set when uniqueItems = true)

Change-Id: I410186281969360da2ce854b288e227fc1425d6c

Changes are triggered by https://review.opendev.org/935559
