### PR TITLE
fix: Respect region_name set in the config

### DIFF
--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -181,7 +181,7 @@ impl OpenStack {
         session.catalog.register_catalog_endpoint(
             "identity",
             identity_service_url,
-            None::<String>,
+            config.region_name.as_ref(),
             Some("public"),
         )?;
 
@@ -369,10 +369,11 @@ impl OpenStack {
         &mut self,
         service_type: &ServiceType,
     ) -> Result<(), OpenStackError> {
-        if let Ok(ep) =
-            self.catalog
-                .get_service_endpoint(service_type.to_string(), None, None::<String>)
-        {
+        if let Ok(ep) = self.catalog.get_service_endpoint(
+            service_type.to_string(),
+            None,
+            self.config.region_name.as_ref(),
+        ) {
             if self.catalog.discovery_allowed(service_type.to_string()) {
                 info!("Performing `{}` endpoint version discovery", service_type);
 

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -216,7 +216,7 @@ impl AsyncOpenStack {
         session.catalog.register_catalog_endpoint(
             "identity",
             identity_service_url,
-            None::<String>,
+            config.region_name.as_ref(),
             Some("public"),
         )?;
 
@@ -448,10 +448,11 @@ where {
         &mut self,
         service_type: &ServiceType,
     ) -> Result<(), OpenStackError> {
-        if let Ok(ep) =
-            self.catalog
-                .get_service_endpoint(service_type.to_string(), None, None::<String>)
-        {
+        if let Ok(ep) = self.catalog.get_service_endpoint(
+            service_type.to_string(),
+            None,
+            self.config.region_name.as_ref(),
+        ) {
             if self.catalog.discovery_allowed(service_type.to_string()) {
                 info!("Performing `{}` endpoint version discovery", service_type);
 


### PR DESCRIPTION
Test on another cloud with multiple regions showed that region_name config
setting was not properly respected during catalog processing.
