### PR TITLE
feat: Address sensitive data logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "regex",
  "reqwest",
  "reserve-port",
+ "secrecy",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2187,6 +2188,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-test",
  "url",
 ]
 
@@ -2903,6 +2905,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,6 +3517,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -63,6 +63,7 @@ lazy_static = { workspace = true }
 open = { version = "^5.3" }
 regex = { workspace = true }
 reqwest = { workspace = true }
+secrecy = { version = "0.10", features = ["serde"] }
 serde = { workspace = true }
 serde_json = {workspace = true}
 serde_urlencoded = "^0.7"
@@ -76,6 +77,7 @@ url = { workspace = true }
 httpmock = "^0.7"
 reserve-port = "^2.1"
 tempfile = { workspace = true }
+tracing-test = { version = "^0.2" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [[test]]

--- a/openstack_sdk/src/api/common.rs
+++ b/openstack_sdk/src/api/common.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use secrecy::{ExposeSecret, SecretString};
 use std::borrow::Cow;
 use std::fmt;
 use std::iter;
@@ -92,6 +93,27 @@ where
     }
 }
 
+/// Serialize `SecretString` as string
+pub fn serialize_sensitive_optional_string<S>(
+    value: &Option<SecretString>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match value {
+        Some(val) => serializer.serialize_str(val.expose_secret()),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// Serialize `Option<SecretString>` as string
+pub fn serialize_sensitive_string<S>(value: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(value.expose_secret())
+}
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;

--- a/openstack_sdk/src/api/identity/v3/auth/token/create.rs
+++ b/openstack_sdk/src/api/identity/v3/auth/token/create.rs
@@ -27,7 +27,9 @@
 //!
 use derive_builder::Builder;
 use http::{HeaderMap, HeaderName, HeaderValue};
+use secrecy::SecretString;
 
+use crate::api::common::{serialize_sensitive_optional_string, serialize_sensitive_string};
 use crate::api::rest_endpoint_prelude::*;
 
 use serde::Deserialize;
@@ -91,9 +93,12 @@ pub struct User<'a> {
 
     /// User Password
     ///
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_sensitive_optional_string"
+    )]
     #[builder(default, setter(into))]
-    pub(crate) password: Option<Cow<'a, str>>,
+    pub(crate) password: Option<SecretString>,
 }
 
 /// The `password` object, contains the authentication information.
@@ -112,12 +117,12 @@ pub struct Password<'a> {
 ///
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
-pub struct Token<'a> {
+pub struct Token {
     /// Authorization Token value
     ///
-    #[serde()]
+    #[serde(serialize_with = "serialize_sensitive_string")]
     #[builder(setter(into))]
-    pub(crate) id: Cow<'a, str>,
+    pub(crate) id: SecretString,
 }
 
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
@@ -143,9 +148,9 @@ pub struct TotpUser<'a> {
 
     /// MFA passcode
     ///
-    #[serde()]
+    #[serde(serialize_with = "serialize_sensitive_string")]
     #[builder(setter(into))]
-    pub(crate) passcode: Cow<'a, str>,
+    pub(crate) passcode: SecretString,
 }
 
 /// Multi Factor Authentication information
@@ -198,9 +203,9 @@ pub struct ApplicationCredential<'a> {
 
     /// The secret for authenticating the application credential.
     ///
-    #[serde()]
+    #[serde(serialize_with = "serialize_sensitive_string")]
     #[builder(setter(into))]
-    pub(crate) secret: Cow<'a, str>,
+    pub(crate) secret: SecretString,
 
     /// A user object, required if an application credential is identified by
     /// name and not ID.
@@ -238,7 +243,7 @@ pub struct Identity<'a> {
     ///
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) token: Option<Token<'a>>,
+    pub(crate) token: Option<Token>,
 
     /// Multi Factor Authentication information
     ///

