### PR TITLE
feat: Wrap deserialization error into dedicated error

### DIFF
--- a/openstack_cli/src/error.rs
+++ b/openstack_cli/src/error.rs
@@ -29,6 +29,18 @@ pub enum OpenStackCliError {
         source: serde_json::Error,
     },
 
+    /// Json deserialization error.
+    #[error(
+        "failed to deserialize data to json. Try using `-o json` to still see the data. \n\t{}",
+        data
+    )]
+    DeserializeJson {
+        /// The source of the error.
+        source: serde_json::Error,
+        /// Source json data
+        data: String,
+    },
+
     /// OpenStack Auth error.
     #[error("authentication error")]
     Auth {
@@ -162,4 +174,14 @@ pub enum OpenStackCliError {
     /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),
+}
+
+impl OpenStackCliError {
+    /// Build a deserialization error
+    pub fn deserialize(error: serde_json::Error, data: String) -> Self {
+        Self::DeserializeJson {
+            source: error,
+            data,
+        }
+    }
 }

--- a/openstack_tui/src/error.rs
+++ b/openstack_tui/src/error.rs
@@ -29,6 +29,15 @@ pub enum TuiError {
         source: serde_json::Error,
     },
 
+    /// Json deserialization error.
+    #[error("failed to deserialize data to json. \n\t{}", source)]
+    DeserializeJson {
+        /// The source of the error.
+        source: serde_json::Error,
+        /// Source json data
+        data: String,
+    },
+
     #[error("error sending action: {}", source)]
     SenderError {
         /// The source of the error.
@@ -47,4 +56,14 @@ pub enum TuiError {
     /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),
+}
+
+impl TuiError {
+    /// Build a deserialization error
+    pub fn deserialize(error: serde_json::Error, data: String) -> Self {
+        Self::DeserializeJson {
+            source: error,
+            data,
+        }
+    }
 }


### PR DESCRIPTION
In order to make better error processing we should ensure json
deserialization error is an explitic error with error information and
the source data. We are going to catch it and perhaps have some helpers
improving error reporting.
