### PR TITLE
chore: Update links to latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ with a dedicated installer in every release and can be retrieved with the
 following command:
 
 ```console
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/gtema/openstack/releases/download/openstack_cli-v0.9.1/openstack_cli-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/gtema/openstack/releases/latest/download/openstack_cli-installer.sh | sh
 ```
 
 TUI can be installed similarly:
 
 ```console
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/gtema/openstack/releases/download/openstack_tui-v0.9.1/openstack_tui-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/gtema/openstack/releases/latest/download/openstack_tui-installer.sh | sh
 ```
 
 


### PR DESCRIPTION
Bring back links for installation pointing to the latest release.