### PR TITLE
chore: Install sarif tools using binstall

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  rust_min: 1.75.0
+  rust_min: 1.76.0
 
 jobs:
   rustfmt:
@@ -71,10 +71,15 @@ jobs:
           toolchain: ${{ env.rust_min }}
           components: rustfmt, clippy
 
-      - name: Install required cargo
-        run: cargo install clippy-sarif sarif-fmt
-
       - uses: swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2.7.5
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@678b06b887cdbf44fa0601e5915f865e17c2241d # v2.44.60
+        with:
+          tool: cargo-binstall
+
+      - name: Install required cargo
+        run: cargo binstall clippy-sarif sarif-fmt
 
       - name: Run rust-clippy
         run:


### PR DESCRIPTION
sarif tools building takes time and requires higher msrv than our
project, so install them as binaries using cargo-binstall
