### PR TITLE
feat: Add `status` structable macros for alternative field

### DIFF
--- a/openstack_cli/src/load_balancer/v2/healthmonitor/list.rs
+++ b/openstack_cli/src/load_balancer/v2/healthmonitor/list.rs
@@ -312,7 +312,7 @@ struct ResponseData {
     /// [Operating Status Codes](#op-status).
     ///
     #[serde()]
-    #[structable(optional, wide)]
+    #[structable(optional, status)]
     operating_status: Option<String>,
 
     #[serde()]

--- a/openstack_cli/src/load_balancer/v2/l7policy/list.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/list.rs
@@ -194,7 +194,7 @@ struct ResponseData {
     /// [Operating Status Codes](#op-status).
     ///
     #[serde()]
-    #[structable(optional, wide)]
+    #[structable(optional, status)]
     operating_status: Option<String>,
 
     /// The position of this policy on the listener. Positions start at 1.

--- a/openstack_cli/src/load_balancer/v2/l7policy/rule/list.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/rule/list.rs
@@ -197,7 +197,7 @@ struct ResponseData {
     /// [Operating Status Codes](#op-status).
     ///
     #[serde()]
-    #[structable(optional, wide)]
+    #[structable(optional, status)]
     operating_status: Option<String>,
 
     /// The ID of the project owning this resource.

--- a/openstack_cli/src/load_balancer/v2/listener/list.rs
+++ b/openstack_cli/src/load_balancer/v2/listener/list.rs
@@ -413,7 +413,7 @@ struct ResponseData {
     /// [Operating Status Codes](#op-status).
     ///
     #[serde()]
-    #[structable(optional, wide)]
+    #[structable(optional, status)]
     operating_status: Option<String>,
 
     /// The ID of the project owning this resource.

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/list.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/list.rs
@@ -275,7 +275,7 @@ struct ResponseData {
     /// [Operating Status Codes](#op-status).
     ///
     #[serde()]
-    #[structable(optional, wide)]
+    #[structable(optional, status)]
     operating_status: Option<String>,
 
     /// The associated pool IDs, if any.

--- a/openstack_cli/src/load_balancer/v2/pool/list.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/list.rs
@@ -292,7 +292,7 @@ struct ResponseData {
     /// [Operating Status Codes](#op-status).
     ///
     #[serde()]
-    #[structable(optional, wide)]
+    #[structable(optional, status)]
     operating_status: Option<String>,
 
     /// The ID of the project owning this resource.

--- a/openstack_cli/src/load_balancer/v2/pool/member/list.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/member/list.rs
@@ -278,7 +278,7 @@ struct ResponseData {
     /// [Operating Status Codes](#op-status).
     ///
     #[serde()]
-    #[structable(optional, wide)]
+    #[structable(optional, status)]
     operating_status: Option<String>,
 
     /// The ID of the project owning this resource.

--- a/openstack_cli/src/network/v2/availability_zone/list.rs
+++ b/openstack_cli/src/network/v2/availability_zone/list.rs
@@ -145,7 +145,7 @@ struct ResponseData {
     /// `unavailable`.
     ///
     #[serde()]
-    #[structable(optional)]
+    #[structable(optional, status)]
     state: Option<String>,
 }
 


### PR DESCRIPTION
Some resources uses `state` or `operating_status` as a sort of `status`
property. Set `status` StructTable marcros for such fields so that
output coloring use those fields.

Change-Id: I1c1faa0f69e1d22b6230db2df90a981ca496e643

Changes are triggered by https://review.opendev.org/936928
