### PR TITLE
fix: Use '--file' instead of '-f' in the image functest

### DIFF
--- a/openstack_cli/tests/image/v2/image/file/roundtrip.rs
+++ b/openstack_cli/tests/image/v2/image/file/roundtrip.rs
@@ -74,7 +74,7 @@ async fn image_upload_download_roundtrip() -> Result<(), Box<dyn std::error::Err
         .arg("image")
         .arg("upload")
         .arg(image_id)
-        .arg("-f")
+        .arg("--file")
         .arg(fname.clone())
         .assert()
         .success();


### PR DESCRIPTION
For some reason it was working before, but is not working now.
