### PR TITLE
chore: Get rid of `to_string` where possible

### DIFF
--- a/openstack_sdk/README.md
+++ b/openstack_sdk/README.md
@@ -49,7 +49,7 @@ async fn list_flavors() -> Result<(), OpenStackError> {
 
     let cfg = ConfigFile::new().unwrap();
     // Get connection config from clouds.yaml/secure.yaml
-    let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+    let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
     // Establish connection
     let mut session = AsyncOpenStack::new(&profile).await?;
 

--- a/openstack_sdk/src/api.rs
+++ b/openstack_sdk/src/api.rs
@@ -25,7 +25,7 @@
 //!    # use openstack_sdk::{AsyncOpenStack, config::ConfigFile, OpenStackError};
 //!    # async fn func() -> Result<(), OpenStackError> {
 //!    # let cfg = ConfigFile::new().unwrap();
-//!    # let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+//!    # let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 //!    # let client = AsyncOpenStack::new(&profile).await?;
 //!    # let ep = openstack_sdk::api::compute::v2::flavor::get::Request::builder().build().unwrap();
 //!    let data_raw: serde_json::Value = ep.query_async(&client).await?;
@@ -44,7 +44,7 @@
 //!    # use bytes::Bytes;
 //!    # async fn func() -> Result<(), OpenStackError> {
 //!    # let cfg = ConfigFile::new().unwrap();
-//!    # let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+//!    # let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 //!    # let client = AsyncOpenStack::new(&profile).await?;
 //!    # let ep = openstack_sdk::api::compute::v2::flavor::get::Request::builder().build().unwrap();
 //!    let rsp: Response<Bytes> = ep.raw_query_async(&client).await?;
@@ -68,7 +68,7 @@
 //!    # use http::Response;
 //!    # async fn func() -> Result<(), OpenStackError> {
 //!    # let cfg = ConfigFile::new().unwrap();
-//!    # let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+//!    # let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 //!    # let client = AsyncOpenStack::new(&profile).await?;
 //!    # let ep = openstack_sdk::api::compute::v2::flavor::find::Request::builder().build().unwrap();
 //!    let data_raw: serde_json::Value = find(ep).query_async(&client).await?;
@@ -87,7 +87,7 @@
 //!    # use http::Response;
 //!    # async fn func() -> Result<(), OpenStackError> {
 //!    # let cfg = ConfigFile::new().unwrap();
-//!    # let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+//!    # let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 //!    # let client = AsyncOpenStack::new(&profile).await?;
 //!    # let ep = openstack_sdk::api::compute::v2::flavor::find::Request::builder().build().unwrap();
 //!    let data_raw: serde_json::Value = find_by_name(ep).query_async(&client).await?;
@@ -106,7 +106,7 @@
 //!    # use openstack_sdk::{AsyncOpenStack, config::ConfigFile, OpenStackError};
 //!    # async fn func() -> Result<(), OpenStackError> {
 //!    # let cfg = ConfigFile::new().unwrap();
-//!    # let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+//!    # let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 //!    # let client = AsyncOpenStack::new(&profile).await?;
 //!    # let ep = openstack_sdk::api::compute::v2::flavor::list::Request::builder().build().unwrap();
 //!    let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(100))
@@ -128,7 +128,7 @@
 //!    # use openstack_sdk::{AsyncOpenStack, config::ConfigFile, OpenStackError};
 //!    # async fn func() -> Result<(), OpenStackError> {
 //!    # let cfg = ConfigFile::new().unwrap();
-//!    # let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+//!    # let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 //!    # let client = AsyncOpenStack::new(&profile).await?;
 //!    # let ep = openstack_sdk::api::compute::v2::flavor::delete::Request::builder().build().unwrap();
 //!    ignore(ep).query_async(&client).await?;

--- a/openstack_sdk/src/api/find.rs
+++ b/openstack_sdk/src/api/find.rs
@@ -260,7 +260,7 @@ mod tests {
             format!("dummies/{}", self.id.as_ref()).into()
         }
         fn service_type(&self) -> ServiceType {
-            ServiceType::Other("dummy".to_string())
+            ServiceType::from("dummy")
         }
         fn response_key(&self) -> Option<Cow<'static, str>> {
             Some("resource".into())
@@ -285,10 +285,10 @@ mod tests {
         }
 
         fn endpoint(&self) -> Cow<'static, str> {
-            "dummies".to_string().into()
+            "dummies".into()
         }
         fn service_type(&self) -> ServiceType {
-            ServiceType::Other("dummy".to_string())
+            ServiceType::from("dummy")
         }
         fn response_key(&self) -> Option<Cow<'static, str>> {
             Some("resources".into())

--- a/openstack_sdk/src/api/ignore.rs
+++ b/openstack_sdk/src/api/ignore.rs
@@ -140,7 +140,7 @@ mod tests {
         }
 
         fn service_type(&self) -> ServiceType {
-            ServiceType::Other("dummy".to_string())
+            ServiceType::from("dummy")
         }
     }
 

