### PR TITLE
chore: Normalize certain names

### DIFF
--- a/openstack_tui/.config/config.json5
+++ b/openstack_tui/.config/config.json5
@@ -2,19 +2,19 @@
   "mode_keybindings": {
     "Home": { },
     "BlockStorageBackups": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "BlockStorageSnapshots": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "BlockStorageVolumes": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "ComputeAggregates": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "ComputeServers": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "0": { "action": {"SetComputeServerFilters": {} }, "description": "Default filters", "type": "Filter"},
       "1": { "action": {"SetComputeServerFilters": {"all_tenants": true} }, "description": "All tenants (admin)", "type": "Filter"},
       "ctrl-d": { "action": "DeleteComputeServer", "description": "Delete" },
@@ -22,35 +22,35 @@
       "a": { "action": "ShowComputeServerInstanceActions", "description": "Instance actions"},
     },
     "ComputeServerInstanceActions": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "e": { "action": "ShowComputeServerInstanceActionEvents", "description": "Events" },
     },
     "ComputeFlavors": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "ComputeHypervisors": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "IdentityApplicationCredentials": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "IdentityGroups": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "u": { "action": "ShowIdentityGroupUsers", "description": "Group users"},
       "d": { "action": "IdentityGroupDelete", "description": "Delete (todo!)"},
       "a": { "action": "IdentityGroupCreate", "description": "Create new group (todo!)"},
     },
     "IdentityGroupUsers": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "a": { "action": "IdentityGroupUserAdd", "description": "Add new user into group (todo!)"},
       "r": { "action": "IdentityGroupUserRemove", "description": "Remove user from group (todo!)"},
     },
     "IdentityProjects": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "s": { "action": "SwitchToProject", "description": "Switch to project"},
     },
     "IdentityUsers": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "e": { "action": "IdentityUserFlipEnable", "description": "Enable/Disable user"},
       "r": { "action": "IdentityUserDelete", "description": "Delete user (todo!)"},
       "a": { "action": "IdentityUserCreate", "description": "Create new user (todo!)"},
@@ -58,29 +58,29 @@
       "c": { "action": "ShowIdentityUserApplicationCredentials", "description": "Application credentials"},
     },
     "ImageImages": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "0": { "action": {"SetImageFilters": {} }, "description": "Default filters", "type": "Filter"},
       "1": { "action": {"SetImageFilters": {"visibility": "public"} },"description": "public", "type": "Filter"},
       "2": { "action": {"SetImageFilters": {"visibility": "shared"} },"description": "shared", "type": "Filter"},
       "3": { "action": {"SetImageFilters": {"visibility": "private"} },"description": "private", "type": "Filter"},
     },
     "NetworkNetworks": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "<enter>": { "action": "ShowNetworkSubnets", "description": "Subnets"},
     },
     "NetworkRouters": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
     },
     "NetworkSubnets": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "0": { "action": {"SetNetworkSubnetFilters": {} }, "description": "All", "type": "Filter"},
     },
     "NetworkSecurityGroups": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "l": { "action": "ShowNetworkSecurityGroupRules", "description": "Rules"},
     },
     "NetworkSecurityGroupRules": {
-      "y": { "action": "DescribeResource", "description": "YAML"},
+      "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "0": { "action": {"SetNetworkSecurityGroupRuleFilters": {}}, "description": "All", "type": "Filter"},
     }
   },
@@ -90,7 +90,7 @@
     "<Ctrl-z>": { "action": "Suspend", "description": "Suspend"},// Suspend the application
     "F1": { "action": {"Mode": "Home"}, "description": "Home"},
     "F2": { "action": "CloudSelect", "description": "Select cloud"},// Switch cloud
-    ":": { "action": "ResourceSelect", "description": "Select resource"},// Select the resource
+    ":": { "action": "ApiRequestSelect", "description": "Select resource"},// Select the resource
     "<F4>": { "action": "SelectProject", "description": "Select project"},
     "<ctrl-r>": {"action": "Refresh", "description": "Reload data"}
   },

--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -38,29 +38,26 @@ pub enum Action {
     /// New cloud connection established
     ConnectedToCloud(Box<openstack_sdk::types::identity::v3::AuthToken>),
     /// Perform API request
-    RequestCloudResource(cloud_types::Resource),
+    PerformApiRequest(cloud_types::ApiRequest),
     /// Propagate single resource data to components
-    ResourceData {
-        resource: cloud_types::Resource,
+    ApiResponseData {
+        request: cloud_types::ApiRequest,
         data: serde_json::Value,
     },
     /// Propagate resources list to components
-    ResourcesData {
-        resource: cloud_types::Resource,
+    ApiResponsesData {
+        request: cloud_types::ApiRequest,
         data: Vec<serde_json::Value>,
     },
     /// Open resource(mode) select popup
-    ResourceSelect,
+    ApiRequestSelect,
+    /// Refresh data
     Refresh,
-    // Next,
-    // Prev,
-    // End,
-    // PageUp,
-    // PageDown,
+
     /// Open describe view with the details
-    DescribeResourceData(serde_json::Value),
+    SetDescribeApiResponseData(serde_json::Value),
     /// Describe resource under cursor
-    DescribeResource,
+    DescribeApiResponse,
     /// Set describe mode loading
     SetDescribeLoading(bool),
     /// Open cloud connection popup
@@ -73,11 +70,11 @@ pub enum Action {
     Clouds(Vec<String>),
 
     /// Confirm operation
-    Confirm(cloud_types::Resource),
+    Confirm(cloud_types::ApiRequest),
     /// Reject (close) Confirmation prompt
-    ConfirmRejected(cloud_types::Resource),
+    ConfirmRejected(cloud_types::ApiRequest),
     /// Close confirmation prompt
-    ConfirmAccepted(cloud_types::Resource),
+    ConfirmAccepted(cloud_types::ApiRequest),
 
     // Compute (neutron)
     SetComputeServerFilters(cloud_types::ComputeServerFilters),

--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -146,29 +146,29 @@ impl Cloud {
                             )))?,
                         }
                     }
