### PR TITLE
fix: Fix few nova response schemas

### DIFF
--- a/openstack_sdk/src/api/compute/v2/server/create_20.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_20.rs
@@ -781,7 +781,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -826,18 +826,21 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .build()
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -851,7 +854,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -880,7 +883,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_21.rs
@@ -769,7 +769,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -814,18 +814,21 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .build()
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -839,7 +842,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -868,7 +871,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_219.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_219.rs
@@ -777,7 +777,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -822,18 +822,21 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .build()
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -847,7 +850,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -876,7 +879,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_232.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_232.rs
@@ -785,7 +785,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -830,18 +830,21 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .build()
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -855,7 +858,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -884,7 +887,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_233.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_233.rs
@@ -781,7 +781,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -826,18 +826,21 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .build()
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -851,7 +854,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -880,7 +883,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_237.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_237.rs
@@ -789,7 +789,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -837,21 +837,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -865,7 +868,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -897,7 +900,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_242.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_242.rs
@@ -797,7 +797,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -845,21 +845,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -873,7 +876,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -905,7 +908,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_252.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_252.rs
@@ -812,7 +812,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -860,21 +860,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -888,7 +891,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -920,7 +923,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_257.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_257.rs
@@ -790,7 +790,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -838,21 +838,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -866,7 +869,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -898,7 +901,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_263.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_263.rs
@@ -801,7 +801,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -849,21 +849,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -877,7 +880,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -909,7 +912,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_267.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_267.rs
@@ -805,7 +805,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -853,21 +853,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -881,7 +884,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -913,7 +916,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_274.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_274.rs
@@ -823,7 +823,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -871,21 +871,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -899,7 +902,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -931,7 +934,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_290.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_290.rs
@@ -839,7 +839,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -887,21 +887,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -915,7 +918,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -947,7 +950,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_294.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_294.rs
@@ -839,7 +839,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -887,21 +887,24 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .server(
-                ServerBuilder::default()
-                    .flavor_ref("foo")
-                    .name("foo")
-                    .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+        assert_eq!(
+            Request::builder()
+                .server(
+                    ServerBuilder::default()
+                        .flavor_ref("foo")
+                        .name("foo")
+                        .networks(ServerNetworks::F1(Vec::from([NetworksBuilder::default()
+                            .build()
+                            .unwrap()])))
                         .build()
-                        .unwrap()])))
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -915,7 +918,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -947,7 +950,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_backup_20.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_backup_20.rs
@@ -141,7 +141,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -187,19 +187,22 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .create_backup(
-                CreateBackupBuilder::default()
-                    .backup_type("foo")
-                    .name("foo")
-                    .rotation(123)
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .create_backup(
+                    CreateBackupBuilder::default()
+                        .backup_type("foo")
+                        .name("foo")
+                        .rotation(123)
+                        .build()
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -213,7 +216,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -244,7 +247,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_backup_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_backup_21.rs
@@ -141,7 +141,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -187,19 +187,22 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .create_backup(
-                CreateBackupBuilder::default()
-                    .backup_type("foo")
-                    .name("foo")
-                    .rotation(123)
-                    .build()
-                    .unwrap()
-            )
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .create_backup(
+                    CreateBackupBuilder::default()
+                        .backup_type("foo")
+                        .name("foo")
+                        .rotation(123)
+                        .build()
+                        .unwrap()
+                )
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -213,7 +216,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -244,7 +247,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_image_20.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_image_20.rs
@@ -132,7 +132,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -171,12 +171,15 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .create_image(CreateImageBuilder::default().name("foo").build().unwrap())
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .create_image(CreateImageBuilder::default().name("foo").build().unwrap())
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -190,7 +193,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -214,7 +217,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_sdk/src/api/compute/v2/server/create_image_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_image_21.rs
@@ -132,7 +132,7 @@ impl RestEndpoint for Request<'_> {
     }
 
     fn response_key(&self) -> Option<Cow<'static, str>> {
-        None
+        Some("server".into())
     }
 
     /// Returns headers to be set into the request
