### PR TITLE
feat: Make StructTable serialize the property

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,6 +2309,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
+ "structable_derive",
 ]
 
 [[package]]

--- a/openstack_types/Cargo.toml
+++ b/openstack_types/Cargo.toml
@@ -39,3 +39,4 @@ placement = []
 chrono = { workspace= true }
 serde = { workspace = true }
 serde_json = {workspace = true}
+structable_derive = { version = "0.1.6", path = "../structable_derive" }

--- a/structable_derive/tests/main.rs
+++ b/structable_derive/tests/main.rs
@@ -11,7 +11,7 @@ struct User {
     last_name: String,
     #[structable(title = "Long", wide)]
     extra: String,
-    #[structable(optional, pretty, wide)]
+    #[structable(optional, serialize, wide)]
     complex_data: Option<Value>,
     #[structable(optional)]
     dummy: Option<String>,


### PR DESCRIPTION
Add possibility to serialize data in the StrucTable derive macro to
prevent need for NewType wrappers just for the sake of serializing data
into the table.
