### PR TITLE
fix: Add new deser_num_str and deser_bool_str

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
       - 'openstack_cli/**'
       - 'openstack_sdk/**'
       - 'openstack_tui/**'
+      - 'openstack_types/**'
       - 'structable_derive/**'
       - 'fuzz/**'
 


### PR DESCRIPTION
Add possibility to avoid IntString, NumString, BoolString newtypes by
implementing different style of deserializer to be used as
`#[serde(deserialize_with="deser_num_str")]
