### PR TITLE
feat: Add octavia query parameters

### DIFF
--- a/openstack_cli/src/load_balancer/v2/amphorae/list.rs
+++ b/openstack_cli/src/load_balancer/v2/amphorae/list.rs
@@ -61,7 +61,67 @@ pub struct AmphoraesCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    #[arg(help_heading = "Query parameters", long)]
+    cached_zone: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    cert_busy: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    cert_expiration: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    compute_flavor: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    compute_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    created_at: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    ha_ip: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    ha_port_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    image_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    lb_network_ip: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    loadbalancer_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    role: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    status: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    updated_at: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    vrrp_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    vrrp_interface: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    vrrp_ip: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    vrrp_port_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    vrrp_priority: Option<String>,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -209,10 +269,70 @@ impl AmphoraesCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.id {
+            ep_builder.id(val);
+        }
+        if let Some(val) = &self.query.loadbalancer_id {
+            ep_builder.loadbalancer_id(val);
+        }
+        if let Some(val) = &self.query.compute_id {
+            ep_builder.compute_id(val);
+        }
+        if let Some(val) = &self.query.lb_network_ip {
+            ep_builder.lb_network_ip(val);
+        }
+        if let Some(val) = &self.query.vrrp_ip {
+            ep_builder.vrrp_ip(val);
+        }
+        if let Some(val) = &self.query.ha_ip {
+            ep_builder.ha_ip(val);
+        }
+        if let Some(val) = &self.query.vrrp_port_id {
+            ep_builder.vrrp_port_id(val);
+        }
+        if let Some(val) = &self.query.ha_port_id {
+            ep_builder.ha_port_id(val);
+        }
+        if let Some(val) = &self.query.cert_expiration {
+            ep_builder.cert_expiration(val);
+        }
+        if let Some(val) = &self.query.cert_busy {
+            ep_builder.cert_busy(val);
+        }
+        if let Some(val) = &self.query.role {
+            ep_builder.role(val);
+        }
+        if let Some(val) = &self.query.status {
+            ep_builder.status(val);
+        }
+        if let Some(val) = &self.query.vrrp_interface {
+            ep_builder.vrrp_interface(val);
+        }
+        if let Some(val) = &self.query.vrrp_id {
+            ep_builder.vrrp_id(val);
+        }
+        if let Some(val) = &self.query.vrrp_priority {
+            ep_builder.vrrp_priority(val);
+        }
+        if let Some(val) = &self.query.cached_zone {
+            ep_builder.cached_zone(val);
+        }
+        if let Some(val) = &self.query.created_at {
+            ep_builder.created_at(val);
+        }
+        if let Some(val) = &self.query.updated_at {
+            ep_builder.updated_at(val);
+        }
+        if let Some(val) = &self.query.image_id {
+            ep_builder.image_id(val);
+        }
+        if let Some(val) = &self.query.compute_flavor {
+            ep_builder.compute_flavor(val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/availability_zone/list.rs
+++ b/openstack_cli/src/load_balancer/v2/availability_zone/list.rs
@@ -50,7 +50,19 @@ pub struct AvailabilityZonesCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    #[arg(help_heading = "Query parameters", long)]
+    availability_zone_profile_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    description: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    name: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    status: Option<String>,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -87,10 +99,22 @@ impl AvailabilityZonesCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.name {
+            ep_builder.name(val);
+        }
+        if let Some(val) = &self.query.description {
+            ep_builder.description(val);
+        }
+        if let Some(val) = &self.query.availability_zone_profile_id {
+            ep_builder.availability_zone_profile_id(val);
+        }
+        if let Some(val) = &self.query.status {
+            ep_builder.status(val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/availability_zone_profile/list.rs
+++ b/openstack_cli/src/load_balancer/v2/availability_zone_profile/list.rs
@@ -50,7 +50,19 @@ pub struct AvailabilityZoneProfilesCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    #[arg(help_heading = "Query parameters", long)]
+    availability_zone_data: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    name: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    provider_name: Option<String>,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -87,10 +99,22 @@ impl AvailabilityZoneProfilesCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.id {
+            ep_builder.id(val);
+        }
+        if let Some(val) = &self.query.name {
+            ep_builder.name(val);
+        }
+        if let Some(val) = &self.query.provider_name {
+            ep_builder.provider_name(val);
+        }
+        if let Some(val) = &self.query.availability_zone_data {
+            ep_builder.availability_zone_data(val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/flavor/list.rs
+++ b/openstack_cli/src/load_balancer/v2/flavor/list.rs
@@ -50,7 +50,22 @@ pub struct FlavorsCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    #[arg(help_heading = "Query parameters", long)]
+    description: Option<String>,
+
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
+    enabled: Option<bool>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    flavor_profile_id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    name: Option<String>,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -91,10 +106,25 @@ impl FlavorsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.id {
+            ep_builder.id(val);
+        }
+        if let Some(val) = &self.query.name {
+            ep_builder.name(val);
+        }
+        if let Some(val) = &self.query.description {
+            ep_builder.description(val);
+        }
+        if let Some(val) = &self.query.flavor_profile_id {
+            ep_builder.flavor_profile_id(val);
+        }
+        if let Some(val) = &self.query.enabled {
+            ep_builder.enabled(*val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/flavor_profile/list.rs
+++ b/openstack_cli/src/load_balancer/v2/flavor_profile/list.rs
@@ -51,7 +51,19 @@ pub struct FlavorProfilesCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    #[arg(help_heading = "Query parameters", long)]
+    flavor_data: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    id: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    name: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    provider_name: Option<String>,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -80,10 +92,22 @@ impl FlavorProfilesCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.id {
+            ep_builder.id(val);
+        }
+        if let Some(val) = &self.query.name {
+            ep_builder.name(val);
+        }
+        if let Some(val) = &self.query.provider_name {
+            ep_builder.provider_name(val);
+        }
+        if let Some(val) = &self.query.flavor_data {
+            ep_builder.flavor_data(val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/l7policy/rule/list.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/rule/list.rs
@@ -31,10 +31,14 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::load_balancer::v2::l7policy::rule::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists all L7 rules for the project.
 ///
@@ -62,7 +66,56 @@ pub struct RulesCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    #[arg(help_heading = "Query parameters", long)]
+    _type: Option<String>,
+
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
+    admin_state_up: Option<bool>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    compare_type: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    created_at: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    invert: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    key: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    operating_status: Option<String>,
+
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
+
+    #[arg(help_heading = "Query parameters", long)]
+    provisioning_status: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    rule_value: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    updated_at: Option<String>,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = false, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -190,6 +243,77 @@ impl RulesCommand {
         // Set path parameters
         ep_builder.l7policy_id(&self.path.l7policy_id);
         // Set query parameters
+        if let Some(val) = &self.query.compare_type {
+            ep_builder.compare_type(val);
+        }
+        if let Some(val) = &self.query.created_at {
+            ep_builder.created_at(val);
+        }
+        if let Some(val) = &self.query.invert {
+            ep_builder.invert(val);
+        }
+        if let Some(val) = &self.query.key {
+            ep_builder.key(val);
+        }
+        if let Some(id) = &self.query.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.query.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
+        }
+        if let Some(val) = &self.query.provisioning_status {
+            ep_builder.provisioning_status(val);
+        }
+        if let Some(val) = &self.query._type {
+            ep_builder._type(val);
+        }
+        if let Some(val) = &self.query.updated_at {
+            ep_builder.updated_at(val);
+        }
+        if let Some(val) = &self.query.rule_value {
+            ep_builder.rule_value(val);
+        }
+        if let Some(val) = &self.query.operating_status {
+            ep_builder.operating_status(val);
+        }
+        if let Some(val) = &self.query.admin_state_up {
+            ep_builder.admin_state_up(*val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/listener/list.rs
+++ b/openstack_cli/src/load_balancer/v2/listener/list.rs
@@ -31,10 +31,14 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::load_balancer::v2::listener::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists all listeners for the project.
 ///
@@ -62,7 +66,169 @@ pub struct ListenersCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    /// The administrative state of the resource
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
+    admin_state_up: Option<bool>,
+
+    /// A list of ALPN protocols. Available protocols: http/1.0, http/1.1, h2
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    alpn_protocols: Option<String>,
+
+    /// The maximum number of connections permitted for this listener. Default
+    /// value is -1 which represents infinite connections or a default value
+    /// defined by the provider driver.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    connection_limit: Option<String>,
+
+    /// The UTC date and timestamp when the resource was created.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    created_at: Option<String>,
+
+    /// The ID of the pool used by the listener if no L7 policies match.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    default_pool_id: Option<String>,
+
+    /// A human-readable description for the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    description: Option<String>,
+
+    /// Defines whether the includeSubDomains directive should be added to the
+    /// Strict-Transport-Security HTTP response header.
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
+    hsts_include_subdomains: Option<bool>,
+
+    /// The value of the max_age directive for the Strict-Transport-Security
+    /// HTTP response header.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    hsts_max_age: Option<i32>,
+
+    /// Defines whether the preload directive should be added to the
+    /// Strict-Transport-Security HTTP response header.
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
+    hsts_preload: Option<bool>,
+
+    /// The ID of the resource
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    id: Option<String>,
+
+    /// Load balancer ID
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    load_balancer_id: Option<String>,
+
+    /// Human-readable name of the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    name: Option<String>,
+
+    /// Return the list of entities that do not have one or more of the given
+    /// tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    not_tags: Option<String>,
+
+    /// Return the list of entities that do not have at least one of the given
+    /// tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    not_tags_any: Option<String>,
+
+    /// The operating status of the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long, value_parser = ["DEGRADED","DRAINING","ERROR","NO_MONITOR","OFFLINE","ONLINE"])]
+    operating_status: Option<String>,
+
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
+
+    /// The protocol for the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long, value_parser = ["HTTP","HTTPS","PROMETHEUS","SCTP","TCP","TERMINATED_HTTPS","UDP"])]
+    protocol: Option<String>,
+
+    /// The protocol port number for the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    protocol_port: Option<i32>,
+
+    /// The provisioning status of the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long, value_parser = ["ACTIVE","DELETED","ERROR","PENDING_CREATE","PENDING_DELETE","PENDING_UPDATE"])]
+    provisioning_status: Option<String>,
+
+    /// Return the list of entities that have this tag or tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tags: Option<String>,
+
+    /// Return the list of entities that have one or more of the given tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tags_any: Option<String>,
+
+    /// Frontend client inactivity timeout in milliseconds.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    timeout_client_data: Option<i32>,
+
+    /// Backend member connection timeout in milliseconds.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    timeout_member_connect: Option<i32>,
+
+    /// Backend member inactivity timeout in milliseconds.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    timeout_member_data: Option<i32>,
+
+    /// Time, in milliseconds, to wait for additional TCP packets for content
+    /// inspection.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    timeout_tcp_inspect: Option<i32>,
+
+    /// List of ciphers in OpenSSL format
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tls_ciphers: Option<String>,
+
+    /// A list of TLS protocol versions.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tls_versions: Option<String>,
+
+    /// The UTC date and timestamp when the resource was last updated.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    updated_at: Option<String>,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = false, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -349,10 +515,132 @@ impl ListenersCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.id {
+            ep_builder.id(val);
+        }
+        if let Some(val) = &self.query.description {
+            ep_builder.description(val);
+        }
+        if let Some(val) = &self.query.name {
+            ep_builder.name(val);
+        }
+        if let Some(id) = &self.query.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.query.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
+        }
+        if let Some(val) = &self.query.connection_limit {
+            ep_builder.connection_limit(val);
+        }
+        if let Some(val) = &self.query.default_pool_id {
+            ep_builder.default_pool_id(val);
+        }
+        if let Some(val) = &self.query.protocol {
+            ep_builder.protocol(val);
+        }
+        if let Some(val) = &self.query.protocol_port {
+            ep_builder.protocol_port(*val);
+        }
+        if let Some(val) = &self.query.created_at {
+            ep_builder.created_at(val);
+        }
+        if let Some(val) = &self.query.updated_at {
+            ep_builder.updated_at(val);
+        }
+        if let Some(val) = &self.query.load_balancer_id {
+            ep_builder.load_balancer_id(val);
+        }
+        if let Some(val) = &self.query.timeout_client_data {
+            ep_builder.timeout_client_data(*val);
+        }
+        if let Some(val) = &self.query.timeout_member_connect {
+            ep_builder.timeout_member_connect(*val);
+        }
+        if let Some(val) = &self.query.timeout_member_data {
+            ep_builder.timeout_member_data(*val);
+        }
+        if let Some(val) = &self.query.timeout_tcp_inspect {
+            ep_builder.timeout_tcp_inspect(*val);
+        }
+        if let Some(val) = &self.query.tls_ciphers {
+            ep_builder.tls_ciphers(val);
+        }
+        if let Some(val) = &self.query.tls_versions {
+            ep_builder.tls_versions(val);
+        }
+        if let Some(val) = &self.query.alpn_protocols {
+            ep_builder.alpn_protocols(val);
+        }
+        if let Some(val) = &self.query.hsts_max_age {
+            ep_builder.hsts_max_age(*val);
+        }
+        if let Some(val) = &self.query.admin_state_up {
+            ep_builder.admin_state_up(*val);
+        }
+        if let Some(val) = &self.query.hsts_include_subdomains {
+            ep_builder.hsts_include_subdomains(*val);
+        }
+        if let Some(val) = &self.query.hsts_preload {
+            ep_builder.hsts_preload(*val);
+        }
+        if let Some(val) = &self.query.provisioning_status {
+            ep_builder.provisioning_status(val);
+        }
+        if let Some(val) = &self.query.operating_status {
+            ep_builder.operating_status(val);
+        }
+        if let Some(val) = &self.query.tags {
+            ep_builder.tags(val);
+        }
+        if let Some(val) = &self.query.tags_any {
+            ep_builder.tags_any(val);
+        }
+        if let Some(val) = &self.query.not_tags {
+            ep_builder.not_tags(val);
+        }
+        if let Some(val) = &self.query.not_tags_any {
+            ep_builder.not_tags_any(val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/pool/list.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/list.rs
@@ -31,10 +31,14 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
+use eyre::OptionExt;
+use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::load_balancer::v2::pool::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use structable_derive::StructTable;
+use tracing::warn;
 
 /// Lists all pools for the project.
 ///
@@ -62,7 +66,106 @@ pub struct PoolsCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    /// The administrative state of the resource
+    ///
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
+    admin_state_up: Option<bool>,
+
+    /// A list of ALPN protocols. Available protocols: http/1.0, http/1.1, h2
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    alpn_protocols: Option<String>,
+
+    /// The UTC date and timestamp when the resource was created.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    created_at: Option<String>,
+
+    /// A human-readable description for the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    description: Option<String>,
+
+    /// The ID of the resource
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    id: Option<String>,
+
+    /// Human-readable name of the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    name: Option<String>,
+
+    /// Return the list of entities that do not have one or more of the given
+    /// tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    not_tags: Option<String>,
+
+    /// Return the list of entities that do not have at least one of the given
+    /// tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    not_tags_any: Option<String>,
+
+    /// The operating status of the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long, value_parser = ["DEGRADED","DRAINING","ERROR","NO_MONITOR","OFFLINE","ONLINE"])]
+    operating_status: Option<String>,
+
+    /// Project resource for which the operation should be performed.
+    #[command(flatten)]
+    project: ProjectInput,
+
+    /// The provisioning status of the resource.
+    ///
+    #[arg(help_heading = "Query parameters", long, value_parser = ["ACTIVE","DELETED","ERROR","PENDING_CREATE","PENDING_DELETE","PENDING_UPDATE"])]
+    provisioning_status: Option<String>,
+
+    /// Return the list of entities that have this tag or tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tags: Option<String>,
+
+    /// Return the list of entities that have one or more of the given tags.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tags_any: Option<String>,
+
+    /// List of ciphers in OpenSSL format
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tls_ciphers: Option<String>,
+
+    #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
+    tls_enabled: Option<bool>,
+
+    /// A list of TLS protocol versions.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    tls_versions: Option<String>,
+
+    /// The UTC date and timestamp when the resource was last updated.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    updated_at: Option<String>,
+}
+
+/// Project input select group
+#[derive(Args)]
+#[group(required = false, multiple = false)]
+struct ProjectInput {
+    /// Project Name.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_NAME")]
+    project_name: Option<String>,
+    /// Project ID.
+    #[arg(long, help_heading = "Path parameters", value_name = "PROJECT_ID")]
+    project_id: Option<String>,
+    /// Current project.
+    #[arg(long, help_heading = "Path parameters", action = clap::ArgAction::SetTrue)]
+    current_project: bool,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -265,10 +368,99 @@ impl PoolsCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.id {
+            ep_builder.id(val);
+        }
+        if let Some(val) = &self.query.description {
+            ep_builder.description(val);
+        }
+        if let Some(val) = &self.query.name {
+            ep_builder.name(val);
+        }
+        if let Some(id) = &self.query.project.project_id {
+            // project_id is passed. No need to lookup
+            ep_builder.project_id(id);
+        } else if let Some(name) = &self.query.project.project_name {
+            // project_name is passed. Need to lookup resource
+            let mut sub_find_builder = find_project::Request::builder();
+            warn!("Querying project by name (because of `--project-name` parameter passed) may not be definite. This may fail in which case parameter `--project-id` should be used instead.");
+
+            sub_find_builder.id(name);
+            let find_ep = sub_find_builder
+                .build()
+                .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+            let find_data: serde_json::Value = find_by_name(find_ep).query_async(client).await?;
+            // Try to extract resource id
+            match find_data.get("id") {
+                Some(val) => match val.as_str() {
+                    Some(id_str) => {
+                        ep_builder.project_id(id_str.to_owned());
+                    }
+                    None => {
+                        return Err(OpenStackCliError::ResourceAttributeNotString(
+                            serde_json::to_string(&val)?,
+                        ))
+                    }
+                },
+                None => {
+                    return Err(OpenStackCliError::ResourceAttributeMissing(
+                        "id".to_string(),
+                    ))
+                }
+            };
+        } else if self.query.project.current_project {
+            ep_builder.project_id(
+                client
+                    .get_auth_info()
+                    .ok_or_eyre("Cannot determine current authentication information")?
+                    .token
+                    .user
+                    .id,
+            );
+        }
+        if let Some(val) = &self.query.admin_state_up {
+            ep_builder.admin_state_up(*val);
+        }
+        if let Some(val) = &self.query.created_at {
+            ep_builder.created_at(val);
+        }
+        if let Some(val) = &self.query.updated_at {
+            ep_builder.updated_at(val);
+        }
+        if let Some(val) = &self.query.tls_enabled {
+            ep_builder.tls_enabled(*val);
+        }
+        if let Some(val) = &self.query.tls_ciphers {
+            ep_builder.tls_ciphers(val);
+        }
+        if let Some(val) = &self.query.tls_versions {
+            ep_builder.tls_versions(val);
+        }
+        if let Some(val) = &self.query.alpn_protocols {
+            ep_builder.alpn_protocols(val);
+        }
+        if let Some(val) = &self.query.provisioning_status {
+            ep_builder.provisioning_status(val);
+        }
+        if let Some(val) = &self.query.operating_status {
+            ep_builder.operating_status(val);
+        }
+        if let Some(val) = &self.query.tags {
+            ep_builder.tags(val);
+        }
+        if let Some(val) = &self.query.tags_any {
+            ep_builder.tags_any(val);
+        }
+        if let Some(val) = &self.query.not_tags {
+            ep_builder.not_tags(val);
+        }
+        if let Some(val) = &self.query.not_tags_any {
+            ep_builder.not_tags_any(val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_cli/src/load_balancer/v2/provider/list.rs
+++ b/openstack_cli/src/load_balancer/v2/provider/list.rs
@@ -56,7 +56,13 @@ pub struct ProvidersCommand {
 
 /// Query parameters
 #[derive(Args)]
-struct QueryParameters {}
+struct QueryParameters {
+    #[arg(help_heading = "Query parameters", long)]
+    description: Option<String>,
+
+    #[arg(help_heading = "Query parameters", long)]
+    name: Option<String>,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -89,10 +95,16 @@ impl ProvidersCommand {
         let op = OutputProcessor::from_args(parsed_args);
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters
+        if let Some(val) = &self.query.description {
+            ep_builder.description(val);
+        }
+        if let Some(val) = &self.query.name {
+            ep_builder.name(val);
+        }
         // Set body parameters
 
         let ep = ep_builder

--- a/openstack_sdk/src/api/load_balancer/v2/amphorae/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/amphorae/list.rs
@@ -32,20 +32,82 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    cached_zone: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    cert_busy: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    cert_expiration: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    compute_flavor: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    compute_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    created_at: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    ha_ip: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    ha_port_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    image_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    lb_network_ip: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    loadbalancer_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    role: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    status: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    updated_at: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    vrrp_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    vrrp_interface: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    vrrp_ip: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    vrrp_port_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    vrrp_priority: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Amphorae.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -70,7 +132,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -80,7 +142,29 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("loadbalancer_id", self.loadbalancer_id.as_ref());
+        params.push_opt("compute_id", self.compute_id.as_ref());
+        params.push_opt("lb_network_ip", self.lb_network_ip.as_ref());
+        params.push_opt("vrrp_ip", self.vrrp_ip.as_ref());
+        params.push_opt("ha_ip", self.ha_ip.as_ref());
+        params.push_opt("vrrp_port_id", self.vrrp_port_id.as_ref());
+        params.push_opt("ha_port_id", self.ha_port_id.as_ref());
+        params.push_opt("cert_expiration", self.cert_expiration.as_ref());
+        params.push_opt("cert_busy", self.cert_busy.as_ref());
+        params.push_opt("role", self.role.as_ref());
+        params.push_opt("status", self.status.as_ref());
+        params.push_opt("vrrp_interface", self.vrrp_interface.as_ref());
+        params.push_opt("vrrp_id", self.vrrp_id.as_ref());
+        params.push_opt("vrrp_priority", self.vrrp_priority.as_ref());
+        params.push_opt("cached_zone", self.cached_zone.as_ref());
+        params.push_opt("created_at", self.created_at.as_ref());
+        params.push_opt("updated_at", self.updated_at.as_ref());
+        params.push_opt("image_id", self.image_id.as_ref());
+        params.push_opt("compute_flavor", self.compute_flavor.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/availability_zone/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/availability_zone/list.rs
@@ -22,20 +22,34 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    availability_zone_profile_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    status: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Availability_Zone.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -60,7 +74,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -70,7 +84,16 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt(
+            "availability_zone_profile_id",
+            self.availability_zone_profile_id.as_ref(),
+        );
+        params.push_opt("status", self.status.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/availability_zone_profile/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/availability_zone_profile/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/availability_zone_profile/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/availability_zone_profile/list.rs
@@ -22,20 +22,34 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    availability_zone_data: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    provider_name: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Availability_Zone_Profile.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -60,7 +74,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -70,7 +84,16 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("provider_name", self.provider_name.as_ref());
+        params.push_opt(
+            "availability_zone_data",
+            self.availability_zone_data.as_ref(),
+        );
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/flavor/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/flavor/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/flavor/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/flavor/list.rs
@@ -22,20 +22,37 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    #[builder(default)]
+    enabled: Option<bool>,
+
+    #[builder(default, setter(into))]
+    flavor_profile_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Flavor.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -60,7 +77,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -70,7 +87,14 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("flavor_profile_id", self.flavor_profile_id.as_ref());
+        params.push_opt("enabled", self.enabled);
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/flavor_profile/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/flavor_profile/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/flavor_profile/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/flavor_profile/list.rs
@@ -22,20 +22,34 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    flavor_data: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    provider_name: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Flavor_Profile.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -60,7 +74,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -70,7 +84,13 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("provider_name", self.provider_name.as_ref());
+        params.push_opt("flavor_data", self.flavor_data.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/healthmonitor/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/healthmonitor/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/healthmonitor/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/healthmonitor/list.rs
@@ -32,20 +32,140 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    /// The type of health monitor.
+    ///
+    #[builder(default, setter(into))]
+    _type: Option<Cow<'a, str>>,
+
+    /// The administrative state of the resource
+    ///
+    #[builder(default)]
+    admin_state_up: Option<bool>,
+
+    /// The UTC date and timestamp when the resource was created.
+    ///
+    #[builder(default, setter(into))]
+    created_at: Option<Cow<'a, str>>,
+
+    /// The time, in seconds, between sending probes to members.
+    ///
+    #[builder(default)]
+    delay: Option<i32>,
+
+    /// A human-readable description for the resource.
+    ///
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    /// The list of HTTP status codes expected in response from the member to
+    /// declare it healthy.
+    ///
+    #[builder(default, setter(into))]
+    expected_codes: Option<Cow<'a, str>>,
+
+    /// The HTTP method that the health monitor uses for requests.
+    ///
+    #[builder(default, setter(into))]
+    http_method: Option<Cow<'a, str>>,
+
+    /// The ID of the resource
+    ///
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    /// The number of successful checks before changing the operating status of
+    /// the member to ONLINE. A valid value is from 1 to 10.
+    ///
+    #[builder(default)]
+    max_retries: Option<i32>,
+
+    /// The number of allowed check failures before changing the operating
+    /// status of the member to ERROR. A valid value is from 1 to 10.
+    ///
+    #[builder(default)]
+    max_retries_down: Option<i32>,
+
+    /// Human-readable name of the resource.
+    ///
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have one or more of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have at least one of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags_any: Option<Cow<'a, str>>,
+
+    /// The operating status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    operating_status: Option<Cow<'a, str>>,
+
+    /// The ID of the pool.
+    ///
+    #[builder(default, setter(into))]
+    pool_id: Option<Cow<'a, str>>,
+
+    /// The ID of the project owning this resource.
+    ///
+    #[builder(default, setter(into))]
+    project_id: Option<Cow<'a, str>>,
+
+    /// The provisioning status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    provisioning_status: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have this tag or tags.
+    ///
+    #[builder(default, setter(into))]
+    tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have one or more of the given tags.
+    ///
+    #[builder(default, setter(into))]
+    tags_any: Option<Cow<'a, str>>,
+
+    /// The maximum time, in seconds, that a monitor waits to connect before it
+    /// times out.
+    ///
+    #[builder(default)]
+    timeout: Option<i32>,
+
+    /// The UTC date and timestamp when the resource was last updated.
+    ///
+    #[builder(default, setter(into))]
+    updated_at: Option<Cow<'a, str>>,
+
+    /// The HTTP URL path of the request sent by the monitor to test the health
+    /// of a backend member. Must be a string that begins with a forward slash
+    /// (/).
+    ///
+    #[builder(default, setter(into))]
+    url_path: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Healthmonitor.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -70,7 +190,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -80,7 +200,31 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("project_id", self.project_id.as_ref());
+        params.push_opt("admin_state_up", self.admin_state_up);
+        params.push_opt("created_at", self.created_at.as_ref());
+        params.push_opt("updated_at", self.updated_at.as_ref());
+        params.push_opt("delay", self.delay);
+        params.push_opt("expected_codes", self.expected_codes.as_ref());
+        params.push_opt("http_method", self.http_method.as_ref());
+        params.push_opt("max_retries", self.max_retries);
+        params.push_opt("max_retries_down", self.max_retries_down);
+        params.push_opt("pool_id", self.pool_id.as_ref());
+        params.push_opt("timeout", self.timeout);
+        params.push_opt("type", self._type.as_ref());
+        params.push_opt("url_path", self.url_path.as_ref());
+        params.push_opt("provisioning_status", self.provisioning_status.as_ref());
+        params.push_opt("operating_status", self.operating_status.as_ref());
+        params.push_opt("tags", self.tags.as_ref());
+        params.push_opt("tags-any", self.tags_any.as_ref());
+        params.push_opt("not-tags", self.not_tags.as_ref());
+        params.push_opt("not-tags-any", self.not_tags_any.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/l7policy/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/l7policy/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/l7policy/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/l7policy/list.rs
@@ -32,20 +32,58 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    action: Option<Cow<'a, str>>,
+
+    #[builder(default)]
+    admin_state_up: Option<bool>,
+
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    listener_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    operating_status: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    position: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    project_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    provisioning_status: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    redirect_pool_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    redirect_prefix: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    redirect_url: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the L7Policy.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -70,7 +108,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -80,7 +118,21 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("action", self.action.as_ref());
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("listener_id", self.listener_id.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("position", self.position.as_ref());
+        params.push_opt("redirect_pool_id", self.redirect_pool_id.as_ref());
+        params.push_opt("redirect_url", self.redirect_url.as_ref());
+        params.push_opt("provisioning_status", self.provisioning_status.as_ref());
+        params.push_opt("operating_status", self.operating_status.as_ref());
+        params.push_opt("redirect_prefix", self.redirect_prefix.as_ref());
+        params.push_opt("project_id", self.project_id.as_ref());
+        params.push_opt("admin_state_up", self.admin_state_up);
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/l7policy/rule/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/l7policy/rule/list.rs
@@ -37,11 +37,44 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    _type: Option<Cow<'a, str>>,
+
+    #[builder(default)]
+    admin_state_up: Option<bool>,
+
+    #[builder(default, setter(into))]
+    compare_type: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    created_at: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    invert: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    key: Option<Cow<'a, str>>,
+
     /// l7policy_id parameter for
     /// /v2/lbaas/l7policies/{l7policy_id}/rules/{rule_id} API
     ///
     #[builder(default, setter(into))]
     l7policy_id: Cow<'a, str>,
+
+    #[builder(default, setter(into))]
+    operating_status: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    project_id: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    provisioning_status: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    rule_value: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    updated_at: Option<Cow<'a, str>>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -92,7 +125,20 @@ impl<'a> RestEndpoint for Request<'a> {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("compare_type", self.compare_type.as_ref());
+        params.push_opt("created_at", self.created_at.as_ref());
+        params.push_opt("invert", self.invert.as_ref());
+        params.push_opt("key", self.key.as_ref());
+        params.push_opt("project_id", self.project_id.as_ref());
+        params.push_opt("provisioning_status", self.provisioning_status.as_ref());
+        params.push_opt("type", self._type.as_ref());
+        params.push_opt("updated_at", self.updated_at.as_ref());
+        params.push_opt("rule_value", self.rule_value.as_ref());
+        params.push_opt("operating_status", self.operating_status.as_ref());
+        params.push_opt("admin_state_up", self.admin_state_up);
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/listener/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/listener/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/listener/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/listener/list.rs
@@ -32,20 +32,170 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    /// The administrative state of the resource
+    ///
+    #[builder(default)]
+    admin_state_up: Option<bool>,
+
+    /// A list of ALPN protocols. Available protocols: http/1.0, http/1.1, h2
+    ///
+    #[builder(default, setter(into))]
+    alpn_protocols: Option<Cow<'a, str>>,
+
+    /// The maximum number of connections permitted for this listener. Default
+    /// value is -1 which represents infinite connections or a default value
+    /// defined by the provider driver.
+    ///
+    #[builder(default, setter(into))]
+    connection_limit: Option<Cow<'a, str>>,
+
+    /// The UTC date and timestamp when the resource was created.
+    ///
+    #[builder(default, setter(into))]
+    created_at: Option<Cow<'a, str>>,
+
+    /// The ID of the pool used by the listener if no L7 policies match.
+    ///
+    #[builder(default, setter(into))]
+    default_pool_id: Option<Cow<'a, str>>,
+
+    /// A human-readable description for the resource.
+    ///
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    /// Defines whether the includeSubDomains directive should be added to the
+    /// Strict-Transport-Security HTTP response header.
+    ///
+    #[builder(default)]
+    hsts_include_subdomains: Option<bool>,
+
+    /// The value of the max_age directive for the Strict-Transport-Security
+    /// HTTP response header.
+    ///
+    #[builder(default)]
+    hsts_max_age: Option<i32>,
+
+    /// Defines whether the preload directive should be added to the
+    /// Strict-Transport-Security HTTP response header.
+    ///
+    #[builder(default)]
+    hsts_preload: Option<bool>,
+
+    /// The ID of the resource
+    ///
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    /// Load balancer ID
+    ///
+    #[builder(default, setter(into))]
+    load_balancer_id: Option<Cow<'a, str>>,
+
+    /// Human-readable name of the resource.
+    ///
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have one or more of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have at least one of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags_any: Option<Cow<'a, str>>,
+
+    /// The operating status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    operating_status: Option<Cow<'a, str>>,
+
+    /// The ID of the project owning this resource.
+    ///
+    #[builder(default, setter(into))]
+    project_id: Option<Cow<'a, str>>,
+
+    /// The protocol for the resource.
+    ///
+    #[builder(default, setter(into))]
+    protocol: Option<Cow<'a, str>>,
+
+    /// The protocol port number for the resource.
+    ///
+    #[builder(default)]
+    protocol_port: Option<i32>,
+
+    /// The provisioning status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    provisioning_status: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have this tag or tags.
+    ///
+    #[builder(default, setter(into))]
+    tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have one or more of the given tags.
+    ///
+    #[builder(default, setter(into))]
+    tags_any: Option<Cow<'a, str>>,
+
+    /// Frontend client inactivity timeout in milliseconds.
+    ///
+    #[builder(default)]
+    timeout_client_data: Option<i32>,
+
+    /// Backend member connection timeout in milliseconds.
+    ///
+    #[builder(default)]
+    timeout_member_connect: Option<i32>,
+
+    /// Backend member inactivity timeout in milliseconds.
+    ///
+    #[builder(default)]
+    timeout_member_data: Option<i32>,
+
+    /// Time, in milliseconds, to wait for additional TCP packets for content
+    /// inspection.
+    ///
+    #[builder(default)]
+    timeout_tcp_inspect: Option<i32>,
+
+    /// List of ciphers in OpenSSL format
+    ///
+    #[builder(default, setter(into))]
+    tls_ciphers: Option<Cow<'a, str>>,
+
+    /// A list of TLS protocol versions.
+    ///
+    #[builder(default, setter(into))]
+    tls_versions: Option<Cow<'a, str>>,
+
+    /// The UTC date and timestamp when the resource was last updated.
+    ///
+    #[builder(default, setter(into))]
+    updated_at: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Listener.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -70,7 +220,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -80,7 +230,37 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("project_id", self.project_id.as_ref());
+        params.push_opt("connection_limit", self.connection_limit.as_ref());
+        params.push_opt("default_pool_id", self.default_pool_id.as_ref());
+        params.push_opt("protocol", self.protocol.as_ref());
+        params.push_opt("protocol_port", self.protocol_port);
+        params.push_opt("created_at", self.created_at.as_ref());
+        params.push_opt("updated_at", self.updated_at.as_ref());
+        params.push_opt("load_balancer_id", self.load_balancer_id.as_ref());
+        params.push_opt("timeout_client_data", self.timeout_client_data);
+        params.push_opt("timeout_member_connect", self.timeout_member_connect);
+        params.push_opt("timeout_member_data", self.timeout_member_data);
+        params.push_opt("timeout_tcp_inspect", self.timeout_tcp_inspect);
+        params.push_opt("tls_ciphers", self.tls_ciphers.as_ref());
+        params.push_opt("tls_versions", self.tls_versions.as_ref());
+        params.push_opt("alpn_protocols", self.alpn_protocols.as_ref());
+        params.push_opt("hsts_max_age", self.hsts_max_age);
+        params.push_opt("admin_state_up", self.admin_state_up);
+        params.push_opt("hsts_include_subdomains", self.hsts_include_subdomains);
+        params.push_opt("hsts_preload", self.hsts_preload);
+        params.push_opt("provisioning_status", self.provisioning_status.as_ref());
+        params.push_opt("operating_status", self.operating_status.as_ref());
+        params.push_opt("tags", self.tags.as_ref());
+        params.push_opt("tags-any", self.tags_any.as_ref());
+        params.push_opt("not-tags", self.not_tags.as_ref());
+        params.push_opt("not-tags-any", self.not_tags_any.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/loadbalancer/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/loadbalancer/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/loadbalancer/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/loadbalancer/list.rs
@@ -32,20 +32,114 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    /// An availability zone name.
+    ///
+    #[builder(default, setter(into))]
+    availability_zone: Option<Cow<'a, str>>,
+
+    /// A human-readable description for the resource.
+    ///
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    /// The ID of the flavor.
+    ///
+    #[builder(default, setter(into))]
+    flavor_id: Option<Cow<'a, str>>,
+
+    /// The ID of the resource
+    ///
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    /// Human-readable name of the resource.
+    ///
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have one or more of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have at least one of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags_any: Option<Cow<'a, str>>,
+
+    /// The operating status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    operating_status: Option<Cow<'a, str>>,
+
+    /// The ID of the project owning this resource.
+    ///
+    #[builder(default, setter(into))]
+    project_id: Option<Cow<'a, str>>,
+
+    /// Provider name for the load balancer.
+    ///
+    #[builder(default, setter(into))]
+    provider: Option<Cow<'a, str>>,
+
+    /// The provisioning status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    provisioning_status: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have this tag or tags.
+    ///
+    #[builder(default, setter(into))]
+    tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have one or more of the given tags.
+    ///
+    #[builder(default, setter(into))]
+    tags_any: Option<Cow<'a, str>>,
+
+    /// The IP address of the Virtual IP (VIP).
+    ///
+    #[builder(default, setter(into))]
+    vip_address: Option<Cow<'a, str>>,
+
+    /// The ID of the network for the Virtual IP (VIP).
+    ///
+    #[builder(default, setter(into))]
+    vip_network_id: Option<Cow<'a, str>>,
+
+    /// The ID of the Virtual IP (VIP) port.
+    ///
+    #[builder(default, setter(into))]
+    vip_port_id: Option<Cow<'a, str>>,
+
+    /// The ID of the QoS Policy which will apply to the Virtual IP (VIP).
+    ///
+    #[builder(default, setter(into))]
+    vip_qos_policy_id: Option<Cow<'a, str>>,
+
+    /// The ID of the subnet for the Virtual IP (VIP).
+    ///
+    #[builder(default, setter(into))]
+    vip_subnet_id: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Loadbalancer.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -70,7 +164,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -80,7 +174,27 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("project_id", self.project_id.as_ref());
+        params.push_opt("flavor_id", self.flavor_id.as_ref());
+        params.push_opt("provider", self.provider.as_ref());
+        params.push_opt("vip_address", self.vip_address.as_ref());
+        params.push_opt("vip_network_id", self.vip_network_id.as_ref());
+        params.push_opt("vip_port_id", self.vip_port_id.as_ref());
+        params.push_opt("vip_subnet_id", self.vip_subnet_id.as_ref());
+        params.push_opt("vip_qos_policy_id", self.vip_qos_policy_id.as_ref());
+        params.push_opt("availability_zone", self.availability_zone.as_ref());
+        params.push_opt("provisioning_status", self.provisioning_status.as_ref());
+        params.push_opt("operating_status", self.operating_status.as_ref());
+        params.push_opt("tags", self.tags.as_ref());
+        params.push_opt("tags-any", self.tags_any.as_ref());
+        params.push_opt("not-tags", self.not_tags.as_ref());
+        params.push_opt("not-tags-any", self.not_tags_any.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/pool/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/pool/find.rs
@@ -69,7 +69,7 @@ where {
 
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
-    type L = List::Request;
+    type L = List::Request<'a>;
     fn get_ep(&self) -> Get::Request<'a> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
@@ -78,7 +78,7 @@ impl<'a> Findable for Request<'a> {
         }
         ep.build().unwrap()
     }
-    fn list_ep(&self) -> List::Request {
+    fn list_ep(&self) -> List::Request<'a> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));

--- a/openstack_sdk/src/api/load_balancer/v2/pool/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/pool/list.rs
@@ -32,20 +32,107 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    /// The administrative state of the resource
+    ///
+    #[builder(default)]
+    admin_state_up: Option<bool>,
+
+    /// A list of ALPN protocols. Available protocols: http/1.0, http/1.1, h2
+    ///
+    #[builder(default, setter(into))]
+    alpn_protocols: Option<Cow<'a, str>>,
+
+    /// The UTC date and timestamp when the resource was created.
+    ///
+    #[builder(default, setter(into))]
+    created_at: Option<Cow<'a, str>>,
+
+    /// A human-readable description for the resource.
+    ///
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    /// The ID of the resource
+    ///
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    /// Human-readable name of the resource.
+    ///
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have one or more of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have at least one of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags_any: Option<Cow<'a, str>>,
+
+    /// The operating status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    operating_status: Option<Cow<'a, str>>,
+
+    /// The ID of the project owning this resource.
+    ///
+    #[builder(default, setter(into))]
+    project_id: Option<Cow<'a, str>>,
+
+    /// The provisioning status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    provisioning_status: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have this tag or tags.
+    ///
+    #[builder(default, setter(into))]
+    tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have one or more of the given tags.
+    ///
+    #[builder(default, setter(into))]
+    tags_any: Option<Cow<'a, str>>,
+
+    /// List of ciphers in OpenSSL format
+    ///
+    #[builder(default, setter(into))]
+    tls_ciphers: Option<Cow<'a, str>>,
+
+    #[builder(default)]
+    tls_enabled: Option<bool>,
+
+    /// A list of TLS protocol versions.
+    ///
+    #[builder(default, setter(into))]
+    tls_versions: Option<Cow<'a, str>>,
+
+    /// The UTC date and timestamp when the resource was last updated.
+    ///
+    #[builder(default, setter(into))]
+    updated_at: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Pool.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -70,7 +157,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -80,7 +167,26 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("project_id", self.project_id.as_ref());
+        params.push_opt("admin_state_up", self.admin_state_up);
+        params.push_opt("created_at", self.created_at.as_ref());
+        params.push_opt("updated_at", self.updated_at.as_ref());
+        params.push_opt("tls_enabled", self.tls_enabled);
+        params.push_opt("tls_ciphers", self.tls_ciphers.as_ref());
+        params.push_opt("tls_versions", self.tls_versions.as_ref());
+        params.push_opt("alpn_protocols", self.alpn_protocols.as_ref());
+        params.push_opt("provisioning_status", self.provisioning_status.as_ref());
+        params.push_opt("operating_status", self.operating_status.as_ref());
+        params.push_opt("tags", self.tags.as_ref());
+        params.push_opt("tags-any", self.tags_any.as_ref());
+        params.push_opt("not-tags", self.not_tags.as_ref());
+        params.push_opt("not-tags-any", self.not_tags_any.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/pool/member/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/pool/member/list.rs
@@ -37,10 +37,113 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// The IP address of the backend member server.
+    ///
+    #[builder(default, setter(into))]
+    address: Option<Cow<'a, str>>,
+
+    /// The administrative state of the resource
+    ///
+    #[builder(default)]
+    admin_state_up: Option<bool>,
+
+    /// Is the member a backup?
+    ///
+    #[builder(default)]
+    backup: Option<bool>,
+
+    /// The UTC date and timestamp when the resource was created.
+    ///
+    #[builder(default, setter(into))]
+    created_at: Option<Cow<'a, str>>,
+
+    /// A human-readable description for the resource.
+    ///
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    /// The ID of the resource
+    ///
+    #[builder(default, setter(into))]
+    id: Option<Cow<'a, str>>,
+
+    /// An alternate IP address used for health monitoring a backend member.
+    ///
+    #[builder(default, setter(into))]
+    monitor_address: Option<Cow<'a, str>>,
+
+    /// An alternate protocol port used for health monitoring a backend member.
+    ///
+    #[builder(default, setter(into))]
+    monitor_port: Option<Cow<'a, str>>,
+
+    /// Human-readable name of the resource.
+    ///
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have one or more of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that do not have at least one of the given
+    /// tags.
+    ///
+    #[builder(default, setter(into))]
+    not_tags_any: Option<Cow<'a, str>>,
+
+    /// The operating status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    operating_status: Option<Cow<'a, str>>,
+
     /// pool_id parameter for /v2/lbaas/pools/{pool_id}/members/{member_id} API
     ///
     #[builder(default, setter(into))]
     pool_id: Cow<'a, str>,
+
+    /// The ID of the project owning this resource.
+    ///
+    #[builder(default, setter(into))]
+    project_id: Option<Cow<'a, str>>,
+
+    /// The protocol port number the backend member server is listening on.
+    ///
+    #[builder(default)]
+    protocol_port: Option<i32>,
+
+    /// The provisioning status of the resource.
+    ///
+    #[builder(default, setter(into))]
+    provisioning_status: Option<Cow<'a, str>>,
+
+    /// The subnet ID the member service is accessible from.
+    ///
+    #[builder(default, setter(into))]
+    subnet_id: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have this tag or tags.
+    ///
+    #[builder(default, setter(into))]
+    tags: Option<Cow<'a, str>>,
+
+    /// Return the list of entities that have one or more of the given tags.
+    ///
+    #[builder(default, setter(into))]
+    tags_any: Option<Cow<'a, str>>,
+
+    /// The UTC date and timestamp when the resource was last updated.
+    ///
+    #[builder(default, setter(into))]
+    updated_at: Option<Cow<'a, str>>,
+
+    /// The weight of a member determines the portion of requests or
+    /// connections it services compared to the other members of the pool.
+    ///
+    #[builder(default)]
+    weight: Option<i32>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
@@ -91,7 +194,29 @@ impl<'a> RestEndpoint for Request<'a> {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("id", self.id.as_ref());
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("name", self.name.as_ref());
+        params.push_opt("project_id", self.project_id.as_ref());
+        params.push_opt("admin_state_up", self.admin_state_up);
+        params.push_opt("created_at", self.created_at.as_ref());
+        params.push_opt("updated_at", self.updated_at.as_ref());
+        params.push_opt("address", self.address.as_ref());
+        params.push_opt("protocol_port", self.protocol_port);
+        params.push_opt("subnet_id", self.subnet_id.as_ref());
+        params.push_opt("weight", self.weight);
+        params.push_opt("monitor_address", self.monitor_address.as_ref());
+        params.push_opt("monitor_port", self.monitor_port.as_ref());
+        params.push_opt("backup", self.backup);
+        params.push_opt("provisioning_status", self.provisioning_status.as_ref());
+        params.push_opt("operating_status", self.operating_status.as_ref());
+        params.push_opt("tags", self.tags.as_ref());
+        params.push_opt("tags-any", self.tags_any.as_ref());
+        params.push_opt("not-tags", self.not_tags.as_ref());
+        params.push_opt("not-tags-any", self.not_tags_any.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/provider/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/provider/list.rs
@@ -27,20 +27,28 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
-pub struct Request {
+pub struct Request<'a> {
+    #[builder(default, setter(into))]
+    description: Option<Cow<'a, str>>,
+
+    #[builder(default, setter(into))]
+    name: Option<Cow<'a, str>>,
+
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
 }
-impl Request {
+impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
-    pub fn builder() -> RequestBuilder {
+    pub fn builder() -> RequestBuilder<'a> {
         RequestBuilder::default()
     }
 }
 
-impl RequestBuilder {
+impl<'a> RequestBuilder<'a> {
     /// Add a single header to the Provider.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -65,7 +73,7 @@ where {
     }
 }
 
-impl RestEndpoint for Request {
+impl<'a> RestEndpoint for Request<'a> {
     fn method(&self) -> http::Method {
         http::Method::GET
     }
@@ -75,7 +83,11 @@ impl RestEndpoint for Request {
     }
 
     fn parameters(&self) -> QueryParams {
-        QueryParams::default()
+        let mut params = QueryParams::default();
+        params.push_opt("description", self.description.as_ref());
+        params.push_opt("name", self.name.as_ref());
+
+        params
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_tui/.config/config.json5
+++ b/openstack_tui/.config/config.json5
@@ -78,6 +78,7 @@
     },
     "LoadBalancers": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
+      "l": { "action": "ShowLoadBalancerListeners", "description": "Listeners"},
     },
     "LoadBalancerListeners": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
@@ -85,6 +86,7 @@
     "LoadBalancerPools": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "<enter>": { "action": "ShowLoadBalancerPoolMembers", "description": "Members"},
+      "h": { "action": "ShowLoadBalancerPoolHealthMonitors", "description": "HealthMonitors"},
     },
     "LoadBalancerPoolMembers": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},

--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -153,12 +153,16 @@ pub enum Action {
     ShowLoadBalancerListeners,
     /// Set LB Pool filters
     SetLoadBalancerPoolFilters(cloud_types::LoadBalancerPoolFilters),
+    /// Show LB Listener Pools
+    ShowLoadBalancerListenerPools,
     /// Set LB Member filters
     SetLoadBalancerPoolMemberFilters(cloud_types::LoadBalancerPoolMemberFilters),
     /// Show LB Pool members
     ShowLoadBalancerPoolMembers,
     /// Set LB Healthmonitor filters
     SetLoadBalancerHealthMonitorFilters(cloud_types::LoadBalancerHealthMonitorFilters),
+    /// Show LB Listener Pools
+    ShowLoadBalancerPoolHealthMonitors,
 
     // Network (neutron)
     /// Set Security group filters

--- a/openstack_tui/src/cloud_worker/load_balancer.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer.rs
@@ -109,10 +109,9 @@ impl LoadBalancerExt for Cloud {
     async fn get_listeners(&mut self, filters: &LoadBalancerListenerFilters) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
             let ep =
-                //openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilder::try_from(
-                //    filters,
-                //)?
-                openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilder::default()
+                openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilder::try_from(
+                    filters,
+                )?
                 .build()?;
 
             let res: Vec<Value> = ep.query_async(session).await?;
@@ -121,9 +120,11 @@ impl LoadBalancerExt for Cloud {
         Ok(Vec::new())
     }
 
-    async fn get_load_balancers(&mut self, _filters: &LoadBalancerFilters) -> Result<Vec<Value>> {
+    async fn get_load_balancers(&mut self, filters: &LoadBalancerFilters) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
-            let ep = openstack_sdk::api::load_balancer::v2::loadbalancer::list::Request::builder()
+            let ep = openstack_sdk::api::load_balancer::v2::loadbalancer::list::RequestBuilder::try_from(
+                    filters,
+                )?
                 .build()?;
 
             let res: Vec<Value> = ep.query_async(session).await?;
@@ -134,11 +135,10 @@ impl LoadBalancerExt for Cloud {
 
     async fn get_pools(&mut self, filters: &LoadBalancerPoolFilters) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
-            //let ep = openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilder::try_from(
-            //   filters,
-            //)?
-            let ep = openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilder::default()
-                .build()?;
+            let ep = openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilder::try_from(
+                filters,
+            )?
+            .build()?;
 
             let res: Vec<Value> = ep.query_async(session).await?;
             return Ok(res);
@@ -169,10 +169,9 @@ impl LoadBalancerExt for Cloud {
     ) -> Result<Vec<Value>> {
         if let Some(session) = &self.cloud {
             let ep =
-                //openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilder::try_from(
-                //    filters,
-                //)?
-                openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilder::default()
+                openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilder::try_from(
+                    filters,
+                )?
                 .build()?;
 
             let res: Vec<Value> = ep.query_async(session).await?;

--- a/openstack_tui/src/cloud_worker/load_balancer/types.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/types.rs
@@ -26,6 +26,19 @@ impl fmt::Display for LoadBalancerFilters {
     }
 }
 
+impl TryFrom<&LoadBalancerFilters>
+    for openstack_sdk::api::load_balancer::v2::loadbalancer::list::RequestBuilder<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(_value: &LoadBalancerFilters) -> Result<Self, Self::Error> {
+        let ep_builder =
+            openstack_sdk::api::load_balancer::v2::loadbalancer::list::Request::builder();
+
+        Ok(ep_builder)
+    }
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadBalancerListenerFilters {
     pub loadbalancer_id: Option<String>,
@@ -48,57 +61,71 @@ impl fmt::Display for LoadBalancerListenerFilters {
     }
 }
 
-// impl TryFrom<&LoadBalancerListenerFilters>
-//     for openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilder<'_>
-// {
-//     type Error = eyre::Report;
-//
-//     fn try_from(value: &LoadBalancerListenerFilters) -> Result<Self, Self::Error> {
-//         let ep_builder = openstack_sdk::api::load_balancer::v2::listener::list::Request::builder();
-//
-//         if let Some(_lb_id) = &value.loadbalancer_id {
-//             // TODO
-//             //ep_builder.loadbalancer_id(lb_id.clone());
-//         }
-//
-//         Ok(ep_builder)
-//     }
-// }
+impl TryFrom<&LoadBalancerListenerFilters>
+    for openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilder<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(value: &LoadBalancerListenerFilters) -> Result<Self, Self::Error> {
+        let mut ep_builder =
+            openstack_sdk::api::load_balancer::v2::listener::list::Request::builder();
+
+        if let Some(lb_id) = &value.loadbalancer_id {
+            ep_builder.load_balancer_id(lb_id.clone());
+        }
+
+        Ok(ep_builder)
+    }
+}
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadBalancerPoolFilters {
-    //pub loadbalancer_id: Option<String>,
-    //pub loadbalancer_name: Option<String>,
+    // pub loadbalancer_id: Option<String>,
+    // pub loadbalancer_name: Option<String>,
+    // pub listener_id: Option<String>,
+    // pub listener_name: Option<String>,
 }
 
 impl fmt::Display for LoadBalancerPoolFilters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-        //let mut parts: Vec<String> = Vec::new();
-        //if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
-        //    parts.push(format!(
-        //        "lb: {}",
-        //        self.loadbalancer_name
-        //            .as_ref()
-        //            .or(self.loadbalancer_id.as_ref())
-        //            .unwrap_or(&String::new())
-        //    ));
-        //}
-        //write!(f, "{}", parts.join(","))
+        let parts: Vec<String> = Vec::new();
+        // if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
+        //     parts.push(format!(
+        //         "lb: {}",
+        //         self.loadbalancer_name
+        //             .as_ref()
+        //             .or(self.loadbalancer_id.as_ref())
+        //             .unwrap_or(&String::new())
+        //     ));
+        // }
+        // if self.listener_id.is_some() || self.listener_name.is_some() {
+        //     parts.push(format!(
+        //         "lsnr: {}",
+        //         self.listener_name
+        //             .as_ref()
+        //             .or(self.listener_id.as_ref())
+        //             .unwrap_or(&String::new())
+        //     ));
+        // }
+        write!(f, "{}", parts.join(","))
     }
 }
 
-// impl TryFrom<&LoadBalancerPoolFilters>
-//     for openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilder<'_>
-// {
-//     type Error = eyre::Report;
-//
-//     fn try_from(_value: &LoadBalancerPoolFilters) -> Result<Self, Self::Error> {
-//         let ep_builder = openstack_sdk::api::load_balancer::v2::pool::list::Request::builder();
-//
-//         Ok(ep_builder)
-//     }
-// }
+impl TryFrom<&LoadBalancerPoolFilters>
+    for openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilder<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(_value: &LoadBalancerPoolFilters) -> Result<Self, Self::Error> {
+        let ep_builder = openstack_sdk::api::load_balancer::v2::pool::list::Request::builder();
+
+        // if let Some(val) = &value.loadbalancer_id {
+        //     ep_builder.load_balancer_id(val.clone());
+        // }
+
+        Ok(ep_builder)
+    }
+}
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadBalancerPoolMemberFilters {
@@ -134,36 +161,39 @@ impl TryFrom<&LoadBalancerPoolMemberFilters>
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadBalancerHealthMonitorFilters {
-    //pub loadbalancer_id: Option<String>,
-    //pub loadbalancer_name: Option<String>,
+    pub pool_id: Option<String>,
+    pub pool_name: Option<String>,
 }
 
 impl fmt::Display for LoadBalancerHealthMonitorFilters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-        //let mut parts: Vec<String> = Vec::new();
-        //if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
-        //    parts.push(format!(
-        //        "lb: {}",
-        //        self.loadbalancer_name
-        //            .as_ref()
-        //            .or(self.loadbalancer_id.as_ref())
-        //            .unwrap_or(&String::new())
-        //    ));
-        //}
-        //write!(f, "{}", parts.join(","))
+        let mut parts: Vec<String> = Vec::new();
+        if self.pool_id.is_some() || self.pool_id.is_some() {
+            parts.push(format!(
+                "pool: {}",
+                self.pool_name
+                    .as_ref()
+                    .or(self.pool_id.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
+        write!(f, "{}", parts.join(","))
     }
 }
 
-// impl TryFrom<&LoadBalancerHealthMonitorFilters>
-//     for openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilder<'_>
-// {
-//     type Error = eyre::Report;
-//
-//     fn try_from(_value: &LoadBalancerHealthMonitorFilters) -> Result<Self, Self::Error> {
-//         let ep_builder =
-//             openstack_sdk::api::load_balancer::v2::healthmonitor::list::Request::builder();
-//
-//         Ok(ep_builder)
-//     }
-// }
+impl TryFrom<&LoadBalancerHealthMonitorFilters>
+    for openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilder<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(value: &LoadBalancerHealthMonitorFilters) -> Result<Self, Self::Error> {
+        let mut ep_builder =
+            openstack_sdk::api::load_balancer::v2::healthmonitor::list::Request::builder();
+
+        if let Some(val) = &value.pool_id {
+            ep_builder.pool_id(val.clone());
+        }
+
+        Ok(ep_builder)
+    }
+}


### PR DESCRIPTION
Sadly there is no reasonable way how to extract information about
supported query parameters ouf ot Octavia code. Moreover there is even
no documentation about that except of basic statement "The Octavia API
v2 supports filtering based on all top level attributes of a resource"
which is only partially true. So for now hardcode those parameter
schemas as known by OpenStackSDK (with exception of definitely wrong
ones).

Change-Id: I3684a6e7d31c8ac8842049373291b234574590aa

Changes are triggered by https://review.opendev.org/936274
