### PR TITLE
feat: Adapt few compute result schema changes

### DIFF
--- a/openstack_cli/src/compute/v2/aggregate/add_host.rs
+++ b/openstack_cli/src/compute/v2/aggregate/add_host.rs
@@ -78,94 +78,45 @@ struct AddHost {
 /// Aggregate response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
-    /// The availability zone of the host aggregate.
-    ///
     #[serde()]
     #[structable(optional)]
     availability_zone: Option<String>,
 
-    /// The date and time when the resource was created. The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
-    /// A boolean indicates whether this aggregate is deleted or not, if it has
-    /// not been deleted, `false` will appear.
-    ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
-    /// The date and time when the resource was deleted. If the resource has
-    /// not been deleted yet, this field will be `null`, The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    deleted_at: Option<String>,
+    #[structable()]
+    deleted_at: String,
 
-    /// An array of host information.
-    ///
     #[serde()]
     #[structable(optional, pretty)]
     hosts: Option<Value>,
 
-    /// The ID of the host aggregate.
-    ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
-    /// Metadata key and value pairs associated with the aggregate.
-    ///
     #[serde()]
     #[structable(optional, pretty)]
     metadata: Option<Value>,
 
-    /// The date and time when the resource was updated, if the resource has
-    /// not been updated, this field will show as `null`. The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    updated_at: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// The UUID of the host aggregate.
-    ///
-    /// **New in version 2.41**
-    ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    updated_at: String,
+
+    #[serde()]
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/create_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_20.rs
@@ -33,7 +33,6 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::create_20;
 use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Creates an aggregate. If specifying an option availability_zone, the
@@ -108,15 +107,15 @@ struct ResponseData {
     /// example, the offset value is `-05:00`.
     ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
     /// A boolean indicates whether this aggregate is deleted or not, if it has
     /// not been deleted, `false` will appear.
     ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
     /// The date and time when the resource was deleted. If the resource has
     /// not been deleted yet, this field will be `null`, The date and time
@@ -135,23 +134,17 @@ struct ResponseData {
     #[structable(optional)]
     deleted_at: Option<String>,
 
-    /// An array of host information.
-    ///
-    #[serde()]
-    #[structable(optional, pretty)]
-    hosts: Option<Value>,
-
     /// The ID of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
-    /// Metadata key and value pairs associated with the aggregate.
+    /// The name of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    metadata: Option<Value>,
+    #[structable()]
+    name: String,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -175,8 +168,8 @@ struct ResponseData {
     /// **New in version 2.41**
     ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/create_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_21.rs
@@ -33,7 +33,6 @@ use crate::StructTable;
 
 use openstack_sdk::api::compute::v2::aggregate::create_21;
 use openstack_sdk::api::QueryAsync;
-use serde_json::Value;
 use structable_derive::StructTable;
 
 /// Creates an aggregate. If specifying an option availability_zone, the
@@ -108,15 +107,15 @@ struct ResponseData {
     /// example, the offset value is `-05:00`.
     ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
     /// A boolean indicates whether this aggregate is deleted or not, if it has
     /// not been deleted, `false` will appear.
     ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
     /// The date and time when the resource was deleted. If the resource has
     /// not been deleted yet, this field will be `null`, The date and time
@@ -135,23 +134,17 @@ struct ResponseData {
     #[structable(optional)]
     deleted_at: Option<String>,
 
-    /// An array of host information.
-    ///
-    #[serde()]
-    #[structable(optional, pretty)]
-    hosts: Option<Value>,
-
     /// The ID of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
-    /// Metadata key and value pairs associated with the aggregate.
+    /// The name of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    metadata: Option<Value>,
+    #[structable()]
+    name: String,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -175,8 +168,8 @@ struct ResponseData {
     /// **New in version 2.41**
     ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/list.rs
+++ b/openstack_cli/src/compute/v2/aggregate/list.rs
@@ -84,15 +84,15 @@ struct ResponseData {
     /// example, the offset value is `-05:00`.
     ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
     /// A boolean indicates whether this aggregate is deleted or not, if it has
     /// not been deleted, `false` will appear.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    deleted: Option<bool>,
+    #[structable(wide)]
+    deleted: bool,
 
     /// The date and time when the resource was deleted. If the resource has
     /// not been deleted yet, this field will be `null`, The date and time
@@ -120,14 +120,20 @@ struct ResponseData {
     /// The ID of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
     #[structable(optional, pretty, wide)]
     metadata: Option<Value>,
+
+    /// The name of the host aggregate.
+    ///
+    #[serde()]
+    #[structable()]
+    name: String,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -151,8 +157,8 @@ struct ResponseData {
     /// **New in version 2.41**
     ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregatesCommand {

--- a/openstack_cli/src/compute/v2/aggregate/remove_host.rs
+++ b/openstack_cli/src/compute/v2/aggregate/remove_host.rs
@@ -78,94 +78,45 @@ struct RemoveHost {
 /// Aggregate response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
-    /// The availability zone of the host aggregate.
-    ///
     #[serde()]
     #[structable(optional)]
     availability_zone: Option<String>,
 
-    /// The date and time when the resource was created. The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
-    /// A boolean indicates whether this aggregate is deleted or not, if it has
-    /// not been deleted, `false` will appear.
-    ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
-    /// The date and time when the resource was deleted. If the resource has
-    /// not been deleted yet, this field will be `null`, The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    deleted_at: Option<String>,
+    #[structable()]
+    deleted_at: String,
 
-    /// An array of host information.
-    ///
     #[serde()]
     #[structable(optional, pretty)]
     hosts: Option<Value>,
 
-    /// The ID of the host aggregate.
-    ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
-    /// Metadata key and value pairs associated with the aggregate.
-    ///
     #[serde()]
     #[structable(optional, pretty)]
     metadata: Option<Value>,
 
-    /// The date and time when the resource was updated, if the resource has
-    /// not been updated, this field will show as `null`. The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    updated_at: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// The UUID of the host aggregate.
-    ///
-    /// **New in version 2.41**
-    ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    updated_at: String,
+
+    #[serde()]
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/set_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_20.rs
@@ -123,15 +123,15 @@ struct ResponseData {
     /// example, the offset value is `-05:00`.
     ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
     /// A boolean indicates whether this aggregate is deleted or not, if it has
     /// not been deleted, `false` will appear.
     ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
     /// The date and time when the resource was deleted. If the resource has
     /// not been deleted yet, this field will be `null`, The date and time
@@ -159,14 +159,20 @@ struct ResponseData {
     /// The ID of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
     #[structable(optional, pretty)]
     metadata: Option<Value>,
+
+    /// The name of the host aggregate.
+    ///
+    #[serde()]
+    #[structable()]
+    name: String,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -190,8 +196,8 @@ struct ResponseData {
     /// **New in version 2.41**
     ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/set_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_21.rs
@@ -123,15 +123,15 @@ struct ResponseData {
     /// example, the offset value is `-05:00`.
     ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
     /// A boolean indicates whether this aggregate is deleted or not, if it has
     /// not been deleted, `false` will appear.
     ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
     /// The date and time when the resource was deleted. If the resource has
     /// not been deleted yet, this field will be `null`, The date and time
@@ -159,14 +159,20 @@ struct ResponseData {
     /// The ID of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
     #[structable(optional, pretty)]
     metadata: Option<Value>,
+
+    /// The name of the host aggregate.
+    ///
+    #[serde()]
+    #[structable()]
+    name: String,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -190,8 +196,8 @@ struct ResponseData {
     /// **New in version 2.41**
     ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/set_metadata.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_metadata.rs
@@ -79,94 +79,45 @@ struct SetMetadata {
 /// Aggregate response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
-    /// The availability zone of the host aggregate.
-    ///
     #[serde()]
     #[structable(optional)]
     availability_zone: Option<String>,
 
-    /// The date and time when the resource was created. The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
-    /// A boolean indicates whether this aggregate is deleted or not, if it has
-    /// not been deleted, `false` will appear.
-    ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
-    /// The date and time when the resource was deleted. If the resource has
-    /// not been deleted yet, this field will be `null`, The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    deleted_at: Option<String>,
+    #[structable()]
+    deleted_at: String,
 
-    /// An array of host information.
-    ///
     #[serde()]
     #[structable(optional, pretty)]
     hosts: Option<Value>,
 
-    /// The ID of the host aggregate.
-    ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
-    /// Metadata key and value pairs associated with the aggregate.
-    ///
     #[serde()]
     #[structable(optional, pretty)]
     metadata: Option<Value>,
 
-    /// The date and time when the resource was updated, if the resource has
-    /// not been updated, this field will show as `null`. The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    ///
     #[serde()]
-    #[structable(optional)]
-    updated_at: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// The UUID of the host aggregate.
-    ///
-    /// **New in version 2.41**
-    ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    updated_at: String,
+
+    #[serde()]
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/aggregate/show.rs
+++ b/openstack_cli/src/compute/v2/aggregate/show.rs
@@ -92,15 +92,15 @@ struct ResponseData {
     /// example, the offset value is `-05:00`.
     ///
     #[serde()]
-    #[structable(optional)]
-    created_at: Option<String>,
+    #[structable()]
+    created_at: String,
 
     /// A boolean indicates whether this aggregate is deleted or not, if it has
     /// not been deleted, `false` will appear.
     ///
     #[serde()]
-    #[structable(optional)]
-    deleted: Option<bool>,
+    #[structable()]
+    deleted: bool,
 
     /// The date and time when the resource was deleted. If the resource has
     /// not been deleted yet, this field will be `null`, The date and time
@@ -128,14 +128,20 @@ struct ResponseData {
     /// The ID of the host aggregate.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<i32>,
+    #[structable()]
+    id: i32,
 
     /// Metadata key and value pairs associated with the aggregate.
     ///
     #[serde()]
     #[structable(optional, pretty)]
     metadata: Option<Value>,
+
+    /// The name of the host aggregate.
+    ///
+    #[serde()]
+    #[structable()]
+    name: String,
 
     /// The date and time when the resource was updated, if the resource has
     /// not been updated, this field will show as `null`. The date and time
@@ -159,8 +165,8 @@ struct ResponseData {
     /// **New in version 2.41**
     ///
     #[serde()]
-    #[structable(optional)]
-    uuid: Option<String>,
+    #[structable()]
+    uuid: String,
 }
 
 impl AggregateCommand {

--- a/openstack_cli/src/compute/v2/assisted_volume_snapshot/create.rs
+++ b/openstack_cli/src/compute/v2/assisted_volume_snapshot/create.rs
@@ -131,8 +131,8 @@ struct ResponseData {
     /// The source volume ID.
     ///
     #[serde(rename = "volumeId")]
-    #[structable(optional, title = "volumeId")]
-    volume_id: Option<String>,
+    #[structable(title = "volumeId")]
+    volume_id: String,
 }
 
 impl AssistedVolumeSnapshotCommand {

--- a/openstack_cli/src/compute/v2/flavor/create_20.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_20.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::IntString;
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::create_20;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -133,6 +131,14 @@ struct Flavor {
 /// Flavor response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
+    /// The description of the flavor.
+    ///
+    /// **New in version 2.55**
+    ///
+    #[serde()]
+    #[structable(optional)]
+    description: Option<String>,
+
     /// The size of the root disk that will be created in GiB. If 0 the root
     /// disk will be set to exactly the size of the image used to deploy the
     /// instance. However, in this case the scheduler cannot select the compute
@@ -142,8 +148,8 @@ struct ResponseData {
     /// `os_compute_api:servers:create:zero_disk_flavor` policy rule.
     ///
     #[serde()]
-    #[structable(optional)]
-    disk: Option<IntString>,
+    #[structable()]
+    disk: i32,
 
     /// A dictionary of the flavor’s extra-specs key-and-value pairs. This will
     /// only be included if the user is allowed by policy to index flavor
@@ -159,29 +165,33 @@ struct ResponseData {
     /// this is really a string.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<String>,
+    #[structable()]
+    id: String,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
     /// for more info.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    links: Option<Value>,
+    #[structable(pretty)]
+    links: Value,
 
     /// The display name of a flavor.
     ///
     #[serde()]
-    #[structable(optional)]
-    name: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// Whether the flavor is public (available to all projects) or scoped to a
-    /// set of projects. Default is True if not specified.
-    ///
     #[serde(rename = "os-flavor-access:is_public")]
-    #[structable(optional, title = "os-flavor-access:is_public")]
-    os_flavor_access_is_public: Option<bool>,
+    #[structable(pretty, title = "os-flavor-access:is_public")]
+    os_flavor_access_is_public: Value,
+
+    /// Whether or not the flavor has been administratively disabled. This is
+    /// typically only visible to administrative users.
+    ///
+    #[serde(rename = "OS-FLV-DISABLED:disabled")]
+    #[structable(title = "OS-FLV-DISABLED:disabled")]
+    os_flv_disabled_disabled: bool,
 
     /// The size of the ephemeral disk that will be created, in GiB. Ephemeral
     /// disks may be written over on server state changes. So should only be
@@ -189,22 +199,18 @@ struct ResponseData {
     /// limitations. Defaults to 0.
     ///
     #[serde(rename = "OS-FLV-EXT-DATA:ephemeral")]
-    #[structable(optional, title = "OS-FLV-EXT-DATA:ephemeral")]
-    os_flv_ext_data_ephemeral: Option<IntString>,
+    #[structable(title = "OS-FLV-EXT-DATA:ephemeral")]
+    os_flv_ext_data_ephemeral: i32,
 
     /// The amount of RAM a flavor has, in MiB.
     ///
     #[serde()]
-    #[structable(optional)]
-    ram: Option<IntString>,
+    #[structable()]
+    ram: i32,
 
-    /// The receive / transmit factor (as a float) that will be set on ports if
-    /// the network backend supports the QOS extension. Otherwise it will be
-    /// ignored. It defaults to 1.0.
-    ///
     #[serde()]
-    #[structable(optional)]
-    rxtx_factor: Option<NumString>,
+    #[structable(pretty)]
+    rxtx_factor: Value,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created. Currently, the
@@ -212,14 +218,14 @@ struct ResponseData {
     /// default return value of swap is 0 instead of empty string.
     ///
     #[serde()]
-    #[structable(optional)]
-    swap: Option<IntString>,
+    #[structable()]
+    swap: i32,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[structable(optional)]
-    vcpus: Option<IntString>,
+    #[structable()]
+    vcpus: i32,
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/create_21.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_21.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::IntString;
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::create_21;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -133,6 +131,14 @@ struct Flavor {
 /// Flavor response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
+    /// The description of the flavor.
+    ///
+    /// **New in version 2.55**
+    ///
+    #[serde()]
+    #[structable(optional)]
+    description: Option<String>,
+
     /// The size of the root disk that will be created in GiB. If 0 the root
     /// disk will be set to exactly the size of the image used to deploy the
     /// instance. However, in this case the scheduler cannot select the compute
@@ -142,8 +148,8 @@ struct ResponseData {
     /// `os_compute_api:servers:create:zero_disk_flavor` policy rule.
     ///
     #[serde()]
-    #[structable(optional)]
-    disk: Option<IntString>,
+    #[structable()]
+    disk: i32,
 
     /// A dictionary of the flavor’s extra-specs key-and-value pairs. This will
     /// only be included if the user is allowed by policy to index flavor
@@ -159,29 +165,33 @@ struct ResponseData {
     /// this is really a string.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<String>,
+    #[structable()]
+    id: String,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
     /// for more info.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    links: Option<Value>,
+    #[structable(pretty)]
+    links: Value,
 
     /// The display name of a flavor.
     ///
     #[serde()]
-    #[structable(optional)]
-    name: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// Whether the flavor is public (available to all projects) or scoped to a
-    /// set of projects. Default is True if not specified.
-    ///
     #[serde(rename = "os-flavor-access:is_public")]
-    #[structable(optional, title = "os-flavor-access:is_public")]
-    os_flavor_access_is_public: Option<bool>,
+    #[structable(pretty, title = "os-flavor-access:is_public")]
+    os_flavor_access_is_public: Value,
+
+    /// Whether or not the flavor has been administratively disabled. This is
+    /// typically only visible to administrative users.
+    ///
+    #[serde(rename = "OS-FLV-DISABLED:disabled")]
+    #[structable(title = "OS-FLV-DISABLED:disabled")]
+    os_flv_disabled_disabled: bool,
 
     /// The size of the ephemeral disk that will be created, in GiB. Ephemeral
     /// disks may be written over on server state changes. So should only be
@@ -189,22 +199,18 @@ struct ResponseData {
     /// limitations. Defaults to 0.
     ///
     #[serde(rename = "OS-FLV-EXT-DATA:ephemeral")]
-    #[structable(optional, title = "OS-FLV-EXT-DATA:ephemeral")]
-    os_flv_ext_data_ephemeral: Option<IntString>,
+    #[structable(title = "OS-FLV-EXT-DATA:ephemeral")]
+    os_flv_ext_data_ephemeral: i32,
 
     /// The amount of RAM a flavor has, in MiB.
     ///
     #[serde()]
-    #[structable(optional)]
-    ram: Option<IntString>,
+    #[structable()]
+    ram: i32,
 
-    /// The receive / transmit factor (as a float) that will be set on ports if
-    /// the network backend supports the QOS extension. Otherwise it will be
-    /// ignored. It defaults to 1.0.
-    ///
     #[serde()]
-    #[structable(optional)]
-    rxtx_factor: Option<NumString>,
+    #[structable(pretty)]
+    rxtx_factor: Value,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created. Currently, the
@@ -212,14 +218,14 @@ struct ResponseData {
     /// default return value of swap is 0 instead of empty string.
     ///
     #[serde()]
-    #[structable(optional)]
-    swap: Option<IntString>,
+    #[structable()]
+    swap: i32,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[structable(optional)]
-    vcpus: Option<IntString>,
+    #[structable()]
+    vcpus: i32,
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/create_255.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_255.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::IntString;
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::create_255;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
@@ -141,6 +139,14 @@ struct Flavor {
 /// Flavor response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
+    /// The description of the flavor.
+    ///
+    /// **New in version 2.55**
+    ///
+    #[serde()]
+    #[structable(optional)]
+    description: Option<String>,
+
     /// The size of the root disk that will be created in GiB. If 0 the root
     /// disk will be set to exactly the size of the image used to deploy the
     /// instance. However, in this case the scheduler cannot select the compute
@@ -150,8 +156,8 @@ struct ResponseData {
     /// `os_compute_api:servers:create:zero_disk_flavor` policy rule.
     ///
     #[serde()]
-    #[structable(optional)]
-    disk: Option<IntString>,
+    #[structable()]
+    disk: i32,
 
     /// A dictionary of the flavor’s extra-specs key-and-value pairs. This will
     /// only be included if the user is allowed by policy to index flavor
@@ -167,29 +173,33 @@ struct ResponseData {
     /// this is really a string.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<String>,
+    #[structable()]
+    id: String,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
     /// for more info.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    links: Option<Value>,
+    #[structable(pretty)]
+    links: Value,
 
     /// The display name of a flavor.
     ///
     #[serde()]
-    #[structable(optional)]
-    name: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// Whether the flavor is public (available to all projects) or scoped to a
-    /// set of projects. Default is True if not specified.
-    ///
     #[serde(rename = "os-flavor-access:is_public")]
-    #[structable(optional, title = "os-flavor-access:is_public")]
-    os_flavor_access_is_public: Option<bool>,
+    #[structable(pretty, title = "os-flavor-access:is_public")]
+    os_flavor_access_is_public: Value,
+
+    /// Whether or not the flavor has been administratively disabled. This is
+    /// typically only visible to administrative users.
+    ///
+    #[serde(rename = "OS-FLV-DISABLED:disabled")]
+    #[structable(title = "OS-FLV-DISABLED:disabled")]
+    os_flv_disabled_disabled: bool,
 
     /// The size of the ephemeral disk that will be created, in GiB. Ephemeral
     /// disks may be written over on server state changes. So should only be
@@ -197,22 +207,18 @@ struct ResponseData {
     /// limitations. Defaults to 0.
     ///
     #[serde(rename = "OS-FLV-EXT-DATA:ephemeral")]
-    #[structable(optional, title = "OS-FLV-EXT-DATA:ephemeral")]
-    os_flv_ext_data_ephemeral: Option<IntString>,
+    #[structable(title = "OS-FLV-EXT-DATA:ephemeral")]
+    os_flv_ext_data_ephemeral: i32,
 
     /// The amount of RAM a flavor has, in MiB.
     ///
     #[serde()]
-    #[structable(optional)]
-    ram: Option<IntString>,
+    #[structable()]
+    ram: i32,
 
-    /// The receive / transmit factor (as a float) that will be set on ports if
-    /// the network backend supports the QOS extension. Otherwise it will be
-    /// ignored. It defaults to 1.0.
-    ///
     #[serde()]
-    #[structable(optional)]
-    rxtx_factor: Option<NumString>,
+    #[structable(pretty)]
+    rxtx_factor: Value,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created. Currently, the
@@ -220,14 +226,14 @@ struct ResponseData {
     /// default return value of swap is 0 instead of empty string.
     ///
     #[serde()]
-    #[structable(optional)]
-    swap: Option<IntString>,
+    #[structable()]
+    swap: i32,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[structable(optional)]
-    vcpus: Option<IntString>,
+    #[structable()]
+    vcpus: i32,
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/list.rs
@@ -31,7 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::extra_spec::list;
 use openstack_sdk::api::QueryAsync;
 use std::collections::HashMap;
@@ -73,7 +72,7 @@ struct PathParameters {
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, NumString>);
+struct ResponseData(HashMap<String, String>);
 
 impl StructTable for ResponseData {
     fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
@@ -82,7 +81,7 @@ impl StructTable for ResponseData {
         rows.extend(
             self.0
                 .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.to_string()])),
+                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
         );
         (headers, rows)
     }

--- a/openstack_cli/src/compute/v2/flavor/extra_spec/show.rs
+++ b/openstack_cli/src/compute/v2/flavor/extra_spec/show.rs
@@ -31,7 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::extra_spec::get;
 use openstack_sdk::api::QueryAsync;
 use std::collections::HashMap;
@@ -82,7 +81,7 @@ struct PathParameters {
 }
 /// Response data as HashMap type
 #[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, NumString>);
+struct ResponseData(HashMap<String, String>);
 
 impl StructTable for ResponseData {
     fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
@@ -91,7 +90,7 @@ impl StructTable for ResponseData {
         rows.extend(
             self.0
                 .iter()
-                .map(|(k, v)| Vec::from([k.clone(), v.to_string()])),
+                .map(|(k, v)| Vec::from([k.clone(), v.clone()])),
         );
         (headers, rows)
     }

--- a/openstack_cli/src/compute/v2/flavor/flavor_access/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/flavor_access/list.rs
@@ -76,14 +76,14 @@ struct ResponseData {
     /// this is really a string.
     ///
     #[serde()]
-    #[structable(optional)]
-    flavor_id: Option<String>,
+    #[structable()]
+    flavor_id: String,
 
     /// The UUID of the tenant in a multi-tenancy cloud.
     ///
     #[serde()]
-    #[structable(optional)]
-    tenant_id: Option<String>,
+    #[structable()]
+    tenant_id: String,
 }
 
 impl FlavorAccessesCommand {

--- a/openstack_cli/src/compute/v2/flavor/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/list.rs
@@ -32,7 +32,6 @@ use crate::OutputConfig;
 use crate::StructTable;
 
 use crate::common::IntString;
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::list_detailed;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
@@ -92,6 +91,14 @@ struct PathParameters {}
 /// Flavors response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
+    /// The description of the flavor.
+    ///
+    /// **New in version 2.55**
+    ///
+    #[serde()]
+    #[structable(optional, wide)]
+    description: Option<String>,
+
     /// The size of the root disk that will be created in GiB. If 0 the root
     /// disk will be set to exactly the size of the image used to deploy the
     /// instance. However, in this case the scheduler cannot select the compute
@@ -101,8 +108,8 @@ struct ResponseData {
     /// `os_compute_api:servers:create:zero_disk_flavor` policy rule.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    disk: Option<IntString>,
+    #[structable(wide)]
+    disk: i32,
 
     /// A dictionary of the flavor’s extra-specs key-and-value pairs. This will
     /// only be included if the user is allowed by policy to index flavor
@@ -118,21 +125,25 @@ struct ResponseData {
     /// this is really a string.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<String>,
+    #[structable()]
+    id: String,
 
     /// The display name of a flavor.
     ///
     #[serde()]
-    #[structable(optional)]
-    name: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// Whether the flavor is public (available to all projects) or scoped to a
-    /// set of projects. Default is True if not specified.
-    ///
     #[serde(rename = "os-flavor-access:is_public")]
-    #[structable(optional, title = "os-flavor-access:is_public", wide)]
-    os_flavor_access_is_public: Option<bool>,
+    #[structable(pretty, title = "os-flavor-access:is_public", wide)]
+    os_flavor_access_is_public: Value,
+
+    /// Whether or not the flavor has been administratively disabled. This is
+    /// typically only visible to administrative users.
+    ///
+    #[serde(rename = "OS-FLV-DISABLED:disabled")]
+    #[structable(title = "OS-FLV-DISABLED:disabled", wide)]
+    os_flv_disabled_disabled: bool,
 
     /// The size of the ephemeral disk that will be created, in GiB. Ephemeral
     /// disks may be written over on server state changes. So should only be
@@ -140,22 +151,18 @@ struct ResponseData {
     /// limitations. Defaults to 0.
     ///
     #[serde(rename = "OS-FLV-EXT-DATA:ephemeral")]
-    #[structable(optional, title = "OS-FLV-EXT-DATA:ephemeral", wide)]
-    os_flv_ext_data_ephemeral: Option<IntString>,
+    #[structable(title = "OS-FLV-EXT-DATA:ephemeral", wide)]
+    os_flv_ext_data_ephemeral: i32,
 
     /// The amount of RAM a flavor has, in MiB.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    ram: Option<IntString>,
+    #[structable(wide)]
+    ram: i32,
 
-    /// The receive / transmit factor (as a float) that will be set on ports if
-    /// the network backend supports the QOS extension. Otherwise it will be
-    /// ignored. It defaults to 1.0.
-    ///
     #[serde()]
-    #[structable(optional, wide)]
-    rxtx_factor: Option<NumString>,
+    #[structable(pretty, wide)]
+    rxtx_factor: Value,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created. Currently, the
@@ -163,14 +170,14 @@ struct ResponseData {
     /// default return value of swap is 0 instead of empty string.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    swap: Option<IntString>,
+    #[structable(wide)]
+    swap: IntString,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[structable(optional, wide)]
-    vcpus: Option<IntString>,
+    #[structable(wide)]
+    vcpus: i32,
 }
 
 impl FlavorsCommand {

--- a/openstack_cli/src/compute/v2/flavor/set_255.rs
+++ b/openstack_cli/src/compute/v2/flavor/set_255.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::IntString;
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::find;
 use openstack_sdk::api::compute::v2::flavor::set_255;
 use openstack_sdk::api::find;
@@ -100,6 +98,12 @@ struct Flavor {
 /// Flavor response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
+    /// The description of the flavor.
+    ///
+    #[serde()]
+    #[structable(optional)]
+    description: Option<String>,
+
     /// The size of the root disk that will be created in GiB. If 0 the root
     /// disk will be set to exactly the size of the image used to deploy the
     /// instance. However, in this case the scheduler cannot select the compute
@@ -109,8 +113,8 @@ struct ResponseData {
     /// `os_compute_api:servers:create:zero_disk_flavor` policy rule.
     ///
     #[serde()]
-    #[structable(optional)]
-    disk: Option<IntString>,
+    #[structable()]
+    disk: i32,
 
     /// A dictionary of the flavor’s extra-specs key-and-value pairs. This will
     /// only be included if the user is allowed by policy to index flavor
@@ -126,29 +130,33 @@ struct ResponseData {
     /// this is really a string.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<String>,
+    #[structable()]
+    id: String,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
     /// for more info.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    links: Option<Value>,
+    #[structable(pretty)]
+    links: Value,
 
     /// The display name of a flavor.
     ///
     #[serde()]
-    #[structable(optional)]
-    name: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// Whether the flavor is public (available to all projects) or scoped to a
-    /// set of projects. Default is True if not specified.
-    ///
     #[serde(rename = "os-flavor-access:is_public")]
-    #[structable(optional, title = "os-flavor-access:is_public")]
-    os_flavor_access_is_public: Option<bool>,
+    #[structable(pretty, title = "os-flavor-access:is_public")]
+    os_flavor_access_is_public: Value,
+
+    /// Whether or not the flavor has been administratively disabled. This is
+    /// typically only visible to administrative users.
+    ///
+    #[serde(rename = "OS-FLV-DISABLED:disabled")]
+    #[structable(title = "OS-FLV-DISABLED:disabled")]
+    os_flv_disabled_disabled: bool,
 
     /// The size of the ephemeral disk that will be created, in GiB. Ephemeral
     /// disks may be written over on server state changes. So should only be
@@ -156,22 +164,18 @@ struct ResponseData {
     /// limitations. Defaults to 0.
     ///
     #[serde(rename = "OS-FLV-EXT-DATA:ephemeral")]
-    #[structable(optional, title = "OS-FLV-EXT-DATA:ephemeral")]
-    os_flv_ext_data_ephemeral: Option<IntString>,
+    #[structable(title = "OS-FLV-EXT-DATA:ephemeral")]
+    os_flv_ext_data_ephemeral: i32,
 
     /// The amount of RAM a flavor has, in MiB.
     ///
     #[serde()]
-    #[structable(optional)]
-    ram: Option<IntString>,
+    #[structable()]
+    ram: i32,
 
-    /// The receive / transmit factor (as a float) that will be set on ports if
-    /// the network backend supports the QOS extension. Otherwise it will be
-    /// ignored. It defaults to 1.0.
-    ///
     #[serde()]
-    #[structable(optional)]
-    rxtx_factor: Option<NumString>,
+    #[structable(pretty)]
+    rxtx_factor: Value,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created. Currently, the
@@ -179,14 +183,14 @@ struct ResponseData {
     /// default return value of swap is 0 instead of empty string.
     ///
     #[serde()]
-    #[structable(optional)]
-    swap: Option<IntString>,
+    #[structable()]
+    swap: i32,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[structable(optional)]
-    vcpus: Option<IntString>,
+    #[structable()]
+    vcpus: i32,
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/flavor/show.rs
+++ b/openstack_cli/src/compute/v2/flavor/show.rs
@@ -31,8 +31,6 @@ use crate::OpenStackCliError;
 use crate::OutputConfig;
 use crate::StructTable;
 
-use crate::common::IntString;
-use crate::common::NumString;
 use openstack_sdk::api::compute::v2::flavor::find;
 use openstack_sdk::api::find;
 use openstack_sdk::api::QueryAsync;
@@ -76,6 +74,14 @@ struct PathParameters {
 /// Flavor response representation
 #[derive(Deserialize, Serialize, Clone, StructTable)]
 struct ResponseData {
+    /// The description of the flavor.
+    ///
+    /// **New in version 2.55**
+    ///
+    #[serde()]
+    #[structable(optional)]
+    description: Option<String>,
+
     /// The size of the root disk that will be created in GiB. If 0 the root
     /// disk will be set to exactly the size of the image used to deploy the
     /// instance. However, in this case the scheduler cannot select the compute
@@ -85,8 +91,8 @@ struct ResponseData {
     /// `os_compute_api:servers:create:zero_disk_flavor` policy rule.
     ///
     #[serde()]
-    #[structable(optional)]
-    disk: Option<IntString>,
+    #[structable()]
+    disk: i32,
 
     /// A dictionary of the flavor’s extra-specs key-and-value pairs. This will
     /// only be included if the user is allowed by policy to index flavor
@@ -102,29 +108,33 @@ struct ResponseData {
     /// this is really a string.
     ///
     #[serde()]
-    #[structable(optional)]
-    id: Option<String>,
+    #[structable()]
+    id: String,
 
     /// Links to the resources in question. See
     /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
     /// for more info.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    links: Option<Value>,
+    #[structable(pretty)]
+    links: Value,
 
     /// The display name of a flavor.
     ///
     #[serde()]
-    #[structable(optional)]
-    name: Option<String>,
+    #[structable()]
+    name: String,
 
-    /// Whether the flavor is public (available to all projects) or scoped to a
-    /// set of projects. Default is True if not specified.
-    ///
     #[serde(rename = "os-flavor-access:is_public")]
-    #[structable(optional, title = "os-flavor-access:is_public")]
-    os_flavor_access_is_public: Option<bool>,
+    #[structable(pretty, title = "os-flavor-access:is_public")]
+    os_flavor_access_is_public: Value,
+
+    /// Whether or not the flavor has been administratively disabled. This is
+    /// typically only visible to administrative users.
+    ///
+    #[serde(rename = "OS-FLV-DISABLED:disabled")]
+    #[structable(title = "OS-FLV-DISABLED:disabled")]
+    os_flv_disabled_disabled: bool,
 
     /// The size of the ephemeral disk that will be created, in GiB. Ephemeral
     /// disks may be written over on server state changes. So should only be
@@ -132,22 +142,18 @@ struct ResponseData {
     /// limitations. Defaults to 0.
     ///
     #[serde(rename = "OS-FLV-EXT-DATA:ephemeral")]
-    #[structable(optional, title = "OS-FLV-EXT-DATA:ephemeral")]
-    os_flv_ext_data_ephemeral: Option<IntString>,
+    #[structable(title = "OS-FLV-EXT-DATA:ephemeral")]
+    os_flv_ext_data_ephemeral: i32,
 
     /// The amount of RAM a flavor has, in MiB.
     ///
     #[serde()]
-    #[structable(optional)]
-    ram: Option<IntString>,
+    #[structable()]
+    ram: i32,
 
-    /// The receive / transmit factor (as a float) that will be set on ports if
-    /// the network backend supports the QOS extension. Otherwise it will be
-    /// ignored. It defaults to 1.0.
-    ///
     #[serde()]
-    #[structable(optional)]
-    rxtx_factor: Option<NumString>,
+    #[structable(pretty)]
+    rxtx_factor: Value,
 
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created. Currently, the
@@ -155,14 +161,14 @@ struct ResponseData {
     /// default return value of swap is 0 instead of empty string.
     ///
     #[serde()]
-    #[structable(optional)]
-    swap: Option<IntString>,
+    #[structable()]
+    swap: i32,
 
     /// The number of virtual CPUs that will be allocated to the server.
     ///
     #[serde()]
-    #[structable(optional)]
-    vcpus: Option<IntString>,
+    #[structable()]
+    vcpus: i32,
 }
 
 impl FlavorCommand {

--- a/openstack_cli/src/compute/v2/instance_usage_audit_log/list.rs
+++ b/openstack_cli/src/compute/v2/instance_usage_audit_log/list.rs
@@ -158,7 +158,7 @@ struct ResponseData {
     /// The state of the instance usage audit task. `DONE` or `RUNNING`.
     ///
     #[serde()]
-    #[structable(optional)]
+    #[structable(optional, status)]
     state: Option<String>,
 
     /// The total number of instance audit task errors.

--- a/openstack_cli/src/compute/v2/version/show.rs
+++ b/openstack_cli/src/compute/v2/version/show.rs
@@ -34,7 +34,7 @@ use crate::StructTable;
 use openstack_sdk::api::compute::v2::version::get;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
-use std::collections::HashMap;
+use structable_derive::StructTable;
 
 /// Command without description in OpenAPI
 ///
@@ -65,22 +65,62 @@ struct PathParameters {
     )]
     id: String,
 }
-/// Response data as HashMap type
-#[derive(Deserialize, Serialize)]
-struct ResponseData(HashMap<String, Value>);
+/// Version response representation
+#[derive(Deserialize, Serialize, Clone, StructTable)]
+struct ResponseData {
+    /// A common name for the version in question. Informative only, it has no
+    /// real semantic meaning.
+    ///
+    #[serde()]
+    #[structable()]
+    id: String,
 
-impl StructTable for ResponseData {
-    fn build(&self, _options: &OutputConfig) -> (Vec<String>, Vec<Vec<String>>) {
-        let headers: Vec<String> = Vec::from(["Name".to_string(), "Value".to_string()]);
-        let mut rows: Vec<Vec<String>> = Vec::new();
-        rows.extend(self.0.iter().map(|(k, v)| {
-            Vec::from([
-                k.clone(),
-                serde_json::to_string(&v).expect("Is a valid data"),
-            ])
-        }));
-        (headers, rows)
-    }
+    /// Links to the resources in question. See
+    /// [API Guide / Links and References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+    /// for more info.
+    ///
+    #[serde()]
+    #[structable(pretty)]
+    links: Value,
+
+    #[serde(rename = "media-types")]
+    #[structable(optional, pretty, title = "media-types")]
+    media_types: Option<Value>,
+
+    /// If this version of the API supports microversions, the minimum
+    /// microversion that is supported. This will be the empty string if
+    /// microversions are not supported.
+    ///
+    #[serde()]
+    #[structable()]
+    min_version: String,
+
+    /// The status of this API version. This can be one of:
+    ///
+    /// - `CURRENT`: this is the preferred version of the API to use
+    /// - `SUPPORTED`: this is an older, but still supported version of the API
+    /// - `DEPRECATED`: a deprecated version of the API that is slated for
+    ///   removal
+    ///
+    #[serde()]
+    #[structable()]
+    status: String,
+
+    /// This is a fixed string. It is `2011-01-21T11:33:21Z` in version 2.0,
+    /// `2013-07-23T11:33:21Z` in version 2.1.
+    ///
+    /// Note
+    ///
+    /// It is vestigial and provides no useful information. It will be
+    /// deprecated and removed in the future.
+    ///
+    #[serde()]
+    #[structable()]
+    updated: String,
+
+    #[serde()]
+    #[structable(optional)]
+    version: Option<String>,
 }
 
 impl VersionCommand {

--- a/openstack_sdk/src/api/compute/v2/version/get.rs
+++ b/openstack_sdk/src/api/compute/v2/version/get.rs
@@ -83,7 +83,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("version".into())
     }
 
     /// Returns headers to be set into the request
@@ -119,7 +119,10 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder().build().unwrap().response_key().is_none())
+        assert_eq!(
+            Request::builder().build().unwrap().response_key().unwrap(),
+            "version"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -132,7 +135,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "version": {} }));
         });
 
         let endpoint = Request::builder().id("id").build().unwrap();
@@ -151,7 +154,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "version": {} }));
         });
 
         let endpoint = Request::builder()


### PR DESCRIPTION
Few schemas changed in nova so that the code is again broken so adapt
templates.

Change-Id: I129cd24c63cb7cbb996bb4c9b95e0c9fdb6a2c14

Changes are triggered by https://review.opendev.org/936281
