### PR TITLE
fix: Auth with project_id and no domain info set

### DIFF
--- a/openstack_sdk/src/auth/authtoken_scope.rs
+++ b/openstack_sdk/src/auth/authtoken_scope.rs
@@ -132,7 +132,13 @@ impl TryFrom<&config::CloudConfig> for AuthTokenScope {
             // Project scope
             Ok(AuthTokenScope::Project(Project {
                 id: auth.project_id.clone(),
-                name: auth.project_name.clone(),
+                // Keystone checks for presence of project_name before project_id therefore it fail
+                // when project_domain is not set. project_id alone is sufficient.
+                name: if auth.project_id.is_none() {
+                    auth.project_name.clone()
+                } else {
+                    None
+                },
                 domain: types_v3::get_domain(auth.project_domain_id, auth.project_domain_name),
             }))
         } else if auth.domain_id.is_some() || auth.domain_name.is_some() {

--- a/openstack_sdk/src/types/identity/v3.rs
+++ b/openstack_sdk/src/types/identity/v3.rs
@@ -115,6 +115,7 @@ pub struct ApplicationCredential {
     /// of other application credentials or trusts.
     pub restricted: Option<bool>,
 }
+
 /// Build Domain type if id or name are given
 #[inline]
 pub(crate) fn get_domain(id: Option<String>, name: Option<String>) -> Option<Domain> {


### PR DESCRIPTION
When project_id is set in the auth but no project_domain is present
Keystone refuses to auth since it checks project_name before the
project_id (which is normally sufficient and does not require
domain_infos). When project_id is present in the auth config do not set
project_name.
