### PR TITLE
chore: Prepare migration from `httpmock` to `mockito`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2027,6 +2036,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "log",
+ "rand 0.9.0",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2208,7 @@ dependencies = [
  "itertools 0.14.0",
  "json-patch",
  "lazy_static",
+ "mockito",
  "open",
  "regex",
  "reqwest",
@@ -3362,6 +3396,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -75,6 +75,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 httpmock = "^0.7"
+mockito = { version = "^1.7" }
 reserve-port = "^2.1"
 tempfile = { workspace = true }
 tracing-test = { version = "^0.2" }

--- a/openstack_sdk/src/api/query.rs
+++ b/openstack_sdk/src/api/query.rs
@@ -31,6 +31,7 @@ use http::{HeaderMap, Response};
 
 pub fn url_to_http_uri(url: Url) -> Uri {
     url.as_str()
+        .trim_end_matches('?')
         .parse::<Uri>()
         .expect("failed to parse a url::Url as an http::Uri")
 }


### PR DESCRIPTION
Sadly `httpmock` crate is not looking very healthy, last release is a year ago
with other very outdated dependencies. Before we make testclient public switch
to `mockito` as more maintained library not to have major break for SDK users
later.