--- a/openstack_sdk/src/api/paged.rs
+++ b/openstack_sdk/src/api/paged.rs
@@ -174,7 +174,7 @@ where
 
             debug!("raw data = {:?}", v.clone());
             if let Some(root_key) = self.endpoint.response_key() {
-                v = v[root_key.to_string()].take();
+                v = v[root_key.as_ref()].take();
             }
 
             if next_url.is_none() {
@@ -186,11 +186,11 @@ where
                     if let Some(last_page_element) = data.last() {
                         if let Some(id) = last_page_element.get("id") {
                             if let Some(val) = id.as_str() {
-                                marker = Some(String::from(val));
+                                marker = Some(val.into());
                             }
                         } else if let Some(id) = last_page_element.get("name") {
                             if let Some(val) = id.as_str() {
-                                marker = Some(String::from(val));
+                                marker = Some(val.into());
                             }
                         }
                     }
@@ -201,7 +201,7 @@ where
                 (self.endpoint.response_list_item_key(), v.as_array_mut())
             {
                 for elem in array {
-                    *elem = elem[item_key.to_string()].take();
+                    *elem = elem[item_key.as_ref()].take();
                 }
             }
             trace!("items data = {:?}", v.clone());

--- a/openstack_sdk/src/api/paged/iter.rs
+++ b/openstack_sdk/src/api/paged/iter.rs
@@ -118,8 +118,7 @@ impl Page {
                 }
             }
             Self::Number(page) => {
-                let page_str = page.to_string();
-                pairs.append_pair("page", &page_str);
+                pairs.append_pair("page", page.to_string().as_ref());
             }
             Self::Keyset(_) => {}
             Self::Done => {
@@ -274,7 +273,7 @@ where
         };
 
         if let Some(root_key) = self.paged.endpoint.response_key() {
-            v = v[root_key.to_string()].take();
+            v = v[root_key.as_ref()].take();
         }
 
         let mut marker: Option<String> = None;
@@ -305,7 +304,7 @@ where
             v.as_array_mut(),
         ) {
             for elem in array {
-                *elem = elem[item_key.to_string()].take();
+                *elem = elem[item_key.as_ref()].take();
             }
         }
 

--- a/openstack_sdk/src/api/paged/next_page.rs
+++ b/openstack_sdk/src/api/paged/next_page.rs
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn test_body_nova_links() {
         let data = json!({"flavors_links": [{"rel": "next", "href": "http://foo.bar"}]});
-        let key: Cow<'static, str> = Cow::Owned("flavors".to_string());
+        let key: Cow<'static, str> = Cow::Owned("flavors".into());
         let res = next_page_from_body(&data, &Some(key), Url::parse("http://dummy").unwrap());
         assert_eq!(res.unwrap().unwrap(), Url::parse("http://foo.bar").unwrap());
     }
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn test_body_no_links() {
         let data = json!({});
-        let key: Cow<'static, str> = Cow::Owned("flavors".to_string());
+        let key: Cow<'static, str> = Cow::Owned("flavors".into());
         let res = next_page_from_body(&data, &Some(key), Url::parse("http://dummy").unwrap());
         assert_eq!(res.unwrap(), None);
     }

--- a/openstack_sdk/src/api/rest_endpoint.rs
+++ b/openstack_sdk/src/api/rest_endpoint.rs
@@ -212,7 +212,7 @@ where
         //.with_context(|| format!("Request to `{}` failed", url))?;
 
         if let Some(root_key) = self.response_key() {
-            v = v[root_key.to_string()].take();
+            v = v[root_key.as_ref()].take();
         }
 
         let headers = rsp.headers();
@@ -249,7 +249,7 @@ where
         let mut v = get_json::<C>(&rsp, query_uri)?;
 
         if let Some(root_key) = self.response_key() {
-            v = v[root_key.to_string()].take();
+            v = v[root_key.as_ref()].take();
         }
 
         let headers = rsp.headers();
@@ -386,7 +386,7 @@ mod tests {
         }
 
         fn service_type(&self) -> ServiceType {
-            ServiceType::Other("dummy".to_string())
+            ServiceType::from("dummy")
         }
     }
 

--- a/openstack_sdk/src/auth/authtoken.rs
+++ b/openstack_sdk/src/auth/authtoken.rs
@@ -237,7 +237,7 @@ impl FromStr for AuthType {
             "v3multifactor" => Ok(Self::V3Multifactor),
             "v3websso" => Ok(Self::V3WebSso),
             other => Err(Self::Err::IdentityMethod {
-                auth_type: other.to_string(),
+                auth_type: other.into(),
             }),
         }
     }
@@ -288,7 +288,7 @@ fn process_auth_type(
         }
         other => {
             return Err(AuthTokenError::IdentityMethod {
-                auth_type: other.as_str().to_string(),
+                auth_type: other.as_str().into(),
             });
         }
     };

