### PR TITLE
chore: Modularize cloud_worker

### DIFF
--- a/openstack_tui/.config/config.json5
+++ b/openstack_tui/.config/config.json5
@@ -16,8 +16,8 @@
     },
     "ComputeServers": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
-      "0": { "action": {"SetComputeServerFilters": {} }, "description": "Default filters", "type": "Filter"},
-      "1": { "action": {"SetComputeServerFilters": {"all_tenants": true} }, "description": "All tenants (admin)", "type": "Filter"},
+      "0": { "action": {"SetComputeServerListFilters": {} }, "description": "Default filters", "type": "Filter"},
+      "1": { "action": {"SetComputeServerListFilters": {"all_tenants": true} }, "description": "All tenants (admin)", "type": "Filter"},
       "ctrl-d": { "action": "DeleteComputeServer", "description": "Delete" },
       "c": { "action": "ShowServerConsoleOutput", "description": "Console output" },
       "a": { "action": "ShowComputeServerInstanceActions", "description": "Instance actions"},
@@ -35,7 +35,7 @@
     },
     "DnsRecordsets": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
-      "0": { "action": {"SetDnsRecordsetFilters": {} }, "description": "Default filters", "type": "Filter"},
+      "0": { "action": {"SetDnsRecordsetListFilters": {} }, "description": "Default filters", "type": "Filter"},
     },
     "DnsZones": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
@@ -70,10 +70,10 @@
     },
     "ImageImages": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
-      "0": { "action": {"SetImageFilters": {} }, "description": "Default filters", "type": "Filter"},
-      "1": { "action": {"SetImageFilters": {"visibility": "public"} },"description": "public", "type": "Filter"},
-      "2": { "action": {"SetImageFilters": {"visibility": "shared"} },"description": "shared", "type": "Filter"},
-      "3": { "action": {"SetImageFilters": {"visibility": "private"} },"description": "private", "type": "Filter"},
+      "0": { "action": {"SetImageListFilters": {} }, "description": "Default filters", "type": "Filter"},
+      "1": { "action": {"SetImageListFilters": {"visibility": "public"} },"description": "public", "type": "Filter"},
+      "2": { "action": {"SetImageListFilters": {"visibility": "shared"} },"description": "shared", "type": "Filter"},
+      "3": { "action": {"SetImageListFilters": {"visibility": "private"} },"description": "private", "type": "Filter"},
       "ctrl-d": { "action": "DeleteImage", "description": "Delete"},
     },
     "LoadBalancers": {
@@ -104,7 +104,7 @@
     },
     "NetworkSubnets": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
-      "0": { "action": {"SetNetworkSubnetFilters": {} }, "description": "All", "type": "Filter"},
+      "0": { "action": {"SetNetworkSubnetListFilters": {} }, "description": "All", "type": "Filter"},
     },
     "NetworkSecurityGroups": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
