### PR TITLE
feat: Add loadbalancer_id QP to octavia pools

### DIFF
--- a/openstack_cli/src/load_balancer/v2/pool/list.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/list.rs
@@ -92,6 +92,11 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     id: Option<String>,
 
+    /// The ID of the load balancer for the pool.
+    ///
+    #[arg(help_heading = "Query parameters", long)]
+    loadbalancer_id: Option<String>,
+
     /// Human-readable name of the resource.
     ///
     #[arg(help_heading = "Query parameters", long)]
@@ -430,6 +435,9 @@ impl PoolsCommand {
         }
         if let Some(val) = &self.query.updated_at {
             ep_builder.updated_at(val);
+        }
+        if let Some(val) = &self.query.loadbalancer_id {
+            ep_builder.loadbalancer_id(val);
         }
         if let Some(val) = &self.query.tls_enabled {
             ep_builder.tls_enabled(*val);

--- a/openstack_sdk/src/api/load_balancer/v2/pool/list.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/pool/list.rs
@@ -62,6 +62,11 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     id: Option<Cow<'a, str>>,
 
+    /// The ID of the load balancer for the pool.
+    ///
+    #[builder(default, setter(into))]
+    loadbalancer_id: Option<Cow<'a, str>>,
+
     /// Human-readable name of the resource.
     ///
     #[builder(default, setter(into))]
@@ -175,6 +180,7 @@ impl<'a> RestEndpoint for Request<'a> {
         params.push_opt("admin_state_up", self.admin_state_up);
         params.push_opt("created_at", self.created_at.as_ref());
         params.push_opt("updated_at", self.updated_at.as_ref());
+        params.push_opt("loadbalancer_id", self.loadbalancer_id.as_ref());
         params.push_opt("tls_enabled", self.tls_enabled);
         params.push_opt("tls_ciphers", self.tls_ciphers.as_ref());
         params.push_opt("tls_versions", self.tls_versions.as_ref());

--- a/openstack_tui/.config/config.json5
+++ b/openstack_tui/.config/config.json5
@@ -79,6 +79,7 @@
     "LoadBalancers": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
       "l": { "action": "ShowLoadBalancerListeners", "description": "Listeners"},
+      "p": { "action": "ShowLoadBalancerPools", "description": "Pools"},
     },
     "LoadBalancerListeners": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},

--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -151,6 +151,8 @@ pub enum Action {
     SetLoadBalancerListenerFilters(cloud_types::LoadBalancerListenerFilters),
     /// Show LB Listeners
     ShowLoadBalancerListeners,
+    /// Show LB Pools
+    ShowLoadBalancerPools,
     /// Set LB Pool filters
     SetLoadBalancerPoolFilters(cloud_types::LoadBalancerPoolFilters),
     /// Show LB Listener Pools

--- a/openstack_tui/src/cloud_worker/load_balancer/types.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/types.rs
@@ -80,33 +80,22 @@ impl TryFrom<&LoadBalancerListenerFilters>
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadBalancerPoolFilters {
-    // pub loadbalancer_id: Option<String>,
-    // pub loadbalancer_name: Option<String>,
-    // pub listener_id: Option<String>,
-    // pub listener_name: Option<String>,
+    pub loadbalancer_id: Option<String>,
+    pub loadbalancer_name: Option<String>,
 }
 
 impl fmt::Display for LoadBalancerPoolFilters {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let parts: Vec<String> = Vec::new();
-        // if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
-        //     parts.push(format!(
-        //         "lb: {}",
-        //         self.loadbalancer_name
-        //             .as_ref()
-        //             .or(self.loadbalancer_id.as_ref())
-        //             .unwrap_or(&String::new())
-        //     ));
-        // }
-        // if self.listener_id.is_some() || self.listener_name.is_some() {
-        //     parts.push(format!(
-        //         "lsnr: {}",
-        //         self.listener_name
-        //             .as_ref()
-        //             .or(self.listener_id.as_ref())
-        //             .unwrap_or(&String::new())
-        //     ));
-        // }
+        let mut parts: Vec<String> = Vec::new();
+        if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
+            parts.push(format!(
+                "lb: {}",
+                self.loadbalancer_name
+                    .as_ref()
+                    .or(self.loadbalancer_id.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
         write!(f, "{}", parts.join(","))
     }
 }
@@ -116,12 +105,12 @@ impl TryFrom<&LoadBalancerPoolFilters>
 {
     type Error = eyre::Report;
 
-    fn try_from(_value: &LoadBalancerPoolFilters) -> Result<Self, Self::Error> {
-        let ep_builder = openstack_sdk::api::load_balancer::v2::pool::list::Request::builder();
+    fn try_from(value: &LoadBalancerPoolFilters) -> Result<Self, Self::Error> {
+        let mut ep_builder = openstack_sdk::api::load_balancer::v2::pool::list::Request::builder();
 
-        // if let Some(val) = &value.loadbalancer_id {
-        //     ep_builder.load_balancer_id(val.clone());
-        // }
+        if let Some(val) = &value.loadbalancer_id {
+            ep_builder.loadbalancer_id(val.clone());
+        }
 
         Ok(ep_builder)
     }

--- a/openstack_tui/src/components/load_balancer/loadbalancers.rs
+++ b/openstack_tui/src/components/load_balancer/loadbalancers.rs
@@ -21,7 +21,9 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ApiRequest, LoadBalancerFilters, LoadBalancerListenerFilters},
+    cloud_worker::types::{
+        ApiRequest, LoadBalancerFilters, LoadBalancerListenerFilters, LoadBalancerPoolFilters,
+    },
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -101,7 +103,7 @@ impl Component for LoadBalancers<'_> {
                     if let Some(command_tx) = self.get_command_tx() {
                         // and have a selected entry
                         if let Some(selected_entry) = self.get_selected() {
-                            // send action to set SecurityGroupRulesFilters
+                            // send action to set filters
                             command_tx.send(Action::SetLoadBalancerListenerFilters(
                                 LoadBalancerListenerFilters {
                                     loadbalancer_id: Some(selected_entry.id.clone()),
@@ -110,6 +112,28 @@ impl Component for LoadBalancers<'_> {
                             ))?;
                             return Ok(Some(Action::Mode {
                                 mode: Mode::LoadBalancerListeners,
+                                stack: true,
+                            }));
+                        }
+                    }
+                }
+            }
+            Action::ShowLoadBalancerPools => {
+                // only if we are currently in the right mode
+                if current_mode == Mode::LoadBalancers {
+                    // and have command_tx
+                    if let Some(command_tx) = self.get_command_tx() {
+                        // and have a selected entry
+                        if let Some(selected_entry) = self.get_selected() {
+                            // send action to set filters
+                            command_tx.send(Action::SetLoadBalancerPoolFilters(
+                                LoadBalancerPoolFilters {
+                                    loadbalancer_id: Some(selected_entry.id.clone()),
+                                    loadbalancer_name: Some(selected_entry.name.clone()),
+                                },
+                            ))?;
+                            return Ok(Some(Action::Mode {
+                                mode: Mode::LoadBalancerPools,
                                 stack: true,
                             }));
                         }


### PR DESCRIPTION
Previously loadbalancer_id query parameter for listing pools was missed.
OpenStackSDK also states listener_id is supported, but practice showed
it is not really the case.

Change-Id: Id8855a509af146d860d233af3bca35aa6b754c72

Changes are triggered by https://review.opendev.org/936432
