### PR TITLE
feat: Add support for system scope

### DIFF
--- a/openstack_sdk/src/config.rs
+++ b/openstack_sdk/src/config.rs
@@ -242,6 +242,9 @@ pub struct Auth {
     pub(crate) application_credential_name: Option<String>,
     /// `Application Credential` Secret
     pub(crate) application_credential_secret: Option<String>,
+
+    /// `System scope`
+    pub(crate) system_scope: Option<String>,
 }
 
 impl fmt::Debug for Auth {
@@ -268,6 +271,7 @@ impl fmt::Debug for Auth {
                 "application_credential_secret",
                 &self.application_credential_secret,
             )
+            .field("system_scope", &self.system_scope)
             .finish()
     }
 }
@@ -337,6 +341,9 @@ pub fn get_config_identity_hash(config: &CloudConfig) -> u64 {
             data.hash(&mut s);
         }
         if let Some(data) = &auth.application_credential_id {
+            data.hash(&mut s);
+        }
+        if let Some(data) = &auth.system_scope {
             data.hash(&mut s);
         }
     }
@@ -418,6 +425,9 @@ impl CloudConfig {
             {
                 auth.application_credential_secret
                     .clone_from(&update_auth.application_credential_secret);
+            }
+            if auth.system_scope.is_none() && update_auth.system_scope.is_some() {
+                auth.system_scope.clone_from(&update_auth.system_scope);
             }
         }
         if self.auth_type.is_none() && update.auth_type.is_some() {

--- a/openstack_sdk/src/state.rs
+++ b/openstack_sdk/src/state.rs
@@ -213,6 +213,14 @@ impl State {
                         }
                     }
                 }
+                AuthTokenScope::System(system) => {
+                    if let AuthTokenScope::System(cached) = k {
+                        // Scope type matches
+                        if system.all == cached.all {
+                            return Some((k.clone(), v.clone()));
+                        }
+                    }
+                }
                 AuthTokenScope::Unscoped => {
                     if let AuthTokenScope::Unscoped = k {
                         return Some((k.clone(), v.clone()));

--- a/openstack_sdk/src/types/identity/v3.rs
+++ b/openstack_sdk/src/types/identity/v3.rs
@@ -36,6 +36,7 @@ pub struct AuthToken {
     pub user: User,
     pub project: Option<Project>,
     pub domain: Option<Domain>,
+    pub system: Option<System>,
     pub issued_at: Option<DateTime<Local>>,
     pub expires_at: DateTime<Local>,
 }
@@ -86,6 +87,13 @@ pub struct Project {
 pub struct Domain {
     pub id: Option<String>,
     pub name: Option<String>,
+}
+
+/// System Scope
+///
+#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize, Debug)]
+pub struct System {
+    pub all: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
`system_scope: all` entry in the clouds.yaml will be treated as system
scope same as python-openstackclient does