--- a/openstack_sdk/src/auth/v3applicationcredential.rs
+++ b/openstack_sdk/src/auth/v3applicationcredential.rs
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn test_fill_raise_no_secret() {
         let config = config::Auth {
-            application_credential_id: Some("foo".to_string()),
+            application_credential_id: Some("foo".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn test_fill_raise_neither_id_nor_name() {
         let config = config::Auth {
-            application_credential_secret: Some("foo".to_string()),
+            application_credential_secret: Some("foo".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -188,8 +188,8 @@ mod tests {
     #[test]
     fn test_fill_raise_no_user_when_name() {
         let config = config::Auth {
-            application_credential_secret: Some("foo".to_string()),
-            application_credential_name: Some("bar".to_string()),
+            application_credential_secret: Some("foo".into()),
+            application_credential_name: Some("bar".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -205,8 +205,8 @@ mod tests {
     #[test]
     fn test_fill_id_and_secret() {
         let config = config::Auth {
-            application_credential_id: Some("foo".to_string()),
-            application_credential_secret: Some("bar".to_string()),
+            application_credential_id: Some("foo".into()),
+            application_credential_secret: Some("bar".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -226,12 +226,12 @@ mod tests {
     #[test]
     fn test_fill_name_and_secret_and_user() {
         let config = config::Auth {
-            application_credential_name: Some("foo".to_string()),
-            application_credential_secret: Some("bar".to_string()),
-            user_id: Some("uid".to_string()),
-            username: Some("un".to_string()),
-            user_domain_id: Some("udi".to_string()),
-            user_domain_name: Some("udn".to_string()),
+            application_credential_name: Some("foo".into()),
+            application_credential_secret: Some("bar".into()),
+            user_id: Some("uid".into()),
+            username: Some("un".into()),
+            user_domain_id: Some("udi".into()),
+            user_domain_name: Some("udn".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();

--- a/openstack_sdk/src/auth/v3password.rs
+++ b/openstack_sdk/src/auth/v3password.rs
@@ -115,7 +115,7 @@ pub fn fill_identity(
             .with_prompt("User Password")
             .interact()
             .unwrap();
-        user.password(password.to_string());
+        user.password(password);
     } else {
         return Err(PasswordError::MissingPassword);
     }
@@ -150,7 +150,7 @@ mod tests {
     #[test]
     fn test_fill_raise_no_user_id_or_name() {
         let config = config::Auth {
-            password: Some("pass".to_string()),
+            password: Some("pass".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn test_fill_raise_no_password() {
         let config = config::Auth {
-            user_id: Some("uid".to_string()),
+            user_id: Some("uid".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -182,11 +182,11 @@ mod tests {
     #[test]
     fn test_fill() {
         let config = config::Auth {
-            user_id: Some("uid".to_string()),
-            username: Some("un".to_string()),
-            user_domain_id: Some("udi".to_string()),
-            user_domain_name: Some("udn".to_string()),
-            password: Some("pass".to_string()),
+            user_id: Some("uid".into()),
+            username: Some("un".into()),
+            user_domain_id: Some("udi".into()),
+            user_domain_name: Some("udn".into()),
+            password: Some("pass".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();

--- a/openstack_sdk/src/auth/v3token.rs
+++ b/openstack_sdk/src/auth/v3token.rs
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn test_fill() {
         let config = config::Auth {
-            token: Some("foo".to_string()),
+            token: Some("foo".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();

--- a/openstack_sdk/src/auth/v3totp.rs
+++ b/openstack_sdk/src/auth/v3totp.rs
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn test_fill_raise_no_user_id() {
         let config = config::Auth {
-            passcode: Some("pass".to_string()),
+            passcode: Some("pass".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn test_fill_raise_no_user_passcode() {
         let config = config::Auth {
-            user_id: Some("uid".to_string()),
+            user_id: Some("uid".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
@@ -173,11 +173,11 @@ mod tests {
     #[test]
     fn test_fill() {
         let config = config::Auth {
-            user_id: Some("uid".to_string()),
-            username: Some("un".to_string()),
-            user_domain_id: Some("udi".to_string()),
-            user_domain_name: Some("udn".to_string()),
-            passcode: Some("pass".to_string()),
+            user_id: Some("uid".into()),
+            username: Some("un".into()),
+            user_domain_id: Some("udi".into()),
+            user_domain_name: Some("udn".into()),
+            passcode: Some("pass".into()),
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();

--- a/openstack_sdk/src/auth/v3websso.rs
+++ b/openstack_sdk/src/auth/v3websso.rs
@@ -252,12 +252,7 @@ async fn handle_request(
             cancel_token.cancel();
 
             Ok(Response::builder()
-                .body(
-                    Full::new(Bytes::from(
-                        include_str!("../../static/callback.html").to_string(),
-                    ))
-                    .boxed(),
-                )
+                .body(Full::new(Bytes::from(include_str!("../../static/callback.html"))).boxed())
                 .unwrap())
         }
         _ => {
@@ -312,7 +307,7 @@ mod tests {
             .unwrap();
 
         websso_handle.await.unwrap().unwrap();
-        assert_eq!(*state.lock().unwrap(), Some(params[0].1.to_string()));
+        assert_eq!(*state.lock().unwrap(), Some(params[0].1.into()));
     }
 
     #[tokio::test]

--- a/openstack_sdk/src/catalog/discovery.rs
+++ b/openstack_sdk/src/catalog/discovery.rs
@@ -111,7 +111,7 @@ pub fn expand_link<S1: AsRef<str>, S2: AsRef<str>>(
         return Err(CatalogError::cannot_be_base(&url));
     }
     url.set_scheme(base_url.scheme())
-        .map_err(|_| CatalogError::UrlScheme(base_url.as_ref().to_string()))?;
+        .map_err(|_| CatalogError::UrlScheme(base_url.as_ref().into()))?;
     url.set_host(base_url.host_str())
         .map_err(|x| CatalogError::url_parse(x, url.as_ref()))?;
     if !url.as_str().ends_with('/') {
@@ -183,11 +183,11 @@ mod tests {
               "id": "v2.1"
         }))
         .unwrap();
-        assert_eq!("v2.1".to_string(), ev.id);
+        assert_eq!("v2.1", ev.id);
         assert_eq!(EndpointVersionStatus::Current, ev.status);
         assert_eq!(None, ev.version);
         assert_eq!(None, ev.min_version);
-        assert_eq!(Some("2.38".to_string()), ev.max_version);
+        assert_eq!(Some("2.38".into()), ev.max_version);
         assert_eq!(ApiVersion::new(2, 38), ev.get_api_version().unwrap());
 
         let ev: EndpointVersion = serde_json::from_value(json!({
@@ -203,15 +203,15 @@ mod tests {
               "id": "v2.1"
         }))
         .unwrap();
-        assert_eq!("v2.1".to_string(), ev.id);
+        assert_eq!("v2.1", ev.id);
         assert_eq!(EndpointVersionStatus::Current, ev.status);
-        assert_eq!(Some("2.38".to_string()), ev.version);
-        assert_eq!(Some("2.1".to_string()), ev.min_version);
+        assert_eq!(Some("2.38".into()), ev.version);
+        assert_eq!(Some("2.1".into()), ev.min_version);
         assert_eq!(None, ev.max_version);
         assert_eq!(
             Vec::from([Link {
-                href: "http://compute.example.com/v2.1/".to_string(),
-                rel: "self".to_string(),
+                href: "http://compute.example.com/v2.1/".into(),
+                rel: "self".into(),
             },]),
             ev.links
         );
@@ -227,14 +227,14 @@ mod tests {
     #[test]
     fn test_endpoint_version_normalize() {
         let version = EndpointVersion {
-            id: "v2.0".to_string(),
+            id: "v2.0".into(),
             status: EndpointVersionStatus::Supported,
-            version: Some("2.0".to_string()),
+            version: Some("2.0".into()),
             min_version: None,
             max_version: None,
             links: Vec::from([Link {
-                href: "http:///localhost/v2/".to_string(),
-                rel: "self".to_string(),
+                href: "http:///localhost/v2/".into(),
+                rel: "self".into(),
             }]),
         };
         let base_url = Url::parse("https://compute.example.com/").unwrap();
@@ -283,14 +283,14 @@ mod tests {
     #[test]
     fn test_endpoint_version_as_endpoint() {
         let version = EndpointVersion {
-            id: "v2.0".to_string(),
+            id: "v2.0".into(),
             status: EndpointVersionStatus::Supported,
-            version: Some("2.0".to_string()),
+            version: Some("2.0".into()),
             min_version: None,
             max_version: None,
             links: Vec::from([Link {
-                href: "http://compute.example.com/v2/".to_string(),
-                rel: "self".to_string(),
+                href: "http://compute.example.com/v2/".into(),
+                rel: "self".into(),
             }]),
         };
         let base_url = Url::parse("https://compute.example.com/").unwrap();
@@ -301,9 +301,9 @@ mod tests {
     #[test]
     fn test_endpoint_version_as_endpoint_no_self_link() {
         let version = EndpointVersion {
-            id: "v2.0".to_string(),
+            id: "v2.0".into(),
             status: EndpointVersionStatus::Supported,
-            version: Some("2.0".to_string()),
+            version: Some("2.0".into()),
             min_version: None,
             max_version: None,
             links: Vec::new(),
@@ -321,14 +321,14 @@ mod tests {
     #[test]
     fn test_endpoint_version_as_endpoint_bad_self_link() {
         let version = EndpointVersion {
-            id: "v2.0".to_string(),
+            id: "v2.0".into(),
             status: EndpointVersionStatus::Supported,
-            version: Some("2.0".to_string()),
+            version: Some("2.0".into()),
             min_version: None,
             max_version: None,
             links: Vec::from([Link {
-                href: "http://".to_string(),
-                rel: "self".to_string(),
+                href: "http://".into(),
+                rel: "self".into(),
             }]),
         };
         let base_url = Url::parse("https://compute.example.com/").unwrap();

--- a/openstack_sdk/src/catalog/error.rs
+++ b/openstack_sdk/src/catalog/error.rs
@@ -82,11 +82,11 @@ impl CatalogError {
     pub fn url_parse<S: AsRef<str>>(source: url::ParseError, url: S) -> Self {
         Self::UrlParse {
             source,
-            url: url.as_ref().to_string(),
+            url: url.as_ref().into(),
         }
     }
 
     pub fn cannot_be_base(url: &Url) -> Self {
-        Self::UrlCannotBeBase(url.as_str().to_string())
+        Self::UrlCannotBeBase(url.as_str().into())
     }
 }

--- a/openstack_sdk/src/catalog/service_endpoint.rs
+++ b/openstack_sdk/src/catalog/service_endpoint.rs
@@ -72,10 +72,10 @@ impl ServiceEndpoint {
     ) -> Result<Self, CatalogError> {
         let url = Url::parse(url.as_ref()).map_err(|x| CatalogError::url_parse(x, url.as_ref()))?;
         if url.cannot_be_a_base() {
-            return Err(CatalogError::UrlCannotBeBase(url.as_ref().to_string()));
+            return Err(CatalogError::UrlCannotBeBase(url.as_ref().into()));
         }
         if !["http", "https"].contains(&url.scheme()) {
-            return Err(CatalogError::UrlScheme(url.as_ref().to_string()));
+            return Err(CatalogError::UrlScheme(url.as_ref().into()));
         }
         let version = ApiVersion::from_url(&url, project_id.as_ref())?;
 
@@ -108,30 +108,30 @@ impl ServiceEndpoint {
 
     /// Set service type
     pub fn set_service_type<S: AsRef<str>>(&mut self, service_type: Option<S>) -> &mut Self {
-        self.service_type = service_type.map(|x| x.as_ref().to_string());
+        self.service_type = service_type.map(|x| x.as_ref().into());
         self
     }
 
     /// Set endpoint region
     pub fn set_region<S: AsRef<str>>(&mut self, region: Option<S>) -> &mut Self {
-        self.region = region.map(|x| x.as_ref().to_string());
+        self.region = region.map(|x| x.as_ref().into());
         self
     }
 
     /// Set endpoint interface
     pub fn set_interface<S: AsRef<str>>(&mut self, interface: Option<S>) -> &mut Self {
-        self.interface = interface.map(|x| x.as_ref().to_string());
+        self.interface = interface.map(|x| x.as_ref().into());
         self
     }
 
     /// Set min_version
     pub fn set_min_version<S: AsRef<str>>(&mut self, version: Option<S>) -> &mut Self {
-        self.min_version = version.map(|x| x.as_ref().to_string());
+        self.min_version = version.map(|x| x.as_ref().into());
         self
     }
     /// Set min_version
     pub fn set_max_version<S: AsRef<str>>(&mut self, version: Option<S>) -> &mut Self {
-        self.max_version = version.map(|x| x.as_ref().to_string());
+        self.max_version = version.map(|x| x.as_ref().into());
         self
     }
     /// Set status
@@ -273,7 +273,7 @@ impl ServiceEndpoints {
         if let Some(region) = &region_name {
             self.0
                 .iter()
-                .find(|&ep| ep.region == Some(region.as_ref().to_string()))
+                .find(|&ep| ep.region == Some(region.as_ref().into()))
         } else {
             self.0.first()
         }

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -81,7 +81,7 @@ enum ClientCert {
 ///
 ///     let cfg = ConfigFile::new().unwrap();
 ///     // Get connection config from clouds.yaml/secure.yaml
-///     let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+///     let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 ///     // Establish connection
 ///     let mut session = OpenStack::new(&profile)?;
 ///
@@ -143,12 +143,12 @@ impl OpenStack {
             File::open(expand_tilde(cacert).unwrap_or(cacert.into()))
                 .map_err(|e| OpenStackError::IO {
                     source: e,
-                    path: cacert.to_string(),
+                    path: cacert.into(),
                 })?
                 .read_to_end(&mut buf)
                 .map_err(|e| OpenStackError::IO {
                     source: e,
-                    path: cacert.to_string(),
+                    path: cacert.into(),
                 })?;
             for cert in Certificate::from_pem_bundle(&buf)? {
                 client_builder = client_builder.add_root_certificate(cert);
@@ -323,7 +323,7 @@ impl OpenStack {
                     }
                     other => {
                         return Err(AuthTokenError::IdentityMethodSync {
-                            auth_type: other.as_str().to_string(),
+                            auth_type: other.as_str().into(),
                         })?
                     }
                 }
@@ -339,7 +339,7 @@ impl OpenStack {
                 .to_str()
                 .expect("x-subject-token is a string");
 
-            self.set_token_auth(token.to_string(), Some(data));
+            self.set_token_auth(token.into(), Some(data));
         }
 
         if let auth::Auth::AuthToken(token_data) = &self.auth {
@@ -406,10 +406,10 @@ impl OpenStack {
                     } else {
                         return Err(OpenStackError::Discovery {
                             service: service_type.to_string(),
-                            url: orig_url.to_string(),
+                            url: orig_url.into(),
                             msg: match service_type {
-                                ServiceType::Identity => "Service is not working.".to_string(),
-                                _ => "No Version document found. Either service is not supporting version discovery, or API is not working".to_string(),
+                                ServiceType::Identity => "Service is not working.".into(),
+                                _ => "No Version document found. Either service is not supporting version discovery, or API is not working".into(),
                             }
                         });
                     }
@@ -421,8 +421,8 @@ impl OpenStack {
                 }
                 return Err(OpenStackError::Discovery {
                     service: service_type.to_string(),
-                    url: orig_url.to_string(),
-                    msg: "Unknown".to_string(),
+                    url: orig_url.into(),
+                    msg: "Unknown".into(),
                 });
             }
             return Ok(());

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -70,7 +70,7 @@ use crate::utils::expand_tilde;
 ///
 ///     let cfg = ConfigFile::new().unwrap();
 ///     // Get connection config from clouds.yaml/secure.yaml
-///     let profile = cfg.get_cloud_config("devstack".to_string()).unwrap().unwrap();
+///     let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 ///     // Establish connection
 ///     let mut session = AsyncOpenStack::new(&profile).await?;
 ///
@@ -178,12 +178,12 @@ impl AsyncOpenStack {
             File::open(expand_tilde(cacert).unwrap_or(cacert.into()))
                 .map_err(|e| OpenStackError::IO {
                     source: e,
-                    path: cacert.to_string(),
+                    path: cacert.into(),
                 })?
                 .read_to_end(&mut buf)
                 .map_err(|e| OpenStackError::IO {
                     source: e,
-                    path: cacert.to_string(),
+                    path: cacert.into(),
                 })?;
             for cert in Certificate::from_pem_bundle(&buf)? {
                 client_builder = client_builder.add_root_certificate(cert);
@@ -417,7 +417,7 @@ where {
                 .to_str()
                 .expect("x-subject-token is a string");
 
-            self.set_token_auth(token.to_string(), Some(data));
+            self.set_token_auth(token.into(), Some(data));
         }
 
         if let auth::Auth::AuthToken(token_data) = &self.auth {
@@ -487,10 +487,10 @@ where {
                     } else {
                         return Err(OpenStackError::Discovery {
                             service: service_type.to_string(),
-                            url: orig_url.to_string(),
+                            url: orig_url.into(),
                             msg: match service_type {
-                                ServiceType::Identity => "Service is not working.".to_string(),
-                                _ => "No Version document found. Either service is not supporting version discovery, or API is not working".to_string(),
+                                ServiceType::Identity => "Service is not working.".into(),
+                                _ => "No Version document found. Either service is not supporting version discovery, or API is not working".into(),
                             }
                         });
                     }
@@ -502,8 +502,8 @@ where {
                 }
                 return Err(OpenStackError::Discovery {
                     service: service_type.to_string(),
-                    url: orig_url.to_string(),
-                    msg: "Unknown".to_string(),
+                    url: orig_url.into(),
+                    msg: "Unknown".into(),
                 });
             }
             return Ok(());

--- a/openstack_sdk/src/test/client.rs
+++ b/openstack_sdk/src/test/client.rs
@@ -350,7 +350,7 @@ impl MockServerClient {
     pub fn new() -> Self {
         let server = MockServer::start();
         let client = HttpClient::new();
-        let base_url = Url::parse(&server.base_url().to_string()).unwrap();
+        let base_url = Url::parse(server.base_url().as_ref()).unwrap();
         Self {
             server,
             client,
@@ -416,7 +416,7 @@ impl MockAsyncServerClient {
     pub async fn new() -> Self {
         let server = MockServer::start_async().await;
         let client = AsyncHttpClient::new();
-        let base_url = Url::parse(&server.base_url().to_string()).unwrap();
+        let base_url = Url::parse(server.base_url().as_ref()).unwrap();
         Self {
             server,
             client,

--- a/openstack_sdk/src/types.rs
+++ b/openstack_sdk/src/types.rs
@@ -72,7 +72,7 @@ impl From<&str> for ServiceType {
             "load-balancer" => ServiceType::LoadBalancer,
             "network" => ServiceType::Network,
             "object-store" => ServiceType::ObjectStore,
-            _ => ServiceType::Other(val.to_string()),
+            _ => ServiceType::Other(val.into()),
         }
     }
 }

--- a/openstack_sdk/src/types/api_version.rs
+++ b/openstack_sdk/src/types/api_version.rs
@@ -119,7 +119,7 @@ impl ApiVersion {
             }
             return Ok(res);
         }
-        Err(ApiVersionError::Invalid(data.as_ref().to_string()))
+        Err(ApiVersionError::Invalid(data.as_ref().into()))
     }
 
     /// Determine the api version from the [RestEndpoint](crate::api::RestEndpoint)

--- a/structable_derive/tests/main.rs
+++ b/structable_derive/tests/main.rs
@@ -55,9 +55,9 @@ fn test_single() {
     };
     let user = User {
         id: 1,
-        first_name: "Scooby".to_string(),
-        last_name: "Doo".to_string(),
-        extra: "XYZ".to_string(),
+        first_name: "Scooby".into(),
+        last_name: "Doo".into(),
+        extra: "XYZ".into(),
         complex_data: Some(json!({"a": "b", "c": "d"})),
         dummy: None,
     };
@@ -65,11 +65,11 @@ fn test_single() {
     assert_eq!(
         data,
         (
-            vec!["Attribute".to_string(), "Value".to_string()],
+            vec!["Attribute".into(), "Value".into()],
             vec![
-                vec!["ID".to_string(), "1".to_string()],
-                vec!["first_name".to_string(), "Scooby".to_string()],
-                vec!["last_name".to_string(), "Doo".to_string()],
+                vec!["ID".into(), "1".into()],
+                vec!["first_name".into(), "Scooby".into()],
+                vec!["last_name".into(), "Doo".into()],
             ]
         )
     );
@@ -84,9 +84,9 @@ fn test_single_wide() {
     };
     let user = User {
         id: 1,
-        first_name: "Scooby".to_string(),
-        last_name: "Doo".to_string(),
-        extra: "XYZ".to_string(),
+        first_name: "Scooby".into(),
+        last_name: "Doo".into(),
+        extra: "XYZ".into(),
         complex_data: Some(json!({"a": "b", "c": "d"})),
         dummy: None,
     };
@@ -94,14 +94,14 @@ fn test_single_wide() {
     assert_eq!(
         data,
         (
-            vec!["Attribute".to_string(), "Value".to_string()],
+            vec!["Attribute".into(), "Value".into()],
             vec![
-                vec!["ID".to_string(), "1".to_string()],
-                vec!["first_name".to_string(), "Scooby".to_string()],
-                vec!["last_name".to_string(), "Doo".to_string()],
-                vec!["Long".to_string(), "XYZ".to_string()],
+                vec!["ID".into(), "1".into()],
+                vec!["first_name".into(), "Scooby".into()],
+                vec!["last_name".into(), "Doo".into()],
+                vec!["Long".into(), "XYZ".into()],
                 vec![
-                    "complex_data".to_string(),
+                    "complex_data".into(),
                     "{\"a\":\"b\",\"c\":\"d\"}".to_string()
                 ],
             ]
@@ -118,9 +118,9 @@ fn test_single_wide_pretty() {
     };
     let user = User {
         id: 1,
-        first_name: "Scooby".to_string(),
-        last_name: "Doo".to_string(),
-        extra: "XYZ".to_string(),
+        first_name: "Scooby".into(),
+        last_name: "Doo".into(),
+        extra: "XYZ".into(),
         complex_data: Some(json!({"a": "b", "c": "d"})),
         dummy: None,
     };
@@ -128,14 +128,14 @@ fn test_single_wide_pretty() {
     assert_eq!(
         data,
         (
-            vec!["Attribute".to_string(), "Value".to_string()],
+            vec!["Attribute".into(), "Value".into()],
             vec![
-                vec!["ID".to_string(), "1".to_string()],
-                vec!["first_name".to_string(), "Scooby".to_string()],
-                vec!["last_name".to_string(), "Doo".to_string()],
-                vec!["Long".to_string(), "XYZ".to_string()],
+                vec!["ID".into(), "1".into()],
+                vec!["first_name".into(), "Scooby".into()],
+                vec!["last_name".into(), "Doo".into()],
+                vec!["Long".into(), "XYZ".into()],
                 vec![
-                    "complex_data".to_string(),
+                    "complex_data".into(),
                     "{\n  \"a\": \"b\",\n  \"c\": \"d\"\n}".to_string()
                 ],
             ]
@@ -153,17 +153,17 @@ fn test_list() {
     let users = vec![
         User {
             id: 1,
-            first_name: "Scooby".to_string(),
-            last_name: "Doo".to_string(),
-            extra: "Foo".to_string(),
+            first_name: "Scooby".into(),
+            last_name: "Doo".into(),
+            extra: "Foo".into(),
             complex_data: Some(json!({"a": "b", "c": "d"})),
             dummy: None,
         },
         User {
             id: 2,
-            first_name: "John".to_string(),
-            last_name: "Cena".to_string(),
-            extra: "Bar".to_string(),
+            first_name: "John".into(),
+            last_name: "Cena".into(),
+            extra: "Bar".into(),
             complex_data: None,
             dummy: None,
         },
@@ -174,24 +174,14 @@ fn test_list() {
         data,
         (
             vec![
-                "ID".to_string(),
-                "first_name".to_string(),
-                "last_name".to_string(),
-                "dummy".to_string()
+                "ID".into(),
+                "first_name".into(),
+                "last_name".into(),
+                "dummy".into()
             ],
             vec![
-                vec![
-                    "1".to_string(),
-                    "Scooby".to_string(),
-                    "Doo".to_string(),
-                    " ".to_string()
-                ],
-                vec![
-                    "2".to_string(),
-                    "John".to_string(),
-                    "Cena".to_string(),
-                    " ".to_string()
-                ],
+                vec!["1".into(), "Scooby".into(), "Doo".into(), " ".into()],
+                vec!["2".into(), "John".into(), "Cena".into(), " ".into()],
             ]
         )
     );
@@ -207,19 +197,19 @@ fn test_list_wide() {
     let users = vec![
         User {
             id: 1,
-            first_name: "Scooby".to_string(),
-            last_name: "Doo".to_string(),
-            extra: "Foo".to_string(),
+            first_name: "Scooby".into(),
+            last_name: "Doo".into(),
+            extra: "Foo".into(),
             complex_data: Some(json!({"a": "b", "c": "d"})),
             dummy: None,
         },
         User {
             id: 2,
-            first_name: "John".to_string(),
-            last_name: "Cena".to_string(),
-            extra: "Bar".to_string(),
+            first_name: "John".into(),
+            last_name: "Cena".into(),
+            extra: "Bar".into(),
             complex_data: None,
-            dummy: Some("foo".to_string()),
+            dummy: Some("foo".into()),
         },
     ];
 
@@ -228,29 +218,29 @@ fn test_list_wide() {
         data,
         (
             vec![
-                "ID".to_string(),
-                "first_name".to_string(),
-                "last_name".to_string(),
-                "Long".to_string(),
-                "complex_data".to_string(),
-                "dummy".to_string()
+                "ID".into(),
+                "first_name".into(),
+                "last_name".into(),
+                "Long".into(),
+                "complex_data".into(),
+                "dummy".into()
             ],
             vec![
                 vec![
-                    "1".to_string(),
-                    "Scooby".to_string(),
-                    "Doo".to_string(),
-                    "Foo".to_string(),
+                    "1".into(),
+                    "Scooby".into(),
+                    "Doo".into(),
+                    "Foo".into(),
                     "{\n  \"a\": \"b\",\n  \"c\": \"d\"\n}".to_string(),
                     " ".to_string()
                 ],
                 vec![
-                    "2".to_string(),
-                    "John".to_string(),
-                    "Cena".to_string(),
-                    "Bar".to_string(),
+                    "2".into(),
+                    "John".into(),
+                    "Cena".into(),
+                    "Bar".into(),
                     " ".to_string(),
-                    "foo".to_string()
+                    "foo".into()
                 ],
             ]
         )
@@ -280,8 +270,8 @@ fn test_deser() {
     assert_eq!(
         data,
         (
-            vec!["Attribute".to_string(), "Value".to_string()],
-            vec![vec!["ID".to_string(), "1".to_string()],]
+            vec!["Attribute".into(), "Value".into()],
+            vec![vec!["ID".into(), "1".into()],]
         )
     );
 }
@@ -291,19 +281,16 @@ fn test_list_status() {
     let raw = vec![
         StatusStruct {
             id: 1,
-            status: String::from("foo"),
+            status: "foo".into(),
         },
         StatusStruct {
             id: 2,
-            status: String::from("bar"),
+            status: "bar".into(),
         },
     ];
 
     let data = raw.status();
-    assert_eq!(
-        data,
-        vec![Some(String::from("foo")), Some(String::from("bar"))]
-    );
+    assert_eq!(data, vec![Some("foo".into()), Some("bar".into())]);
 }
 
 #[test]
@@ -318,11 +305,11 @@ fn test_list_status_no_status() {
 fn test_single_status() {
     let raw = StatusStruct {
         id: 1,
-        status: String::from("foo"),
+        status: "foo".into(),
     };
 
     let data = raw.status();
-    assert_eq!(data, vec![Some(String::from("foo")),]);
+    assert_eq!(data, vec![Some("foo".into()),]);
 }
 
 #[test]
@@ -337,9 +324,9 @@ fn test_single_no_status() {
 fn test_single_option_status() {
     let raw = OptionStatusStruct {
         id: 1,
-        status: Some(String::from("foo")),
+        status: Some("foo".into()),
     };
 
     let data = raw.status();
-    assert_eq!(data, vec![Some(String::from("foo")),]);
+    assert_eq!(data, vec![Some("foo".into()),]);
 }


### PR DESCRIPTION
There is a wide spread recommendation to avoid using to_string() in
favor of into() and to_owned(). Follow it except few places where it
must (at least for now) stay.
