### PR TITLE
feat: Adapt clippy run to include bin targets

### DIFF
--- a/openstack_cli/src/identity/v3/role_assignment/list.rs
+++ b/openstack_cli/src/identity/v3/role_assignment/list.rs
@@ -34,6 +34,7 @@ use crate::StructTable;
 use openstack_sdk::api::identity::v3::role_assignment::list;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 
 /// Get a list of role assignments.
@@ -211,6 +212,21 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, pretty)]
     user: Option<Value>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseLinks {
+    _self: Option<String>,
+}
+
+impl fmt::Display for ResponseLinks {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([format!(
+            "_self={}",
+            self._self.clone().map_or(String::new(), |v| v.to_string())
+        )]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl RoleAssignmentsCommand {

--- a/openstack_tui/src/cloud_worker/block_storage/v3/backup/delete.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/backup/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::block_storage::v3::backup::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/delete.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::block_storage::v3::snapshot::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/block_storage/v3/volume/delete.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/volume/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::block_storage::v3::volume::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/compute/v2/aggregate/delete.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/aggregate/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::aggregate::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/compute/v2/aggregate/get.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/aggregate/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::aggregate::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/compute/v2/flavor/get.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/flavor/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::flavor::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/compute/v2/hypervisor/get.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/hypervisor/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::hypervisor::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/compute/v2/quota_set/details.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/quota_set/details.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::quota_set::details::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/compute/v2/server/delete.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::server::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/compute/v2/server/get.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::server::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/compute/v2/server/get_console_output.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/get_console_output.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::server::os_get_console_output::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 
@@ -62,7 +61,7 @@ impl TryFrom<&OsGetConsoleOutput>
     fn try_from(value: &OsGetConsoleOutput) -> Result<Self, Self::Error> {
         let mut ep_builder = Self::default();
         if let Some(val) = &value.length {
-            ep_builder.length(*val);
+            ep_builder.length((*val).map(Into::into));
         }
         Ok(ep_builder)
     }

--- a/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/get.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::compute::v2::server::instance_action::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/delete.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::dns::v2::zone::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/delete.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::dns::v2::zone::recordset::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/identity/v3/group/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::identity::v3::group::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/identity/v3/group/user/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/user/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::identity::v3::group::user::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/identity/v3/project/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/project/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::identity::v3::project::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::identity::v3::user::application_credential::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/identity/v3/user/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::identity::v3::user::delete::RequestBuilder;
 use openstack_sdk::api::ignore;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/identity/v3/user/set.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/set.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::identity::v3::user::set::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/image/v2/image/delete.rs
+++ b/openstack_tui/src/cloud_worker/image/v2/image/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::image::v2::image::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::load_balancer::v2::healthmonitor::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/get.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::load_balancer::v2::healthmonitor::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/listener/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/listener/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::load_balancer::v2::listener::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/listener/get.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/listener/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::load_balancer::v2::listener::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::load_balancer::v2::loadbalancer::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/get.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::load_balancer::v2::loadbalancer::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::load_balancer::v2::pool::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/get.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::load_balancer::v2::pool::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::load_balancer::v2::pool::member::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/get.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::load_balancer::v2::pool::member::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/quota/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/quota/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::load_balancer::v2::quota::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/quota/get.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/quota/get.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::load_balancer::v2::quota::get::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/network/v2/network/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/network/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::network::v2::network::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/network/v2/quota/details.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/quota/details.rs
@@ -24,7 +24,6 @@ use crate::action::Action;
 use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
-use crate::utils::StructTable;
 use openstack_sdk::api::network::v2::quota::details::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};
 

--- a/openstack_tui/src/cloud_worker/network/v2/router/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/router/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::network::v2::router::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/network/v2/security_group/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::network::v2::security_group::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/network/v2/security_group_rule/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group_rule/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::network::v2::security_group_rule::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};

--- a/openstack_tui/src/cloud_worker/network/v2/subnet/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/subnet/delete.rs
@@ -25,7 +25,6 @@ use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::{ApiRequest, ExecuteApiRequest};
 
 use crate::cloud_worker::ConfirmableRequest;
-use crate::utils::StructTable;
 use openstack_sdk::api::ignore;
 use openstack_sdk::api::network::v2::subnet::delete::RequestBuilder;
 use openstack_sdk::{api::QueryAsync, AsyncOpenStack};


### PR DESCRIPTION
Since clippy run is limiting targets to --lib and --tests the tui is not
being processed. Include also --bins but still limit targets since there
are more things not generated by codegenerator.

Change-Id: I9a0d83743cebbc6bfcdf2ffb1e5086055b392cdb

Changes are triggered by https://review.opendev.org/940593