--- a/openstack_sdk/src/auth/v3applicationcredential.rs
+++ b/openstack_sdk/src/auth/v3applicationcredential.rs
@@ -148,6 +148,8 @@ pub fn fill_identity(
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use tracing::info;
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::api::identity::v3::auth::token::create as token_v3;
@@ -254,5 +256,24 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_secret_not_in_log() {
+        let config = config::Auth {
+            application_credential_name: Some("foo".into()),
+            application_credential_secret: Some("secret_value".into()),
+            user_id: Some("uid".into()),
+            username: Some("un".into()),
+            user_domain_id: Some("udi".into()),
+            user_domain_name: Some("udn".into()),
+            ..Default::default()
+        };
+        let mut identity = token_v3::IdentityBuilder::default();
+        fill_identity(&mut identity, &config).unwrap();
+        let identity = identity.build().unwrap();
+        info!("Auth is {:?}", identity);
+        assert!(!logs_contain("secret_value"));
     }
 }

--- a/openstack_sdk/src/auth/v3token.rs
+++ b/openstack_sdk/src/auth/v3token.rs
@@ -92,6 +92,8 @@ impl TryFrom<&AuthToken> for token_v3::Identity<'_> {
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use tracing::info;
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::api::identity::v3::auth::token::create as token_v3;
@@ -127,5 +129,19 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_token_not_in_log() {
+        let config = config::Auth {
+            token: Some("secret".into()),
+            ..Default::default()
+        };
+        let mut identity = token_v3::IdentityBuilder::default();
+        fill_identity(&mut identity, &config, false).unwrap();
+        let identity = identity.build().unwrap();
+        info!("Auth is {:?}", identity);
+        assert!(!logs_contain("secret"));
     }
 }

--- a/openstack_sdk/src/auth/v3totp.rs
+++ b/openstack_sdk/src/auth/v3totp.rs
@@ -133,6 +133,8 @@ pub fn fill_identity(
 #[cfg(test)]
 mod tests {
     use serde_json::json;
+    use tracing::info;
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::api::identity::v3::auth::token::create as token_v3;
@@ -198,5 +200,23 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    #[traced_test]
+    fn test_passcode_not_in_log() {
+        let config = config::Auth {
+            user_id: Some("uid".into()),
+            username: Some("un".into()),
+            user_domain_id: Some("udi".into()),
+            user_domain_name: Some("udn".into()),
+            passcode: Some("secret".into()),
+            ..Default::default()
+        };
+        let mut identity = token_v3::IdentityBuilder::default();
+        fill_identity(&mut identity, &config, false).unwrap();
+        let identity = identity.build().unwrap();
+        info!("Auth is {:?}", identity);
+        assert!(!logs_contain("secret"));
     }
 }

--- a/openstack_sdk/src/types.rs
+++ b/openstack_sdk/src/types.rs
@@ -15,6 +15,7 @@
 //! Types of the SDK
 
 #![allow(dead_code)]
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -177,6 +178,28 @@ impl From<Option<&String>> for EntryStatus {
             None => Self::Normal,
         }
     }
+}
+
+/// Serialize `SecretString` as string
+pub fn serialize_sensitive_optional_string<S>(
+    value: &Option<SecretString>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match value {
+        Some(val) => serializer.serialize_str(val.expose_secret()),
+        None => serializer.serialize_none(),
+    }
+}
+
+/// Serialize `Option<SecretString>` as string
+pub fn serialize_sensitive_string<S>(value: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(value.expose_secret())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In the config and in auth call we deal with the sensitive data (password,
token, etc). Ensuring it is not leaked it not so trivial but aparently the
`secrecy` crate is able to serve the needs. Since we need to be able to
serialize password into the Json we can't ensure at the moment that the value
does not appear in logs, but at least it will not when the holding structure
is included in the log.

With this we can remove `(crate)` visibility restriction from config structs.

And while on that also finally implement censoring of the json requests to
prevent sensitive auth data to appear in trace logs