-                    Action::RequestCloudResource(resource) => {
+                    Action::PerformApiRequest(request) => {
                         // Request the resource using the service extension trait
-                        match ServiceType::from(resource.clone()) {
+                        match ServiceType::from(request.clone()) {
                             ServiceType::BlockStorage => {
                                 <Cloud as BlockStorageExt>::perform_api_request(
-                                    self, &app_tx, resource,
+                                    self, &app_tx, request,
                                 )
                                 .await?
                             }
                             ServiceType::Compute => {
-                                <Cloud as ComputeExt>::perform_api_request(self, &app_tx, resource)
+                                <Cloud as ComputeExt>::perform_api_request(self, &app_tx, request)
                                     .await?
                             }
                             ServiceType::Identity => {
-                                <Cloud as IdentityExt>::perform_api_request(self, &app_tx, resource)
+                                <Cloud as IdentityExt>::perform_api_request(self, &app_tx, request)
                                     .await?
                             }
                             ServiceType::Image => {
-                                <Cloud as ImageExt>::perform_api_request(self, &app_tx, resource)
+                                <Cloud as ImageExt>::perform_api_request(self, &app_tx, request)
                                     .await?
                             }
                             ServiceType::Network => {
-                                <Cloud as NetworkExt>::perform_api_request(self, &app_tx, resource)
+                                <Cloud as NetworkExt>::perform_api_request(self, &app_tx, request)
                                     .await?
                             }
                             _ => todo!(),

--- a/openstack_tui/src/cloud_worker/block_storage.rs
+++ b/openstack_tui/src/cloud_worker/block_storage.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use openstack_sdk::{api::Pagination, api::QueryAsync};
 
 use crate::action::Action;
-use crate::cloud_worker::{Cloud, Resource};
+use crate::cloud_worker::{ApiRequest, Cloud};
 
 pub mod types;
 use types::*;
@@ -28,7 +28,7 @@ pub trait BlockStorageExt {
     async fn perform_api_request(
         &mut self,
         app_tx: &UnboundedSender<Action>,
-        resource: Resource,
+        request: ApiRequest,
     ) -> Result<()>;
 
     /// List Backups
@@ -43,26 +43,27 @@ impl BlockStorageExt for Cloud {
     async fn perform_api_request(
         &mut self,
         app_tx: &UnboundedSender<Action>,
-        resource: Resource,
+        request: ApiRequest,
     ) -> Result<()> {
-        match resource {
-            Resource::BlockStorageBackups(ref filters) => match self.get_backups(filters).await {
-                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+        match request {
+            ApiRequest::BlockStorageBackups(ref filters) => match self.get_backups(filters).await {
+                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                 Err(err) => app_tx.send(Action::Error(format!(
                     "Failed to fetch block-storage backups: {:?}",
                     err
                 )))?,
             },
-            Resource::BlockStorageSnapshots(ref filters) => match self.get_snapshots(filters).await
-            {
-                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch block-storage snapshots: {:?}",
-                    err
-                )))?,
-            },
-            Resource::BlockStorageVolumes(ref filters) => match self.get_volumes(filters).await {
-                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+            ApiRequest::BlockStorageSnapshots(ref filters) => {
+                match self.get_snapshots(filters).await {
+                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
+                    Err(err) => app_tx.send(Action::Error(format!(
+                        "Failed to fetch block-storage snapshots: {:?}",
+                        err
+                    )))?,
+                }
+            }
+            ApiRequest::BlockStorageVolumes(ref filters) => match self.get_volumes(filters).await {
+                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                 Err(err) => app_tx.send(Action::Error(format!(
                     "Failed to fetch block-storage volumes: {:?}",
                     err

--- a/openstack_tui/src/cloud_worker/image.rs
+++ b/openstack_tui/src/cloud_worker/image.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use openstack_sdk::{api::Pagination, api::QueryAsync};
 
 use crate::action::Action;
-use crate::cloud_worker::{Cloud, Resource};
+use crate::cloud_worker::{ApiRequest, Cloud};
 
 pub mod types;
 use types::*;
@@ -28,7 +28,7 @@ pub trait ImageExt {
     async fn perform_api_request(
         &mut self,
         app_tx: &UnboundedSender<Action>,
-        resource: Resource,
+        request: ApiRequest,
     ) -> Result<()>;
 
     async fn get_images(&mut self, filters: &ImageFilters) -> Result<Vec<Value>>;
@@ -38,11 +38,11 @@ impl ImageExt for Cloud {
     async fn perform_api_request(
         &mut self,
         app_tx: &UnboundedSender<Action>,
-        resource: Resource,
+        request: ApiRequest,
     ) -> Result<()> {
-        match resource {
-            Resource::ImageImages(ref filters) => match self.get_images(filters).await {
-                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+        match request {
+            ApiRequest::ImageImages(ref filters) => match self.get_images(filters).await {
+                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                 Err(err) => {
                     app_tx.send(Action::Error(format!("Failed to fetch images: {:?}", err)))?
                 }

--- a/openstack_tui/src/cloud_worker/network.rs
+++ b/openstack_tui/src/cloud_worker/network.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use openstack_sdk::{api::Pagination, api::QueryAsync};
 
 use crate::action::Action;
-use crate::cloud_worker::{Cloud, Resource};
+use crate::cloud_worker::{ApiRequest, Cloud};
 
 pub mod types;
 use types::*;
@@ -29,7 +29,7 @@ pub trait NetworkExt {
     async fn perform_api_request(
         &mut self,
         app_tx: &UnboundedSender<Action>,
-        resource: Resource,
+        request: ApiRequest,
     ) -> Result<()>;
 
     /// List networks
@@ -61,49 +61,49 @@ impl NetworkExt for Cloud {
     async fn perform_api_request(
         &mut self,
         app_tx: &UnboundedSender<Action>,
-        resource: Resource,
+        request: ApiRequest,
     ) -> Result<()> {
-        match resource {
-            Resource::NetworkNetworks(ref filters) => match self.get_networks(filters).await {
-                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+        match request {
+            ApiRequest::NetworkNetworks(ref filters) => match self.get_networks(filters).await {
+                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                 Err(err) => app_tx.send(Action::Error(format!(
                     "Failed to fetch networks: {:?}",
                     err
                 )))?,
             },
-            Resource::NetworkRouters(ref filters) => match self.get_routers(filters).await {
-                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+            ApiRequest::NetworkRouters(ref filters) => match self.get_routers(filters).await {
+                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                 Err(err) => {
                     app_tx.send(Action::Error(format!("Failed to fetch routers: {:?}", err)))?
                 }
             },
-            Resource::NetworkQuota => match self.get_quota().await {
-                Ok(data) => app_tx.send(Action::ResourceData { resource, data })?,
+            ApiRequest::NetworkQuota => match self.get_quota().await {
+                Ok(data) => app_tx.send(Action::ApiResponseData { request, data })?,
                 Err(err) => app_tx.send(Action::Error(format!(
                     "Failed to fetch network quota: {:?}",
                     err
                 )))?,
             },
-            Resource::NetworkSecurityGroups(ref filters) => {
+            ApiRequest::NetworkSecurityGroups(ref filters) => {
                 match self.get_security_groups(filters).await {
-                    Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                     Err(err) => app_tx.send(Action::Error(format!(
                         "Failed to fetch security groups: {:?}",
                         err
                     )))?,
                 }
             }
-            Resource::NetworkSecurityGroupRules(ref filters) => {
+            ApiRequest::NetworkSecurityGroupRules(ref filters) => {
                 match self.get_security_group_rules(filters).await {
-                    Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                     Err(err) => app_tx.send(Action::Error(format!(
                         "Failed to fetch security group rules: {:?}",
                         err
                     )))?,
                 }
             }
-            Resource::NetworkSubnets(ref filters) => match self.get_subnets(filters).await {
-                Ok(data) => app_tx.send(Action::ResourcesData { resource, data })?,
+            ApiRequest::NetworkSubnets(ref filters) => match self.get_subnets(filters).await {
+                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
                 Err(err) => {
                     app_tx.send(Action::Error(format!("Failed to fetch subnets: {:?}", err)))?
                 }

--- a/openstack_tui/src/cloud_worker/types.rs
+++ b/openstack_tui/src/cloud_worker/types.rs
@@ -26,7 +26,7 @@ pub use crate::cloud_worker::network::types::*;
 
 /// OpenStack "resource"
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
-pub enum Resource {
+pub enum ApiRequest {
     // Block storage resources
     /// Cinder backup
     BlockStorageBackups(BlockStorageBackupFilters),
@@ -61,43 +61,43 @@ pub enum Resource {
     NetworkQuota,
 }
 
-impl From<Resource> for ServiceType {
-    fn from(item: Resource) -> Self {
+impl From<ApiRequest> for ServiceType {
+    fn from(item: ApiRequest) -> Self {
         match item {
-            Resource::BlockStorageBackups(_)
-            | Resource::BlockStorageSnapshots(_)
-            | Resource::BlockStorageVolumes(_) => Self::BlockStorage,
-            Resource::ComputeServers(_)
-            | Resource::ComputeServerDelete(_)
-            | Resource::ComputeServerConsoleOutput(_)
-            | Resource::ComputeServerInstanceAction(_)
-            | Resource::ComputeServerInstanceActions(_)
-            | Resource::ComputeFlavors(_)
-            | Resource::ComputeQuota
-            | Resource::ComputeAggregates(_)
-            | Resource::ComputeHypervisors(_) => Self::Compute,
-            Resource::IdentityAuthProjects(_)
-            | Resource::IdentityApplicationCredentials(_)
-            | Resource::IdentityGroups(_)
-            | Resource::IdentityGroupUsers(_)
-            | Resource::IdentityProjects(_)
-            | Resource::IdentityUserUpdate(_)
-            | Resource::IdentityUsers(_) => Self::Identity,
-            Resource::ImageImages(_) => Self::Image,
-            Resource::NetworkNetworks(_)
-            | Resource::NetworkRouters(_)
-            | Resource::NetworkQuota
-            | Resource::NetworkSecurityGroups(_)
-            | Resource::NetworkSecurityGroupRules(_)
-            | Resource::NetworkSubnets(_) => Self::Network,
+            ApiRequest::BlockStorageBackups(_)
+            | ApiRequest::BlockStorageSnapshots(_)
+            | ApiRequest::BlockStorageVolumes(_) => Self::BlockStorage,
+            ApiRequest::ComputeServers(_)
+            | ApiRequest::ComputeServerDelete(_)
+            | ApiRequest::ComputeServerConsoleOutput(_)
+            | ApiRequest::ComputeServerInstanceAction(_)
+            | ApiRequest::ComputeServerInstanceActions(_)
+            | ApiRequest::ComputeFlavors(_)
+            | ApiRequest::ComputeQuota
+            | ApiRequest::ComputeAggregates(_)
+            | ApiRequest::ComputeHypervisors(_) => Self::Compute,
+            ApiRequest::IdentityAuthProjects(_)
+            | ApiRequest::IdentityApplicationCredentials(_)
+            | ApiRequest::IdentityGroups(_)
+            | ApiRequest::IdentityGroupUsers(_)
+            | ApiRequest::IdentityProjects(_)
+            | ApiRequest::IdentityUserUpdate(_)
+            | ApiRequest::IdentityUsers(_) => Self::Identity,
+            ApiRequest::ImageImages(_) => Self::Image,
+            ApiRequest::NetworkNetworks(_)
+            | ApiRequest::NetworkRouters(_)
+            | ApiRequest::NetworkQuota
+            | ApiRequest::NetworkSecurityGroups(_)
+            | ApiRequest::NetworkSecurityGroupRules(_)
+            | ApiRequest::NetworkSubnets(_) => Self::Network,
         }
     }
 }
 
-impl ConfirmableRequest for Resource {
+impl ConfirmableRequest for ApiRequest {
     fn get_confirm_message(&self) -> Option<String> {
         match &self {
-            Resource::ComputeServerDelete(x) => x.get_confirm_message(),
+            ApiRequest::ComputeServerDelete(x) => x.get_confirm_message(),
             _ => None,
         }
     }

--- a/openstack_tui/src/components/block_storage/backups.rs
+++ b/openstack_tui/src/components/block_storage/backups.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{BlockStorageBackupFilters, Resource},
+    cloud_worker::types::{ApiRequest, BlockStorageBackupFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -68,22 +68,22 @@ impl Component for BlockStorageBackups<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::BlockStorageBackups = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::BlockStorageBackups(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::BlockStorageBackups(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::BlockStorageBackups) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::BlockStorageBackups(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::BlockStorageBackups(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::BlockStorageBackups(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::BlockStorageBackups(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/block_storage/snapshots.rs
+++ b/openstack_tui/src/components/block_storage/snapshots.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{BlockStorageSnapshotFilters, Resource},
+    cloud_worker::types::{ApiRequest, BlockStorageSnapshotFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -64,22 +64,22 @@ impl Component for BlockStorageSnapshots<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::BlockStorageSnapshots = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::BlockStorageSnapshots(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::BlockStorageSnapshots(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::BlockStorageSnapshots) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::BlockStorageSnapshots(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::BlockStorageSnapshots(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::BlockStorageSnapshots(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::BlockStorageSnapshots(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/block_storage/volumes.rs
+++ b/openstack_tui/src/components/block_storage/volumes.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{BlockStorageVolumeFilters, Resource},
+    cloud_worker::types::{ApiRequest, BlockStorageVolumeFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -68,22 +68,22 @@ impl Component for BlockStorageVolumes<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::BlockStorageVolumes = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::BlockStorageVolumes(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::BlockStorageVolumes(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::BlockStorageVolumes) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::BlockStorageVolumes(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::BlockStorageVolumes(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::BlockStorageVolumes(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::BlockStorageVolumes(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/compute/aggregates.rs
+++ b/openstack_tui/src/components/compute/aggregates.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ComputeAggregateFilters, Resource},
+    cloud_worker::types::{ApiRequest, ComputeAggregateFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -63,22 +63,22 @@ impl Component for ComputeAggregates<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::ComputeAggregates = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::ComputeAggregates(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::ComputeAggregates(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::ComputeAggregates) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::ComputeAggregates(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::ComputeAggregates(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::ComputeAggregates(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::ComputeAggregates(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ComputeFlavorFilters, Resource},
+    cloud_worker::types::{ApiRequest, ComputeFlavorFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -66,22 +66,22 @@ impl Component for ComputeFlavors<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::ComputeFlavors = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::ComputeFlavors(self.get_filters().clone()),
-                    )));
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::ComputeFlavors(
+                        self.get_filters().clone(),
+                    ))));
                 }
             }
             Action::Mode(Mode::ComputeFlavors) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::ComputeFlavors(self.get_filters().clone()),
-                )));
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::ComputeFlavors(
+                    self.get_filters().clone(),
+                ))));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::ComputeFlavors(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::ComputeFlavors(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/compute/hypervisors.rs
+++ b/openstack_tui/src/components/compute/hypervisors.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ComputeHypervisorFilters, Resource},
+    cloud_worker::types::{ApiRequest, ComputeHypervisorFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -64,22 +64,22 @@ impl Component for ComputeHypervisors<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::ComputeHypervisors = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::ComputeHypervisors(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::ComputeHypervisors(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::ComputeHypervisors) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::ComputeHypervisors(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::ComputeHypervisors(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::ComputeHypervisors(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::ComputeHypervisors(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/compute/server_instance_action_events.rs
+++ b/openstack_tui/src/components/compute/server_instance_action_events.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ComputeServerInstanceActionFilters, Resource},
+    cloud_worker::types::{ApiRequest, ComputeServerInstanceActionFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -70,15 +70,15 @@ impl Component for ComputeServerInstanceActionEvents<'_> {
             }
             Action::Mode(Mode::ComputeServerInstanceActionEvents) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::ComputeServerInstanceAction(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::ComputeServerInstanceAction(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourceData {
-                resource: Resource::ComputeServerInstanceAction(_),
+            Action::ApiResponseData {
+                request: ApiRequest::ComputeServerInstanceAction(_),
                 data,
             } => {
                 if let Some(events) = data.get("events") {
@@ -91,8 +91,8 @@ impl Component for ComputeServerInstanceActionEvents<'_> {
                 if filters.request_id.is_some() {
                     self.set_filters(filters);
                     self.set_loading(true);
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::ComputeServerInstanceAction(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::ComputeServerInstanceAction(self.get_filters().clone()),
                     )));
                 }
             }

--- a/openstack_tui/src/components/compute/server_instance_actions.rs
+++ b/openstack_tui/src/components/compute/server_instance_actions.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ComputeServerInstanceActionFilters, Resource},
+    cloud_worker::types::{ApiRequest, ComputeServerInstanceActionFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -67,22 +67,22 @@ impl Component for ComputeServerInstanceActions<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::ComputeServerInstanceActions = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::ComputeServerInstanceActions(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::ComputeServerInstanceActions(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::ComputeServerInstanceActions) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::ComputeServerInstanceActions(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::ComputeServerInstanceActions(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::ComputeServerInstanceActions(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::ComputeServerInstanceActions(_),
                 data,
             } => {
                 self.set_data(data)?;
@@ -90,8 +90,8 @@ impl Component for ComputeServerInstanceActions<'_> {
             Action::SetComputeServerInstanceActionFilters(filters) => {
                 self.set_filters(filters);
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::ComputeServerInstanceActions(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::ComputeServerInstanceActions(self.get_filters().clone()),
                 )));
             }
             Action::ShowComputeServerInstanceActionEvents => {

--- a/openstack_tui/src/components/confirm_popup.rs
+++ b/openstack_tui/src/components/confirm_popup.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ConfirmableRequest, Resource},
+    cloud_worker::types::{ApiRequest, ConfirmableRequest},
     components::Component,
     config::Config,
     error::TuiError,
@@ -40,14 +40,14 @@ use crate::{
 
 pub struct ConfirmPopup {
     command_tx: Option<UnboundedSender<Action>>,
-    request: Resource,
+    request: ApiRequest,
     config: Config,
     button_group: ButtonGroup<'static>,
     button_group_state: ButtonGroupState,
 }
 
 impl ConfirmPopup {
-    pub fn new(request: &Resource) -> Self {
+    pub fn new(request: &ApiRequest) -> Self {
         Self {
             command_tx: None,
             request: request.clone(),

--- a/openstack_tui/src/components/describe.rs
+++ b/openstack_tui/src/components/describe.rs
@@ -299,7 +299,7 @@ impl Component for Describe {
                 self.set_data(Value::Null)?;
                 self.set_loading(val);
             }
-            Action::DescribeResourceData(data) => {
+            Action::SetDescribeApiResponseData(data) => {
                 self.set_loading(false);
                 self.set_data(data)?;
             }

--- a/openstack_tui/src/components/header.rs
+++ b/openstack_tui/src/components/header.rs
@@ -177,7 +177,7 @@ impl Component for Header {
                         })
                         .sorted()
                         .for_each(|(k, v, t)| match t {
-                            CommandType::ResourceAction => {
+                            CommandType::ApiRequestAction => {
                                 self.mode_action_keybindings.push((k, v));
                             }
                             CommandType::Filter => {

--- a/openstack_tui/src/components/home.rs
+++ b/openstack_tui/src/components/home.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-    action::Action, cloud_worker::types::Resource, components::Component, config::Config,
+    action::Action, cloud_worker::types::ApiRequest, components::Component, config::Config,
     error::TuiError, mode::Mode,
 };
 
@@ -109,8 +109,8 @@ impl Home {
 
     fn refresh_data(&mut self) -> Result<Option<Action>, TuiError> {
         if let Some(command_tx) = &self.command_tx {
-            command_tx.send(Action::RequestCloudResource(Resource::ComputeQuota))?;
-            command_tx.send(Action::RequestCloudResource(Resource::NetworkQuota))?;
+            command_tx.send(Action::PerformApiRequest(ApiRequest::ComputeQuota))?;
+            command_tx.send(Action::PerformApiRequest(ApiRequest::NetworkQuota))?;
         }
         Ok(None)
     }
@@ -152,15 +152,15 @@ impl Component for Home {
                 self.tick();
             }
 
-            Action::ResourceData {
-                resource: Resource::ComputeQuota { .. },
+            Action::ApiResponseData {
+                request: ApiRequest::ComputeQuota { .. },
                 data,
             } => {
                 self.set_compute_data(data)?;
                 self.set_loading(false);
             }
-            Action::ResourceData {
-                resource: Resource::NetworkQuota { .. },
+            Action::ApiResponseData {
+                request: ApiRequest::NetworkQuota { .. },
                 data,
             } => {
                 self.set_network_data(data)?;

--- a/openstack_tui/src/components/identity/application_credentials.rs
+++ b/openstack_tui/src/components/identity/application_credentials.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{IdentityApplicationCredentialFilters, Resource},
+    cloud_worker::types::{ApiRequest, IdentityApplicationCredentialFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -71,23 +71,23 @@ impl Component for IdentityApplicationCredentials<'_> {
             }
             Action::Mode(Mode::IdentityApplicationCredentials) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::IdentityApplicationCredentials(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::IdentityApplicationCredentials(self.get_filters().clone()),
                 )));
             }
             Action::SetIdentityApplicationCredentialFilters(filters) => {
                 self.set_filters(filters);
                 self.set_data(Vec::new())?;
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::IdentityApplicationCredentials(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::IdentityApplicationCredentials(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::IdentityApplicationCredentials(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::IdentityApplicationCredentials(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/identity/group_users.rs
+++ b/openstack_tui/src/components/identity/group_users.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{IdentityGroupUserFilters, Resource},
+    cloud_worker::types::{ApiRequest, IdentityGroupUserFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -64,30 +64,30 @@ impl Component for IdentityGroupUsers<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::IdentityUsers = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::IdentityGroupUsers(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::IdentityGroupUsers(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::IdentityGroupUsers) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::IdentityGroupUsers(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::IdentityGroupUsers(self.get_filters().clone()),
                 )));
             }
             Action::SetIdentityGroupUserFilters(filters) => {
                 self.set_filters(filters);
                 self.set_data(Vec::new())?;
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::IdentityGroupUsers(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::IdentityGroupUsers(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::IdentityGroupUsers(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::IdentityGroupUsers(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/identity/groups.rs
+++ b/openstack_tui/src/components/identity/groups.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{IdentityGroupFilters, IdentityGroupUserFilters, Resource},
+    cloud_worker::types::{ApiRequest, IdentityGroupFilters, IdentityGroupUserFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -68,16 +68,16 @@ impl Component for IdentityGroups<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::IdentityGroups = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::IdentityGroups(self.get_filters().clone()),
-                    )));
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::IdentityGroups(
+                        self.get_filters().clone(),
+                    ))));
                 }
             }
             Action::Mode(Mode::IdentityGroups) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::IdentityGroups(self.get_filters().clone()),
-                )));
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::IdentityGroups(
+                    self.get_filters().clone(),
+                ))));
             }
             Action::ShowIdentityGroupUsers => {
                 // only if we are currently in the IdentityGroup mode
@@ -99,11 +99,11 @@ impl Component for IdentityGroups<'_> {
                     }
                 }
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::IdentityGroups(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::IdentityGroups(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/identity/projects.rs
+++ b/openstack_tui/src/components/identity/projects.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{IdentityProjectFilters, Resource},
+    cloud_worker::types::{ApiRequest, IdentityProjectFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -65,22 +65,22 @@ impl Component for IdentityProjects<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::IdentityProjects = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::IdentityProjects(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::IdentityProjects(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::IdentityProjects) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::IdentityProjects(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::IdentityProjects(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::IdentityProjects(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::IdentityProjects(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/identity/users.rs
+++ b/openstack_tui/src/components/identity/users.rs
@@ -22,7 +22,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use crate::{
     action::Action,
     cloud_worker::types::{
-        IdentityApplicationCredentialFilters, IdentityUserFilters, IdentityUserUpdate, Resource,
+        ApiRequest, IdentityApplicationCredentialFilters, IdentityUserFilters, IdentityUserUpdate,
     },
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
@@ -72,14 +72,14 @@ impl Component for IdentityUsers<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::IdentityUsers = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(Resource::IdentityUsers(
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::IdentityUsers(
                         self.get_filters().clone(),
                     ))));
                 }
             }
             Action::Mode(Mode::IdentityUsers) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(Resource::IdentityUsers(
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::IdentityUsers(
                     self.get_filters().clone(),
                 ))));
             }
@@ -91,8 +91,8 @@ impl Component for IdentityUsers<'_> {
                         // and have a selected entry
                         if let Some(group_row) = self.get_selected() {
                             // send action to set GroupUserFilters
-                            command_tx.send(Action::RequestCloudResource(
-                                Resource::IdentityUserUpdate(IdentityUserUpdate {
+                            command_tx.send(Action::PerformApiRequest(
+                                ApiRequest::IdentityUserUpdate(IdentityUserUpdate {
                                     id: group_row.id.clone(),
                                     name: None,
                                     enabled: Some(!group_row.enabled),
@@ -122,17 +122,17 @@ impl Component for IdentityUsers<'_> {
                     }
                 }
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::IdentityUsers(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::IdentityUsers(_),
                 data,
             } => {
                 self.set_data(data)?;
             }
-            Action::ResourceData {
-                resource: Resource::IdentityUserUpdate(_),
+            Action::ApiResponseData {
+                request: ApiRequest::IdentityUserUpdate(_),
                 data,
             } => {
                 // Since user update only returns some info (i.e. it doesn't contain email) we need

--- a/openstack_tui/src/components/image/images.rs
+++ b/openstack_tui/src/components/image/images.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ImageFilters, Resource},
+    cloud_worker::types::{ApiRequest, ImageFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -69,22 +69,22 @@ impl Component for Images<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::ImageImages = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(Resource::ImageImages(
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::ImageImages(
                         self.get_filters().clone(),
                     ))));
                 }
             }
             Action::Mode(Mode::ImageImages) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(Resource::ImageImages(
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::ImageImages(
                     self.get_filters().clone(),
                 ))));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::ImageImages(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::ImageImages(_),
                 data,
             } => {
                 self.set_data(data)?;
@@ -92,7 +92,7 @@ impl Component for Images<'_> {
             Action::SetImageFilters(filters) => {
                 self.set_filters(filters);
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(Resource::ImageImages(
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::ImageImages(
                     self.get_filters().clone(),
                 ))));
             }

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{NetworkNetworkFilters, NetworkSubnetFilters, Resource},
+    cloud_worker::types::{ApiRequest, NetworkNetworkFilters, NetworkSubnetFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -67,15 +67,15 @@ impl Component for NetworkNetworks<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::NetworkNetworks = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::NetworkNetworks(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::NetworkNetworks(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::NetworkNetworks) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::NetworkNetworks(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::NetworkNetworks(self.get_filters().clone()),
                 )));
             }
             Action::ShowNetworkSubnets => {
@@ -96,11 +96,11 @@ impl Component for NetworkNetworks<'_> {
                     }
                 }
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::NetworkNetworks(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::NetworkNetworks(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/network/routers.rs
+++ b/openstack_tui/src/components/network/routers.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{NetworkRouterFilters, Resource},
+    cloud_worker::types::{ApiRequest, NetworkRouterFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -67,16 +67,16 @@ impl Component for NetworkRouters<'_> {
                 if let Mode::NetworkRouters = current_mode {
                     self.set_loading(true);
                     self.set_data(Vec::new())?;
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::NetworkRouters(self.get_filters().clone()),
-                    )));
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::NetworkRouters(
+                        self.get_filters().clone(),
+                    ))));
                 }
             }
             Action::Mode(Mode::NetworkRouters) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::NetworkRouters(self.get_filters().clone()),
-                )));
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::NetworkRouters(
+                    self.get_filters().clone(),
+                ))));
             }
             // Action::ShowRouterSubnets => {
             //     // only if we are currently in the IdentityGroup mode
@@ -96,11 +96,11 @@ impl Component for NetworkRouters<'_> {
             //         }
             //     }
             // }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::NetworkRouters(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::NetworkRouters(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/network/security_group_rules.rs
+++ b/openstack_tui/src/components/network/security_group_rules.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{NetworkSecurityGroupRuleFilters, Resource},
+    cloud_worker::types::{ApiRequest, NetworkSecurityGroupRuleFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -73,30 +73,30 @@ impl Component for NetworkSecurityGroupRules<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::NetworkSecurityGroupRules = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::NetworkSecurityGroupRules(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::NetworkSecurityGroupRules(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::NetworkSecurityGroupRules) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::NetworkSecurityGroupRules(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::NetworkSecurityGroupRules(self.get_filters().clone()),
                 )));
             }
             Action::SetNetworkSecurityGroupRuleFilters(filters) => {
                 self.set_filters(filters);
                 self.set_data(Vec::new())?;
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::NetworkSecurityGroupRules(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::NetworkSecurityGroupRules(self.get_filters().clone()),
                 )));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::NetworkSecurityGroupRules(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::NetworkSecurityGroupRules(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/network/security_groups.rs
+++ b/openstack_tui/src/components/network/security_groups.rs
@@ -21,7 +21,9 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{NetworkSecurityGroupFilters, NetworkSecurityGroupRuleFilters, Resource},
+    cloud_worker::types::{
+        ApiRequest, NetworkSecurityGroupFilters, NetworkSecurityGroupRuleFilters,
+    },
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -66,15 +68,15 @@ impl Component for NetworkSecurityGroups<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::NetworkSecurityGroups = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::NetworkSecurityGroups(self.get_filters().clone()),
+                    return Ok(Some(Action::PerformApiRequest(
+                        ApiRequest::NetworkSecurityGroups(self.get_filters().clone()),
                     )));
                 }
             }
             Action::Mode(Mode::NetworkSecurityGroups) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::NetworkSecurityGroups(self.get_filters().clone()),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::NetworkSecurityGroups(self.get_filters().clone()),
                 )));
             }
             Action::ShowNetworkSecurityGroupRules => {
@@ -97,11 +99,11 @@ impl Component for NetworkSecurityGroups<'_> {
                     }
                 }
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::NetworkSecurityGroups(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::NetworkSecurityGroups(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/network/subnets.rs
+++ b/openstack_tui/src/components/network/subnets.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{NetworkSubnetFilters, Resource},
+    cloud_worker::types::{ApiRequest, NetworkSubnetFilters},
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -65,22 +65,22 @@ impl Component for NetworkSubnets<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::NetworkSubnets = current_mode {
-                    return Ok(Some(Action::RequestCloudResource(
-                        Resource::NetworkSubnets(self.get_filters().clone()),
-                    )));
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::NetworkSubnets(
+                        self.get_filters().clone(),
+                    ))));
                 }
             }
             Action::Mode(Mode::NetworkSubnets) | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::NetworkSubnets(self.get_filters().clone()),
-                )));
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::NetworkSubnets(
+                    self.get_filters().clone(),
+                ))));
             }
-            Action::DescribeResource => self.describe_selected_entry()?,
+            Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
-            Action::ResourcesData {
-                resource: Resource::NetworkSubnets(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::NetworkSubnets(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -24,7 +24,7 @@ use structable_derive::StructTable;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{IdentityAuthProjectFilters, Resource},
+    cloud_worker::types::{ApiRequest, IdentityAuthProjectFilters},
     components::{Component, FuzzySelectList},
     config::Config,
     error::TuiError,
@@ -99,12 +99,12 @@ impl Component for ProjectSelect {
             }
             Action::ConnectedToCloud(_) => {
                 self.set_loading(true);
-                return Ok(Some(Action::RequestCloudResource(
-                    Resource::IdentityAuthProjects(IdentityAuthProjectFilters {}),
+                return Ok(Some(Action::PerformApiRequest(
+                    ApiRequest::IdentityAuthProjects(IdentityAuthProjectFilters {}),
                 )));
             }
-            Action::ResourcesData {
-                resource: Resource::IdentityAuthProjects(_),
+            Action::ApiResponsesData {
+                request: ApiRequest::IdentityAuthProjects(_),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/resource_select_popup.rs
+++ b/openstack_tui/src/components/resource_select_popup.rs
@@ -31,7 +31,7 @@ use crate::{
 };
 
 #[derive(Default)]
-pub struct ResourceSelect {
+pub struct ApiRequestSelect {
     command_tx: Option<UnboundedSender<Action>>,
     config: Config,
     pub keymap: HashMap<KeyEvent, Action>,
@@ -39,7 +39,7 @@ pub struct ResourceSelect {
     fuzzy_list: FuzzySelectList,
 }
 
-impl ResourceSelect {
+impl ApiRequestSelect {
     pub fn new() -> Self {
         Self::default()
     }
@@ -56,7 +56,7 @@ impl ResourceSelect {
     pub fn render_tick(&mut self) {}
 }
 
-impl Component for ResourceSelect {
+impl Component for ApiRequestSelect {
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<(), TuiError> {
         self.command_tx = Some(tx);
         Ok(())

--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -553,7 +553,7 @@ where
         if let Some(command_tx) = self.get_command_tx() {
             // and have a selected entry
             if let Some(raw_value) = self.get_selected_raw() {
-                command_tx.send(Action::DescribeResourceData(raw_value.clone()))?;
+                command_tx.send(Action::SetDescribeApiResponseData(raw_value.clone()))?;
                 command_tx.send(Action::Mode(Mode::Describe))?;
             } else {
                 debug!("No current selected entry");

--- a/openstack_tui/src/config.rs
+++ b/openstack_tui/src/config.rs
@@ -104,9 +104,9 @@ impl Config {
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
 pub enum CommandType {
-    /// Resource action
+    /// ApiRequest action
     #[default]
-    ResourceAction,
+    ApiRequestAction,
     /// Filter command
     Filter,
 }


### PR DESCRIPTION
Now that we start performing updates and other sort of operations naming
"Resource" does not work anymore. Replace it with ApiRequest and
correspondingly introduce ApiResponseXXX
