### PR TITLE
feat: Return readable error instead of crashing in data upload

### DIFF
--- a/openstack_cli/src/bin/osc.rs
+++ b/openstack_cli/src/bin/osc.rs
@@ -97,6 +97,7 @@ fn initialize_panic_handler() -> Result<()> {
                     Some(OpenStackCliError::ConnectionNotFound { .. }) => false,
                     Some(OpenStackCliError::OpenStackApi { .. }) => false,
                     Some(OpenStackCliError::ReScope { .. }) => false,
+                    Some(OpenStackCliError::InputParameters { .. }) => false,
                     _ => true,
                 }
             }

--- a/openstack_cli/src/common.rs
+++ b/openstack_cli/src/common.rs
@@ -16,12 +16,11 @@
 use crate::error::OpenStackCliError;
 
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 use std::io::IsTerminal;
-
-use serde_json::Value;
 
 use indicatif::{ProgressBar, ProgressStyle};
 use std::path::Path;
@@ -434,7 +433,12 @@ pub(crate) async fn build_upload_asyncread(
         // Reading from stdin
         build_upload_asyncread_from_stdin().await
     } else {
-        match src_name.unwrap().as_str() {
+        match src_name
+            .ok_or(OpenStackCliError::InputParameters(
+                "upload source name must be provided when stdin is not being piped".into(),
+            ))?
+            .as_str()
+        {
             "-" => build_upload_asyncread_from_stdin().await,
             file_name => build_upload_asyncread_from_file(file_name).await,
         }

--- a/openstack_cli/src/error.rs
+++ b/openstack_cli/src/error.rs
@@ -155,6 +155,10 @@ pub enum OpenStackCliError {
         source: dialoguer::Error,
     },
 
+    /// Input parameters
+    #[error("input parameters error: {0}")]
+    InputParameters(String),
+
     /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),


### PR DESCRIPTION
Another unwrap is being replaced with human readable error saying that
source name must be specified when uploading image without piping the
stdin.