@@ -112,7 +112,7 @@
     },
     "NetworkSecurityGroupRules": {
       "y": { "action": "DescribeApiResponse", "description": "YAML"},
-      "0": { "action": {"SetNetworkSecurityGroupRuleFilters": {}}, "description": "All", "type": "Filter"},
+      "0": { "action": {"SetNetworkSecurityGroupRuleListFilters": {}}, "description": "All", "type": "Filter"},
     }
   },
   "global_keybindings": {

--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -54,6 +54,11 @@ pub enum Action {
         request: cloud_types::ApiRequest,
         data: Vec<serde_json::Value>,
     },
+    /// Propagate resources list to components
+    ApiResponsesData1 {
+        request: cloud_types::ApiRequest,
+        data: Vec<serde_json::Value>,
+    },
     /// Open resource(mode) select popup
     ApiRequestSelect,
     /// Refresh data
@@ -86,8 +91,8 @@ pub enum Action {
     DeleteBlockStorageVolume,
 
     // Compute (Nova)
-    SetComputeServerFilters(cloud_types::ComputeServerFilters),
-    SetComputeServerInstanceActionFilters(cloud_types::ComputeServerInstanceActionFilters),
+    SetComputeServerListFilters(cloud_types::ComputeServerList),
+    SetComputeServerInstanceActionListFilters(cloud_types::ComputeServerInstanceActionList),
     /// Show servers provisioned with selected flavor
     ShowComputeServersWithFlavor,
     /// Delete selected server
@@ -101,11 +106,11 @@ pub enum Action {
 
     // DNS (Designate)
     /// Set DNS Zone filters
-    SetDnsZoneFilters(cloud_types::DnsZoneFilters),
+    SetDnsZoneListFilters(cloud_types::DnsZoneList),
     /// Delete DNS zone
     DeleteDnsZone,
     /// Set DNS Recordset filters
-    SetDnsRecordsetFilters(cloud_types::DnsRecordsetFilters),
+    SetDnsRecordsetListFilters(cloud_types::DnsRecordsetList),
     /// Zone recordsets
     ShowDnsZoneRecordsets,
 
@@ -119,7 +124,7 @@ pub enum Action {
     /// Action user invokes to switch mode for selected entity
     ShowIdentityGroupUsers,
     /// Set GroupUser filters
-    SetIdentityGroupUserFilters(cloud_types::IdentityGroupUserFilters),
+    SetIdentityGroupUserListFilters(cloud_types::IdentityGroupUserList),
     /// Add user into the group
     IdentityGroupUserAdd,
     /// Remove user from the group
@@ -127,7 +132,7 @@ pub enum Action {
     //  Users
     // Set ApplicationCredentials filters
     ShowIdentityUserApplicationCredentials,
-    SetIdentityApplicationCredentialFilters(cloud_types::IdentityApplicationCredentialFilters),
+    SetIdentityApplicationCredentialListFilters(cloud_types::IdentityApplicationCredentialList),
     /// Toggle user enabled property
     IdentityUserFlipEnable,
     /// Remove user
@@ -140,42 +145,42 @@ pub enum Action {
     SwitchToProject,
 
     // Image (glance)
-    SetImageFilters(cloud_types::ImageFilters),
+    SetImageListFilters(cloud_types::ImageImageList),
     /// Delete image
     DeleteImage,
 
     // LB
     /// Set LB filters
-    SetLoadBalancerFilters(cloud_types::LoadBalancerFilters),
+    SetLoadBalancerListFilters(cloud_types::LoadBalancerLoadbalancerList),
     /// Set LB Listener filters
-    SetLoadBalancerListenerFilters(cloud_types::LoadBalancerListenerFilters),
+    SetLoadBalancerListenerListFilters(cloud_types::LoadBalancerListenerList),
     /// Show LB Listeners
     ShowLoadBalancerListeners,
     /// Show LB Pools
     ShowLoadBalancerPools,
     /// Set LB Pool filters
-    SetLoadBalancerPoolFilters(cloud_types::LoadBalancerPoolFilters),
+    SetLoadBalancerPoolListFilters(cloud_types::LoadBalancerPoolList),
     /// Show LB Listener Pools
     ShowLoadBalancerListenerPools,
     /// Set LB Member filters
-    SetLoadBalancerPoolMemberFilters(cloud_types::LoadBalancerPoolMemberFilters),
+    SetLoadBalancerPoolMemberListFilters(cloud_types::LoadBalancerPoolMemberList),
     /// Show LB Pool members
     ShowLoadBalancerPoolMembers,
     /// Set LB Healthmonitor filters
-    SetLoadBalancerHealthMonitorFilters(cloud_types::LoadBalancerHealthMonitorFilters),
+    SetLoadBalancerHealthMonitorListFilters(cloud_types::LoadBalancerHealthmonitorList),
     /// Show LB Listener Pools
     ShowLoadBalancerPoolHealthMonitors,
 
     // Network (neutron)
     /// Set Security group filters
-    SetNetworkSecurityGroupFilters(cloud_types::NetworkSecurityGroupFilters),
+    SetNetworkSecurityGroupListFilters(cloud_types::NetworkSecurityGroupList),
     /// Switch to NetworkSecurityGroupRules
     ShowNetworkSecurityGroupRules,
     /// Switch to routers view
     ShowNetworkRouters,
     /// Set Security group rule filters
-    SetNetworkSecurityGroupRuleFilters(cloud_types::NetworkSecurityGroupRuleFilters),
-    SetNetworkSubnetFilters(cloud_types::NetworkSubnetFilters),
+    SetNetworkSecurityGroupRuleListFilters(cloud_types::NetworkSecurityGroupRuleList),
+    SetNetworkSubnetListFilters(cloud_types::NetworkSubnetList),
     /// Show Subnetworks of a network
     ShowNetworkSubnets,
 }

--- a/openstack_tui/src/cloud_worker/block_storage/backup.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/backup.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::block_storage::types::BlockStorageApiRequest;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::ExecuteApiRequest;
+
+/// Backup API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BlockStorageBackupApiRequest {
+    /// List
+    List(BlockStorageBackupList),
+}
+
+impl From<BlockStorageBackupApiRequest> for ApiRequest {
+    fn from(item: BlockStorageBackupApiRequest) -> Self {
+        ApiRequest::BlockStorage(BlockStorageApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for BlockStorageBackupApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            BlockStorageBackupApiRequest::List(ref filters) => {
+                let ep: openstack_sdk::api::block_storage::v3::backup::list_detailed::Request<'_> =
+                    filters.try_into().wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockStorageBackupList {}
+
+impl fmt::Display for BlockStorageBackupList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&BlockStorageBackupList>
+    for openstack_sdk::api::block_storage::v3::backup::list_detailed::Request<'_>
+{
+    type Error = openstack_sdk::api::block_storage::v3::backup::list_detailed::RequestBuilderError;
+
+    fn try_from(_value: &BlockStorageBackupList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        // TODO(gtema) cinder rejects "name" in few clouds
+        ep_builder.sort_key("created_at");
+
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/block_storage/snapshot.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/snapshot.rs
@@ -1,0 +1,89 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::block_storage::types::BlockStorageApiRequest;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::ExecuteApiRequest;
+
+/// Snapshot API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BlockStorageSnapshotApiRequest {
+    /// List
+    List(BlockStorageSnapshotList),
+}
+
+impl From<BlockStorageSnapshotApiRequest> for ApiRequest {
+    fn from(item: BlockStorageSnapshotApiRequest) -> Self {
+        ApiRequest::BlockStorage(BlockStorageApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for BlockStorageSnapshotApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            BlockStorageSnapshotApiRequest::List(ref filters) => {
+                let ep: openstack_sdk::api::block_storage::v3::snapshot::list_detailed::Request<
+                    '_,
+                > = filters.try_into().wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockStorageSnapshotList {}
+
+impl fmt::Display for BlockStorageSnapshotList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&BlockStorageSnapshotList>
+    for openstack_sdk::api::block_storage::v3::snapshot::list_detailed::Request<'_>
+{
+    type Error =
+        openstack_sdk::api::block_storage::v3::snapshot::list_detailed::RequestBuilderError;
+
+    fn try_from(_value: &BlockStorageSnapshotList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        // TODO(gtema) cinder rejects "name" in few clouds
+        ep_builder.sort_key("created_at");
+
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/block_storage/volume.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/volume.rs
@@ -1,0 +1,139 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::block_storage::types::BlockStorageApiRequest;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+use crate::cloud_worker::ConfirmableRequest;
+
+/// Volume API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BlockStorageVolumeApiRequest {
+    /// Delete
+    Delete(BlockStorageVolumeDelete),
+    /// List
+    List(BlockStorageVolumeList),
+}
+
+impl From<BlockStorageVolumeApiRequest> for ApiRequest {
+    fn from(item: BlockStorageVolumeApiRequest) -> Self {
+        ApiRequest::BlockStorage(BlockStorageApiRequest::from(item))
+    }
+}
+
+impl ConfirmableRequest for BlockStorageVolumeApiRequest {
+    fn get_confirm_message(&self) -> Option<String> {
+        match &self {
+            BlockStorageVolumeApiRequest::Delete(req) => req.get_confirm_message(),
+            _ => None,
+        }
+    }
+}
+
+impl ExecuteApiRequest for BlockStorageVolumeApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            BlockStorageVolumeApiRequest::Delete(ref filters) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::block_storage::v3::volume::delete::Request<'_>,
+                >::try_into(filters)
+                .wrap_err("Cannot prepare request")?;
+                openstack_sdk::api::ignore(ep).query_async(session).await?;
+                app_tx.send(Action::Refresh)?;
+            }
+            BlockStorageVolumeApiRequest::List(ref filters) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::block_storage::v3::volume::list_detailed::Request<'_>,
+                >::try_into(filters)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockStorageVolumeList {}
+
+impl fmt::Display for BlockStorageVolumeList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&BlockStorageVolumeList>
+    for openstack_sdk::api::block_storage::v3::volume::list_detailed::Request<'_>
+{
+    type Error = openstack_sdk::api::block_storage::v3::volume::list_detailed::RequestBuilderError;
+
+    fn try_from(_value: &BlockStorageVolumeList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        // TODO(gtema) cinder rejects "name" in few clouds
+        ep_builder.sort_key("created_at");
+
+        ep_builder.build()
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockStorageVolumeDelete {
+    pub volume_id: String,
+    pub volume_name: Option<String>,
+}
+
+impl fmt::Display for BlockStorageVolumeDelete {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl ConfirmableRequest for BlockStorageVolumeDelete {
+    fn get_confirm_message(&self) -> Option<String> {
+        Some(format!(
+            "Delete volume {} ?",
+            self.volume_name.clone().unwrap_or(self.volume_id.clone())
+        ))
+    }
+}
+
+impl TryFrom<&BlockStorageVolumeDelete>
+    for openstack_sdk::api::block_storage::v3::volume::delete::Request<'_>
+{
+    type Error = openstack_sdk::api::block_storage::v3::volume::delete::RequestBuilderError;
+
+    fn try_from(value: &BlockStorageVolumeDelete) -> Result<Self, Self::Error> {
+        Self::builder().id(value.volume_id.clone()).build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/compute.rs
+++ b/openstack_tui/src/cloud_worker/compute.rs
@@ -13,268 +13,43 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::debug;
 
-use openstack_sdk::{api::Pagination, api::QueryAsync};
+use openstack_sdk::AsyncOpenStack;
 
 use crate::action::Action;
-use crate::cloud_worker::{ApiRequest, Cloud};
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::types::ExecuteApiRequest;
+use crate::cloud_worker::ApiRequest;
 
+pub mod aggregate;
+pub mod flavor;
+pub mod hypervisor;
+pub mod quota_set;
+pub mod server;
 pub mod types;
+
 use types::*;
 
-pub trait ComputeExt {
-    async fn perform_api_request(
-        &mut self,
+impl ExecuteApiRequest for ComputeApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
         app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()>;
-
-    async fn get_flavors(&mut self, filters: &ComputeFlavorFilters) -> Result<Vec<Value>>;
-    async fn get_servers(&mut self, filters: &ComputeServerFilters) -> Result<Vec<Value>>;
-    /// Delete server
-    async fn delete_server(&mut self, request: &ComputeServerDelete) -> Result<()>;
-
-    /// Fetch server actions
-    async fn get_server_instance_actions(
-        &mut self,
-        filters: &ComputeServerInstanceActionFilters,
-    ) -> Result<Vec<Value>>;
-    /// Fetch server action details
-    async fn get_server_instance_action(
-        &mut self,
-        filters: &ComputeServerInstanceActionFilters,
-    ) -> Result<Value>;
-    async fn get_server_console_output<S: AsRef<str>>(&mut self, id: S) -> Result<Value>;
-    async fn get_quota(&mut self) -> Result<Value>;
-    async fn get_hypervisors(&mut self, filters: &ComputeHypervisorFilters) -> Result<Vec<Value>>;
-    async fn get_aggregates(&mut self, filters: &ComputeAggregateFilters) -> Result<Vec<Value>>;
-}
-
-impl ComputeExt for Cloud {
-    async fn perform_api_request(
-        &mut self,
-        app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()> {
-        match request {
-            ApiRequest::ComputeFlavors(ref filters) => match self.get_flavors(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch compute flavors: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::ComputeServers(ref filters) => match self.get_servers(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch compute servers: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::ComputeServerDelete(ref request) => match self.delete_server(request).await
-            {
-                Ok(_) => app_tx.send(Action::Refresh)?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to delete compute server: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::ComputeServerInstanceActions(ref filters) => {
-                match self.get_server_instance_actions(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch compute server instance actions: {:?}",
-                        err
-                    )))?,
-                }
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            ComputeApiRequest::Aggregate(data) => {
+                data.execute_request(session, request, app_tx).await
             }
-            ApiRequest::ComputeServerInstanceAction(ref filters) => {
-                match self.get_server_instance_action(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponseData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch compute server instance action info: {:?}",
-                        err
-                    )))?,
-                }
+            ComputeApiRequest::Flavor(data) => data.execute_request(session, request, app_tx).await,
+            ComputeApiRequest::Hypervisor(data) => {
+                data.execute_request(session, request, app_tx).await
             }
-            ApiRequest::ComputeServerConsoleOutput(ref id) => {
-                match self.get_server_console_output(id).await {
-                    Ok(data) => app_tx.send(Action::ApiResponseData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch server console output: {:?}",
-                        err
-                    )))?,
-                }
+            ComputeApiRequest::QuotaSet(data) => {
+                data.execute_request(session, request, app_tx).await
             }
-            ApiRequest::ComputeQuota => match self.get_quota().await {
-                Ok(data) => app_tx.send(Action::ApiResponseData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch compute quota: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::ComputeAggregates(ref filters) => {
-                match self.get_aggregates(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch compute aggregates: {:?}",
-                        err
-                    )))?,
-                }
-            }
-            ApiRequest::ComputeHypervisors(ref filters) => {
-                match self.get_hypervisors(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch compute hypervisors: {:?}",
-                        err
-                    )))?,
-                }
-            }
-            _ => {
-                todo!()
-            }
+            ComputeApiRequest::Server(data) => data.execute_request(session, request, app_tx).await,
         }
-        Ok(())
-    }
-
-    async fn get_flavors(&mut self, _filters: &ComputeFlavorFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::compute::v2::flavor::list_detailed::RequestBuilder::try_from(
-                    _filters,
-                )?
-                .build()?;
-
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
-                .query_async(session)
-                .await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_servers(&mut self, filters: &ComputeServerFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::compute::v2::server::list_detailed::RequestBuilder::try_from(
-                    filters,
-                )?
-                .build()?;
-
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
-                .query_async(session)
-                .await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn delete_server(&mut self, request: &ComputeServerDelete) -> Result<()> {
-        if let Some(session) = &self.cloud {
-            let ep = openstack_sdk::api::compute::v2::server::delete::Request::builder()
-                .id(request.server_id.clone())
-                .build()?;
-
-            openstack_sdk::api::ignore(ep).query_async(session).await?;
-            return Ok(());
-        }
-        Ok(())
-    }
-
-    async fn get_server_instance_actions(
-        &mut self,
-        filters: &ComputeServerInstanceActionFilters,
-    ) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::compute::v2::server::instance_action::list::RequestBuilder::try_from(filters)?.build()?;
-
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
-                .query_async(session)
-                .await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_server_instance_action(
-        &mut self,
-        filters: &ComputeServerInstanceActionFilters,
-    ) -> Result<Value> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::compute::v2::server::instance_action::get::RequestBuilder::try_from(filters)?.build()?;
-
-            let res: Value = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Value::Null)
-    }
-
-    async fn get_server_console_output<S: AsRef<str>>(&mut self, id: S) -> Result<Value> {
-        if let Some(session) = &self.cloud {
-            debug!("Fetching server console output for {:?}", id.as_ref());
-            let ep =
-                openstack_sdk::api::compute::v2::server::os_get_console_output::Request::builder()
-                    .id(id.as_ref())
-                    .os_get_console_output(openstack_sdk::api::compute::v2::server::os_get_console_output::OsGetConsoleOutputBuilder::default().build()?)
-                    .build()?;
-
-            let res: Value = ep.query_async(session).await?;
-            return Ok(res.get("output").unwrap_or(&Value::Null).to_owned());
-        }
-        Ok(Value::Null)
-    }
-
-    async fn get_hypervisors(&mut self, filters: &ComputeHypervisorFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::compute::v2::hypervisor::list_detailed::RequestBuilder::try_from(
-                    filters,
-                )?
-                .build()?;
-
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
-                .query_async(session)
-                .await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_aggregates(&mut self, filters: &ComputeAggregateFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep = openstack_sdk::api::compute::v2::aggregate::list::RequestBuilder::try_from(
-                filters,
-            )?
-            .build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_quota(&mut self) -> Result<Value> {
-        if let Some(session) = &self.cloud {
-            let mut ep_builder =
-                openstack_sdk::api::compute::v2::quota_set::details::Request::builder();
-
-            if let Some(auth) = session.get_auth_info() {
-                if let Some(project) = auth.token.project {
-                    if let Some(pid) = project.id {
-                        ep_builder.id(pid);
-                        let ep = ep_builder.build()?;
-                        let res: Value = ep.query_async(session).await?;
-                        return Ok(res);
-                    }
-                }
-            }
-        }
-        Ok(Value::Null)
     }
 }

--- a/openstack_tui/src/cloud_worker/compute/aggregate.rs
+++ b/openstack_tui/src/cloud_worker/compute/aggregate.rs
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::compute::types::ComputeApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Aggregate API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComputeAggregateApiRequest {
+    /// List
+    List(ComputeAggregateList),
+}
+
+impl From<ComputeAggregateApiRequest> for ApiRequest {
+    fn from(item: ComputeAggregateApiRequest) -> Self {
+        ApiRequest::Compute(ComputeApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for ComputeAggregateApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            ComputeAggregateApiRequest::List(ref filters) => {
+                let ep: openstack_sdk::api::compute::v2::hypervisor::list::Request<'_> =
+                    filters.try_into().wrap_err("Cannot prepare request")?;
+
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeAggregateList {}
+
+impl fmt::Display for ComputeAggregateList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeAggregateList>
+    for openstack_sdk::api::compute::v2::hypervisor::list::Request<'_>
+{
+    type Error = openstack_sdk::api::compute::v2::hypervisor::list::RequestBuilderError;
+
+    fn try_from(_value: &ComputeAggregateList) -> Result<Self, Self::Error> {
+        openstack_sdk::api::compute::v2::hypervisor::list::Request::builder().build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/compute/flavor.rs
+++ b/openstack_tui/src/cloud_worker/compute/flavor.rs
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::compute::types::ComputeApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Flavor API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComputeFlavorApiRequest {
+    /// List
+    List(ComputeFlavorList),
+}
+
+impl From<ComputeFlavorApiRequest> for ApiRequest {
+    fn from(item: ComputeFlavorApiRequest) -> Self {
+        ApiRequest::Compute(ComputeApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for ComputeFlavorApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            ComputeFlavorApiRequest::List(ref filters) => {
+                let ep: openstack_sdk::api::compute::v2::flavor::list_detailed::Request<'_> =
+                    filters.try_into().wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeFlavorList {}
+
+impl fmt::Display for ComputeFlavorList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeFlavorList>
+    for openstack_sdk::api::compute::v2::flavor::list_detailed::Request<'_>
+{
+    type Error = openstack_sdk::api::compute::v2::flavor::list_detailed::RequestBuilderError;
+
+    fn try_from(_value: &ComputeFlavorList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        ep_builder.sort_key("name");
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/compute/hypervisor.rs
+++ b/openstack_tui/src/cloud_worker/compute/hypervisor.rs
@@ -1,0 +1,82 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::compute::types::ComputeApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Hypervisor API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComputeHypervisorApiRequest {
+    /// List
+    List(ComputeHypervisorList),
+}
+
+impl From<ComputeHypervisorApiRequest> for ApiRequest {
+    fn from(item: ComputeHypervisorApiRequest) -> Self {
+        ApiRequest::Compute(ComputeApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for ComputeHypervisorApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            ComputeHypervisorApiRequest::List(ref filters) => {
+                let ep: openstack_sdk::api::compute::v2::hypervisor::list_detailed::Request<'_> =
+                    filters.try_into().wrap_err("Cannot prepare request")?;
+
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep
+                        .query_async(session)
+                        .await
+                        .wrap_err("fetching hypervisors failed")?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeHypervisorList {}
+
+impl fmt::Display for ComputeHypervisorList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeHypervisorList>
+    for openstack_sdk::api::compute::v2::hypervisor::list_detailed::Request<'_>
+{
+    type Error = openstack_sdk::api::compute::v2::hypervisor::list_detailed::RequestBuilderError;
+
+    fn try_from(_value: &ComputeHypervisorList) -> Result<Self, Self::Error> {
+        openstack_sdk::api::compute::v2::hypervisor::list_detailed::Request::builder().build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/compute/quota_set.rs
+++ b/openstack_tui/src/cloud_worker/compute/quota_set.rs
@@ -1,0 +1,83 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::compute::types::ComputeApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// QuotaSet
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComputeQuotaSetApiRequest {
+    /// Details
+    Details(ComputeQuotaSetDetails),
+}
+
+impl From<ComputeQuotaSetApiRequest> for ApiRequest {
+    fn from(item: ComputeQuotaSetApiRequest) -> Self {
+        ApiRequest::Compute(ComputeApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for ComputeQuotaSetApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            ComputeQuotaSetApiRequest::Details(ref filters) => {
+                let ep: openstack_sdk::api::compute::v2::quota_set::details::Request<'_> =
+                    filters.try_into().wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponseData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeQuotaSetDetails {
+    pub project_id: String,
+}
+
+impl fmt::Display for ComputeQuotaSetDetails {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeQuotaSetDetails>
+    for openstack_sdk::api::compute::v2::quota_set::details::Request<'_>
+{
+    type Error = openstack_sdk::api::compute::v2::quota_set::details::RequestBuilderError;
+
+    fn try_from(value: &ComputeQuotaSetDetails) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        ep_builder.id(value.project_id.clone());
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/compute/server.rs
+++ b/openstack_tui/src/cloud_worker/compute/server.rs
@@ -1,0 +1,294 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{OptionExt, Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::common::ConfirmableRequest;
+use crate::cloud_worker::compute::types::ComputeApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Server API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComputeServerApiRequest {
+    /// List servers
+    List(ComputeServerList),
+    /// Delete server
+    Delete(ComputeServerDelete),
+    /// Get server console output
+    GetConsoleOutput(ComputeServerGetConsoleOutput),
+    /// Get instance actions
+    InstanceActionList(ComputeServerInstanceActionList),
+    /// Get single instance action data
+    InstanceActionShow(ComputeServerInstanceActionList),
+}
+
+impl From<ComputeServerApiRequest> for ApiRequest {
+    fn from(item: ComputeServerApiRequest) -> Self {
+        ApiRequest::Compute(ComputeApiRequest::from(item))
+    }
+}
+
+impl ConfirmableRequest for ComputeServerApiRequest {
+    fn get_confirm_message(&self) -> Option<String> {
+        match &self {
+            ComputeServerApiRequest::Delete(x) => x.get_confirm_message(),
+            _ => None,
+        }
+    }
+}
+
+impl ExecuteApiRequest for ComputeServerApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            ComputeServerApiRequest::List(ref req) => {
+                let ep: openstack_sdk::api::compute::v2::server::list_detailed::Request<'_> =
+                    req.try_into().wrap_err("cannot prepare request")?;
+
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+            ComputeServerApiRequest::Delete(ref req) => {
+                let ep: openstack_sdk::api::compute::v2::server::delete::Request<'_> =
+                    req.try_into().wrap_err("cannot prepare request")?;
+
+                openstack_sdk::api::ignore(ep).query_async(session).await?;
+
+                app_tx.send(Action::Refresh)?;
+            }
+            ComputeServerApiRequest::GetConsoleOutput(ref req) => {
+                let ep = openstack_sdk::api::compute::v2::server::os_get_console_output::Request::
+                    try_from(req).wrap_err("cannot prepare request")?;
+
+                let res: Value = ep.query_async(session).await?;
+                app_tx.send(Action::ApiResponseData {
+                    request: request.clone(),
+                    data: res.get("output").unwrap_or(&Value::Null).to_owned(),
+                })?;
+            }
+            ComputeServerApiRequest::InstanceActionList(ref req) => {
+                let ep =
+                openstack_sdk::api::compute::v2::server::instance_action::list::Request::try_from(req).wrap_err("cannot prepare request")?;
+
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+            ComputeServerApiRequest::InstanceActionShow(ref filters) => {
+                let ep =
+                openstack_sdk::api::compute::v2::server::instance_action::get::Request::try_from(filters).wrap_err("cannot prepare request")?;
+
+                app_tx.send(Action::ApiResponseData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeServerList {
+    /// All tenants (admin only)
+    pub all_tenants: Option<bool>,
+    /// List servers with specific flavor
+    pub flavor_id: Option<String>,
+    /// Flavor name (used only for display)
+    pub flavor_name: Option<String>,
+}
+
+impl fmt::Display for ComputeServerList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        if self.all_tenants.is_some() {
+            parts.push(String::from("all"));
+        }
+        if self.flavor_id.is_some() || self.flavor_name.is_some() {
+            parts.push(format!(
+                "flavor: {}",
+                self.flavor_name
+                    .as_ref()
+                    .or(self.flavor_name.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+impl TryFrom<&ComputeServerList>
+    for openstack_sdk::api::compute::v2::server::list_detailed::Request<'_>
+{
+    type Error = openstack_sdk::api::compute::v2::server::list_detailed::RequestBuilderError;
+
+    fn try_from(value: &ComputeServerList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        ep_builder.sort_key("display_name");
+        ep_builder.sort_dir("asc");
+
+        if let Some(true) = &value.all_tenants {
+            ep_builder.all_tenants("true");
+        }
+
+        if let Some(flavor_id) = &value.flavor_id {
+            ep_builder.flavor(flavor_id.clone());
+        }
+
+        ep_builder.build()
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeServerDelete {
+    pub server_id: String,
+    pub server_name: Option<String>,
+}
+
+impl fmt::Display for ComputeServerDelete {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeServerDelete>
+    for openstack_sdk::api::compute::v2::server::delete::Request<'_>
+{
+    type Error = openstack_sdk::api::compute::v2::server::delete::RequestBuilderError;
+
+    fn try_from(value: &ComputeServerDelete) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        ep_builder.id(value.server_id.clone());
+        ep_builder.build()
+    }
+}
+
+impl ConfirmableRequest for ComputeServerDelete {
+    fn get_confirm_message(&self) -> Option<String> {
+        Some(format!(
+            "Delete server {} ?",
+            self.server_name.clone().unwrap_or(self.server_id.clone())
+        ))
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeServerGetConsoleOutput {
+    pub server_id: String,
+    pub length: Option<i32>,
+}
+
+impl TryFrom<&ComputeServerGetConsoleOutput>
+    for openstack_sdk::api::compute::v2::server::os_get_console_output::Request<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(value: &ComputeServerGetConsoleOutput) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        ep_builder.id(value.server_id.clone());
+        let mut len = openstack_sdk::api::compute::v2::server::os_get_console_output::OsGetConsoleOutputBuilder::default();
+        if let Some(length) = value.length {
+            len.length(length);
+        }
+        ep_builder.os_get_console_output(len.build()?);
+        Ok(ep_builder.build()?)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComputeServerInstanceActionList {
+    /// Server ID
+    pub server_id: Option<String>,
+    /// Server name
+    pub server_name: Option<String>,
+    /// Request id
+    pub request_id: Option<String>,
+}
+
+impl fmt::Display for ComputeServerInstanceActionList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.server_id.is_some() || self.server_name.is_some() {
+            write!(
+                f,
+                "server: {}",
+                self.server_name
+                    .as_ref()
+                    .or(self.server_name.as_ref())
+                    .unwrap_or(&String::new())
+            )?;
+        }
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&ComputeServerInstanceActionList>
+    for openstack_sdk::api::compute::v2::server::instance_action::list::Request<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(filters: &ComputeServerInstanceActionList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        ep_builder.server_id(
+            filters
+                .server_id
+                .clone()
+                .ok_or_eyre("Server ID must be set")?,
+        );
+
+        Ok(ep_builder.build()?)
+    }
+}
+
+impl TryFrom<&ComputeServerInstanceActionList>
+    for openstack_sdk::api::compute::v2::server::instance_action::get::Request<'_>
+{
+    type Error = eyre::Report;
+
+    fn try_from(filters: &ComputeServerInstanceActionList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+
+        ep_builder.server_id(
+            filters
+                .server_id
+                .clone()
+                .ok_or_eyre("Server ID must be set")?,
+        );
+        ep_builder.id(filters
+            .request_id
+            .clone()
+            .ok_or_eyre("InstanceAction ID must be set")?);
+
+        Ok(ep_builder.build()?)
+    }
+}

--- a/openstack_tui/src/cloud_worker/compute/types.rs
+++ b/openstack_tui/src/cloud_worker/compute/types.rs
@@ -12,213 +12,65 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use eyre::{OptionExt, Result};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
-use crate::cloud_worker::common::ConfirmableRequest;
+pub use crate::cloud_worker::compute::aggregate::*;
+pub use crate::cloud_worker::compute::flavor::*;
+pub use crate::cloud_worker::compute::hypervisor::*;
+pub use crate::cloud_worker::compute::quota_set::*;
+pub use crate::cloud_worker::compute::server::*;
+use crate::cloud_worker::ConfirmableRequest;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ComputeFlavorFilters {}
+/// Compute operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ComputeApiRequest {
+    /// Aggregate resource
+    Aggregate(ComputeAggregateApiRequest),
+    /// Flavor resource
+    Flavor(ComputeFlavorApiRequest),
+    /// Hypervisor
+    Hypervisor(ComputeHypervisorApiRequest),
+    /// Compute quota
+    QuotaSet(ComputeQuotaSetApiRequest),
+    /// Compute server
+    Server(ComputeServerApiRequest),
+}
 
-impl fmt::Display for ComputeFlavorFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
+impl From<ComputeAggregateApiRequest> for ComputeApiRequest {
+    fn from(item: ComputeAggregateApiRequest) -> Self {
+        ComputeApiRequest::Aggregate(item)
     }
 }
 
-impl TryFrom<&ComputeFlavorFilters>
-    for openstack_sdk::api::compute::v2::flavor::list_detailed::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(_value: &ComputeFlavorFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::compute::v2::flavor::list_detailed::Request::builder();
-
-        ep_builder.sort_key("name");
-        Ok(ep_builder)
+impl From<ComputeFlavorApiRequest> for ComputeApiRequest {
+    fn from(item: ComputeFlavorApiRequest) -> Self {
+        ComputeApiRequest::Flavor(item)
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ComputeServerFilters {
-    /// All tenants (admin only)
-    pub all_tenants: Option<bool>,
-    /// List servers with specific flavor
-    pub flavor_id: Option<String>,
-    /// Flavor name (used only for display)
-    pub flavor_name: Option<String>,
-}
-
-impl fmt::Display for ComputeServerFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut parts: Vec<String> = Vec::new();
-        if self.all_tenants.is_some() {
-            parts.push(String::from("all"));
-        }
-        if self.flavor_id.is_some() || self.flavor_name.is_some() {
-            parts.push(format!(
-                "flavor: {}",
-                self.flavor_name
-                    .as_ref()
-                    .or(self.flavor_name.as_ref())
-                    .unwrap_or(&String::new())
-            ));
-        }
-        write!(f, "{}", parts.join(","))
+impl From<ComputeHypervisorApiRequest> for ComputeApiRequest {
+    fn from(item: ComputeHypervisorApiRequest) -> Self {
+        ComputeApiRequest::Hypervisor(item)
     }
 }
 
-impl TryFrom<&ComputeServerFilters>
-    for openstack_sdk::api::compute::v2::server::list_detailed::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(value: &ComputeServerFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::compute::v2::server::list_detailed::Request::builder();
-
-        ep_builder.sort_key("display_name");
-        ep_builder.sort_dir("asc");
-
-        if let Some(true) = &value.all_tenants {
-            ep_builder.all_tenants("true");
-        }
-
-        if let Some(flavor_id) = &value.flavor_id {
-            ep_builder.flavor(flavor_id.clone());
-        }
-
-        Ok(ep_builder)
+impl From<ComputeQuotaSetApiRequest> for ComputeApiRequest {
+    fn from(item: ComputeQuotaSetApiRequest) -> Self {
+        ComputeApiRequest::QuotaSet(item)
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ComputeServerDelete {
-    pub server_id: String,
-    pub server_name: Option<String>,
-}
-
-impl fmt::Display for ComputeServerDelete {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
+impl From<ComputeServerApiRequest> for ComputeApiRequest {
+    fn from(item: ComputeServerApiRequest) -> Self {
+        ComputeApiRequest::Server(item)
     }
 }
 
-impl ConfirmableRequest for ComputeServerDelete {
+impl ConfirmableRequest for ComputeApiRequest {
     fn get_confirm_message(&self) -> Option<String> {
-        Some(format!(
-            "Delete server {} ?",
-            self.server_name.clone().unwrap_or(self.server_id.clone())
-        ))
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ComputeServerInstanceActionFilters {
-    /// Server ID
-    pub server_id: Option<String>,
-    /// Server name
-    pub server_name: Option<String>,
-    /// Request id
-    pub request_id: Option<String>,
-}
-
-impl fmt::Display for ComputeServerInstanceActionFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.server_id.is_some() || self.server_name.is_some() {
-            write!(
-                f,
-                "server: {}",
-                self.server_name
-                    .as_ref()
-                    .or(self.server_name.as_ref())
-                    .unwrap_or(&String::new())
-            )?;
+        match &self {
+            ComputeApiRequest::Server(req) => req.get_confirm_message(),
+            _ => None,
         }
-
-        write!(f, "")
-    }
-}
-
-impl TryFrom<&ComputeServerInstanceActionFilters>
-    for openstack_sdk::api::compute::v2::server::instance_action::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(filters: &ComputeServerInstanceActionFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::compute::v2::server::instance_action::list::Request::builder();
-
-        ep_builder.server_id(
-            filters
-                .server_id
-                .clone()
-                .ok_or_eyre("Server ID must be set")?,
-        );
-
-        Ok(ep_builder)
-    }
-}
-
-impl TryFrom<&ComputeServerInstanceActionFilters>
-    for openstack_sdk::api::compute::v2::server::instance_action::get::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(filters: &ComputeServerInstanceActionFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::compute::v2::server::instance_action::get::Request::builder();
-
-        ep_builder.server_id(
-            filters
-                .server_id
-                .clone()
-                .ok_or_eyre("Server ID must be set")?,
-        );
-        ep_builder.id(filters
-            .request_id
-            .clone()
-            .ok_or_eyre("InstanceAction ID must be set")?);
-
-        Ok(ep_builder)
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ComputeHypervisorFilters {}
-
-impl fmt::Display for ComputeHypervisorFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-
-impl TryFrom<&ComputeHypervisorFilters>
-    for openstack_sdk::api::compute::v2::hypervisor::list_detailed::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(_value: &ComputeHypervisorFilters) -> Result<Self, Self::Error> {
-        Ok(openstack_sdk::api::compute::v2::hypervisor::list_detailed::Request::builder())
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ComputeAggregateFilters {}
-
-impl fmt::Display for ComputeAggregateFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-impl TryFrom<&ComputeAggregateFilters>
-    for openstack_sdk::api::compute::v2::aggregate::list::RequestBuilder
-{
-    type Error = eyre::Report;
-
-    fn try_from(_value: &ComputeAggregateFilters) -> Result<Self, Self::Error> {
-        Ok(openstack_sdk::api::compute::v2::aggregate::list::Request::builder())
     }
 }

--- a/openstack_tui/src/cloud_worker/dns.rs
+++ b/openstack_tui/src/cloud_worker/dns.rs
@@ -13,114 +13,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
 
-use openstack_sdk::{api::Pagination, api::QueryAsync};
+use openstack_sdk::AsyncOpenStack;
 
 use crate::action::Action;
-use crate::cloud_worker::{ApiRequest, Cloud};
+use crate::cloud_worker::dns::types::DnsApiRequest;
+use crate::cloud_worker::types::ExecuteApiRequest;
+use crate::cloud_worker::{ApiRequest, CloudWorkerError};
 
+pub mod recordset;
 pub mod types;
-use types::*;
+pub mod zone;
 
-pub trait DnsExt {
-    async fn perform_api_request(
-        &mut self,
+impl ExecuteApiRequest for DnsApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
         app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()>;
-
-    async fn get_recordsets(&mut self, filters: &DnsRecordsetFilters) -> Result<Vec<Value>>;
-    async fn get_zones(&mut self, filters: &DnsZoneFilters) -> Result<Vec<Value>>;
-    async fn delete_zone(&mut self, request: &DnsZoneDelete) -> Result<()>;
-}
-
-impl DnsExt for Cloud {
-    async fn perform_api_request(
-        &mut self,
-        app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()> {
-        match request {
-            ApiRequest::DnsRecordsets(ref filters) => match self.get_recordsets(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch dns recordsets: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::DnsZones(ref filters) => match self.get_zones(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch dns zones: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::DnsZoneDelete(ref request) => match self.delete_zone(request).await {
-                Ok(_data) => app_tx.send(Action::Refresh)?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to delete dns zone: {:?}",
-                    err
-                )))?,
-            },
-            _ => {
-                todo!()
-            }
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            DnsApiRequest::Recordset(data) => data.execute_request(session, request, app_tx).await,
+            DnsApiRequest::Zone(data) => data.execute_request(session, request, app_tx).await,
         }
-        Ok(())
-    }
-
-    async fn get_recordsets(&mut self, request: &DnsRecordsetFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let res: Vec<Value> = if request.zone_id.is_some() {
-                let ep =
-                    openstack_sdk::api::dns::v2::zone::recordset::list::RequestBuilder::try_from(
-                        request,
-                    )?
-                    .build()?;
-                openstack_sdk::api::paged(ep, Pagination::All)
-                    .query_async(session)
-                    .await?
-            } else {
-                let ep = openstack_sdk::api::dns::v2::recordset::list::RequestBuilder::try_from(
-                    request,
-                )?
-                .build()?;
-                openstack_sdk::api::paged(ep, Pagination::All)
-                    .query_async(session)
-                    .await?
-            };
-
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_zones(&mut self, _request: &DnsZoneFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let mut ep_builder = openstack_sdk::api::dns::v2::zone::list::Request::builder();
-            ep_builder.sort_key("name");
-            ep_builder.sort_dir("asc");
-
-            let ep = ep_builder.build()?;
-            let res: Vec<Value> = openstack_sdk::api::paged(ep, Pagination::All)
-                .query_async(session)
-                .await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn delete_zone(&mut self, request: &DnsZoneDelete) -> Result<()> {
-        if let Some(session) = &self.cloud {
-            let ep = openstack_sdk::api::dns::v2::zone::delete::Request::builder()
-                .id(request.zone_id.clone())
-                .build()?;
-
-            openstack_sdk::api::ignore(ep).query_async(session).await?;
-            return Ok(());
-        }
-        Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/dns/recordset.rs
+++ b/openstack_tui/src/cloud_worker/dns/recordset.rs
@@ -1,0 +1,125 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::dns::types::DnsApiRequest;
+use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::ExecuteApiRequest;
+
+/// Recordset API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DnsRecordsetApiRequest {
+    /// List
+    List(DnsRecordsetList),
+}
+
+impl From<DnsRecordsetApiRequest> for ApiRequest {
+    fn from(item: DnsRecordsetApiRequest) -> Self {
+        ApiRequest::Dns(DnsApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for DnsRecordsetApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            DnsRecordsetApiRequest::List(ref filters) => {
+                let res: Vec<Value> = if filters.zone_id.is_some() {
+                    let ep = TryInto::<
+                        openstack_sdk::api::dns::v2::zone::recordset::list::Request<'_>,
+                    >::try_into(filters)
+                    .wrap_err("Cannot prepare request")?;
+                    paged(ep, Pagination::All).query_async(session).await?
+                } else {
+                    let ep = TryInto::<openstack_sdk::api::dns::v2::recordset::list::Request<'_>>::try_into(
+                            filters,
+                        )
+                        .wrap_err("Cannot prepare request")?;
+                    paged(ep, Pagination::All).query_async(session).await?
+                };
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: res,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DnsRecordsetList {
+    /// Zone Id
+    pub zone_id: Option<String>,
+    /// Optional name (for info purposes)
+    pub zone_name: Option<String>,
+}
+
+impl fmt::Display for DnsRecordsetList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        if self.zone_id.is_some() || self.zone_name.is_some() {
+            parts.push(format!(
+                "zone: {}",
+                self.zone_name
+                    .as_ref()
+                    .or(self.zone_name.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+impl TryFrom<&DnsRecordsetList>
+    for openstack_sdk::api::dns::v2::zone::recordset::list::Request<'_>
+{
+    type Error = openstack_sdk::api::dns::v2::zone::recordset::list::RequestBuilderError;
+
+    fn try_from(value: &DnsRecordsetList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        ep_builder.sort_key("name");
+        ep_builder.sort_dir("asc");
+
+        if let Some(zone_id) = &value.zone_id {
+            ep_builder.zone_id(zone_id.clone());
+        }
+
+        ep_builder.build()
+    }
+}
+
+impl TryFrom<&DnsRecordsetList> for openstack_sdk::api::dns::v2::recordset::list::Request<'_> {
+    type Error = openstack_sdk::api::dns::v2::recordset::list::RequestBuilderError;
+
+    fn try_from(_value: &DnsRecordsetList) -> Result<Self, Self::Error> {
+        Self::builder().sort_key("name").sort_dir("asc").build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/dns/zone.rs
+++ b/openstack_tui/src/cloud_worker/dns/zone.rs
@@ -1,0 +1,129 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::dns::types::DnsApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+use crate::cloud_worker::ConfirmableRequest;
+
+/// Zone API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DnsZoneApiRequest {
+    /// Delete
+    Delete(DnsZoneDelete),
+    /// List Zones
+    List(DnsZoneList),
+}
+
+impl From<DnsZoneApiRequest> for ApiRequest {
+    fn from(item: DnsZoneApiRequest) -> Self {
+        ApiRequest::Dns(DnsApiRequest::from(item))
+    }
+}
+
+impl ConfirmableRequest for DnsZoneApiRequest {
+    fn get_confirm_message(&self) -> Option<String> {
+        match &self {
+            DnsZoneApiRequest::Delete(req) => req.get_confirm_message(),
+            _ => None,
+        }
+    }
+}
+
+impl ExecuteApiRequest for DnsZoneApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            DnsZoneApiRequest::Delete(ref filters) => {
+                let ep =
+                    TryInto::<openstack_sdk::api::dns::v2::zone::delete::Request<'_>>::try_into(
+                        filters,
+                    )
+                    .wrap_err("Cannot prepare request")?;
+                openstack_sdk::api::ignore(ep).query_async(session).await?;
+                app_tx.send(Action::Refresh)?;
+            }
+            DnsZoneApiRequest::List(ref filters) => {
+                let ep: openstack_sdk::api::dns::v2::zone::list::Request<'_> =
+                    filters.try_into().wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DnsZoneList {}
+
+impl fmt::Display for DnsZoneList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&DnsZoneList> for openstack_sdk::api::dns::v2::zone::list::Request<'_> {
+    type Error = openstack_sdk::api::dns::v2::zone::list::RequestBuilderError;
+
+    fn try_from(_value: &DnsZoneList) -> Result<Self, Self::Error> {
+        Self::builder().sort_key("name").sort_dir("asc").build()
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DnsZoneDelete {
+    pub zone_id: String,
+    pub zone_name: Option<String>,
+}
+
+impl fmt::Display for DnsZoneDelete {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl ConfirmableRequest for DnsZoneDelete {
+    fn get_confirm_message(&self) -> Option<String> {
+        Some(format!(
+            "Delete DNS Zone {} ?",
+            self.zone_name.clone().unwrap_or(self.zone_id.clone())
+        ))
+    }
+}
+
+impl TryFrom<&DnsZoneDelete> for openstack_sdk::api::dns::v2::zone::delete::Request<'_> {
+    type Error = openstack_sdk::api::dns::v2::zone::delete::RequestBuilderError;
+
+    fn try_from(value: &DnsZoneDelete) -> Result<Self, Self::Error> {
+        Self::builder().id(value.zone_id.clone()).build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/identity.rs
+++ b/openstack_tui/src/cloud_worker/identity.rs
@@ -13,239 +13,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::debug;
 
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::AsyncOpenStack;
 
 use crate::action::Action;
-use crate::cloud_worker::{ApiRequest, Cloud};
+use crate::cloud_worker::types::ExecuteApiRequest;
+use crate::cloud_worker::{ApiRequest, CloudWorkerError};
 
+pub mod auth;
+pub mod group;
+pub mod project;
 pub mod types;
+pub mod user;
 use types::*;
 
-pub trait IdentityExt {
-    async fn perform_api_request(
-        &mut self,
+impl ExecuteApiRequest for IdentityApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
         app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()>;
-
-    async fn get_auth_projects(
-        &mut self,
-        filters: &IdentityAuthProjectFilters,
-    ) -> Result<Vec<Value>>;
-
-    async fn get_groups(&mut self, _filters: &IdentityGroupFilters) -> Result<Vec<Value>>;
-    async fn get_group_users(&mut self, _filters: &IdentityGroupUserFilters) -> Result<Vec<Value>>;
-    async fn get_projects(&mut self, _filters: &IdentityProjectFilters) -> Result<Vec<Value>>;
-    /// Get all users
-    async fn get_users(&mut self, _filters: &IdentityUserFilters) -> Result<Vec<Value>>;
-    /// Update user
-    async fn update_user(&mut self, data: &IdentityUserUpdate) -> Result<Value>;
-    /// Get user application credentials
-    async fn get_user_application_credentials(
-        &mut self,
-        _filters: &IdentityApplicationCredentialFilters,
-    ) -> Result<Vec<Value>>;
-}
-
-impl IdentityExt for Cloud {
-    async fn perform_api_request(
-        &mut self,
-        app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()> {
-        match request {
-            ApiRequest::IdentityAuthProjects(ref filters) => {
-                match self.get_auth_projects(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch available project scopes: {:?}",
-                        err
-                    )))?,
-                }
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            IdentityApiRequest::Auth(data) => data.execute_request(session, request, app_tx).await,
+            IdentityApiRequest::Group(data) => data.execute_request(session, request, app_tx).await,
+            IdentityApiRequest::Project(data) => {
+                data.execute_request(session, request, app_tx).await
             }
-            ApiRequest::IdentityGroups(ref filters) => match self.get_groups(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch available groups\n\nSome clouds require to use domain scope with the user having `manager` role\n{:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::IdentityGroupUsers(ref filters) => match self.get_group_users(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch available group users\n\nSome clouds require to use domain scope with the user having `manager` role\n{:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::IdentityProjects(ref filters) => match self.get_projects(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch available projects: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::IdentityUsers(ref filters) => match self.get_users(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch available users\n\nSome clouds require to use domain scope with the user having `manager` role\n{:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::IdentityUserUpdate(ref data) => match self.update_user(data).await {
-                Ok(data) => app_tx.send(Action::ApiResponseData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to update user\n\nSome clouds require to use domain scope with the user having `manager` role\n{:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::IdentityApplicationCredentials(ref filters) => {
-                let mut maybe_changed_filters = filters.clone();
-                if maybe_changed_filters.user_id.is_empty() {
-                    if let Some(session) = &self.cloud {
-                        if let Some(auth) = session.get_auth_info() {
-                            maybe_changed_filters.user_id = auth.token.user.id;
-                            maybe_changed_filters.user_name = Some(auth.token.user.name);
-                            app_tx.send(Action::SetIdentityApplicationCredentialFilters(maybe_changed_filters))?;
-                        }
-                    }
-                } else {
-                    match self.get_user_application_credentials(&maybe_changed_filters).await {
-                        Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                        Err(err) => app_tx.send(Action::Error(format!(
-                            "Failed to fetch available application credentials\n\nSome clouds require to use domain scope with the user having `manager` role\n{:?}",
-                            err
-                        )))?,
-                    }
-                }
-            },
-            _ => {
-                todo!()
-            }
+            IdentityApiRequest::User(data) => data.execute_request(session, request, app_tx).await,
         }
-        Ok(())
-    }
-
-    async fn get_auth_projects(
-        &mut self,
-        _filters: &IdentityAuthProjectFilters,
-    ) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep_builder =
-                openstack_sdk::api::identity::v3::auth::project::list::Request::builder();
-
-            //if let Some(vis) = &filters.visibility {
-            //    ep_builder.visibility(vis);
-            //}
-            let ep = ep_builder.build()?;
-            let res: Vec<Value> = ep.query_async(session).await?;
-            //let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_projects(&mut self, _filters: &IdentityProjectFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep_builder = openstack_sdk::api::identity::v3::project::list::Request::builder();
-
-            //if let Some(vis) = &filters.visibility {
-            //    ep_builder.visibility(vis);
-            //}
-            let ep = ep_builder.build()?;
-            let res: Vec<Value> = ep.query_async(session).await?;
-            //let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_groups(&mut self, _filters: &IdentityGroupFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep_builder = openstack_sdk::api::identity::v3::group::list::Request::builder();
-
-            //if let Some(vis) = &filters.visibility {
-            //    ep_builder.visibility(vis);
-            //}
-            let ep = ep_builder.build()?;
-            let res: Vec<Value> = ep.query_async(session).await?;
-            //let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_group_users(&mut self, filters: &IdentityGroupUserFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep = openstack_sdk::api::identity::v3::group::user::list::Request::builder()
-                .group_id(&filters.group_id)
-                .build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_users(&mut self, _filters: &IdentityUserFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep_builder = openstack_sdk::api::identity::v3::user::list::Request::builder();
-
-            //if let Some(vis) = &filters.visibility {
-            //    ep_builder.visibility(vis);
-            //}
-            let ep = ep_builder.build()?;
-            let res: Vec<Value> = ep.query_async(session).await?;
-            //let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn update_user(&mut self, data: &IdentityUserUpdate) -> Result<Value> {
-        if let Some(session) = &self.cloud {
-            let mut ep_builder = openstack_sdk::api::identity::v3::user::set::Request::builder();
-            let mut user_builder =
-                openstack_sdk::api::identity::v3::user::set::UserBuilder::default();
-            ep_builder.id(data.id.clone());
-            if let Some(name) = &data.name {
-                user_builder.name(name);
-            }
-            if let Some(enabled) = &data.enabled {
-                user_builder.enabled(*enabled);
-            }
-            ep_builder.user(user_builder.build()?);
-
-            let ep = ep_builder.build()?;
-            let res: Value = ep.query_async(session).await?;
-            debug!("Updated user information: {:?}", res);
-            return Ok(res);
-        }
-        Ok(Value::Null)
-    }
-
-    async fn get_user_application_credentials(
-        &mut self,
-        filters: &IdentityApplicationCredentialFilters,
-    ) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let mut ep_builder = openstack_sdk::api::identity::v3::user::application_credential::list::Request::builder();
-            if filters.user_id.is_empty() {
-                if let Some(auth) = session.get_auth_info() {
-                    ep_builder.user_id(auth.token.user.id);
-                }
-            } else {
-                ep_builder.user_id(filters.user_id.clone());
-            }
-
-            let ep = ep_builder.build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
     }
 }

--- a/openstack_tui/src/cloud_worker/identity/auth.rs
+++ b/openstack_tui/src/cloud_worker/identity/auth.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::identity::types::IdentityApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Auth metaresource API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdentityAuthApiRequest {
+    /// Projects
+    Projects(IdentityAuthProjectList),
+}
+
+impl From<IdentityAuthApiRequest> for ApiRequest {
+    fn from(item: IdentityAuthApiRequest) -> Self {
+        ApiRequest::Identity(IdentityApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for IdentityAuthApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            IdentityAuthApiRequest::Projects(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::identity::v3::auth::project::list::Request,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityAuthProjectList {}
+impl fmt::Display for IdentityAuthProjectList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&IdentityAuthProjectList>
+    for openstack_sdk::api::identity::v3::auth::project::list::Request
+{
+    type Error = openstack_sdk::api::identity::v3::auth::project::list::RequestBuilderError;
+
+    fn try_from(_value: &IdentityAuthProjectList) -> Result<Self, Self::Error> {
+        Self::builder().build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/identity/group.rs
+++ b/openstack_tui/src/cloud_worker/identity/group.rs
@@ -1,0 +1,119 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::identity::types::IdentityApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Group API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdentityGroupApiRequest {
+    /// List
+    List(IdentityGroupList),
+    /// Users
+    UserList(IdentityGroupUserList),
+}
+
+impl From<IdentityGroupApiRequest> for ApiRequest {
+    fn from(item: IdentityGroupApiRequest) -> Self {
+        ApiRequest::Identity(IdentityApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for IdentityGroupApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            IdentityGroupApiRequest::List(ref req) => {
+                let ep =
+                    TryInto::<openstack_sdk::api::identity::v3::group::list::Request<'_>>::try_into(
+                        req,
+                    )
+                    .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+            IdentityGroupApiRequest::UserList(ref req) => {
+                let ep =
+                    TryInto::<openstack_sdk::api::identity::v3::group::user::list::Request<'_>>::try_into(
+                        req,
+                    )
+                    .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityGroupList {}
+impl fmt::Display for IdentityGroupList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&IdentityGroupList> for openstack_sdk::api::identity::v3::group::list::Request<'_> {
+    type Error = openstack_sdk::api::identity::v3::group::list::RequestBuilderError;
+
+    fn try_from(_value: &IdentityGroupList) -> Result<Self, Self::Error> {
+        Self::builder().build()
+    }
+}
+
+/// Group Users filter
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityGroupUserList {
+    /// Group id (used by API)
+    pub group_id: String,
+    /// Group name (Set by caller for display only)
+    pub group_name: Option<String>,
+}
+
+impl fmt::Display for IdentityGroupUserList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "group: {}",
+            self.group_name.as_ref().unwrap_or(&self.group_id)
+        )
+    }
+}
+
+impl TryFrom<&IdentityGroupUserList>
+    for openstack_sdk::api::identity::v3::group::user::list::Request<'_>
+{
+    type Error = openstack_sdk::api::identity::v3::group::user::list::RequestBuilderError;
+
+    fn try_from(value: &IdentityGroupUserList) -> Result<Self, Self::Error> {
+        Self::builder().group_id(value.group_id.clone()).build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/identity/project.rs
+++ b/openstack_tui/src/cloud_worker/identity/project.rs
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::identity::types::IdentityApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Project API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdentityProjectApiRequest {
+    /// List
+    List(IdentityProjectList),
+}
+
+impl From<IdentityProjectApiRequest> for ApiRequest {
+    fn from(item: IdentityProjectApiRequest) -> Self {
+        ApiRequest::Identity(IdentityApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for IdentityProjectApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            IdentityProjectApiRequest::List(ref req) => {
+                let ep =
+                    TryInto::<openstack_sdk::api::identity::v3::project::list::Request<'_>>::try_into(
+                        req,
+                    )
+                    .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityProjectList {}
+impl fmt::Display for IdentityProjectList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&IdentityProjectList>
+    for openstack_sdk::api::identity::v3::project::list::Request<'_>
+{
+    type Error = openstack_sdk::api::identity::v3::project::list::RequestBuilderError;
+
+    fn try_from(_value: &IdentityProjectList) -> Result<Self, Self::Error> {
+        Self::builder().build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/identity/types.rs
+++ b/openstack_tui/src/cloud_worker/identity/types.rs
@@ -13,82 +13,45 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityAuthProjectFilters {}
-impl fmt::Display for IdentityAuthProjectFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityProjectFilters {}
-impl fmt::Display for IdentityProjectFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
+pub use crate::cloud_worker::identity::auth::*;
+pub use crate::cloud_worker::identity::group::*;
+pub use crate::cloud_worker::identity::project::*;
+pub use crate::cloud_worker::identity::user::*;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityUserFilters {}
-impl fmt::Display for IdentityUserFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
+/// Identity operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdentityApiRequest {
+    /// Auth
+    Auth(IdentityAuthApiRequest),
+    /// Groups
+    Group(IdentityGroupApiRequest),
+    /// Projects
+    Project(IdentityProjectApiRequest),
+    //    Group,
+    User(IdentityUserApiRequest),
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityGroupFilters {}
-impl fmt::Display for IdentityGroupFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
+impl From<IdentityAuthApiRequest> for IdentityApiRequest {
+    fn from(item: IdentityAuthApiRequest) -> Self {
+        IdentityApiRequest::Auth(item)
     }
 }
 
-/// Group Users filter
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityGroupUserFilters {
-    /// Group id (used by API)
-    pub group_id: String,
-    /// Group name (Set by caller for display only)
-    pub group_name: Option<String>,
-}
-impl fmt::Display for IdentityGroupUserFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "group: {}",
-            self.group_name.as_ref().unwrap_or(&self.group_id)
-        )
+impl From<IdentityGroupApiRequest> for IdentityApiRequest {
+    fn from(item: IdentityGroupApiRequest) -> Self {
+        IdentityApiRequest::Group(item)
     }
 }
 
-/// Update user properties
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityUserUpdate {
-    /// User ID
-    pub id: String,
-    /// New user name
-    pub name: Option<String>,
-    /// Enabled
-    pub enabled: Option<bool>,
+impl From<IdentityProjectApiRequest> for IdentityApiRequest {
+    fn from(item: IdentityProjectApiRequest) -> Self {
+        IdentityApiRequest::Project(item)
+    }
 }
 
-/// User Application Credentials filter
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IdentityApplicationCredentialFilters {
-    /// User id (used by API)
-    pub user_id: String,
-    /// User name (Set by caller for display only)
-    pub user_name: Option<String>,
-}
-impl fmt::Display for IdentityApplicationCredentialFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "user: {}",
-            self.user_name.as_ref().unwrap_or(&self.user_id)
-        )
+impl From<IdentityUserApiRequest> for IdentityApiRequest {
+    fn from(item: IdentityUserApiRequest) -> Self {
+        IdentityApiRequest::User(item)
     }
 }

--- a/openstack_tui/src/cloud_worker/identity/user.rs
+++ b/openstack_tui/src/cloud_worker/identity/user.rs
@@ -1,0 +1,146 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::identity::types::IdentityApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+mod application_credential;
+
+pub use application_credential::*;
+
+/// User API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdentityUserApiRequest {
+    /// Application Credentials
+    ApplicationCredential(IdentityApplicationCredentialApiRequest),
+    /// List
+    List(IdentityUserList),
+    /// Update
+    Update(IdentityUserUpdate),
+}
+
+impl From<IdentityUserApiRequest> for ApiRequest {
+    fn from(item: IdentityUserApiRequest) -> Self {
+        ApiRequest::Identity(IdentityApiRequest::from(item))
+    }
+}
+
+impl From<IdentityApplicationCredentialApiRequest> for IdentityUserApiRequest {
+    fn from(item: IdentityApplicationCredentialApiRequest) -> Self {
+        IdentityUserApiRequest::ApplicationCredential(item)
+    }
+}
+
+impl From<IdentityApplicationCredentialApiRequest> for IdentityApiRequest {
+    fn from(item: IdentityApplicationCredentialApiRequest) -> Self {
+        IdentityApiRequest::User(IdentityUserApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for IdentityUserApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            IdentityUserApiRequest::ApplicationCredential(ref req) => {
+                req.execute_request(session, request, app_tx).await?
+            }
+            IdentityUserApiRequest::List(ref req) => {
+                let ep =
+                    TryInto::<openstack_sdk::api::identity::v3::user::list::Request<'_>>::try_into(
+                        req,
+                    )
+                    .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+            IdentityUserApiRequest::Update(ref req) => {
+                let ep =
+                    TryInto::<openstack_sdk::api::identity::v3::user::set::Request<'_>>::try_into(
+                        req,
+                    )
+                    .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponseData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityUserList {}
+impl fmt::Display for IdentityUserList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&IdentityUserList> for openstack_sdk::api::identity::v3::user::list::Request<'_> {
+    type Error = openstack_sdk::api::identity::v3::user::list::RequestBuilderError;
+
+    fn try_from(_value: &IdentityUserList) -> Result<Self, Self::Error> {
+        Self::builder().build()
+    }
+}
+
+/// Update user properties
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityUserUpdate {
+    /// User ID
+    pub id: String,
+    /// New user name
+    pub name: Option<String>,
+    /// Enabled
+    pub enabled: Option<bool>,
+}
+
+impl fmt::Display for IdentityUserUpdate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "user: {}", self.name.as_ref().unwrap_or(&self.id))
+    }
+}
+
+impl TryFrom<&IdentityUserUpdate> for openstack_sdk::api::identity::v3::user::set::Request<'_> {
+    type Error = eyre::Report;
+
+    fn try_from(value: &IdentityUserUpdate) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        let mut user_builder = openstack_sdk::api::identity::v3::user::set::UserBuilder::default();
+        ep_builder.id(value.id.clone());
+        if let Some(name) = &value.name {
+            user_builder.name(name.clone());
+        }
+        if let Some(enabled) = &value.enabled {
+            user_builder.enabled(*enabled);
+        }
+        ep_builder.user(user_builder.build()?);
+        Ok(ep_builder.build()?)
+    }
+}

--- a/openstack_tui/src/cloud_worker/identity/user/application_credential.rs
+++ b/openstack_tui/src/cloud_worker/identity/user/application_credential.rs
@@ -1,0 +1,91 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::identity::types::IdentityApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Application Credential API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdentityApplicationCredentialApiRequest {
+    /// List
+    List(IdentityApplicationCredentialList),
+}
+
+impl From<IdentityApplicationCredentialApiRequest> for ApiRequest {
+    fn from(item: IdentityApplicationCredentialApiRequest) -> Self {
+        ApiRequest::Identity(IdentityApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for IdentityApplicationCredentialApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            IdentityApplicationCredentialApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::identity::v3::user::application_credential::list::Request<
+                        '_,
+                    >,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityApplicationCredentialList {
+    /// User id (used by API)
+    pub user_id: String,
+    /// User name (Set by caller for display only)
+    pub user_name: Option<String>,
+}
+
+impl fmt::Display for IdentityApplicationCredentialList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "user: {}",
+            self.user_name.as_ref().unwrap_or(&self.user_id)
+        )
+    }
+}
+
+impl TryFrom<&IdentityApplicationCredentialList>
+    for openstack_sdk::api::identity::v3::user::application_credential::list::Request<'_>
+{
+    type Error =
+        openstack_sdk::api::identity::v3::user::application_credential::list::RequestBuilderError;
+
+    fn try_from(value: &IdentityApplicationCredentialList) -> Result<Self, Self::Error> {
+        Self::builder().user_id(value.user_id.clone()).build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/image/image.rs
+++ b/openstack_tui/src/cloud_worker/image/image.rs
@@ -1,0 +1,142 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{
+    api::{paged, Pagination, QueryAsync},
+    AsyncOpenStack,
+};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::image::types::ImageApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+use crate::cloud_worker::ConfirmableRequest;
+
+/// Image API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ImageImageApiRequest {
+    /// Delete
+    Delete(ImageImageDelete),
+    /// List Images
+    List(ImageImageList),
+}
+
+impl From<ImageImageApiRequest> for ApiRequest {
+    fn from(item: ImageImageApiRequest) -> Self {
+        ApiRequest::Image(ImageApiRequest::from(item))
+    }
+}
+
+impl ConfirmableRequest for ImageImageApiRequest {
+    fn get_confirm_message(&self) -> Option<String> {
+        match &self {
+            ImageImageApiRequest::Delete(req) => req.get_confirm_message(),
+            _ => None,
+        }
+    }
+}
+
+impl ExecuteApiRequest for ImageImageApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            ImageImageApiRequest::Delete(ref filters) => {
+                let ep =
+                    TryInto::<openstack_sdk::api::image::v2::image::delete::Request<'_>>::try_into(
+                        filters,
+                    )
+                    .wrap_err("Cannot prepare request")?;
+                openstack_sdk::api::ignore(ep).query_async(session).await?;
+                app_tx.send(Action::Refresh)?;
+            }
+            ImageImageApiRequest::List(ref filters) => {
+                let ep: openstack_sdk::api::image::v2::image::list::Request<'_> =
+                    filters.try_into().wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: paged(ep, Pagination::All).query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImageImageList {
+    pub visibility: Option<String>,
+}
+
+impl fmt::Display for ImageImageList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(val) = &self.visibility {
+            write!(f, "{}", val)?;
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<&ImageImageList> for openstack_sdk::api::image::v2::image::list::Request<'_> {
+    type Error = openstack_sdk::api::image::v2::image::list::RequestBuilderError;
+
+    fn try_from(value: &ImageImageList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        ep_builder.sort_key("name");
+        ep_builder.sort_dir("asc");
+
+        if let Some(vis) = &value.visibility {
+            ep_builder.visibility(vis.clone());
+        }
+
+        ep_builder.build()
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImageImageDelete {
+    pub image_id: String,
+    pub image_name: Option<String>,
+}
+
+impl fmt::Display for ImageImageDelete {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl ConfirmableRequest for ImageImageDelete {
+    fn get_confirm_message(&self) -> Option<String> {
+        Some(format!(
+            "Delete image {} ?",
+            self.image_name.clone().unwrap_or(self.image_id.clone())
+        ))
+    }
+}
+
+impl TryFrom<&ImageImageDelete> for openstack_sdk::api::image::v2::image::delete::Request<'_> {
+    type Error = openstack_sdk::api::image::v2::image::delete::RequestBuilderError;
+
+    fn try_from(value: &ImageImageDelete) -> Result<Self, Self::Error> {
+        Self::builder().id(value.image_id.clone()).build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/image/types.rs
+++ b/openstack_tui/src/cloud_worker/image/types.rs
@@ -13,40 +13,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use crate::cloud_worker::common::ConfirmableRequest;
+pub use crate::cloud_worker::image::image::*;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ImageFilters {
-    pub visibility: Option<String>,
+/// Image operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ImageApiRequest {
+    Image(ImageImageApiRequest),
 }
-impl fmt::Display for ImageFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(val) = &self.visibility {
-            write!(f, "{}", val)?;
-        }
-        Ok(())
+
+impl From<ImageImageApiRequest> for ImageApiRequest {
+    fn from(item: ImageImageApiRequest) -> Self {
+        ImageApiRequest::Image(item)
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ImageImageDelete {
-    pub image_id: String,
-    pub image_name: Option<String>,
-}
-
-impl fmt::Display for ImageImageDelete {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-
-impl ConfirmableRequest for ImageImageDelete {
+impl ConfirmableRequest for ImageApiRequest {
     fn get_confirm_message(&self) -> Option<String> {
-        Some(format!(
-            "Delete image {} ?",
-            self.image_name.clone().unwrap_or(self.image_id.clone())
-        ))
+        match &self {
+            ImageApiRequest::Image(req) => req.get_confirm_message(),
+        }
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer.rs
@@ -12,171 +12,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use eyre::Result;
-use serde_json::Value;
 use tokio::sync::mpsc::UnboundedSender;
 
-use openstack_sdk::api::QueryAsync;
+use openstack_sdk::AsyncOpenStack;
 
 use crate::action::Action;
-use crate::cloud_worker::{ApiRequest, Cloud};
+use crate::cloud_worker::ExecuteApiRequest;
+use crate::cloud_worker::LoadBalancerApiRequest;
+use crate::cloud_worker::{ApiRequest, CloudWorkerError};
 
+pub mod healthmonitor;
+pub mod listener;
+pub mod loadbalancer;
+pub mod pool;
 pub mod types;
-use types::*;
 
-pub trait LoadBalancerExt {
-    async fn perform_api_request(
-        &mut self,
+impl ExecuteApiRequest for LoadBalancerApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
         app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()>;
-
-    /// List Loadbalancers
-    async fn get_load_balancers(&mut self, filters: &LoadBalancerFilters) -> Result<Vec<Value>>;
-    /// List Listeners
-    async fn get_listeners(&mut self, filters: &LoadBalancerListenerFilters) -> Result<Vec<Value>>;
-    /// List Pools
-    async fn get_pools(&mut self, filters: &LoadBalancerPoolFilters) -> Result<Vec<Value>>;
-    /// List Listeners
-    async fn get_pool_members(
-        &mut self,
-        filters: &LoadBalancerPoolMemberFilters,
-    ) -> Result<Vec<Value>>;
-    /// List Listeners
-    async fn get_health_monitors(
-        &mut self,
-        filters: &LoadBalancerHealthMonitorFilters,
-    ) -> Result<Vec<Value>>;
-}
-
-impl LoadBalancerExt for Cloud {
-    async fn perform_api_request(
-        &mut self,
-        app_tx: &UnboundedSender<Action>,
-        request: ApiRequest,
-    ) -> Result<()> {
-        match request {
-            ApiRequest::LoadBalancers(ref filters) => {
-                match self.get_load_balancers(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch load balancers: {:?}",
-                        err
-                    )))?,
-                }
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            LoadBalancerApiRequest::Healthmonitor(data) => {
+                data.execute_request(session, request, app_tx).await
             }
-            ApiRequest::LoadBalancerListeners(ref filters) => {
-                match self.get_listeners(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch lb listeners: {:?}",
-                        err
-                    )))?,
-                }
+            LoadBalancerApiRequest::Loadbalancer(data) => {
+                data.execute_request(session, request, app_tx).await
             }
-            ApiRequest::LoadBalancerPools(ref filters) => match self.get_pools(filters).await {
-                Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                Err(err) => app_tx.send(Action::Error(format!(
-                    "Failed to fetch lb pools: {:?}",
-                    err
-                )))?,
-            },
-            ApiRequest::LoadBalancerPoolMembers(ref filters) => {
-                match self.get_pool_members(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch lb members: {:?}",
-                        err
-                    )))?,
-                }
+            LoadBalancerApiRequest::Listener(data) => {
+                data.execute_request(session, request, app_tx).await
             }
-            ApiRequest::LoadBalancerHealthMonitors(ref filters) => {
-                match self.get_health_monitors(filters).await {
-                    Ok(data) => app_tx.send(Action::ApiResponsesData { request, data })?,
-                    Err(err) => app_tx.send(Action::Error(format!(
-                        "Failed to fetch lb healthmonitors: {:?}",
-                        err
-                    )))?,
-                }
-            }
-            _ => {
-                todo!()
+            LoadBalancerApiRequest::Pool(data) => {
+                data.execute_request(session, request, app_tx).await
             }
         }
-        Ok(())
-    }
-
-    async fn get_listeners(&mut self, filters: &LoadBalancerListenerFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilder::try_from(
-                    filters,
-                )?
-                .build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_load_balancers(&mut self, filters: &LoadBalancerFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep = openstack_sdk::api::load_balancer::v2::loadbalancer::list::RequestBuilder::try_from(
-                    filters,
-                )?
-                .build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_pools(&mut self, filters: &LoadBalancerPoolFilters) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep = openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilder::try_from(
-                filters,
-            )?
-            .build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_pool_members(
-        &mut self,
-        filters: &LoadBalancerPoolMemberFilters,
-    ) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::load_balancer::v2::pool::member::list::RequestBuilder::try_from(
-                    filters,
-                )?
-                .build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
-    }
-
-    async fn get_health_monitors(
-        &mut self,
-        filters: &LoadBalancerHealthMonitorFilters,
-    ) -> Result<Vec<Value>> {
-        if let Some(session) = &self.cloud {
-            let ep =
-                openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilder::try_from(
-                    filters,
-                )?
-                .build()?;
-
-            let res: Vec<Value> = ep.query_async(session).await?;
-            return Ok(res);
-        }
-        Ok(Vec::new())
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer/healthmonitor.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/healthmonitor.rs
@@ -1,0 +1,96 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::load_balancer::types::LoadBalancerApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Health Monitor API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoadBalancerHealthmonitorApiRequest {
+    /// List
+    List(LoadBalancerHealthmonitorList),
+}
+
+impl From<LoadBalancerHealthmonitorApiRequest> for ApiRequest {
+    fn from(item: LoadBalancerHealthmonitorApiRequest) -> Self {
+        ApiRequest::LoadBalancer(LoadBalancerApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for LoadBalancerHealthmonitorApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            LoadBalancerHealthmonitorApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::load_balancer::v2::healthmonitor::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoadBalancerHealthmonitorList {
+    pub pool_id: Option<String>,
+    pub pool_name: Option<String>,
+}
+
+impl fmt::Display for LoadBalancerHealthmonitorList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        if self.pool_id.is_some() || self.pool_id.is_some() {
+            parts.push(format!(
+                "pool: {}",
+                self.pool_name
+                    .as_ref()
+                    .or(self.pool_id.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+impl TryFrom<&LoadBalancerHealthmonitorList>
+    for openstack_sdk::api::load_balancer::v2::healthmonitor::list::Request<'_>
+{
+    type Error = openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilderError;
+
+    fn try_from(value: &LoadBalancerHealthmonitorList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        if let Some(pool_id) = &value.pool_id {
+            ep_builder.pool_id(pool_id.clone());
+        }
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/load_balancer/listener.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/listener.rs
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::load_balancer::types::LoadBalancerApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Listener API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoadBalancerListenerApiRequest {
+    /// List
+    List(LoadBalancerListenerList),
+}
+
+impl From<LoadBalancerListenerApiRequest> for ApiRequest {
+    fn from(item: LoadBalancerListenerApiRequest) -> Self {
+        ApiRequest::LoadBalancer(LoadBalancerApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for LoadBalancerListenerApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            LoadBalancerListenerApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::load_balancer::v2::listener::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoadBalancerListenerList {
+    pub loadbalancer_id: Option<String>,
+    pub loadbalancer_name: Option<String>,
+}
+
+impl fmt::Display for LoadBalancerListenerList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
+            parts.push(format!(
+                "lb: {}",
+                self.loadbalancer_name
+                    .as_ref()
+                    .or(self.loadbalancer_id.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+impl TryFrom<&LoadBalancerListenerList>
+    for openstack_sdk::api::load_balancer::v2::listener::list::Request<'_>
+{
+    type Error = openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilderError;
+
+    fn try_from(value: &LoadBalancerListenerList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        if let Some(lb_id) = &value.loadbalancer_id {
+            ep_builder.load_balancer_id(lb_id.clone());
+        }
+
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/load_balancer/loadbalancer.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/loadbalancer.rs
@@ -1,0 +1,78 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::load_balancer::types::LoadBalancerApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Load Balancer API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoadBalancerLoadbalancerApiRequest {
+    /// List
+    List(LoadBalancerLoadbalancerList),
+}
+
+impl From<LoadBalancerLoadbalancerApiRequest> for ApiRequest {
+    fn from(item: LoadBalancerLoadbalancerApiRequest) -> Self {
+        ApiRequest::LoadBalancer(LoadBalancerApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for LoadBalancerLoadbalancerApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            LoadBalancerLoadbalancerApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::load_balancer::v2::loadbalancer::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoadBalancerLoadbalancerList {}
+impl fmt::Display for LoadBalancerLoadbalancerList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&LoadBalancerLoadbalancerList>
+    for openstack_sdk::api::load_balancer::v2::loadbalancer::list::Request<'_>
+{
+    type Error = openstack_sdk::api::load_balancer::v2::loadbalancer::list::RequestBuilderError;
+
+    fn try_from(_value: &LoadBalancerLoadbalancerList) -> Result<Self, Self::Error> {
+        Self::builder().build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/load_balancer/pool.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/pool.rs
@@ -1,0 +1,118 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::load_balancer::types::LoadBalancerApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+pub mod member;
+
+pub use member::*;
+
+/// Pool API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoadBalancerPoolApiRequest {
+    /// List
+    List(LoadBalancerPoolList),
+    /// Member
+    Member(LoadBalancerPoolMemberApiRequest),
+}
+
+impl From<LoadBalancerPoolApiRequest> for ApiRequest {
+    fn from(item: LoadBalancerPoolApiRequest) -> Self {
+        ApiRequest::LoadBalancer(LoadBalancerApiRequest::from(item))
+    }
+}
+
+impl From<LoadBalancerPoolMemberApiRequest> for LoadBalancerPoolApiRequest {
+    fn from(item: LoadBalancerPoolMemberApiRequest) -> Self {
+        LoadBalancerPoolApiRequest::Member(item)
+    }
+}
+
+impl From<LoadBalancerPoolMemberApiRequest> for LoadBalancerApiRequest {
+    fn from(item: LoadBalancerPoolMemberApiRequest) -> Self {
+        LoadBalancerApiRequest::Pool(LoadBalancerPoolApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for LoadBalancerPoolApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            LoadBalancerPoolApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::load_balancer::v2::pool::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+            LoadBalancerPoolApiRequest::Member(ref req) => {
+                req.execute_request(session, request, app_tx).await?
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoadBalancerPoolList {
+    pub loadbalancer_id: Option<String>,
+    pub loadbalancer_name: Option<String>,
+}
+
+impl fmt::Display for LoadBalancerPoolList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
+            parts.push(format!(
+                "lb: {}",
+                self.loadbalancer_name
+                    .as_ref()
+                    .or(self.loadbalancer_id.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+impl TryFrom<&LoadBalancerPoolList>
+    for openstack_sdk::api::load_balancer::v2::pool::list::Request<'_>
+{
+    type Error = openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilderError;
+
+    fn try_from(value: &LoadBalancerPoolList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        if let Some(lb_id) = &value.loadbalancer_id {
+            ep_builder.loadbalancer_id(lb_id.clone());
+        }
+
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/load_balancer/pool/member.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/pool/member.rs
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::load_balancer::types::LoadBalancerApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Pool Member API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoadBalancerPoolMemberApiRequest {
+    /// List
+    List(LoadBalancerPoolMemberList),
+}
+
+impl From<LoadBalancerPoolMemberApiRequest> for ApiRequest {
+    fn from(item: LoadBalancerPoolMemberApiRequest) -> Self {
+        ApiRequest::LoadBalancer(LoadBalancerApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for LoadBalancerPoolMemberApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            LoadBalancerPoolMemberApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::load_balancer::v2::pool::member::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoadBalancerPoolMemberList {
+    pub pool_id: String,
+    pub pool_name: Option<String>,
+}
+
+impl fmt::Display for LoadBalancerPoolMemberList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        parts.push(format!(
+            "pool: {}",
+            self.pool_name.as_ref().unwrap_or(&self.pool_id)
+        ));
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+impl TryFrom<&LoadBalancerPoolMemberList>
+    for openstack_sdk::api::load_balancer::v2::pool::member::list::Request<'_>
+{
+    type Error = openstack_sdk::api::load_balancer::v2::pool::member::list::RequestBuilderError;
+
+    fn try_from(value: &LoadBalancerPoolMemberList) -> Result<Self, Self::Error> {
+        Self::builder().pool_id(value.pool_id.clone()).build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/load_balancer/types.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/types.rs
@@ -13,176 +13,45 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
-//use crate::cloud_worker::common::ConfirmableRequest;
+pub use crate::cloud_worker::load_balancer::healthmonitor::*;
+pub use crate::cloud_worker::load_balancer::listener::*;
+pub use crate::cloud_worker::load_balancer::loadbalancer::*;
+pub use crate::cloud_worker::load_balancer::pool::*;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadBalancerFilters {}
+/// LoadBalancer operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LoadBalancerApiRequest {
+    /// Health monitors
+    Healthmonitor(LoadBalancerHealthmonitorApiRequest),
+    /// Loadbalancers
+    Loadbalancer(LoadBalancerLoadbalancerApiRequest),
+    /// Listeners
+    Listener(LoadBalancerListenerApiRequest),
+    /// Pools
+    Pool(LoadBalancerPoolApiRequest),
+}
 
-impl fmt::Display for LoadBalancerFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
+impl From<LoadBalancerHealthmonitorApiRequest> for LoadBalancerApiRequest {
+    fn from(item: LoadBalancerHealthmonitorApiRequest) -> Self {
+        LoadBalancerApiRequest::Healthmonitor(item)
     }
 }
 
-impl TryFrom<&LoadBalancerFilters>
-    for openstack_sdk::api::load_balancer::v2::loadbalancer::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(_value: &LoadBalancerFilters) -> Result<Self, Self::Error> {
-        let ep_builder =
-            openstack_sdk::api::load_balancer::v2::loadbalancer::list::Request::builder();
-
-        Ok(ep_builder)
+impl From<LoadBalancerLoadbalancerApiRequest> for LoadBalancerApiRequest {
+    fn from(item: LoadBalancerLoadbalancerApiRequest) -> Self {
+        LoadBalancerApiRequest::Loadbalancer(item)
     }
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadBalancerListenerFilters {
-    pub loadbalancer_id: Option<String>,
-    pub loadbalancer_name: Option<String>,
-}
-
-impl fmt::Display for LoadBalancerListenerFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut parts: Vec<String> = Vec::new();
-        if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
-            parts.push(format!(
-                "lb: {}",
-                self.loadbalancer_name
-                    .as_ref()
-                    .or(self.loadbalancer_id.as_ref())
-                    .unwrap_or(&String::new())
-            ));
-        }
-        write!(f, "{}", parts.join(","))
+impl From<LoadBalancerListenerApiRequest> for LoadBalancerApiRequest {
+    fn from(item: LoadBalancerListenerApiRequest) -> Self {
+        LoadBalancerApiRequest::Listener(item)
     }
 }
 
-impl TryFrom<&LoadBalancerListenerFilters>
-    for openstack_sdk::api::load_balancer::v2::listener::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(value: &LoadBalancerListenerFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::load_balancer::v2::listener::list::Request::builder();
-
-        if let Some(lb_id) = &value.loadbalancer_id {
-            ep_builder.load_balancer_id(lb_id.clone());
-        }
-
-        Ok(ep_builder)
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadBalancerPoolFilters {
-    pub loadbalancer_id: Option<String>,
-    pub loadbalancer_name: Option<String>,
-}
-
-impl fmt::Display for LoadBalancerPoolFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut parts: Vec<String> = Vec::new();
-        if self.loadbalancer_id.is_some() || self.loadbalancer_name.is_some() {
-            parts.push(format!(
-                "lb: {}",
-                self.loadbalancer_name
-                    .as_ref()
-                    .or(self.loadbalancer_id.as_ref())
-                    .unwrap_or(&String::new())
-            ));
-        }
-        write!(f, "{}", parts.join(","))
-    }
-}
-
-impl TryFrom<&LoadBalancerPoolFilters>
-    for openstack_sdk::api::load_balancer::v2::pool::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(value: &LoadBalancerPoolFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder = openstack_sdk::api::load_balancer::v2::pool::list::Request::builder();
-
-        if let Some(val) = &value.loadbalancer_id {
-            ep_builder.loadbalancer_id(val.clone());
-        }
-
-        Ok(ep_builder)
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadBalancerPoolMemberFilters {
-    pub pool_id: String,
-    pub pool_name: Option<String>,
-}
-
-impl fmt::Display for LoadBalancerPoolMemberFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut parts: Vec<String> = Vec::new();
-        parts.push(format!(
-            "pool: {}",
-            self.pool_name.as_ref().unwrap_or(&self.pool_id)
-        ));
-        write!(f, "{}", parts.join(","))
-    }
-}
-
-impl TryFrom<&LoadBalancerPoolMemberFilters>
-    for openstack_sdk::api::load_balancer::v2::pool::member::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(value: &LoadBalancerPoolMemberFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::load_balancer::v2::pool::member::list::Request::builder();
-
-        ep_builder.pool_id(value.pool_id.clone());
-
-        Ok(ep_builder)
-    }
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct LoadBalancerHealthMonitorFilters {
-    pub pool_id: Option<String>,
-    pub pool_name: Option<String>,
-}
-
-impl fmt::Display for LoadBalancerHealthMonitorFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut parts: Vec<String> = Vec::new();
-        if self.pool_id.is_some() || self.pool_id.is_some() {
-            parts.push(format!(
-                "pool: {}",
-                self.pool_name
-                    .as_ref()
-                    .or(self.pool_id.as_ref())
-                    .unwrap_or(&String::new())
-            ));
-        }
-        write!(f, "{}", parts.join(","))
-    }
-}
-
-impl TryFrom<&LoadBalancerHealthMonitorFilters>
-    for openstack_sdk::api::load_balancer::v2::healthmonitor::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(value: &LoadBalancerHealthMonitorFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::load_balancer::v2::healthmonitor::list::Request::builder();
-
-        if let Some(val) = &value.pool_id {
-            ep_builder.pool_id(val.clone());
-        }
-
-        Ok(ep_builder)
+impl From<LoadBalancerPoolApiRequest> for LoadBalancerApiRequest {
+    fn from(item: LoadBalancerPoolApiRequest) -> Self {
+        LoadBalancerApiRequest::Pool(item)
     }
 }

--- a/openstack_tui/src/cloud_worker/network/network.rs
+++ b/openstack_tui/src/cloud_worker/network/network.rs
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::network::types::NetworkApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Network API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkNetworkApiRequest {
+    /// List
+    List(NetworkNetworkList),
+}
+
+impl From<NetworkNetworkApiRequest> for ApiRequest {
+    fn from(item: NetworkNetworkApiRequest) -> Self {
+        ApiRequest::Network(NetworkApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for NetworkNetworkApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            NetworkNetworkApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::network::v2::network::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkNetworkList {}
+impl fmt::Display for NetworkNetworkList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&NetworkNetworkList> for openstack_sdk::api::network::v2::network::list::Request<'_> {
+    type Error = openstack_sdk::api::network::v2::network::list::RequestBuilderError;
+
+    fn try_from(_value: &NetworkNetworkList) -> Result<Self, Self::Error> {
+        Self::builder()
+            .sort_key(["name"].into_iter())
+            .sort_dir(["asc"].into_iter())
+            .build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/network/quota.rs
+++ b/openstack_tui/src/cloud_worker/network/quota.rs
@@ -1,0 +1,81 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::network::types::NetworkApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Quota API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkQuotaApiRequest {
+    /// Details
+    Details(NetworkQuotaDetails),
+}
+
+impl From<NetworkQuotaApiRequest> for ApiRequest {
+    fn from(item: NetworkQuotaApiRequest) -> Self {
+        ApiRequest::Network(NetworkApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for NetworkQuotaApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            NetworkQuotaApiRequest::Details(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::network::v2::quota::details::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponseData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkQuotaDetails {
+    /// Project ID
+    pub project_id: String,
+}
+impl fmt::Display for NetworkQuotaDetails {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&NetworkQuotaDetails>
+    for openstack_sdk::api::network::v2::quota::details::Request<'_>
+{
+    type Error = openstack_sdk::api::network::v2::quota::details::RequestBuilderError;
+
+    fn try_from(value: &NetworkQuotaDetails) -> Result<Self, Self::Error> {
+        Self::builder().id(value.project_id.clone()).build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/network/router.rs
+++ b/openstack_tui/src/cloud_worker/network/router.rs
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::network::types::NetworkApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Router API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkRouterApiRequest {
+    /// List
+    List(NetworkRouterList),
+}
+
+impl From<NetworkRouterApiRequest> for ApiRequest {
+    fn from(item: NetworkRouterApiRequest) -> Self {
+        ApiRequest::Network(NetworkApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for NetworkRouterApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            NetworkRouterApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::network::v2::router::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkRouterList {}
+impl fmt::Display for NetworkRouterList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&NetworkRouterList> for openstack_sdk::api::network::v2::router::list::Request<'_> {
+    type Error = openstack_sdk::api::network::v2::router::list::RequestBuilderError;
+
+    fn try_from(_value: &NetworkRouterList) -> Result<Self, Self::Error> {
+        Self::builder()
+            .sort_key(["name"].into_iter())
+            .sort_dir(["asc"].into_iter())
+            .build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/network/security_group.rs
+++ b/openstack_tui/src/cloud_worker/network/security_group.rs
@@ -1,0 +1,81 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::network::types::NetworkApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Security Group API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkSecurityGroupApiRequest {
+    /// List
+    List(NetworkSecurityGroupList),
+}
+
+impl From<NetworkSecurityGroupApiRequest> for ApiRequest {
+    fn from(item: NetworkSecurityGroupApiRequest) -> Self {
+        ApiRequest::Network(NetworkApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for NetworkSecurityGroupApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            NetworkSecurityGroupApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::network::v2::security_group::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkSecurityGroupList {}
+impl fmt::Display for NetworkSecurityGroupList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl TryFrom<&NetworkSecurityGroupList>
+    for openstack_sdk::api::network::v2::security_group::list::Request<'_>
+{
+    type Error = openstack_sdk::api::network::v2::security_group::list::RequestBuilderError;
+
+    fn try_from(_value: &NetworkSecurityGroupList) -> Result<Self, Self::Error> {
+        Self::builder()
+            .sort_key(["name"].into_iter())
+            .sort_dir(["asc"].into_iter())
+            .build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/network/security_group_rule.rs
+++ b/openstack_tui/src/cloud_worker/network/security_group_rule.rs
@@ -1,0 +1,106 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::network::types::NetworkApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Security Group Rule API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkSecurityGroupRuleApiRequest {
+    /// List
+    List(NetworkSecurityGroupRuleList),
+}
+
+impl From<NetworkSecurityGroupRuleApiRequest> for ApiRequest {
+    fn from(item: NetworkSecurityGroupRuleApiRequest) -> Self {
+        ApiRequest::Network(NetworkApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for NetworkSecurityGroupRuleApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            NetworkSecurityGroupRuleApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::network::v2::security_group_rule::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkSecurityGroupRuleList {
+    pub security_group_id: Option<String>,
+    pub security_group_name: Option<String>,
+}
+
+impl fmt::Display for NetworkSecurityGroupRuleList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.security_group_id.is_some() || self.security_group_name.is_some() {
+            write!(
+                f,
+                "security_group: {}",
+                self.security_group_name
+                    .as_ref()
+                    .or(self.security_group_id.as_ref())
+                    .unwrap_or(&String::new())
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<&NetworkSecurityGroupRuleList>
+    for openstack_sdk::api::network::v2::security_group_rule::list::Request<'_>
+{
+    type Error = openstack_sdk::api::network::v2::security_group_rule::list::RequestBuilderError;
+
+    fn try_from(value: &NetworkSecurityGroupRuleList) -> Result<Self, Self::Error> {
+        let mut ep_builder =
+            openstack_sdk::api::network::v2::security_group_rule::list::Request::builder();
+
+        ep_builder.sort_key(["ethertype", "direction", "protocol", "port_range_min"].into_iter());
+        ep_builder.sort_dir(["asc", "asc", "asc", "asc"].into_iter());
+
+        if let Some(security_group_id) = &value.security_group_id {
+            ep_builder.security_group_id(security_group_id.clone());
+        }
+
+        if let Some(security_group_id) = &value.security_group_id {
+            ep_builder.security_group_id(security_group_id.clone());
+        }
+
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/network/subnet.rs
+++ b/openstack_tui/src/cloud_worker/network/subnet.rs
@@ -1,0 +1,98 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tokio::sync::mpsc::UnboundedSender;
+
+use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
+
+use crate::action::Action;
+use crate::cloud_worker::common::CloudWorkerError;
+use crate::cloud_worker::network::types::NetworkApiRequest;
+use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
+
+/// Subnet API operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkSubnetApiRequest {
+    /// List
+    List(NetworkSubnetList),
+}
+
+impl From<NetworkSubnetApiRequest> for ApiRequest {
+    fn from(item: NetworkSubnetApiRequest) -> Self {
+        ApiRequest::Network(NetworkApiRequest::from(item))
+    }
+}
+
+impl ExecuteApiRequest for NetworkSubnetApiRequest {
+    async fn execute_request(
+        &self,
+        session: &mut AsyncOpenStack,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
+    ) -> Result<(), CloudWorkerError> {
+        match self {
+            NetworkSubnetApiRequest::List(ref req) => {
+                let ep = TryInto::<
+                    openstack_sdk::api::network::v2::subnet::list::Request<'_>,
+                >::try_into(req)
+                .wrap_err("Cannot prepare request")?;
+                app_tx.send(Action::ApiResponsesData {
+                    request: request.clone(),
+                    data: ep.query_async(session).await?,
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkSubnetList {
+    /// Network id
+    pub network_id: Option<String>,
+    /// Name of the parent network
+    pub network_name: Option<String>,
+}
+impl fmt::Display for NetworkSubnetList {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts: Vec<String> = Vec::new();
+        if self.network_id.is_some() || self.network_name.is_some() {
+            parts.push(format!(
+                "network: {}",
+                self.network_name
+                    .as_ref()
+                    .or(self.network_id.as_ref())
+                    .unwrap_or(&String::new())
+            ));
+        }
+        write!(f, "{}", parts.join(","))
+    }
+}
+
+impl TryFrom<&NetworkSubnetList> for openstack_sdk::api::network::v2::subnet::list::Request<'_> {
+    type Error = openstack_sdk::api::network::v2::subnet::list::RequestBuilderError;
+
+    fn try_from(value: &NetworkSubnetList) -> Result<Self, Self::Error> {
+        let mut ep_builder = Self::builder();
+        ep_builder.sort_key(["name"].into_iter());
+        ep_builder.sort_dir(["asc"].into_iter());
+        if let Some(val) = &value.network_id {
+            ep_builder.network_id(val.clone());
+        }
+
+        ep_builder.build()
+    }
+}

--- a/openstack_tui/src/cloud_worker/network/types.rs
+++ b/openstack_tui/src/cloud_worker/network/types.rs
@@ -13,166 +13,63 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
-/// Network filters
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NetworkNetworkFilters {}
-impl fmt::Display for NetworkNetworkFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
+pub use crate::cloud_worker::network::network::*;
+pub use crate::cloud_worker::network::quota::*;
+pub use crate::cloud_worker::network::router::*;
+pub use crate::cloud_worker::network::security_group::*;
+pub use crate::cloud_worker::network::security_group_rule::*;
+pub use crate::cloud_worker::network::subnet::*;
+
+/// Network operations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NetworkApiRequest {
+    /// Networks
+    Network(NetworkNetworkApiRequest),
+    /// Quota
+    Quota(NetworkQuotaApiRequest),
+    /// Routers
+    Router(NetworkRouterApiRequest),
+    /// Security groups
+    SecurityGroup(NetworkSecurityGroupApiRequest),
+    /// Security group rules
+    SecurityGroupRule(NetworkSecurityGroupRuleApiRequest),
+    /// Subnets
+    Subnet(NetworkSubnetApiRequest),
+}
+
+impl From<NetworkNetworkApiRequest> for NetworkApiRequest {
+    fn from(item: NetworkNetworkApiRequest) -> Self {
+        NetworkApiRequest::Network(item)
     }
 }
 
-impl TryFrom<&NetworkNetworkFilters>
-    for openstack_sdk::api::network::v2::network::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(_value: &NetworkNetworkFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder = openstack_sdk::api::network::v2::network::list::Request::builder();
-
-        ep_builder.sort_key(["name"].into_iter());
-        ep_builder.sort_dir(["asc"].into_iter());
-
-        Ok(ep_builder)
+impl From<NetworkQuotaApiRequest> for NetworkApiRequest {
+    fn from(item: NetworkQuotaApiRequest) -> Self {
+        NetworkApiRequest::Quota(item)
     }
 }
 
-/// Router filters
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NetworkRouterFilters {}
-impl fmt::Display for NetworkRouterFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
+impl From<NetworkRouterApiRequest> for NetworkApiRequest {
+    fn from(item: NetworkRouterApiRequest) -> Self {
+        NetworkApiRequest::Router(item)
     }
 }
 
-impl TryFrom<&NetworkRouterFilters>
-    for openstack_sdk::api::network::v2::router::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(_value: &NetworkRouterFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder = openstack_sdk::api::network::v2::router::list::Request::builder();
-
-        ep_builder.sort_key(["name"].into_iter());
-        ep_builder.sort_dir(["asc"].into_iter());
-
-        Ok(ep_builder)
+impl From<NetworkSecurityGroupApiRequest> for NetworkApiRequest {
+    fn from(item: NetworkSecurityGroupApiRequest) -> Self {
+        NetworkApiRequest::SecurityGroup(item)
     }
 }
 
-/// Subnet filters
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NetworkSubnetFilters {
-    pub network_id: Option<String>,
-    /// Name of the parent network
-    pub network_name: Option<String>,
-}
-impl fmt::Display for NetworkSubnetFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.network_id.is_some() || self.network_name.is_some() {
-            write!(
-                f,
-                "network: {}",
-                self.network_name
-                    .as_ref()
-                    .or(self.network_id.as_ref())
-                    .unwrap_or(&String::new())
-            )?;
-        }
-        Ok(())
+impl From<NetworkSecurityGroupRuleApiRequest> for NetworkApiRequest {
+    fn from(item: NetworkSecurityGroupRuleApiRequest) -> Self {
+        NetworkApiRequest::SecurityGroupRule(item)
     }
 }
 
-impl TryFrom<&NetworkSubnetFilters>
-    for openstack_sdk::api::network::v2::subnet::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(value: &NetworkSubnetFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder = openstack_sdk::api::network::v2::subnet::list::Request::builder();
-
-        ep_builder.sort_key(["name"].into_iter());
-        ep_builder.sort_dir(["asc"].into_iter());
-
-        if let Some(network_id) = &value.network_id {
-            ep_builder.network_id(network_id.clone());
-        }
-
-        Ok(ep_builder)
-    }
-}
-
-/// Security groups
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NetworkSecurityGroupFilters {}
-impl fmt::Display for NetworkSecurityGroupFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "")
-    }
-}
-
-impl TryFrom<&NetworkSecurityGroupFilters>
-    for openstack_sdk::api::network::v2::security_group::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(_value: &NetworkSecurityGroupFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::network::v2::security_group::list::Request::builder();
-
-        ep_builder.sort_key(["name"].into_iter());
-        ep_builder.sort_dir(["asc"].into_iter());
-
-        Ok(ep_builder)
-    }
-}
-
-/// Security group rules
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NetworkSecurityGroupRuleFilters {
-    pub security_group_id: Option<String>,
-    pub security_group_name: Option<String>,
-}
-
-impl fmt::Display for NetworkSecurityGroupRuleFilters {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.security_group_id.is_some() || self.security_group_name.is_some() {
-            write!(
-                f,
-                "security_group: {}",
-                self.security_group_name
-                    .as_ref()
-                    .or(self.security_group_id.as_ref())
-                    .unwrap_or(&String::new())
-            )?;
-        }
-        Ok(())
-    }
-}
-
-impl TryFrom<&NetworkSecurityGroupRuleFilters>
-    for openstack_sdk::api::network::v2::security_group_rule::list::RequestBuilder<'_>
-{
-    type Error = eyre::Report;
-
-    fn try_from(value: &NetworkSecurityGroupRuleFilters) -> Result<Self, Self::Error> {
-        let mut ep_builder =
-            openstack_sdk::api::network::v2::security_group_rule::list::Request::builder();
-
-        ep_builder.sort_key(["ethertype", "direction", "protocol", "port_range_min"].into_iter());
-        ep_builder.sort_dir(["asc", "asc", "asc", "asc"].into_iter());
-
-        if let Some(security_group_id) = &value.security_group_id {
-            ep_builder.security_group_id(security_group_id.clone());
-        }
-
-        if let Some(security_group_id) = &value.security_group_id {
-            ep_builder.security_group_id(security_group_id.clone());
-        }
-
-        Ok(ep_builder)
+impl From<NetworkSubnetApiRequest> for NetworkApiRequest {
+    fn from(item: NetworkSubnetApiRequest) -> Self {
+        NetworkApiRequest::Subnet(item)
     }
 }

--- a/openstack_tui/src/components/compute/server_instance_action_events.rs
+++ b/openstack_tui/src/components/compute/server_instance_action_events.rs
@@ -21,7 +21,9 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ApiRequest, ComputeServerInstanceActionFilters},
+    cloud_worker::types::{
+        ApiRequest, ComputeApiRequest, ComputeServerApiRequest, ComputeServerInstanceActionList,
+    },
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -47,7 +49,7 @@ pub struct ServerInstanceActionEventData {
 }
 
 pub type ComputeServerInstanceActionEvents<'a> =
-    TableViewComponentBase<'a, ServerInstanceActionEventData, ComputeServerInstanceActionFilters>;
+    TableViewComponentBase<'a, ServerInstanceActionEventData, ComputeServerInstanceActionList>;
 
 impl Component for ComputeServerInstanceActionEvents<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
@@ -74,15 +76,18 @@ impl Component for ComputeServerInstanceActionEvents<'_> {
             }
             | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::PerformApiRequest(
-                    ApiRequest::ComputeServerInstanceAction(self.get_filters().clone()),
-                )));
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                    ComputeServerApiRequest::InstanceActionShow(self.get_filters().clone()),
+                ))));
             }
             Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
             Action::ApiResponseData {
-                request: ApiRequest::ComputeServerInstanceAction(_),
+                request:
+                    ApiRequest::Compute(ComputeApiRequest::Server(
+                        ComputeServerApiRequest::InstanceActionShow(_),
+                    )),
                 data,
             } => {
                 if let Some(events) = data.get("events") {
@@ -91,13 +96,13 @@ impl Component for ComputeServerInstanceActionEvents<'_> {
                     }
                 }
             }
-            Action::SetComputeServerInstanceActionFilters(filters) => {
+            Action::SetComputeServerInstanceActionListFilters(filters) => {
                 if filters.request_id.is_some() {
                     self.set_filters(filters);
                     self.set_loading(true);
-                    return Ok(Some(Action::PerformApiRequest(
-                        ApiRequest::ComputeServerInstanceAction(self.get_filters().clone()),
-                    )));
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                        ComputeServerApiRequest::InstanceActionShow(self.get_filters().clone()),
+                    ))));
                 }
             }
 

--- a/openstack_tui/src/components/identity/projects.rs
+++ b/openstack_tui/src/components/identity/projects.rs
@@ -21,7 +21,9 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ApiRequest, IdentityProjectFilters},
+    cloud_worker::types::{
+        ApiRequest, IdentityApiRequest, IdentityProjectApiRequest, IdentityProjectList,
+    },
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -45,7 +47,7 @@ pub struct ProjectData {
     domain_id: String,
 }
 
-pub type IdentityProjects<'a> = TableViewComponentBase<'a, ProjectData, IdentityProjectFilters>;
+pub type IdentityProjects<'a> = TableViewComponentBase<'a, ProjectData, IdentityProjectList>;
 
 impl Component for IdentityProjects<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
@@ -65,9 +67,9 @@ impl Component for IdentityProjects<'_> {
                 self.set_loading(true);
                 self.set_data(Vec::new())?;
                 if let Mode::IdentityProjects = current_mode {
-                    return Ok(Some(Action::PerformApiRequest(
-                        ApiRequest::IdentityProjects(self.get_filters().clone()),
-                    )));
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                        IdentityProjectApiRequest::List(self.get_filters().clone()),
+                    ))));
                 }
             }
             Action::Mode {
@@ -76,15 +78,18 @@ impl Component for IdentityProjects<'_> {
             }
             | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::PerformApiRequest(
-                    ApiRequest::IdentityProjects(self.get_filters().clone()),
-                )));
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                    IdentityProjectApiRequest::List(self.get_filters().clone()),
+                ))));
             }
             Action::DescribeApiResponse => self.describe_selected_entry()?,
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
             Action::ApiResponsesData {
-                request: ApiRequest::IdentityProjects(_),
+                request:
+                    ApiRequest::Identity(IdentityApiRequest::Project(IdentityProjectApiRequest::List(
+                        _,
+                    ))),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/network/routers.rs
+++ b/openstack_tui/src/components/network/routers.rs
@@ -21,7 +21,9 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ApiRequest, NetworkRouterFilters},
+    cloud_worker::types::{
+        ApiRequest, NetworkApiRequest, NetworkRouterApiRequest, NetworkRouterList,
+    },
     components::{table_view::TableViewComponentBase, Component},
     config::Config,
     error::TuiError,
@@ -47,7 +49,7 @@ pub struct RouterData {
     updated: String,
 }
 
-pub type NetworkRouters<'a> = TableViewComponentBase<'a, RouterData, NetworkRouterFilters>;
+pub type NetworkRouters<'a> = TableViewComponentBase<'a, RouterData, NetworkRouterList>;
 
 impl Component for NetworkRouters<'_> {
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
@@ -67,8 +69,8 @@ impl Component for NetworkRouters<'_> {
                 if let Mode::NetworkRouters = current_mode {
                     self.set_loading(true);
                     self.set_data(Vec::new())?;
-                    return Ok(Some(Action::PerformApiRequest(ApiRequest::NetworkRouters(
-                        self.get_filters().clone(),
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                        NetworkRouterApiRequest::List(self.get_filters().clone()),
                     ))));
                 }
             }
@@ -78,8 +80,8 @@ impl Component for NetworkRouters<'_> {
             }
             | Action::Refresh => {
                 self.set_loading(true);
-                return Ok(Some(Action::PerformApiRequest(ApiRequest::NetworkRouters(
-                    self.get_filters().clone(),
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                    NetworkRouterApiRequest::List(self.get_filters().clone()),
                 ))));
             }
             // Action::ShowRouterSubnets => {
@@ -89,8 +91,8 @@ impl Component for NetworkRouters<'_> {
             //         if let Some(command_tx) = self.get_command_tx() {
             //             // and have a selected entry
             //             if let Some(group_row) = self.get_selected() {
-            //                 command_tx.send(Action::SetRouterSubnetFilters(
-            //                     RouterSubnetFilters {
+            //                 command_tx.send(Action::SetRouterSubnetListFilters(
+            //                     RouterSubnetListFilters {
             //                         network_id: Some(group_row.id.clone()),
             //                         network_name: Some(group_row.name.clone()),
             //                     },
@@ -104,7 +106,8 @@ impl Component for NetworkRouters<'_> {
             Action::Tick => self.app_tick()?,
             Action::Render => self.render_tick()?,
             Action::ApiResponsesData {
-                request: ApiRequest::NetworkRouters(_),
+                request:
+                    ApiRequest::Network(NetworkApiRequest::Router(NetworkRouterApiRequest::List(_))),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -24,7 +24,9 @@ use structable_derive::StructTable;
 
 use crate::{
     action::Action,
-    cloud_worker::types::{ApiRequest, IdentityAuthProjectFilters},
+    cloud_worker::types::{
+        ApiRequest, IdentityApiRequest, IdentityAuthApiRequest, IdentityAuthProjectList,
+    },
     components::{Component, FuzzySelectList},
     config::Config,
     error::TuiError,
@@ -99,12 +101,13 @@ impl Component for ProjectSelect {
             }
             Action::ConnectedToCloud(_) => {
                 self.set_loading(true);
-                return Ok(Some(Action::PerformApiRequest(
-                    ApiRequest::IdentityAuthProjects(IdentityAuthProjectFilters {}),
-                )));
+                return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                    IdentityAuthApiRequest::Projects(IdentityAuthProjectList {}),
+                ))));
             }
             Action::ApiResponsesData {
-                request: ApiRequest::IdentityAuthProjects(_),
+                request:
+                    ApiRequest::Identity(IdentityApiRequest::Auth(IdentityAuthApiRequest::Projects(_))),
                 data,
             } => {
                 self.set_data(data)?;

--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -313,7 +313,7 @@ where
     }
 
     pub fn set_data(&mut self, data: Vec<Value>) -> Result<(), TuiError> {
-        let items: Vec<T> = serde_json::from_value(serde_json::Value::Array(data.clone()))?;
+        let items = serde_json::from_value::<Vec<T>>(serde_json::Value::Array(data.clone()))?;
         if data != self.raw_items {
             self.items = items;
             self.raw_items = data.clone();


### PR DESCRIPTION
Replace service extension traits with nested enums implementing
`execute_request` trait. This allows better modularization of single
resources instead of single huge implementation with lots of easily
testable objects. This adds quote a bit of code but heavily improves
maintenance and allows code generation.
