### PR TITLE
feat: Fix network external_gateway_info schema

### DIFF
--- a/openstack_cli/src/network/v2/router/add_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/add_external_gateways.rs
@@ -36,6 +36,7 @@ use crate::common::BoolString;
 use openstack_sdk::api::network::v2::router::add_external_gateways;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 
 /// Request body
@@ -150,8 +151,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    external_gateway_info: Option<Value>,
+    #[structable(optional)]
+    external_gateway_info: Option<ResponseExternalGatewayInfo>,
 
     /// The ID of the flavor associated with the router.
     ///
@@ -215,6 +216,41 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     updated_at: Option<String>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseExternalGatewayInfo {
+    enable_snat: Option<BoolString>,
+    external_fixed_ips: Option<Value>,
+    network_id: String,
+    qos_policy_id: Option<String>,
+}
+
+impl fmt::Display for ResponseExternalGatewayInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([
+            format!(
+                "enable_snat={}",
+                self.enable_snat
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!(
+                "external_fixed_ips={}",
+                self.external_fixed_ips
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!("network_id={}", self.network_id),
+            format!(
+                "qos_policy_id={}",
+                self.qos_policy_id
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+        ]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl RouterCommand {

--- a/openstack_cli/src/network/v2/router/list.rs
+++ b/openstack_cli/src/network/v2/router/list.rs
@@ -36,6 +36,7 @@ use openstack_sdk::api::network::v2::router::list;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 
 /// Lists logical routers that the project who submits the request can access.
@@ -241,8 +242,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional, pretty, wide)]
-    external_gateway_info: Option<Value>,
+    #[structable(optional, wide)]
+    external_gateway_info: Option<ResponseExternalGatewayInfo>,
 
     /// The ID of the flavor associated with the router.
     ///
@@ -306,6 +307,41 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     updated_at: Option<String>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseExternalGatewayInfo {
+    enable_snat: Option<BoolString>,
+    external_fixed_ips: Option<Value>,
+    network_id: String,
+    qos_policy_id: Option<String>,
+}
+
+impl fmt::Display for ResponseExternalGatewayInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([
+            format!(
+                "enable_snat={}",
+                self.enable_snat
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!(
+                "external_fixed_ips={}",
+                self.external_fixed_ips
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!("network_id={}", self.network_id),
+            format!(
+                "qos_policy_id={}",
+                self.qos_policy_id
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+        ]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl RoutersCommand {

--- a/openstack_cli/src/network/v2/router/remove_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/remove_external_gateways.rs
@@ -36,6 +36,7 @@ use crate::common::BoolString;
 use openstack_sdk::api::network::v2::router::remove_external_gateways;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 
 /// Request body
@@ -150,8 +151,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    external_gateway_info: Option<Value>,
+    #[structable(optional)]
+    external_gateway_info: Option<ResponseExternalGatewayInfo>,
 
     /// The ID of the flavor associated with the router.
     ///
@@ -215,6 +216,41 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     updated_at: Option<String>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseExternalGatewayInfo {
+    enable_snat: Option<BoolString>,
+    external_fixed_ips: Option<Value>,
+    network_id: String,
+    qos_policy_id: Option<String>,
+}
+
+impl fmt::Display for ResponseExternalGatewayInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([
+            format!(
+                "enable_snat={}",
+                self.enable_snat
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!(
+                "external_fixed_ips={}",
+                self.external_fixed_ips
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!("network_id={}", self.network_id),
+            format!(
+                "qos_policy_id={}",
+                self.qos_policy_id
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+        ]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl RouterCommand {

--- a/openstack_cli/src/network/v2/router/show.rs
+++ b/openstack_cli/src/network/v2/router/show.rs
@@ -36,6 +36,7 @@ use openstack_sdk::api::find;
 use openstack_sdk::api::network::v2::router::find;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 
 /// Shows details for a router.
@@ -145,8 +146,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    external_gateway_info: Option<Value>,
+    #[structable(optional)]
+    external_gateway_info: Option<ResponseExternalGatewayInfo>,
 
     /// The ID of the flavor associated with the router.
     ///
@@ -210,6 +211,41 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     updated_at: Option<String>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseExternalGatewayInfo {
+    enable_snat: Option<BoolString>,
+    external_fixed_ips: Option<Value>,
+    network_id: String,
+    qos_policy_id: Option<String>,
+}
+
+impl fmt::Display for ResponseExternalGatewayInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([
+            format!(
+                "enable_snat={}",
+                self.enable_snat
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!(
+                "external_fixed_ips={}",
+                self.external_fixed_ips
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!("network_id={}", self.network_id),
+            format!(
+                "qos_policy_id={}",
+                self.qos_policy_id
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+        ]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl RouterCommand {

--- a/openstack_cli/src/network/v2/router/update_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/update_external_gateways.rs
@@ -36,6 +36,7 @@ use crate::common::BoolString;
 use openstack_sdk::api::network::v2::router::update_external_gateways;
 use openstack_sdk::api::QueryAsync;
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 
 /// Request body
@@ -150,8 +151,8 @@ struct ResponseData {
     /// this would be `null`.
     ///
     #[serde()]
-    #[structable(optional, pretty)]
-    external_gateway_info: Option<Value>,
+    #[structable(optional)]
+    external_gateway_info: Option<ResponseExternalGatewayInfo>,
 
     /// The ID of the flavor associated with the router.
     ///
@@ -215,6 +216,41 @@ struct ResponseData {
     #[serde()]
     #[structable(optional)]
     updated_at: Option<String>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseExternalGatewayInfo {
+    enable_snat: Option<BoolString>,
+    external_fixed_ips: Option<Value>,
+    network_id: String,
+    qos_policy_id: Option<String>,
+}
+
+impl fmt::Display for ResponseExternalGatewayInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([
+            format!(
+                "enable_snat={}",
+                self.enable_snat
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!(
+                "external_fixed_ips={}",
+                self.external_fixed_ips
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+            format!("network_id={}", self.network_id),
+            format!(
+                "qos_policy_id={}",
+                self.qos_policy_id
+                    .clone()
+                    .map_or(String::new(), |v| v.to_string())
+            ),
+        ]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl RouterCommand {

--- a/openstack_sdk/src/api/network/v2/router/create.rs
+++ b/openstack_sdk/src/api/network/v2/router/create.rs
@@ -42,10 +42,14 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
 pub struct ExternalFixedIps<'a> {
+    /// IP Address
+    ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) ip_address: Option<Cow<'a, str>>,
 
+    /// The subnet ID from which the IP address is assigned
+    ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) subnet_id: Option<Cow<'a, str>>,
@@ -69,6 +73,10 @@ pub struct ExternalGatewayInfo<'a> {
     #[serde()]
     #[builder(setter(into))]
     pub(crate) network_id: Cow<'a, str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into))]
+    pub(crate) qos_policy_id: Option<Option<Cow<'a, str>>>,
 }
 
 /// A `router` object.
@@ -120,7 +128,7 @@ pub struct Router<'a> {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) external_gateway_info: Option<ExternalGatewayInfo<'a>>,
+    pub(crate) external_gateway_info: Option<Option<ExternalGatewayInfo<'a>>>,
 
     /// The ID of the flavor associated with the router.
     ///

--- a/openstack_sdk/src/api/network/v2/router/set.rs
+++ b/openstack_sdk/src/api/network/v2/router/set.rs
@@ -37,10 +37,14 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
 pub struct ExternalFixedIps<'a> {
+    /// IP Address
+    ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) ip_address: Option<Cow<'a, str>>,
 
+    /// The subnet ID from which the IP address is assigned
+    ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) subnet_id: Option<Cow<'a, str>>,
@@ -64,6 +68,10 @@ pub struct ExternalGatewayInfo<'a> {
     #[serde()]
     #[builder(setter(into))]
     pub(crate) network_id: Cow<'a, str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(into))]
+    pub(crate) qos_policy_id: Option<Option<Cow<'a, str>>>,
 }
 
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
@@ -120,7 +128,7 @@ pub struct Router<'a> {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) external_gateway_info: Option<ExternalGatewayInfo<'a>>,
+    pub(crate) external_gateway_info: Option<Option<ExternalGatewayInfo<'a>>>,
 
     /// `true` indicates a highly-available router. It is available when
     /// `l3-ha` extension is enabled.


### PR DESCRIPTION
Recently validation of the external_gateway_info has been modified in
the Neutron so that we are not able to detect the schema anymore. Adapt
it to how it "look like it is intended".

Change-Id: I8976a019cd11b4cb3d8780553bb72b7ce6627519

Changes are triggered by https://review.opendev.org/943036
