### PR TITLE
feat: Send response action also for delete events

### DIFF
--- a/openstack_tui/src/cloud_worker/block_storage/v3/backup/delete.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/backup/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for BlockStorageBackupDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/delete.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for BlockStorageSnapshotDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/block_storage/v3/volume/delete.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/volume/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for BlockStorageVolumeDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/compute/v2/aggregate/delete.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/aggregate/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for ComputeAggregateDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/compute/v2/server/delete.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for ComputeServerDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/delete.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for DnsZoneDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/delete.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/delete.rs
@@ -70,13 +70,18 @@ impl ExecuteApiRequest for DnsZoneRecordsetDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/identity/v3/group/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for IdentityGroupDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/identity/v3/group/user/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/user/delete.rs
@@ -70,13 +70,18 @@ impl ExecuteApiRequest for IdentityGroupUserDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/identity/v3/project/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/project/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for IdentityProjectDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/delete.rs
@@ -70,13 +70,18 @@ impl ExecuteApiRequest for IdentityUserApplicationCredentialDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/identity/v3/user/delete.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for IdentityUserDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/image/v2/image/delete.rs
+++ b/openstack_tui/src/cloud_worker/image/v2/image/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for ImageImageDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for LoadBalancerHealthmonitorDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/listener/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/listener/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for LoadBalancerListenerDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for LoadBalancerLoadbalancerDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for LoadBalancerPoolDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/delete.rs
@@ -70,13 +70,18 @@ impl ExecuteApiRequest for LoadBalancerPoolMemberDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/quota/delete.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/quota/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for LoadBalancerQuotaDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/network/v2/router/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/router/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for NetworkRouterDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/network/v2/security_group/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for NetworkSecurityGroupDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/network/v2/security_group_rule/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group_rule/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for NetworkSecurityGroupRuleDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }

--- a/openstack_tui/src/cloud_worker/network/v2/subnet/delete.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/subnet/delete.rs
@@ -62,13 +62,18 @@ impl ExecuteApiRequest for NetworkSubnetDelete {
     async fn execute_request(
         &self,
         session: &mut AsyncOpenStack,
-        _request: &ApiRequest,
-        _app_tx: &UnboundedSender<Action>,
+        request: &ApiRequest,
+        app_tx: &UnboundedSender<Action>,
     ) -> Result<(), CloudWorkerError> {
         let ep = TryInto::<RequestBuilder>::try_into(self)?
             .build()
             .wrap_err("Cannot prepare request")?;
         ignore(ep).query_async(session).await?;
+        // Let caller know deletion was completed
+        app_tx.send(Action::ApiResponseData {
+            request: request.clone(),
+            data: serde_json::Value::Null,
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
When TUI user invoked delete event we want to know it was completed
successfully. For that send a response with request data and explicit Null as
response.

Change-Id: I844d2d89883481b4a874aadf4aee8156c84cf536

Changes are triggered by https://review.opendev.org/940676
