### PR TITLE
feat: Add get_auth_state method to obtain auth status

### DIFF
--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -23,6 +23,7 @@ use std::{fs::File, io::Read};
 use tracing::{debug, error, event, info, instrument, trace, warn, Level};
 
 use bytes::Bytes;
+use chrono::TimeDelta;
 use http::{Response as HttpResponse, StatusCode};
 
 use reqwest::{
@@ -38,7 +39,7 @@ use crate::api::query::RawQuery;
 use crate::auth::{
     self, authtoken,
     authtoken::{AuthTokenError, AuthType},
-    Auth,
+    Auth, AuthState,
 };
 use crate::config::{get_config_identity_hash, ConfigFile};
 use crate::state;
@@ -435,6 +436,16 @@ impl OpenStack {
     pub fn get_auth_token(&self) -> Option<String> {
         if let Auth::AuthToken(token) = &self.auth {
             return Some(token.token.clone());
+        }
+        None
+    }
+
+    /// Return current authentication status
+    ///
+    /// Offset can be used to calculate imminent expiration.
+    pub fn get_auth_state(&self, offset: Option<TimeDelta>) -> Option<AuthState> {
+        if let Auth::AuthToken(token) = &self.auth {
+            return Some(token.get_state(offset));
         }
         None
     }

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -22,6 +22,7 @@ use tracing::{debug, error, event, info, instrument, trace, warn, Level};
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use chrono::TimeDelta;
 use futures::io::{Error as IoError, ErrorKind as IoErrorKind};
 use futures::stream::TryStreamExt;
 use http::{HeaderMap, Response as HttpResponse, StatusCode};
@@ -40,7 +41,7 @@ use crate::api::RestClient;
 use crate::auth::{
     self, authtoken,
     authtoken::{AuthTokenError, AuthType},
-    Auth,
+    Auth, AuthState,
 };
 use crate::config::{get_config_identity_hash, ConfigFile};
 use crate::state;
@@ -522,6 +523,16 @@ where {
     pub fn get_auth_info(&self) -> Option<AuthResponse> {
         if let Auth::AuthToken(token) = &self.auth {
             return token.auth_info.clone();
+        }
+        None
+    }
+
+    /// Return current authentication status
+    ///
+    /// Offset can be used to calculate imminent expiration.
+    pub fn get_auth_state(&self, offset: Option<TimeDelta>) -> Option<AuthState> {
+        if let Auth::AuthToken(token) = &self.auth {
+            return Some(token.get_state(offset));
         }
         None
     }

--- a/openstack_sdk/src/state.rs
+++ b/openstack_sdk/src/state.rs
@@ -56,7 +56,7 @@ pub(crate) struct ScopeAuths(HashMap<AuthTokenScope, AuthToken>);
 impl ScopeAuths {
     /// Filter out all invalid auth data keeping only valid ones
     fn filter_invalid_auths(&mut self) -> &mut Self {
-        self.0.retain(|_, v| AuthState::Valid == v.get_state());
+        self.0.retain(|_, v| AuthState::Valid == v.get_state(None));
         self
     }
 
@@ -64,7 +64,7 @@ impl ScopeAuths {
     fn find_valid_unscoped_auth(&self) -> Option<AuthToken> {
         for (k, v) in self.0.iter() {
             if let AuthTokenScope::Unscoped = k {
-                if let AuthState::Valid = v.get_state() {
+                if let AuthState::Valid = v.get_state(None) {
                     return Some(v.clone());
                 }
             }
@@ -75,7 +75,7 @@ impl ScopeAuths {
     /// Find first matching unscoped authz
     fn find_first_valid_auth(&self) -> Option<AuthToken> {
         for (_, v) in self.0.iter() {
-            if let AuthState::Valid = v.get_state() {
+            if let AuthState::Valid = v.get_state(None) {
                 return Some(v.clone());
             }
         }

--- a/openstack_sdk/src/types/identity/v3.rs
+++ b/openstack_sdk/src/types/identity/v3.rs
@@ -37,8 +37,8 @@ pub struct AuthToken {
     pub project: Option<Project>,
     pub domain: Option<Domain>,
     pub system: Option<System>,
-    pub issued_at: Option<DateTime<Local>>,
-    pub expires_at: DateTime<Local>,
+    pub issued_at: Option<DateTime<Utc>>,
+    pub expires_at: DateTime<Utc>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]


### PR DESCRIPTION
Allow client to figure out auth status: expired, valid, soon_to_expire
to allow easy reaction.
