### PR TITLE
feat: Replace wrong simplification of vec of vec of strings

### DIFF
--- a/openstack_cli/src/block_storage/v3/group/create_313.rs
+++ b/openstack_cli/src/block_storage/v3/group/create_313.rs
@@ -90,6 +90,8 @@ struct Group {
     /// multiple- storage back ends, see
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     volume_types: Vec<String>,
 }

--- a/openstack_cli/src/block_storage/v3/qos_spec/delete_keys.rs
+++ b/openstack_cli/src/block_storage/v3/qos_spec/delete_keys.rs
@@ -48,6 +48,8 @@ pub struct QosSpecCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     keys: Vec<String>,
 }

--- a/openstack_cli/src/compute/v2/aggregate/image/cache_281.rs
+++ b/openstack_cli/src/compute/v2/aggregate/image/cache_281.rs
@@ -60,6 +60,8 @@ pub struct ImageCommand {
 
     /// A list of image objects to cache.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     cache: Vec<String>,
 }

--- a/openstack_cli/src/compute/v2/server/create_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_20.rs
@@ -157,6 +157,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -185,6 +187,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -283,6 +287,8 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -313,6 +319,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -331,6 +339,8 @@ struct Server {
     /// the `name` attribute. If you omit this attribute, the API creates the
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
@@ -371,12 +381,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -406,6 +420,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_21.rs
@@ -154,6 +154,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -182,6 +184,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -274,6 +278,8 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -304,6 +310,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -322,6 +330,8 @@ struct Server {
     /// the `name` attribute. If you omit this attribute, the API creates the
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
@@ -362,12 +372,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -397,6 +411,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_219.rs
+++ b/openstack_cli/src/compute/v2/server/create_219.rs
@@ -154,6 +154,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -182,6 +184,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -282,6 +286,8 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -312,6 +318,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -330,6 +338,8 @@ struct Server {
     /// the `name` attribute. If you omit this attribute, the API creates the
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
@@ -370,12 +380,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -405,6 +419,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_232.rs
+++ b/openstack_cli/src/compute/v2/server/create_232.rs
@@ -154,6 +154,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -182,6 +184,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -282,6 +286,8 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -312,6 +318,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -330,6 +338,8 @@ struct Server {
     /// the `name` attribute. If you omit this attribute, the API creates the
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
@@ -370,12 +380,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -405,6 +419,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_233.rs
+++ b/openstack_cli/src/compute/v2/server/create_233.rs
@@ -154,6 +154,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -182,6 +184,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -282,6 +286,8 @@ struct Server {
     /// or device tags. These are requested as strings for the networks value,
     /// not in a list. See the associated example.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -312,6 +318,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -330,6 +338,8 @@ struct Server {
     /// the `name` attribute. If you omit this attribute, the API creates the
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
@@ -370,12 +380,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -405,6 +419,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_237.rs
+++ b/openstack_cli/src/compute/v2/server/create_237.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -332,6 +338,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -350,6 +358,8 @@ struct Server {
     /// the `name` attribute. If you omit this attribute, the API creates the
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
@@ -390,12 +400,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -425,6 +439,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_242.rs
+++ b/openstack_cli/src/compute/v2/server/create_242.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -332,6 +338,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -350,6 +358,8 @@ struct Server {
     /// the `name` attribute. If you omit this attribute, the API creates the
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
@@ -390,12 +400,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -425,6 +439,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_252.rs
+++ b/openstack_cli/src/compute/v2/server/create_252.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -332,6 +338,8 @@ struct Server {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 
@@ -351,6 +359,8 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
@@ -365,6 +375,8 @@ struct Server {
     /// - Each server can have up to 50 tags.
     ///
     /// **New in version 2.52**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
@@ -405,12 +417,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -440,6 +456,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_257.rs
+++ b/openstack_cli/src/compute/v2/server/create_257.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -341,6 +347,8 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
@@ -355,6 +363,8 @@ struct Server {
     /// - Each server can have up to 50 tags.
     ///
     /// **New in version 2.52**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
@@ -395,12 +405,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -430,6 +444,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_263.rs
+++ b/openstack_cli/src/compute/v2/server/create_263.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -341,6 +347,8 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
@@ -356,6 +364,8 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -366,6 +376,8 @@ struct Server {
     /// volume-backed instances.
     ///
     /// **New in version 2.63**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
@@ -406,12 +418,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -441,6 +457,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_267.rs
+++ b/openstack_cli/src/compute/v2/server/create_267.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -341,6 +347,8 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
@@ -356,6 +364,8 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -366,6 +376,8 @@ struct Server {
     /// volume-backed instances.
     ///
     /// **New in version 2.63**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
@@ -406,12 +418,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -441,6 +457,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_274.rs
+++ b/openstack_cli/src/compute/v2/server/create_274.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -359,6 +365,8 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
@@ -374,6 +382,8 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -384,6 +394,8 @@ struct Server {
     /// volume-backed instances.
     ///
     /// **New in version 2.63**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
@@ -424,12 +436,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -459,6 +475,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_290.rs
+++ b/openstack_cli/src/compute/v2/server/create_290.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -375,6 +381,8 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
@@ -390,6 +398,8 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -400,6 +410,8 @@ struct Server {
     /// volume-backed instances.
     ///
     /// **New in version 2.63**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
@@ -440,12 +452,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -475,6 +491,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/create_294.rs
+++ b/openstack_cli/src/compute/v2/server/create_294.rs
@@ -135,6 +135,8 @@ struct ServerNetworks {
     #[arg(action=clap::ArgAction::SetTrue, help_heading = "Body parameters", long, required=false)]
     auto_networks: bool,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     networks: Option<Vec<Value>>,
 
@@ -174,6 +176,8 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping: Option<Vec<Value>>,
 
@@ -202,6 +206,8 @@ struct Server {
     ///
     /// A bug has caused the `tag` attribute to no longer be accepted starting
     /// with version 2.33. It has been restored in version 2.42.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     block_device_mapping_v2: Option<Vec<Value>>,
@@ -375,6 +381,8 @@ struct Server {
     /// server in the `default` security group. Requested security groups are
     /// not applied to pre-existing ports.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
@@ -390,6 +398,8 @@ struct Server {
     ///
     /// **New in version 2.52**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -400,6 +410,8 @@ struct Server {
     /// volume-backed instances.
     ///
     /// **New in version 2.63**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
@@ -440,12 +452,16 @@ struct OsSchedulerHints {
     /// `DifferentCellFilter` is available on cloud side that is cell v1
     /// environment.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_cell: Option<Vec<String>>,
 
     /// A list of server UUIDs or a server UUID. Schedule the server on a
     /// different host from a set of servers. It is available when
     /// `DifferentHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     different_host: Option<Vec<String>>,
@@ -475,6 +491,8 @@ struct OsSchedulerHints {
     /// A list of server UUIDs or a server UUID. Schedule the server on the
     /// same host as another server in a set of servers. It is available when
     /// `SameHostFilter` is available on cloud side.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     same_host: Option<Vec<String>>,

--- a/openstack_cli/src/compute/v2/server/interface/create_20.rs
+++ b/openstack_cli/src/compute/v2/server/interface/create_20.rs
@@ -82,6 +82,8 @@ struct InterfaceAttachment {
     /// Fixed IP addresses. If you request a specific fixed IP address without
     /// a `net_id`, the request returns a `Bad Request (400)` response code.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     fixed_ips: Option<Vec<String>>,
 

--- a/openstack_cli/src/compute/v2/server/interface/create_249.rs
+++ b/openstack_cli/src/compute/v2/server/interface/create_249.rs
@@ -82,6 +82,8 @@ struct InterfaceAttachment {
     /// Fixed IP addresses. If you request a specific fixed IP address without
     /// a `net_id`, the request returns a `Bad Request (400)` response code.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     fixed_ips: Option<Vec<String>>,
 

--- a/openstack_cli/src/compute/v2/server/rebuild_20.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_20.rs
@@ -153,6 +153,8 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 

--- a/openstack_cli/src/compute/v2/server/rebuild_21.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_21.rs
@@ -153,6 +153,8 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 

--- a/openstack_cli/src/compute/v2/server/rebuild_219.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_219.rs
@@ -161,6 +161,8 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 

--- a/openstack_cli/src/compute/v2/server/rebuild_254.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_254.rs
@@ -177,6 +177,8 @@ struct Rebuild {
     ///
     /// **Available until version 2.56**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     personality: Option<Vec<Value>>,
 

--- a/openstack_cli/src/compute/v2/server/rebuild_263.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_263.rs
@@ -191,6 +191,8 @@ struct Rebuild {
     ///
     /// **New in version 2.63**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 

--- a/openstack_cli/src/compute/v2/server/rebuild_290.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_290.rs
@@ -207,6 +207,8 @@ struct Rebuild {
     ///
     /// **New in version 2.63**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 

--- a/openstack_cli/src/compute/v2/server/rebuild_294.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_294.rs
@@ -207,6 +207,8 @@ struct Rebuild {
     ///
     /// **New in version 2.63**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     trusted_image_certificates: Option<Vec<String>>,
 

--- a/openstack_cli/src/compute/v2/server/tag/replace_226.rs
+++ b/openstack_cli/src/compute/v2/server/tag/replace_226.rs
@@ -54,6 +54,8 @@ pub struct TagCommand {
 
     /// A list of tags. The maximum count of tags in this list is 50.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/compute/v2/server_external_event/create_20.rs
+++ b/openstack_cli/src/compute/v2/server_external_event/create_20.rs
@@ -65,6 +65,8 @@ pub struct ServerExternalEventCommand {
 
     /// List of external events to process.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     events: Vec<Value>,
 }

--- a/openstack_cli/src/compute/v2/server_external_event/create_251.rs
+++ b/openstack_cli/src/compute/v2/server_external_event/create_251.rs
@@ -65,6 +65,8 @@ pub struct ServerExternalEventCommand {
 
     /// List of external events to process.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     events: Vec<Value>,
 }

--- a/openstack_cli/src/compute/v2/server_external_event/create_276.rs
+++ b/openstack_cli/src/compute/v2/server_external_event/create_276.rs
@@ -65,6 +65,8 @@ pub struct ServerExternalEventCommand {
 
     /// List of external events to process.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     events: Vec<Value>,
 }

--- a/openstack_cli/src/compute/v2/server_external_event/create_282.rs
+++ b/openstack_cli/src/compute/v2/server_external_event/create_282.rs
@@ -65,6 +65,8 @@ pub struct ServerExternalEventCommand {
 
     /// List of external events to process.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     events: Vec<Value>,
 }

--- a/openstack_cli/src/compute/v2/server_external_event/create_293.rs
+++ b/openstack_cli/src/compute/v2/server_external_event/create_293.rs
@@ -65,6 +65,8 @@ pub struct ServerExternalEventCommand {
 
     /// List of external events to process.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     events: Vec<Value>,
 }

--- a/openstack_cli/src/compute/v2/server_group/create_20.rs
+++ b/openstack_cli/src/compute/v2/server_group/create_20.rs
@@ -93,6 +93,8 @@ struct ServerGroup {
     ///
     /// **Available until version 2.63**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     policies: Vec<String>,
 }

--- a/openstack_cli/src/compute/v2/server_group/create_215.rs
+++ b/openstack_cli/src/compute/v2/server_group/create_215.rs
@@ -93,6 +93,8 @@ struct ServerGroup {
     ///
     /// **Available until version 2.63**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     policies: Vec<String>,
 }

--- a/openstack_cli/src/container_infrastructure_management/v1/certificate/create.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1/certificate/create.rs
@@ -64,6 +64,8 @@ pub struct CertificateCommand {
     #[arg(help_heading = "Body parameters", long)]
     csr: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     links: Option<Vec<Value>>,
 

--- a/openstack_cli/src/container_infrastructure_management/v1/cluster/action/resize/create.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1/cluster/action/resize/create.rs
@@ -56,6 +56,8 @@ pub struct ResizeCommand {
     #[arg(help_heading = "Body parameters", long)]
     nodegroup: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     nodes_to_remove: Option<Vec<String>>,
 

--- a/openstack_cli/src/container_infrastructure_management/v1/cluster/create.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1/cluster/create.rs
@@ -159,9 +159,13 @@ pub struct ClusterCommand {
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     labels_skipped: Option<Vec<(String, String)>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     links: Option<Vec<Value>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     master_addresses: Option<Vec<String>>,
 
@@ -197,6 +201,8 @@ pub struct ClusterCommand {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     node_addresses: Option<Vec<String>>,
 

--- a/openstack_cli/src/container_infrastructure_management/v1/cluster/nodegroup/create.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1/cluster/nodegroup/create.rs
@@ -91,6 +91,8 @@ pub struct NodegroupCommand {
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     labels_skipped: Option<Vec<(String, String)>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     links: Option<Vec<Value>>,
 
@@ -106,6 +108,8 @@ pub struct NodegroupCommand {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     node_addresses: Option<Vec<String>>,
 

--- a/openstack_cli/src/container_infrastructure_management/v1/clustertemplate/create.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1/clustertemplate/create.rs
@@ -183,6 +183,8 @@ pub struct ClustertemplateCommand {
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     labels: Option<Vec<(String, String)>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     links: Option<Vec<Value>>,
 

--- a/openstack_cli/src/container_infrastructure_management/v1/federation/create.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1/federation/create.rs
@@ -60,9 +60,13 @@ pub struct FederationCommand {
     #[arg(help_heading = "Body parameters", long)]
     hostcluster_id: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     links: Option<Vec<Value>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     member_ids: Option<Vec<String>>,
 

--- a/openstack_cli/src/dns/v2/zone/create.rs
+++ b/openstack_cli/src/dns/v2/zone/create.rs
@@ -71,6 +71,8 @@ pub struct ZoneCommand {
     /// Mandatory for secondary zones. The servers to slave from to get DNS
     /// information
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     masters: Option<Vec<String>>,
 

--- a/openstack_cli/src/dns/v2/zone/recordset/create.rs
+++ b/openstack_cli/src/dns/v2/zone/recordset/create.rs
@@ -68,6 +68,8 @@ pub struct RecordsetCommand {
     /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
     /// hostname.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     records: Option<Vec<String>>,
 

--- a/openstack_cli/src/dns/v2/zone/recordset/set.rs
+++ b/openstack_cli/src/dns/v2/zone/recordset/set.rs
@@ -64,6 +64,8 @@ pub struct RecordsetCommand {
     /// type - e.g. A records must be IPv4 addresses, CNAME records must be a
     /// hostname.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     records: Option<Vec<String>>,
 

--- a/openstack_cli/src/dns/v2/zone/share/list.rs
+++ b/openstack_cli/src/dns/v2/zone/share/list.rs
@@ -39,6 +39,7 @@ use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::{paged, Pagination};
 use serde_json::Value;
+use std::fmt;
 use structable_derive::StructTable;
 use tracing::warn;
 
@@ -112,6 +113,28 @@ struct ResponseData {
     #[serde()]
     #[structable(optional, pretty)]
     shared_zones: Option<Value>,
+}
+/// `struct` response type
+#[derive(Default, Clone, Deserialize, Serialize)]
+struct ResponseLinks {
+    _self: Option<String>,
+    zone: Option<String>,
+}
+
+impl fmt::Display for ResponseLinks {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = Vec::from([
+            format!(
+                "_self={}",
+                self._self.clone().map_or(String::new(), |v| v.to_string())
+            ),
+            format!(
+                "zone={}",
+                self.zone.clone().map_or(String::new(), |v| v.to_string())
+            ),
+        ]);
+        write!(f, "{}", data.join(";"))
+    }
 }
 
 impl SharesCommand {

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/create.rs
@@ -191,6 +191,8 @@ struct Identity {
     /// The authentication method. For password authentication, specify
     /// `password`.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, required=false)]
     methods: Vec<Methods>,
 

--- a/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
+++ b/openstack_cli/src/identity/v3/auth/os_federation/saml2/ecp/create.rs
@@ -191,6 +191,8 @@ struct Identity {
     /// The authentication method. For password authentication, specify
     /// `password`.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, required=false)]
     methods: Vec<Methods>,
 

--- a/openstack_cli/src/identity/v3/auth/token/create.rs
+++ b/openstack_cli/src/identity/v3/auth/token/create.rs
@@ -197,6 +197,8 @@ struct Identity {
     /// The authentication method. For password authentication, specify
     /// `password`.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, required=false)]
     methods: Vec<Methods>,
 

--- a/openstack_cli/src/identity/v3/domain/create.rs
+++ b/openstack_cli/src/identity/v3/domain/create.rs
@@ -111,6 +111,8 @@ struct Domain {
     #[command(flatten)]
     options: Option<Options>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 }

--- a/openstack_cli/src/identity/v3/domain/set.rs
+++ b/openstack_cli/src/identity/v3/domain/set.rs
@@ -116,6 +116,8 @@ struct Domain {
     #[command(flatten)]
     options: Option<Options>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 }

--- a/openstack_cli/src/identity/v3/limit/create.rs
+++ b/openstack_cli/src/identity/v3/limit/create.rs
@@ -55,6 +55,8 @@ pub struct LimitCommand {
 
     /// A list of `limits` objects
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     limits: Vec<Value>,
 }

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
@@ -99,6 +99,8 @@ struct IdentityProvider {
 
     /// List of the unique identity provider's remote IDs
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     remote_ids: Option<Vec<String>>,
 }

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
@@ -90,6 +90,8 @@ struct IdentityProvider {
 
     /// List of the unique identity provider's remote IDs
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     remote_ids: Option<Vec<String>>,
 }

--- a/openstack_cli/src/identity/v3/os_federation/mapping/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/mapping/create.rs
@@ -74,6 +74,8 @@ struct PathParameters {
 /// Mapping Body data
 #[derive(Args, Clone)]
 struct Mapping {
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     rules: Vec<Value>,
 

--- a/openstack_cli/src/identity/v3/os_federation/mapping/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/mapping/set.rs
@@ -74,6 +74,8 @@ struct PathParameters {
 /// Mapping Body data
 #[derive(Args, Clone)]
 struct Mapping {
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     rules: Vec<Value>,
 

--- a/openstack_cli/src/identity/v3/os_trust/trust/create.rs
+++ b/openstack_cli/src/identity/v3/os_trust/trust/create.rs
@@ -138,6 +138,8 @@ struct Trust {
     #[arg(help_heading = "Body parameters", long)]
     remaining_uses: Option<Option<i32>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     roles: Option<Vec<Value>>,
 

--- a/openstack_cli/src/identity/v3/project/create.rs
+++ b/openstack_cli/src/identity/v3/project/create.rs
@@ -142,6 +142,8 @@ struct Project {
     /// A list of simple strings assigned to a project. Tags can be used to
     /// classify projects into groups.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 }

--- a/openstack_cli/src/identity/v3/project/set.rs
+++ b/openstack_cli/src/identity/v3/project/set.rs
@@ -113,6 +113,8 @@ struct Project {
     /// A list of simple strings assigned to a project. Tags can be used to
     /// classify projects into groups.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 }

--- a/openstack_cli/src/identity/v3/project/tag/replace.rs
+++ b/openstack_cli/src/identity/v3/project/tag/replace.rs
@@ -58,6 +58,8 @@ pub struct TagCommand {
 
     /// A list of simple strings assigned to a project.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/identity/v3/registered_limit/create.rs
+++ b/openstack_cli/src/identity/v3/registered_limit/create.rs
@@ -56,6 +56,8 @@ pub struct RegisteredLimitCommand {
 
     /// A list of `registered_limits` objects
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     registered_limits: Vec<Value>,
 }

--- a/openstack_cli/src/identity/v3/user/application_credential/create.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/create.rs
@@ -95,6 +95,8 @@ struct UserInput {
 struct ApplicationCredential {
     /// A list of `access_rules` objects
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     access_rules: Option<Vec<Value>>,
 
@@ -130,6 +132,8 @@ struct ApplicationCredential {
     /// may only contain roles that the user has assigned on the project. If
     /// not provided, the roles assigned to the application credential will be
     /// the same as the roles in the current token.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     roles: Option<Vec<Value>>,

--- a/openstack_cli/src/identity/v3/user/create.rs
+++ b/openstack_cli/src/identity/v3/user/create.rs
@@ -88,8 +88,10 @@ struct Options {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multi_factor_auth_enabled: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
-    multi_factor_auth_rules: Option<Vec<String>>,
+    /// Parameter is an array, may be provided multiple times.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="[String] as JSON", value_parser=parse_json)]
+    multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }
 
 /// User Body data
@@ -142,6 +144,8 @@ struct User {
     /// ]
     ///
     /// ```
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     federated: Option<Vec<Value>>,
@@ -327,12 +331,7 @@ impl UserCommand {
                 options_builder.ignore_user_inactivity(*val);
             }
             if let Some(val) = &val.multi_factor_auth_rules {
-                options_builder.multi_factor_auth_rules(
-                    val.iter()
-                        .cloned()
-                        .map(|x| Vec::from([x.split(',').collect()]))
-                        .collect::<Vec<_>>(),
-                );
+                options_builder.multi_factor_auth_rules(val.iter());
             }
             if let Some(val) = &val.multi_factor_auth_enabled {
                 options_builder.multi_factor_auth_enabled(*val);

--- a/openstack_cli/src/identity/v3/user/set.rs
+++ b/openstack_cli/src/identity/v3/user/set.rs
@@ -102,8 +102,10 @@ struct Options {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     multi_factor_auth_enabled: Option<bool>,
 
-    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
-    multi_factor_auth_rules: Option<Vec<String>>,
+    /// Parameter is an array, may be provided multiple times.
+    ///
+    #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="[String] as JSON", value_parser=parse_json)]
+    multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }
 
 /// User Body data
@@ -145,6 +147,8 @@ struct User {
     /// ]
     ///
     /// ```
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     federated: Option<Vec<Value>>,
@@ -337,12 +341,7 @@ impl UserCommand {
                 options_builder.ignore_user_inactivity(*val);
             }
             if let Some(val) = &val.multi_factor_auth_rules {
-                options_builder.multi_factor_auth_rules(
-                    val.iter()
-                        .cloned()
-                        .map(|x| Vec::from([x.split(',').collect()]))
-                        .collect::<Vec<_>>(),
-                );
+                options_builder.multi_factor_auth_rules(val.iter());
             }
             if let Some(val) = &val.multi_factor_auth_enabled {
                 options_builder.multi_factor_auth_enabled(*val);

--- a/openstack_cli/src/image/v2/image/create.rs
+++ b/openstack_cli/src/image/v2/image/create.rs
@@ -132,6 +132,8 @@ pub struct ImageCommand {
 
     /// A set of URLs to access the image file kept in external store
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     locations: Option<Vec<Value>>,
 
@@ -168,6 +170,8 @@ pub struct ImageCommand {
 
     /// List of tags for this image. Each tag is a string of at most 255 chars.
     /// The maximum number of tags allowed on an image is set by the operator.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,

--- a/openstack_cli/src/image/v2/image/import/create.rs
+++ b/openstack_cli/src/image/v2/image/import/create.rs
@@ -139,6 +139,8 @@ pub struct ImportCommand {
     /// If present contains the list of store id to import the image binary
     /// data to.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     stores: Option<Vec<String>>,
 }

--- a/openstack_cli/src/image/v2/image/patch.rs
+++ b/openstack_cli/src/image/v2/image/patch.rs
@@ -129,6 +129,8 @@ pub struct ImageCommand {
     /// service’s configuration file.* **Because it presents a security risk,
     /// this option is disabled by default.**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     locations: Option<Vec<Value>>,
 
@@ -173,6 +175,8 @@ pub struct ImageCommand {
     protected: Option<bool>,
 
     /// List of tags for this image, possibly an empty list.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,

--- a/openstack_cli/src/image/v2/metadef/namespace/create.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/create.rs
@@ -67,6 +67,8 @@ pub struct NamespaceCommand {
     #[arg(help_heading = "Body parameters", long)]
     namespace: String,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     objects: Option<Vec<Value>>,
 
@@ -83,9 +85,13 @@ pub struct NamespaceCommand {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     protected: Option<bool>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     resource_type_associations: Option<Vec<Value>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/image/v2/metadef/namespace/object/create.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/object/create.rs
@@ -59,6 +59,8 @@ pub struct ObjectCommand {
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     properties: Option<Vec<(String, Value)>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     required: Option<Vec<String>>,
 }

--- a/openstack_cli/src/image/v2/metadef/namespace/object/set.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/object/set.rs
@@ -59,6 +59,8 @@ pub struct ObjectCommand {
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
     properties: Option<Vec<(String, Value)>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     required: Option<Vec<String>>,
 }

--- a/openstack_cli/src/image/v2/metadef/namespace/property/create.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/create.rs
@@ -59,6 +59,8 @@ pub struct PropertyCommand {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     _enum: Option<Vec<String>>,
 
@@ -86,6 +88,8 @@ pub struct PropertyCommand {
     #[arg(help_heading = "Body parameters", long)]
     name: String,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     operators: Option<Vec<String>>,
 
@@ -95,6 +99,8 @@ pub struct PropertyCommand {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     readonly: Option<bool>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     required: Option<Vec<String>>,
 

--- a/openstack_cli/src/image/v2/metadef/namespace/property/set.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/set.rs
@@ -59,6 +59,8 @@ pub struct PropertyCommand {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     _enum: Option<Vec<String>>,
 
@@ -86,6 +88,8 @@ pub struct PropertyCommand {
     #[arg(help_heading = "Body parameters", long)]
     name: String,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     operators: Option<Vec<String>>,
 
@@ -95,6 +99,8 @@ pub struct PropertyCommand {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     readonly: Option<bool>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     required: Option<Vec<String>>,
 

--- a/openstack_cli/src/image/v2/metadef/namespace/set.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/set.rs
@@ -67,6 +67,8 @@ pub struct NamespaceCommand {
     #[arg(help_heading = "Body parameters", long)]
     namespace: String,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     objects: Option<Vec<Value>>,
 
@@ -83,9 +85,13 @@ pub struct NamespaceCommand {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     protected: Option<bool>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     resource_type_associations: Option<Vec<Value>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/healthmonitor/create.rs
+++ b/openstack_cli/src/load_balancer/v2/healthmonitor/create.rs
@@ -200,6 +200,8 @@ struct Healthmonitor {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/healthmonitor/set.rs
+++ b/openstack_cli/src/load_balancer/v2/healthmonitor/set.rs
@@ -167,6 +167,8 @@ struct Healthmonitor {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/l7policy/create.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/create.rs
@@ -179,9 +179,13 @@ struct L7policy {
     #[arg(help_heading = "Body parameters", long)]
     redirect_url: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     rules: Option<Vec<Value>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/l7policy/rule/create.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/rule/create.rs
@@ -156,6 +156,8 @@ struct Rule {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/l7policy/rule/set.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/rule/set.rs
@@ -144,6 +144,8 @@ struct Rule {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/l7policy/set.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/set.rs
@@ -158,6 +158,8 @@ struct L7policy {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 }

--- a/openstack_cli/src/load_balancer/v2/listener/create.rs
+++ b/openstack_cli/src/load_balancer/v2/listener/create.rs
@@ -148,9 +148,13 @@ struct Listener {
     ///
     /// **New in version 2.12**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     allowed_cidrs: Option<Vec<String>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     alpn_protocols: Option<Vec<String>>,
 
@@ -253,6 +257,8 @@ struct Listener {
 
     /// A list of L7 policy objects.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     l7policies: Option<Vec<Value>>,
 
@@ -289,9 +295,13 @@ struct Listener {
     /// “certificate” containing the certificates and keys for
     /// `TERMINATED_HTTPS` listeners.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     sni_container_refs: Option<Vec<String>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -330,6 +340,8 @@ struct Listener {
     #[arg(help_heading = "Body parameters", long)]
     tls_ciphers: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tls_versions: Option<Vec<String>>,
 }

--- a/openstack_cli/src/load_balancer/v2/listener/set.rs
+++ b/openstack_cli/src/load_balancer/v2/listener/set.rs
@@ -105,12 +105,16 @@ struct Listener {
     ///
     /// **New in version 2.12**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     allowed_cidrs: Option<Vec<String>>,
 
     /// A list of ALPN protocols. Available protocols: http/1.0, http/1.1, h2
     ///
     /// **New in version 2.20**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     alpn_protocols: Option<Vec<String>>,
@@ -219,12 +223,16 @@ struct Listener {
     /// “certificate” containing the certificates and keys for
     /// `TERMINATED_HTTPS` listeners.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     sni_container_refs: Option<Vec<String>>,
 
     /// A list of simple strings assigned to the resource.
     ///
     /// **New in version 2.5**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
@@ -270,6 +278,8 @@ struct Listener {
     /// TLSv1.1, TLSv1.2, TLSv1.3
     ///
     /// **New in version 2.17**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tls_versions: Option<Vec<String>>,

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/create.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/create.rs
@@ -149,6 +149,8 @@ struct Loadbalancer {
     ///
     /// **New in version 2.26**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     additional_vips: Option<Vec<Value>>,
 
@@ -175,6 +177,8 @@ struct Loadbalancer {
 
     /// The associated listener IDs, if any.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     listeners: Option<Vec<Value>>,
 
@@ -183,6 +187,8 @@ struct Loadbalancer {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     pools: Option<Vec<Value>>,
 
@@ -196,6 +202,8 @@ struct Loadbalancer {
     #[arg(help_heading = "Body parameters", long)]
     provider: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -228,6 +236,8 @@ struct Loadbalancer {
     /// Balancer.
     ///
     /// **New in version 2.29**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     vip_sg_ids: Option<Vec<String>>,

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/set.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/set.rs
@@ -105,6 +105,8 @@ struct Loadbalancer {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -113,6 +115,8 @@ struct Loadbalancer {
     #[arg(help_heading = "Body parameters", long)]
     vip_qos_policy_id: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     vip_sg_ids: Option<Vec<String>>,
 }

--- a/openstack_cli/src/load_balancer/v2/pool/create.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/create.rs
@@ -157,6 +157,8 @@ struct Pool {
     ///
     /// **New in version 2.24**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     alpn_protocols: Option<Vec<String>>,
 
@@ -208,6 +210,8 @@ struct Pool {
     #[arg(help_heading = "Body parameters", long)]
     loadbalancer_id: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     members: Option<Vec<Value>>,
 
@@ -234,6 +238,8 @@ struct Pool {
     #[command(flatten)]
     session_persistence: Option<SessionPersistence>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -271,6 +277,8 @@ struct Pool {
     /// TLSv1.1, TLSv1.2, TLSv1.3
     ///
     /// **New in version 2.17**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tls_versions: Option<Vec<String>>,

--- a/openstack_cli/src/load_balancer/v2/pool/member/create.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/member/create.rs
@@ -175,6 +175,8 @@ struct Member {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/pool/member/replace.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/member/replace.rs
@@ -78,6 +78,8 @@ pub struct MemberCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     members: Vec<Value>,
 }

--- a/openstack_cli/src/load_balancer/v2/pool/member/set.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/member/set.rs
@@ -133,6 +133,8 @@ struct Member {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/load_balancer/v2/pool/set.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/set.rs
@@ -128,6 +128,8 @@ struct Pool {
     ///
     /// **New in version 2.24**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     alpn_protocols: Option<Vec<String>>,
 
@@ -176,6 +178,8 @@ struct Pool {
     ///
     /// **New in version 2.5**
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 
@@ -210,6 +214,8 @@ struct Pool {
     /// TLSv1.1, TLSv1.2, TLSv1.3
     ///
     /// **New in version 2.17**
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tls_versions: Option<Vec<String>>,

--- a/openstack_cli/src/network/v2/address_group/add_addresses.rs
+++ b/openstack_cli/src/network/v2/address_group/add_addresses.rs
@@ -73,6 +73,8 @@ struct PathParameters {
 struct AddressGroup {
     /// A list of IP addresses.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     addresses: Option<Vec<String>>,
 }

--- a/openstack_cli/src/network/v2/address_group/create.rs
+++ b/openstack_cli/src/network/v2/address_group/create.rs
@@ -71,6 +71,8 @@ struct PathParameters {}
 struct AddressGroup {
     /// A list of IP addresses.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     addresses: Option<Vec<String>>,
 

--- a/openstack_cli/src/network/v2/address_group/remove_addresses.rs
+++ b/openstack_cli/src/network/v2/address_group/remove_addresses.rs
@@ -73,6 +73,8 @@ struct PathParameters {
 struct AddressGroup {
     /// A list of IP addresses.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     addresses: Option<Vec<String>>,
 }

--- a/openstack_cli/src/network/v2/flavor/create.rs
+++ b/openstack_cli/src/network/v2/flavor/create.rs
@@ -107,6 +107,8 @@ struct Flavor {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     service_profiles: Option<Vec<String>>,
 

--- a/openstack_cli/src/network/v2/flavor/set.rs
+++ b/openstack_cli/src/network/v2/flavor/set.rs
@@ -99,6 +99,8 @@ struct Flavor {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     service_profiles: Option<Vec<String>>,
 }

--- a/openstack_cli/src/network/v2/floatingip/tag/replace.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/network/create.rs
+++ b/openstack_cli/src/network/v2/network/create.rs
@@ -84,6 +84,8 @@ struct Network {
 
     /// The availability zone candidate for the network.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     availability_zone_hints: Option<Vec<String>>,
 
@@ -145,6 +147,8 @@ struct Network {
     router_external: Option<bool>,
 
     /// A list of provider `segment` objects.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     segments: Option<Vec<Value>>,

--- a/openstack_cli/src/network/v2/network/set.rs
+++ b/openstack_cli/src/network/v2/network/set.rs
@@ -145,6 +145,8 @@ struct Network {
 
     /// A list of provider `segment` objects.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     segments: Option<Vec<Value>>,
 

--- a/openstack_cli/src/network/v2/network/tag/replace.rs
+++ b/openstack_cli/src/network/v2/network/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/network_segment_range/tag/replace.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/policy/tag/replace.rs
+++ b/openstack_cli/src/network/v2/policy/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/port/create.rs
+++ b/openstack_cli/src/network/v2/port/create.rs
@@ -114,6 +114,8 @@ struct Port {
     /// connected to the port can send a packet with source address which
     /// matches one of the specified allowed address pairs.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allowed_address_pairs: Option<Vec<Value>>,
 
@@ -188,6 +190,8 @@ struct Port {
     /// A set of zero or more extra DHCP option pairs. An option pair consists
     /// of an option value and name.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     extra_dhcp_opts: Option<Vec<Value>>,
 
@@ -204,6 +208,8 @@ struct Port {
     /// - If you specify only an IP address, OpenStack Networking tries to
     ///   allocate the IP address if the address is a valid IP for any of the
     ///   subnets on the specified network.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     fixed_ips: Option<Vec<Value>>,
@@ -264,9 +270,13 @@ struct Port {
 
     /// The IDs of security groups applied to the port.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Option<Vec<String>>,
 

--- a/openstack_cli/src/network/v2/port/set.rs
+++ b/openstack_cli/src/network/v2/port/set.rs
@@ -156,6 +156,8 @@ struct Port {
     /// connected to the port can send a packet with source address which
     /// matches one of the specified allowed address pairs.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allowed_address_pairs: Option<Vec<Value>>,
 
@@ -232,6 +234,8 @@ struct Port {
     /// A set of zero or more extra DHCP option pairs. An option pair consists
     /// of an option value and name.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     extra_dhcp_opts: Option<Vec<Value>>,
 
@@ -248,6 +252,8 @@ struct Port {
     /// - If you specify only an IP address, OpenStack Networking tries to
     ///   allocate the IP address if the address is a valid IP for any of the
     ///   subnets on the specified network.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     fixed_ips: Option<Vec<Value>>,
@@ -296,6 +302,8 @@ struct Port {
     qos_policy_id: Option<String>,
 
     /// The IDs of security groups applied to the port.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     security_groups: Option<Vec<String>>,

--- a/openstack_cli/src/network/v2/port/tag/replace.rs
+++ b/openstack_cli/src/network/v2/port/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/router/add_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/add_external_gateways.rs
@@ -77,6 +77,8 @@ struct PathParameters {
 struct Router {
     /// The list of external gateways of the router.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_gateways: Option<Vec<Value>>,
 }

--- a/openstack_cli/src/network/v2/router/add_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/add_extraroutes.rs
@@ -77,6 +77,8 @@ struct Router {
     /// with `destination` and `nexthop` parameters. It is available when
     /// `extraroute` extension is enabled.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     routes: Option<Vec<Value>>,
 }

--- a/openstack_cli/src/network/v2/router/create.rs
+++ b/openstack_cli/src/network/v2/router/create.rs
@@ -85,6 +85,8 @@ struct ExternalGatewayInfo {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_snat: Option<bool>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_fixed_ips: Option<Vec<Value>>,
 
@@ -106,6 +108,8 @@ struct Router {
 
     /// The availability zone candidates for the router. It is available when
     /// `router_availability_zone` extension is enabled.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     availability_zone_hints: Option<Vec<String>>,

--- a/openstack_cli/src/network/v2/router/remove_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/remove_external_gateways.rs
@@ -77,6 +77,8 @@ struct PathParameters {
 struct Router {
     /// The list of external gateways of the router.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_gateways: Option<Vec<Value>>,
 }

--- a/openstack_cli/src/network/v2/router/remove_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/remove_extraroutes.rs
@@ -77,6 +77,8 @@ struct Router {
     /// with `destination` and `nexthop` parameters. It is available when
     /// `extraroute` extension is enabled.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     routes: Option<Vec<Value>>,
 }

--- a/openstack_cli/src/network/v2/router/set.rs
+++ b/openstack_cli/src/network/v2/router/set.rs
@@ -91,6 +91,8 @@ struct ExternalGatewayInfo {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enable_snat: Option<bool>,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_fixed_ips: Option<Vec<Value>>,
 
@@ -152,6 +154,8 @@ struct Router {
     /// The extra routes configuration for L3 router. A list of dictionaries
     /// with `destination` and `nexthop` parameters. It is available when
     /// `extraroute` extension is enabled. Default is an empty list (`[]`).
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     routes: Option<Vec<Value>>,

--- a/openstack_cli/src/network/v2/router/tag/replace.rs
+++ b/openstack_cli/src/network/v2/router/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/router/update_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/update_external_gateways.rs
@@ -77,6 +77,8 @@ struct PathParameters {
 struct Router {
     /// The list of external gateways of the router.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     external_gateways: Option<Vec<Value>>,
 }

--- a/openstack_cli/src/network/v2/security_group/tag/replace.rs
+++ b/openstack_cli/src/network/v2/security_group/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/subnet/create.rs
+++ b/openstack_cli/src/network/v2/subnet/create.rs
@@ -124,6 +124,8 @@ struct Subnet {
     /// automatically allocates pools for covering all IP addresses in the
     /// CIDR, excluding the address reserved for the subnet gateway by default.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allocation_pools: Option<Vec<Value>>,
 
@@ -140,6 +142,8 @@ struct Subnet {
 
     /// List of dns name servers associated with the subnet. Default is an
     /// empty list.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     dns_nameservers: Option<Vec<String>>,
@@ -166,6 +170,8 @@ struct Subnet {
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     host_routes: Option<Vec<Value>>,
@@ -212,6 +218,8 @@ struct Subnet {
     segment_id: Option<String>,
 
     /// The service types associated with the subnet.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     service_types: Option<Vec<String>>,

--- a/openstack_cli/src/network/v2/subnet/set.rs
+++ b/openstack_cli/src/network/v2/subnet/set.rs
@@ -89,6 +89,8 @@ struct Subnet {
     /// automatically allocates pools for covering all IP addresses in the
     /// CIDR, excluding the address reserved for the subnet gateway by default.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allocation_pools: Option<Vec<Value>>,
 
@@ -100,6 +102,8 @@ struct Subnet {
 
     /// List of dns name servers associated with the subnet. Default is an
     /// empty list.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     dns_nameservers: Option<Vec<String>>,
@@ -127,6 +131,8 @@ struct Subnet {
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     host_routes: Option<Vec<Value>>,
 
@@ -142,6 +148,8 @@ struct Subnet {
     segment_id: Option<String>,
 
     /// The service types associated with the subnet.
+    ///
+    /// Parameter is an array, may be provided multiple times.
     ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     service_types: Option<Vec<String>>,

--- a/openstack_cli/src/network/v2/subnet/tag/replace.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/subnetpool/create.rs
+++ b/openstack_cli/src/network/v2/subnetpool/create.rs
@@ -127,6 +127,8 @@ struct Subnetpool {
     /// prefix must be unique among all subnet prefixes in all subnet pools
     /// that are associated with the address scope.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     prefixes: Option<Vec<String>>,
 

--- a/openstack_cli/src/network/v2/subnetpool/set.rs
+++ b/openstack_cli/src/network/v2/subnetpool/set.rs
@@ -138,6 +138,8 @@ struct Subnetpool {
     /// prefix must be unique among all subnet prefixes in all subnet pools
     /// that are associated with the address scope.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     prefixes: Option<Vec<String>>,
 }

--- a/openstack_cli/src/network/v2/subnetpool/tag/replace.rs
+++ b/openstack_cli/src/network/v2/subnetpool/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/trunk/tag/replace.rs
+++ b/openstack_cli/src/network/v2/trunk/tag/replace.rs
@@ -46,6 +46,8 @@ pub struct TagCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     tags: Vec<String>,
 }

--- a/openstack_cli/src/network/v2/vpn/endpoint_group/create.rs
+++ b/openstack_cli/src/network/v2/vpn/endpoint_group/create.rs
@@ -90,6 +90,8 @@ struct EndpointGroup {
     /// List of endpoints of the same type, for the endpoint group. The values
     /// will depend on type.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     endpoints: Option<Vec<String>>,
 

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
@@ -149,6 +149,8 @@ struct IpsecSiteConnection {
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
     /// net_address > / < prefix > .
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     peer_cidrs: Option<Vec<String>>,
 

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
@@ -150,6 +150,8 @@ struct IpsecSiteConnection {
     /// (Deprecated) Unique list of valid peer private CIDRs in the form \<
     /// net_address > / < prefix > .
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     peer_cidrs: Option<Vec<String>>,
 

--- a/openstack_cli/src/placement/v1/allocation/set_10.rs
+++ b/openstack_cli/src/placement/v1/allocation/set_10.rs
@@ -59,6 +59,8 @@ pub struct AllocationCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allocations: Vec<Value>,
 }

--- a/openstack_cli/src/placement/v1/allocation/set_18.rs
+++ b/openstack_cli/src/placement/v1/allocation/set_18.rs
@@ -59,6 +59,8 @@ pub struct AllocationCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long, value_name="JSON", value_parser=parse_json)]
     allocations: Vec<Value>,
 

--- a/openstack_cli/src/placement/v1/resource_provider/aggregate/set_119.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/aggregate/set_119.rs
@@ -52,6 +52,8 @@ pub struct AggregateCommand {
     #[command(flatten)]
     path: PathParameters,
 
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     aggregates: Vec<String>,
 

--- a/openstack_cli/src/placement/v1/resource_provider/trait/set.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/trait/set.rs
@@ -55,6 +55,8 @@ pub struct TraitCommand {
 
     /// A list of traits.
     ///
+    /// Parameter is an array, may be provided multiple times.
+    ///
     #[arg(action=clap::ArgAction::Append, help_heading = "Body parameters", long)]
     traits: Vec<String>,
 }

--- a/openstack_sdk/src/api/identity/v3/user/create.rs
+++ b/openstack_sdk/src/api/identity/v3/user/create.rs
@@ -89,8 +89,23 @@ pub struct Options<'a> {
     pub(crate) multi_factor_auth_enabled: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
+    #[builder(default, private, setter(name = "_multi_factor_auth_rules"))]
     pub(crate) multi_factor_auth_rules: Option<Vec<Vec<Cow<'a, str>>>>,
+}
+
+impl<'a> OptionsBuilder<'a> {
+    pub fn multi_factor_auth_rules<I1, I2, V>(&mut self, iter: I1) -> &mut Self
+    where
+        I1: Iterator<Item = I2>,
+        I2: IntoIterator<Item = V>,
+        V: Into<Cow<'a, str>>,
+    {
+        self.multi_factor_auth_rules
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
+            .extend(iter.map(|x| Vec::from_iter(x.into_iter().map(Into::into))));
+        self
+    }
 }
 
 /// A `user` object

--- a/openstack_sdk/src/api/identity/v3/user/set.rs
+++ b/openstack_sdk/src/api/identity/v3/user/set.rs
@@ -92,8 +92,23 @@ pub struct Options<'a> {
     pub(crate) multi_factor_auth_enabled: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default, setter(into))]
+    #[builder(default, private, setter(name = "_multi_factor_auth_rules"))]
     pub(crate) multi_factor_auth_rules: Option<Vec<Vec<Cow<'a, str>>>>,
+}
+
+impl<'a> OptionsBuilder<'a> {
+    pub fn multi_factor_auth_rules<I1, I2, V>(&mut self, iter: I1) -> &mut Self
+    where
+        I1: Iterator<Item = I2>,
+        I2: IntoIterator<Item = V>,
+        V: Into<Cow<'a, str>>,
+    {
+        self.multi_factor_auth_rules
+            .get_or_insert(None)
+            .get_or_insert_with(Vec::new)
+            .extend(iter.map(|x| Vec::from_iter(x.into_iter().map(Into::into))));
+        self
+    }
 }
 
 /// A `user` object

--- a/openstack_tui/src/cloud_worker/identity/v3/user/set.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/set.rs
@@ -128,7 +128,7 @@ pub struct Options {
     #[builder(default)]
     pub multi_factor_auth_enabled: Option<bool>,
 
-    #[builder(default, setter(into))]
+    #[builder(default, private, setter(name = "_multi_factor_auth_rules"))]
     pub multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }
 
@@ -152,12 +152,7 @@ impl TryFrom<&Options> for openstack_sdk::api::identity::v3::user::set::OptionsB
             ep_builder.ignore_user_inactivity(*val);
         }
         if let Some(val) = &value.multi_factor_auth_rules {
-            ep_builder.multi_factor_auth_rules(
-                val.iter()
-                    .cloned()
-                    .map(|x1| x1.into_iter().map(Into::into).collect::<Vec<_>>())
-                    .collect::<Vec<_>>(),
-            );
+            ep_builder.multi_factor_auth_rules(val.iter().cloned());
         }
         if let Some(val) = &value.multi_factor_auth_enabled {
             ep_builder.multi_factor_auth_enabled(*val);


### PR DESCRIPTION
In Keystone.user MFA rules are vec of vec of strings. Current simplification
renders it as vec of strings loosing one level. Also indicate to the user array
parameters are actually arrays.

Change-Id: I382aa157b4b4286daf91f08af001a5db0247a88f

Changes are triggered by https://review.opendev.org/945015
