### PR TITLE
feat: Fix LB failover schemas

### DIFF
--- a/openstack_cli/src/load_balancer/v2/amphorae/failover.rs
+++ b/openstack_cli/src/load_balancer/v2/amphorae/failover.rs
@@ -31,13 +31,17 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_key_val;
 use openstack_sdk::api::load_balancer::v2::amphorae::failover;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
 
-/// Request of the octavia/amphorae/amphora_id/failover:put operation
+/// Force an amphora to failover.
+///
+/// If you are not an administrative user, the service returns the HTTP
+/// `Forbidden (403)` response code.
+///
+/// This operation does not require a request body.
 ///
 #[derive(Args)]
 #[command(about = "Failover Amphora")]
@@ -49,10 +53,6 @@ pub struct AmphoraeCommand {
     /// Path parameters
     #[command(flatten)]
     path: PathParameters,
-
-    #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
-    #[arg(help_heading = "Body parameters")]
-    properties: Option<Vec<(String, Value)>>,
 }
 
 /// Query parameters
@@ -107,9 +107,6 @@ impl AmphoraeCommand {
         ep_builder.amphora_id(&self.path.amphora_id);
         // Set query parameters
         // Set body parameters
-        if let Some(properties) = &self.properties {
-            ep_builder.properties(properties.iter().cloned());
-        }
 
         let ep = ep_builder
             .build()

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/failover.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/failover.rs
@@ -31,13 +31,15 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::parse_key_val;
 use openstack_sdk::api::load_balancer::v2::loadbalancer::failover;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
 use std::collections::HashMap;
 
-/// Request of the lbaas/loadbalancers/loadbalancer_id/failover:put operation
+/// Performs a failover of a load balancer.
+///
+/// This operation is only available to users with load balancer administrative
+/// rights.
 ///
 #[derive(Args)]
 #[command(about = "Failover a load balancer")]
@@ -49,10 +51,6 @@ pub struct LoadbalancerCommand {
     /// Path parameters
     #[command(flatten)]
     path: PathParameters,
-
-    #[arg(long="property", value_name="key=value", value_parser=parse_key_val::<String, Value>)]
-    #[arg(help_heading = "Body parameters")]
-    properties: Option<Vec<(String, Value)>>,
 }
 
 /// Query parameters
@@ -108,9 +106,6 @@ impl LoadbalancerCommand {
         ep_builder.id(&self.path.id);
         // Set query parameters
         // Set body parameters
-        if let Some(properties) = &self.properties {
-            ep_builder.properties(properties.iter().cloned());
-        }
 
         let ep = ep_builder
             .build()

--- a/openstack_sdk/src/api/load_balancer/v2/amphorae/failover.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/amphorae/failover.rs
@@ -27,9 +27,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
-use serde_json::Value;
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
@@ -41,9 +39,6 @@ pub struct Request<'a> {
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
-
-    #[builder(setter(name = "_properties"), default, private)]
-    _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
@@ -52,7 +47,7 @@ impl<'a> Request<'a> {
     }
 }
 
-impl<'a> RequestBuilder<'a> {
+impl RequestBuilder<'_> {
     /// Add a single header to the Amphorae.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -75,18 +70,6 @@ where {
             .extend(iter.map(Into::into));
         self
     }
-
-    pub fn properties<I, K, V>(&mut self, iter: I) -> &mut Self
-    where
-        I: Iterator<Item = (K, V)>,
-        K: Into<Cow<'a, str>>,
-        V: Into<Value>,
-    {
-        self._properties
-            .get_or_insert_with(BTreeMap::new)
-            .extend(iter.map(|(k, v)| (k.into(), v.into())));
-        self
-    }
 }
 
 impl RestEndpoint for Request<'_> {
@@ -104,16 +87,6 @@ impl RestEndpoint for Request<'_> {
 
     fn parameters(&self) -> QueryParams {
         QueryParams::default()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-
-        for (key, val) in &self._properties {
-            params.push(key.clone(), val.clone());
-        }
-
-        params.into_body()
     }
 
     fn service_type(&self) -> ServiceType {

--- a/openstack_sdk/src/api/load_balancer/v2/loadbalancer/failover.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/loadbalancer/failover.rs
@@ -25,9 +25,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
-use serde_json::Value;
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
@@ -40,9 +38,6 @@ pub struct Request<'a> {
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,
-
-    #[builder(setter(name = "_properties"), default, private)]
-    _properties: BTreeMap<Cow<'a, str>, Value>,
 }
 impl<'a> Request<'a> {
     /// Create a builder for the endpoint.
@@ -51,7 +46,7 @@ impl<'a> Request<'a> {
     }
 }
 
-impl<'a> RequestBuilder<'a> {
+impl RequestBuilder<'_> {
     /// Add a single header to the Loadbalancer.
     pub fn header(&mut self, header_name: &'static str, header_value: &'static str) -> &mut Self
 where {
@@ -74,18 +69,6 @@ where {
             .extend(iter.map(Into::into));
         self
     }
-
-    pub fn properties<I, K, V>(&mut self, iter: I) -> &mut Self
-    where
-        I: Iterator<Item = (K, V)>,
-        K: Into<Cow<'a, str>>,
-        V: Into<Value>,
-    {
-        self._properties
-            .get_or_insert_with(BTreeMap::new)
-            .extend(iter.map(|(k, v)| (k.into(), v.into())));
-        self
-    }
 }
 
 impl RestEndpoint for Request<'_> {
@@ -99,16 +82,6 @@ impl RestEndpoint for Request<'_> {
 
     fn parameters(&self) -> QueryParams {
         QueryParams::default()
-    }
-
-    fn body(&self) -> Result<Option<(&'static str, Vec<u8>)>, BodyError> {
-        let mut params = JsonBodyParams::default();
-
-        for (key, val) in &self._properties {
-            params.push(key.clone(), val.clone());
-        }
-
-        params.into_body()
     }
 
     fn service_type(&self) -> ServiceType {


### PR DESCRIPTION
LB and amphora failover schemas are explicit null.

Without that generated code fails with `Request must be a JSON dict`.

Change-Id: Ic2a8b46e1c29b0a1e85efe8757d241d3c31b28aa

Changes are triggered by https://review.opendev.org/937368
