### PR TITLE
chore: Fix linter for openstack_types again

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,6 +16,7 @@ on:
       - 'openstack_cli/**'
       - 'openstack_sdk/**'
       - 'openstack_tui/**'
+      - 'openstack_types/**'
       - 'structable_derive/**'
       - 'fuzz/**'
 
@@ -25,11 +26,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  rust_min: 1.85.0
 
 jobs:
   rustfmt:
-    name: Run rustfmt on the minimum supported toolchain
+    name: Run rustfmt on the latest supported toolchain
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -39,10 +39,10 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install Rust ${{ env.rust_min }}
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
         with:
-          toolchain: ${{ env.rust_min }}
+          toolchain: stable
           components: rustfmt
 
       - uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,11 +30,9 @@ repos:
         name: cargo fmt
         description: Format rust files with cargo fmt
         entry: cargo fmt
-        args: ["--"]
+        args: ["--", "--check", "--collor", "always"]
         language: rust
         types: [rust]
-        minimum_pre_commit_version: 2.21.0
-        require_serial: true
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.16.3
     hooks:

--- a/openstack_types/src/common.rs
+++ b/openstack_types/src/common.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Common types that can be used in responses of the API operations
-use serde::{Deserialize, Deserializer, Serialize, de::Visitor};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
 use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
@@ -299,10 +299,10 @@ pub enum NameOrId {
 
 #[cfg(test)]
 mod tests {
-    use serde::de::IntoDeserializer;
     use serde::de::value::{
         BoolDeserializer, Error as ValueError, F64Deserializer, StrDeserializer, U64Deserializer,
     };
+    use serde::de::IntoDeserializer;
     use serde_json::json;
 
     use super::*;


### PR DESCRIPTION
filemask on the linters flow was skipping the run on changes into the
openstack_types. Fix that and ensure cargo fmt runs on the latest rust,
cause this is exactly the version the main development happens and now
there is a difference in imports ordering between 1.85 and 1.86
