### PR TITLE
feat(test): Introduce FakeOpenStackClient

### DIFF
--- a/openstack_sdk/src/api/find.rs
+++ b/openstack_sdk/src/api/find.rs
@@ -222,21 +222,18 @@ where
 
 #[cfg(test)]
 mod tests {
-
+    use httpmock::MockServer;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    use crate::api::find::Findable;
-    use crate::api::rest_endpoint_prelude::*;
     #[cfg(feature = "sync")]
     use crate::api::Query;
     #[cfg(feature = "async")]
     use crate::api::QueryAsync;
+    use crate::api::find::Findable;
+    use crate::api::rest_endpoint_prelude::*;
     use crate::api::{self, ApiError};
-    #[cfg(feature = "async")]
-    use crate::test::client::MockAsyncServerClient;
-    #[cfg(feature = "sync")]
-    use crate::test::client::MockServerClient;
+    use crate::test::client::FakeOpenStackClient;
     use derive_builder::Builder;
 
     #[derive(Debug, Builder, Clone)]
@@ -328,8 +325,9 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_get_1() {
-        let client = MockServerClient::new();
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(200)
                 .header("content-type", "application/json")
@@ -348,8 +346,9 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_get_1_async() {
-        let client = MockAsyncServerClient::new().await;
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(200)
                 .header("content-type", "application/json")
@@ -368,12 +367,13 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_get_0_list_1() {
-        let client = MockServerClient::new();
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(404);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -391,12 +391,13 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_get_0_list_1_async() {
-        let client = MockAsyncServerClient::new().await;
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(404);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -414,12 +415,13 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_get_0_400_list_1() {
-        let client = MockServerClient::new();
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(400);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -437,12 +439,13 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_get_0_400_list_1_async() {
-        let client = MockAsyncServerClient::new().await;
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(400);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -460,8 +463,9 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_by_name_0_list_1() {
-        let client = MockServerClient::new();
-        let list_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -478,8 +482,9 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_by_name_list_1_async() {
-        let client = MockAsyncServerClient::new().await;
-        let list_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -496,12 +501,13 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_get_0_list_2() {
-        let client = MockServerClient::new();
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(404);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -522,12 +528,13 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_get_0_list_2_async() {
-        let client = MockAsyncServerClient::new().await;
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(404);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -548,8 +555,9 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_by_name_list_2() {
-        let client = MockServerClient::new();
-        let list_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -569,8 +577,9 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_by_name_list_2_async() {
-        let client = MockAsyncServerClient::new().await;
-        let list_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -590,12 +599,13 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_get_0_list_0() {
-        let client = MockServerClient::new();
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(404);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -616,12 +626,13 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_get_0_list_0_async() {
-        let client = MockAsyncServerClient::new().await;
-        let get_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let get_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummies/abc");
             then.status(404);
         });
-        let list_mock = client.server.mock(|when, then| {
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -642,8 +653,9 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_by_name_list_0() {
-        let client = MockServerClient::new();
-        let list_mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");
@@ -663,8 +675,9 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_by_name_list_0_async() {
-        let client = MockAsyncServerClient::new().await;
-        let list_mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let list_mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET)
                 .path("/dummies")
                 .query_param("name", "abc");

--- a/openstack_sdk/src/api/ignore.rs
+++ b/openstack_sdk/src/api/ignore.rs
@@ -112,20 +112,17 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use http::StatusCode;
+    use httpmock::MockServer;
     use serde_json::json;
 
-    use crate::api::rest_endpoint_prelude::*;
     #[cfg(feature = "sync")]
     use crate::api::Query;
     #[cfg(feature = "async")]
     use crate::api::QueryAsync;
+    use crate::api::rest_endpoint_prelude::*;
     use crate::api::{self, ApiError};
-    #[cfg(feature = "async")]
-    use crate::test::client::MockAsyncServerClient;
-    #[cfg(feature = "sync")]
-    use crate::test::client::MockServerClient;
+    use crate::test::client::FakeOpenStackClient;
     use crate::types::ServiceType;
 
     struct Dummy;
@@ -147,8 +144,9 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_openstack_non_json_response() {
-        let client = MockServerClient::new();
-        let mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::OK.into()).body("not json");
         });
@@ -160,8 +158,9 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_openstack_non_json_response_async() {
-        let client = MockAsyncServerClient::new().await;
-        let mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::OK.into()).body("not json");
         });
@@ -173,8 +172,9 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_openstack_error_bad_json() {
-        let client = MockServerClient::new();
-        let mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::CONFLICT.into());
         });
@@ -191,8 +191,9 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_openstack_error_bad_json_async() {
-        let client = MockAsyncServerClient::new().await;
-        let mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::CONFLICT.into());
         });
@@ -209,8 +210,9 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_openstack_error_detection() {
-        let client = MockServerClient::new();
-        let mock = client.server.mock(|when, then| {
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::CONFLICT.into())
                 .json_body(json!({"message": "dummy error message"}));
@@ -228,8 +230,9 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_openstack_error_detection_async() {
-        let client = MockAsyncServerClient::new().await;
-        let mock = client.server.mock(|when, then| {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::CONFLICT.into())
                 .json_body(json!({"message": "dummy error message"}));
@@ -247,9 +250,10 @@ mod tests {
     #[cfg(feature = "sync")]
     #[test]
     fn test_openstack_error_detection_unknown() {
-        let client = MockServerClient::new();
+        let server = MockServer::start();
+        let client = FakeOpenStackClient::new(server.base_url());
         let err_obj = json!({"bogus": "dummy error message"});
-        let mock = client.server.mock(|when, then| {
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::CONFLICT.into())
                 .json_body(err_obj.clone());
@@ -267,9 +271,10 @@ mod tests {
     #[cfg(feature = "async")]
     #[tokio::test]
     async fn test_openstack_error_detection_unknown_async() {
-        let client = MockAsyncServerClient::new().await;
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
         let err_obj = json!({"bogus": "dummy error message"});
-        let mock = client.server.mock(|when, then| {
+        let mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/dummy");
             then.status(StatusCode::CONFLICT.into())
                 .json_body(err_obj.clone());

--- a/openstack_sdk/src/api/paged/next_page.rs
+++ b/openstack_sdk/src/api/paged/next_page.rs
@@ -157,7 +157,7 @@ pub(crate) fn next_page_from_body(
                             None => {
                                 return Err(PaginationError::Body {
                                     msg: "`rel` element is missing in links".into(),
-                                })
+                                });
                             }
                         }
                     }


### PR DESCRIPTION
In order to allow downstream users to test their resources create fake client
that can be used together with mock server. This is a first step. In the next
step all existing tests will be converted to this new fake client. Afterwards
it will be exposed dropping current MockServerClient and MockAsyncServerClient.
