### PR TITLE
fix: Handle missing token in the auth response

### DIFF
--- a/openstack_sdk/src/auth.rs
+++ b/openstack_sdk/src/auth.rs
@@ -58,6 +58,9 @@ pub enum AuthError {
         #[from]
         source: AuthTokenError,
     },
+
+    #[error("token missing in the response")]
+    AuthTokenNotInResponse,
 }
 
 // Explicitly implement From to easier propagate nested errors

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -39,7 +39,7 @@ use crate::api::query::RawQuery;
 use crate::auth::{
     self, authtoken,
     authtoken::{AuthTokenError, AuthType},
-    Auth, AuthState,
+    Auth, AuthError, AuthState,
 };
 use crate::config::{get_config_identity_hash, ConfigFile};
 use crate::state;
@@ -336,7 +336,7 @@ impl OpenStack {
             let token = rsp
                 .headers()
                 .get("x-subject-token")
-                .expect("x-subject-token present")
+                .ok_or(AuthError::AuthTokenNotInResponse)?
                 .to_str()
                 .expect("x-subject-token is a string");
 

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -41,7 +41,7 @@ use crate::api::RestClient;
 use crate::auth::{
     self, authtoken,
     authtoken::{AuthTokenError, AuthType},
-    Auth, AuthState,
+    Auth, AuthError, AuthState,
 };
 use crate::config::{get_config_identity_hash, ConfigFile};
 use crate::state;
@@ -414,7 +414,7 @@ where {
             let token = rsp
                 .headers()
                 .get("x-subject-token")
-                .expect("x-subject-token present")
+                .ok_or(AuthError::AuthTokenNotInResponse)?
                 .to_str()
                 .expect("x-subject-token is a string");
 


### PR DESCRIPTION
When the Auth response does not contain the token where we expect it a cryptic
error is thrown (well, this only handles with incorrect Keystone, but still).