@@ -171,12 +171,15 @@ mod tests {
 
     #[test]
     fn test_response_key() {
-        assert!(Request::builder()
-            .create_image(CreateImageBuilder::default().name("foo").build().unwrap())
-            .build()
-            .unwrap()
-            .response_key()
-            .is_none())
+        assert_eq!(
+            Request::builder()
+                .create_image(CreateImageBuilder::default().name("foo").build().unwrap())
+                .build()
+                .unwrap()
+                .response_key()
+                .unwrap(),
+            "server"
+        );
     }
 
     #[cfg(feature = "sync")]
@@ -190,7 +193,7 @@ mod tests {
 
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()
@@ -214,7 +217,7 @@ mod tests {
                 .header("not_foo", "not_bar");
             then.status(200)
                 .header("content-type", "application/json")
-                .json_body(json!({ "dummy": {} }));
+                .json_body(json!({ "server": {} }));
         });
 
         let endpoint = Request::builder()

--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -165,7 +165,7 @@ impl Cloud {
                         }
 
                         request
-                            .execute_request(conn, &request, &app_tx)
+                            .execute_request(conn, request, &app_tx)
                             .await
                             .or_else(|err| {
                                 app_tx.send(Action::Error {

--- a/openstack_types/src/compute/v2/keypair/response/create.rs
+++ b/openstack_types/src/compute/v2/keypair/response/create.rs
@@ -22,29 +22,9 @@ use structable::{StructTable, StructTableOptions};
 /// Keypair response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct KeypairResponse {
-    /// The date and time when the resource was created.
-    #[serde(default)]
-    #[structable(optional)]
-    pub created_at: Option<String>,
-
-    /// A boolean indicates whether this keypair is deleted or not. The value
-    /// is always false (not deleted).
-    #[serde(default)]
-    #[structable(optional)]
-    pub deleted: Option<bool>,
-
-    /// It is always null.
-    #[serde(default)]
-    #[structable(optional)]
-    pub deleted_at: Option<String>,
-
     /// The fingerprint for the keypair.
     #[structable()]
     pub fingerprint: String,
-
-    /// The keypair ID.
-    #[structable()]
-    pub id: i32,
 
     /// The name for the keypair.
     #[structable()]
@@ -70,13 +50,4 @@ pub struct KeypairResponse {
     #[serde(rename = "type")]
     #[structable(title = "type")]
     pub _type: String,
-
-    /// It is always null.
-    #[serde(default)]
-    #[structable(optional)]
-    pub updated_at: Option<String>,
-
-    /// The user_id for a keypair.
-    #[structable()]
-    pub user_id: String,
 }

--- a/openstack_types/src/compute/v2/keypair/response/get.rs
+++ b/openstack_types/src/compute/v2/keypair/response/get.rs
@@ -22,32 +22,6 @@ use structable::{StructTable, StructTableOptions};
 /// Keypair response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct KeypairResponse {
-    /// The date and time when the resource was created. The date and time
-    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
-    ///
-    /// ```text
-    /// CCYY-MM-DDThh:mm:ss±hh:mm
-    ///
-    /// ```
-    ///
-    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
-    /// included, is the time zone as an offset from UTC. In the previous
-    /// example, the offset value is `-05:00`.
-    #[serde(default)]
-    #[structable(optional)]
-    pub created_at: Option<String>,
-
-    /// A boolean indicates whether this keypair is deleted or not. The value
-    /// is always `false` (not deleted).
-    #[serde(default)]
-    #[structable(optional)]
-    pub deleted: Option<bool>,
-
-    /// It is always `null`.
-    #[serde(default)]
-    #[structable(optional)]
-    pub deleted_at: Option<String>,
-
     /// The fingerprint for the keypair.
     #[structable()]
     pub fingerprint: String,
@@ -70,13 +44,4 @@ pub struct KeypairResponse {
     #[serde(rename = "type")]
     #[structable(title = "type")]
     pub _type: String,
-
-    /// It is always `null`.
-    #[serde(default)]
-    #[structable(optional)]
-    pub updated_at: Option<String>,
-
-    /// The user_id for a keypair.
-    #[structable()]
-    pub user_id: String,
 }


### PR DESCRIPTION
- keypair create response does not contain ID
- server create response has a response_key (server). This is not really
  true, since creation may return reservation_id, but this is not
  typical and we can try to find a solution for that later. For now make
  sure cli server creation works.

Change-Id: I3f52f0e6686767dcc8862543c4c3a155f42ead0e

Changes are triggered by https://review.opendev.org/948063
