### PR TITLE
feat: Initialize magnum service structure

### DIFF
--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -26,6 +26,7 @@ default = [
   "openstack_sdk/async",
   "block_storage",
   "compute",
+  "container_infra",
   "dns",
   "identity",
   "image",
@@ -36,6 +37,7 @@ default = [
 ]
 block_storage = ["openstack_sdk/block_storage"]
 compute = ["openstack_sdk/compute"]
+container_infra = ["openstack_sdk/container_infra"]
 dns = ["openstack_sdk/dns"]
 identity = ["openstack_sdk/identity"]
 image = ["openstack_sdk/image"]

--- a/openstack_cli/src/container_infrastructure_management/mod.rs
+++ b/openstack_cli/src/container_infrastructure_management/mod.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Container Infrastructure Management (Magnum) service commands
+pub mod v1;

--- a/openstack_cli/src/container_infrastructure_management/v1.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1.rs
@@ -1,0 +1,50 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Container Infrastructure Management API v1 command
+
+use clap::{Parser, Subcommand};
+
+use openstack_sdk::{types::ServiceType, AsyncOpenStack};
+
+use crate::{Cli, OpenStackCliError};
+
+/// Container Infra service (Magnum) operations
+#[derive(Parser)]
+pub struct ComputeCommand {
+    /// Container service resource
+    #[command(subcommand)]
+    command: ComputeCommands,
+}
+
+/// Compute resources commands
+#[allow(missing_docs)]
+#[derive(Subcommand)]
+pub enum ComputeCommands {}
+
+impl ComputeCommand {
+    /// Perform command action
+    pub async fn take_action(
+        &self,
+        parsed_args: &Cli,
+        session: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        session
+            .discover_service_endpoint(&ServiceType::ContainerInfrastructureManagement)
+            .await?;
+
+        //match &self.command {
+        //}
+    }
+}

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -17,6 +17,7 @@ default = [
   "sync",
   "block_storage",
   "compute",
+  "container_infra",
   "dns",
   "identity",
   "image",
@@ -27,6 +28,7 @@ default = [
 ]
 block_storage = []
 compute = []
+container_infra = []
 dns = []
 identity = []
 image = []

--- a/openstack_sdk/src/api.rs
+++ b/openstack_sdk/src/api.rs
@@ -153,6 +153,8 @@ mod rest_endpoint;
 pub mod block_storage;
 #[cfg(feature = "compute")]
 pub mod compute;
+#[cfg(feature = "container_infra")]
+pub mod container_infrastructure_management;
 #[cfg(feature = "dns")]
 pub mod dns;
 #[allow(dead_code)]

--- a/openstack_sdk/src/api/container_infrastructure_management.rs
+++ b/openstack_sdk/src/api/container_infrastructure_management.rs
@@ -1,0 +1,16 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Container Infrastructure Management service (Magnum) bindings
+pub mod v1;

--- a/openstack_sdk/src/api/container_infrastructure_management/v1.rs
+++ b/openstack_sdk/src/api/container_infrastructure_management/v1.rs
@@ -1,0 +1,13 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0

--- a/openstack_sdk/src/api/rest_endpoint.rs
+++ b/openstack_sdk/src/api/rest_endpoint.rs
@@ -105,6 +105,7 @@ pub(crate) fn set_latest_microversion<E>(
     let mh_service_type = match endpoint.service_type() {
         ServiceType::BlockStorage => Some("volume"),
         ServiceType::Compute => Some("compute"),
+        ServiceType::ContainerInfrastructureManagement => Some("container-infra"),
         ServiceType::Placement => Some("placement"),
         _ => None,
     };

--- a/openstack_sdk/src/types.rs
+++ b/openstack_sdk/src/types.rs
@@ -34,6 +34,7 @@ pub use crate::types::api_version::ApiVersion;
 pub enum ServiceType {
     BlockStorage,
     Compute,
+    ContainerInfrastructureManagement,
     Dns,
     Image,
     Identity,
@@ -49,6 +50,9 @@ impl fmt::Display for ServiceType {
         match self {
             ServiceType::BlockStorage => write!(f, "block-storage"),
             ServiceType::Compute => write!(f, "compute"),
+            ServiceType::ContainerInfrastructureManagement => {
+                write!(f, "container-infrastructure-management")
+            }
             ServiceType::Dns => write!(f, "dns"),
             ServiceType::Image => write!(f, "image"),
             ServiceType::Identity => write!(f, "identity"),
@@ -66,6 +70,7 @@ impl From<&str> for ServiceType {
         match val {
             "block-storage" => ServiceType::BlockStorage,
             "compute" => ServiceType::Compute,
+            "container-infrastructure-management" => ServiceType::ContainerInfrastructureManagement,
             "dns" => ServiceType::Dns,
             "identity" => ServiceType::Identity,
             "image" => ServiceType::Image,


### PR DESCRIPTION
Prepare for the magnum code being generated. This adds basic folder structure,
service type and forces version discovery to also support magnum requests.
