### PR TITLE
fix: Discover block-storage endpoint in the TUI

### DIFF
--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -64,6 +64,9 @@ impl Cloud {
             .discover_service_endpoint(&openstack_sdk::types::ServiceType::Compute)
             .await?;
         session
+            .discover_service_endpoint(&openstack_sdk::types::ServiceType::BlockStorage)
+            .await?;
+        session
             .discover_service_endpoint(&openstack_sdk::types::ServiceType::Dns)
             .await?;
         session
@@ -92,6 +95,9 @@ impl Cloud {
 
             session
                 .discover_service_endpoint(&openstack_sdk::types::ServiceType::Compute)
+                .await?;
+            session
+                .discover_service_endpoint(&openstack_sdk::types::ServiceType::BlockStorage)
                 .await?;
             session
                 .discover_service_endpoint(&openstack_sdk::types::ServiceType::Image)


### PR DESCRIPTION
Perform block-storage endpoint version discovery in the TUI. This fixes
used microversion and at the same time sets proper region.
