### PR TITLE
feat: Enable identity endpoint-filter commands

### DIFF
--- a/openstack_cli/src/identity/v3.rs
+++ b/openstack_cli/src/identity/v3.rs
@@ -25,6 +25,7 @@ mod domain;
 mod endpoint;
 mod group;
 mod limit;
+mod os_ep_filter;
 mod os_federation;
 mod project;
 mod region;
@@ -66,6 +67,8 @@ pub enum IdentityCommands {
     Credential(credential::CredentialCommand),
     Domain(domain::DomainCommand),
     Endpoint(endpoint::EndpointCommand),
+    #[command(alias = "OS-EP-FILTER")]
+    EndpointFilter(os_ep_filter::EndpointFilterCommand),
     Federation(os_federation::FederationCommand),
     Group(group::GroupCommand),
     Limit(limit::LimitCommand),
@@ -95,6 +98,7 @@ impl IdentityCommand {
             IdentityCommands::Credential(cmd) => cmd.take_action(parsed_args, session).await,
             IdentityCommands::Domain(cmd) => cmd.take_action(parsed_args, session).await,
             IdentityCommands::Endpoint(cmd) => cmd.take_action(parsed_args, session).await,
+            IdentityCommands::EndpointFilter(cmd) => cmd.take_action(parsed_args, session).await,
             IdentityCommands::Federation(cmd) => cmd.take_action(parsed_args, session).await,
             IdentityCommands::Group(cmd) => cmd.take_action(parsed_args, session).await,
             IdentityCommands::Limit(cmd) => cmd.take_action(parsed_args, session).await,

--- a/openstack_cli/src/identity/v3/os_ep_filter.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter.rs
@@ -1,0 +1,69 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity Endpoint Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod endpoint;
+mod endpoint_group;
+mod project;
+
+/// OS-EP-FILTER API
+///
+/// This API enables the creation of custom catalogs using project scope. The result is the ability
+/// to advertise specific endpoints based on the project in use. The association can be done two
+/// different ways. The first is by building a direct association between the project and the
+/// endpoint, which implies that all tokens scoped to that particular project will receive a
+/// specific endpoint, or set of endpoints, in the service catalog. The second is by creating an
+/// endpoint group. An endpoint group is a filter that consists of at least one endpoint attribute.
+/// By associating a project to an endpoint group, all service catalogs scoped to that project will
+/// contain endpoints that match the attributes defined in the endpoint group. Using endpoint
+/// groups is a way to dynamically associate an endpoint, or a group of endpoints, to a specific
+/// project.
+#[derive(Parser)]
+pub struct EndpointFilterCommand {
+    #[command(subcommand)]
+    command: EndpointFilterCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum EndpointFilterCommands {
+    Endpoint(Box<endpoint::EndpointCommand>),
+    EndpointGroup(Box<endpoint_group::EndpointGroupCommand>),
+    Project(Box<project::ProjectCommand>),
+}
+
+impl EndpointFilterCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            EndpointFilterCommands::Endpoint(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointFilterCommands::EndpointGroup(cmd) => {
+                cmd.take_action(parsed_args, session).await
+            }
+            EndpointFilterCommands::Project(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint.rs
@@ -1,0 +1,50 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity Endpoint Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod project;
+
+/// Endpoint project API
+#[derive(Parser)]
+pub struct EndpointCommand {
+    #[command(subcommand)]
+    command: EndpointCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum EndpointCommands {
+    Project(Box<project::ProjectCommand>),
+}
+
+impl EndpointCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            EndpointCommands::Project(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint/project.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint/project.rs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity Endpoint Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod get;
+
+/// Endpoint project API
+#[derive(Parser)]
+pub struct ProjectCommand {
+    #[command(subcommand)]
+    command: ProjectCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum ProjectCommands {
+    #[command(alias = "get")]
+    List(Box<get::ProjectCommand>),
+}
+
+impl ProjectCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            ProjectCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group.rs
@@ -1,0 +1,68 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity EndpointGroup Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod create;
+mod delete;
+mod endpoint;
+mod list;
+mod project;
+mod set;
+mod show;
+
+/// EndpointGroup project API
+#[derive(Parser)]
+pub struct EndpointGroupCommand {
+    #[command(subcommand)]
+    command: EndpointGroupCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum EndpointGroupCommands {
+    Create(Box<create::EndpointGroupCommand>),
+    Delete(Box<delete::EndpointGroupCommand>),
+    Endpoint(Box<endpoint::EndpointCommand>),
+    List(Box<list::EndpointGroupsCommand>),
+    Project(Box<project::ProjectCommand>),
+    Set(Box<set::EndpointGroupCommand>),
+    Show(Box<show::EndpointGroupCommand>),
+}
+
+impl EndpointGroupCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            EndpointGroupCommands::Create(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointGroupCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointGroupCommands::Endpoint(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointGroupCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointGroupCommands::Project(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointGroupCommands::Set(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointGroupCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/create.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/create.rs
@@ -31,7 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_json;
 use crate::common::parse_key_val;
 use openstack_sdk::api::identity::v3::os_ep_filter::endpoint_group::create;
 use openstack_sdk::api::QueryAsync;

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/endpoint.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/endpoint.rs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity Endpointg Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod get;
+
+/// Endpoint project API
+#[derive(Parser)]
+pub struct EndpointCommand {
+    #[command(subcommand)]
+    command: EndpointCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum EndpointCommands {
+    #[command(alias = "get")]
+    List(Box<get::EndpointCommand>),
+}
+
+impl EndpointCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            EndpointCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity Project Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod delete;
+mod list;
+mod set;
+mod show;
+
+/// Project project API
+#[derive(Parser)]
+pub struct ProjectCommand {
+    #[command(subcommand)]
+    command: ProjectCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum ProjectCommands {
+    Delete(Box<delete::ProjectCommand>),
+    List(Box<list::ProjectsCommand>),
+    Set(Box<set::ProjectCommand>),
+    Show(Box<show::ProjectCommand>),
+}
+
+impl ProjectCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            ProjectCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            ProjectCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            ProjectCommands::Set(cmd) => cmd.take_action(parsed_args, session).await,
+            ProjectCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project/delete.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project/delete.rs
@@ -32,8 +32,6 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use bytes::Bytes;
-use eyre::eyre;
-use eyre::OptionExt;
 use http::Response;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_ep_filter::endpoint_group::project::delete;

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project/set.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project/set.rs
@@ -31,10 +31,7 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_json;
 use crate::common::parse_key_val;
-use eyre::eyre;
-use eyre::OptionExt;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_ep_filter::endpoint_group::project::set;
 use openstack_sdk::api::identity::v3::project::find as find_project;

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project/show.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/project/show.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use eyre::eyre;
-use eyre::OptionExt;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_ep_filter::endpoint_group::project::get;
 use openstack_sdk::api::identity::v3::project::find as find_project;

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/set.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/set.rs
@@ -31,7 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_json;
 use crate::common::parse_key_val;
 use openstack_sdk::api::identity::v3::os_ep_filter::endpoint_group::set;
 use openstack_sdk::api::QueryAsync;

--- a/openstack_cli/src/identity/v3/os_ep_filter/project.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project.rs
@@ -1,0 +1,53 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity Endpoint Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod endpoint;
+mod endpoint_group;
+
+/// Endpoint project API
+#[derive(Parser)]
+pub struct ProjectCommand {
+    #[command(subcommand)]
+    command: ProjectCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum ProjectCommands {
+    Endpoint(Box<endpoint::EndpointCommand>),
+    EndpointGroup(Box<endpoint_group::EndpointGroupCommand>),
+}
+
+impl ProjectCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            ProjectCommands::Endpoint(cmd) => cmd.take_action(parsed_args, session).await,
+            ProjectCommands::EndpointGroup(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint.rs
@@ -1,0 +1,59 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity Endpoint Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod delete;
+mod list;
+mod set;
+mod show;
+
+/// Endpoint project API
+#[derive(Parser)]
+pub struct EndpointCommand {
+    #[command(subcommand)]
+    command: EndpointCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum EndpointCommands {
+    Delete(Box<delete::EndpointCommand>),
+    List(Box<list::EndpointsCommand>),
+    Set(Box<set::EndpointCommand>),
+    Show(Box<show::EndpointCommand>),
+}
+
+impl EndpointCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            EndpointCommands::Delete(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointCommands::Set(cmd) => cmd.take_action(parsed_args, session).await,
+            EndpointCommands::Show(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/set.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint/set.rs
@@ -31,7 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_json;
 use crate::common::parse_key_val;
 use eyre::eyre;
 use eyre::OptionExt;

--- a/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint_group.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/project/endpoint_group.rs
@@ -1,0 +1,51 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity EndpointGroup Filter commands
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::AsyncOpenStack;
+
+use crate::{Cli, OpenStackCliError};
+
+mod get;
+
+/// EndpointGroup project API
+#[derive(Parser)]
+pub struct EndpointGroupCommand {
+    #[command(subcommand)]
+    command: EndpointGroupCommands,
+}
+
+/// Supported subcommands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum EndpointGroupCommands {
+    #[command(alias = "get")]
+    List(Box<get::EndpointGroupCommand>),
+}
+
+impl EndpointGroupCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            EndpointGroupCommands::List(cmd) => cmd.take_action(parsed_args, session).await,
+        }
+    }
+}

--- a/openstack_cli/tests/identity/v3/os_ep_filter/endpoint/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/endpoint/mod.rs
@@ -12,23 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
-mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
 mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +21,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args(["identity", "endpoint-filter", "endpoint", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/endpoint/project/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/endpoint/project/mod.rs
@@ -12,23 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
-mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
-mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
+mod get_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +21,13 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args([
+        "identity",
+        "endpoint-filter",
+        "endpoint",
+        "project",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/endpoint_group/endpoint/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/endpoint_group/endpoint/mod.rs
@@ -12,23 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
-mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
-mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
+mod get_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +21,13 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args([
+        "identity",
+        "endpoint-filter",
+        "endpoint-group",
+        "endpoint",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/endpoint_group/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/endpoint_group/mod.rs
@@ -12,23 +12,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
+mod create_autogen;
+mod delete_autogen;
 mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
+mod list_autogen;
 mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
+mod set_autogen;
+mod show_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +27,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args(["identity", "endpoint-filter", "endpoint-group", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/endpoint_group/project/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/endpoint_group/project/mod.rs
@@ -12,23 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
-mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
-mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
+mod delete_autogen;
+mod list_autogen;
+mod set_autogen;
+mod show_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +24,13 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args([
+        "identity",
+        "endpoint-filter",
+        "endpoint-group",
+        "project",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/mod.rs
@@ -12,23 +12,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
 mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
+mod endpoint_group;
 mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +23,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args(["identity", "endpoint-filter", "--help"]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/project/endpoint/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/project/endpoint/mod.rs
@@ -12,23 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
-mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
-mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
+mod delete_autogen;
+mod list_autogen;
+mod set_autogen;
+mod show_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +24,13 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args([
+        "identity",
+        "endpoint-filter",
+        "project",
+        "endpoint",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/project/endpoint_group/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/project/endpoint_group/mod.rs
@@ -12,23 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
-mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
-mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
+mod get_autogen;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +21,13 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args([
+        "identity",
+        "endpoint-filter",
+        "project",
+        "endpoint-group",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v3/os_ep_filter/project/mod.rs
+++ b/openstack_cli/tests/identity/v3/os_ep_filter/project/mod.rs
@@ -12,23 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod auth;
-// mod catalog;
-mod credential;
-mod domain;
 mod endpoint;
-mod group;
-mod limit;
-mod os_ep_filter;
-mod os_federation;
-mod project;
-mod region;
-mod registered_limit;
-mod role;
-mod role_assignment;
-mod role_inference;
-mod service;
-mod user;
+mod endpoint_group;
 
 use assert_cmd::prelude::*;
 use std::process::Command;
@@ -37,7 +22,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.arg("identity").arg("--help");
+    cmd.args(["identity", "endpoint-filter", "project", "--help"]);
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
Those are not very useful for now since we miss majority of the openapi
schemas, but to ensure we get it right once the schemas are there
enabling commands.
