### PR TITLE
fix: Fix fip.port_details schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,12 @@ jobs:
         run: |
           docker run --init --rm -d -v "$GITHUB_WORKSPACE/openstack_types/data":"/data" -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 /data/block-storage/v3.yaml -d
 
+      - name: Start prism mock server - Network
+        run: |
+          docker run --init --rm -d -v "$GITHUB_WORKSPACE/openstack_types/data":"/data" -p 4020:4010 stoplight/prism:4 mock -h 0.0.0.0 /data/network/v2.yaml -d
+
       - name: Run tests
         env:
           OPENSTACK_BLOCK_STORAGE_ENDPOINT: http://localhost:4010/v3
+          OPENSTACK_NETWORK_ENDPOINT: http://localhost:4020/v2.0
         run: cargo test -p openstack_types --test mocked

--- a/openstack_types/data/network/v2.26.yaml
+++ b/openstack_types/data/network/v2.26.yaml
@@ -11390,42 +11390,39 @@ components:
               description: |-
                 A valid DNS domain.
             port_details:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Human-readable name of the resource.
-                  network_id:
-                    type: string
-                    format: uuid
-                    description: The ID of the attached network.
-                  admin_state_up:
-                    type:
-                      - string
-                      - boolean
-                    description: The administrative state of the resource, which is
-                      up (`true`) or down (`false`).
-                  mac_address:
-                    type: string
-                    description: The MAC address of the port. If the port uses the
-                      `direct-physical` `vnic_type` then the value of this field is
-                      overwritten with the MAC address provided in the active binding:profile
-                      if any.
-                  device_id:
-                    type: string
-                    description: The ID of the device that uses this port. For example,
-                      a server instance or a logical router.
-                  device_owner:
-                    type: string
-                    description: The entity type that uses this port. For example,
-                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                      or `network:router_interface` (router interface).
-                  status:
-                    type: string
-                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                      and `ERROR`.
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Human-readable name of the resource.
+                network_id:
+                  type: string
+                  format: uuid
+                  description: The ID of the attached network.
+                admin_state_up:
+                  type:
+                    - string
+                    - boolean
+                  description: The administrative state of the resource, which is
+                    up (`true`) or down (`false`).
+                mac_address:
+                  type: string
+                  description: The MAC address of the port. If the port uses the `direct-physical`
+                    `vnic_type` then the value of this field is overwritten with the
+                    MAC address provided in the active binding:profile if any.
+                device_id:
+                  type: string
+                  description: The ID of the device that uses this port. For example,
+                    a server instance or a logical router.
+                device_owner:
+                  type: string
+                  description: The entity type that uses this port. For example, `compute:nova`
+                    (server instance), `network:dhcp` (DHCP agent) or `network:router_interface`
+                    (router interface).
+                status:
+                  type: string
+                  description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                    and `ERROR`.
               description: |-
                 The information of the port that this floating IP associates with.
                 In particular, if the floating IP is associated with a port, this field
@@ -11585,42 +11582,40 @@ components:
                 description: |-
                   A valid DNS domain.
               port_details:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      description: Human-readable name of the resource.
-                    network_id:
-                      type: string
-                      format: uuid
-                      description: The ID of the attached network.
-                    admin_state_up:
-                      type:
-                        - string
-                        - boolean
-                      description: The administrative state of the resource, which
-                        is up (`true`) or down (`false`).
-                    mac_address:
-                      type: string
-                      description: The MAC address of the port. If the port uses the
-                        `direct-physical` `vnic_type` then the value of this field
-                        is overwritten with the MAC address provided in the active
-                        binding:profile if any.
-                    device_id:
-                      type: string
-                      description: The ID of the device that uses this port. For example,
-                        a server instance or a logical router.
-                    device_owner:
-                      type: string
-                      description: The entity type that uses this port. For example,
-                        `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                        or `network:router_interface` (router interface).
-                    status:
-                      type: string
-                      description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                        and `ERROR`.
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Human-readable name of the resource.
+                  network_id:
+                    type: string
+                    format: uuid
+                    description: The ID of the attached network.
+                  admin_state_up:
+                    type:
+                      - string
+                      - boolean
+                    description: The administrative state of the resource, which is
+                      up (`true`) or down (`false`).
+                  mac_address:
+                    type: string
+                    description: The MAC address of the port. If the port uses the
+                      `direct-physical` `vnic_type` then the value of this field is
+                      overwritten with the MAC address provided in the active binding:profile
+                      if any.
+                  device_id:
+                    type: string
+                    description: The ID of the device that uses this port. For example,
+                      a server instance or a logical router.
+                  device_owner:
+                    type: string
+                    description: The entity type that uses this port. For example,
+                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
+                      or `network:router_interface` (router interface).
+                  status:
+                    type: string
+                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                      and `ERROR`.
                 description: |-
                   The information of the port that this floating IP associates with.
                   In particular, if the floating IP is associated with a port, this field
@@ -11815,42 +11810,39 @@ components:
               description: |-
                 A valid DNS domain.
             port_details:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Human-readable name of the resource.
-                  network_id:
-                    type: string
-                    format: uuid
-                    description: The ID of the attached network.
-                  admin_state_up:
-                    type:
-                      - string
-                      - boolean
-                    description: The administrative state of the resource, which is
-                      up (`true`) or down (`false`).
-                  mac_address:
-                    type: string
-                    description: The MAC address of the port. If the port uses the
-                      `direct-physical` `vnic_type` then the value of this field is
-                      overwritten with the MAC address provided in the active binding:profile
-                      if any.
-                  device_id:
-                    type: string
-                    description: The ID of the device that uses this port. For example,
-                      a server instance or a logical router.
-                  device_owner:
-                    type: string
-                    description: The entity type that uses this port. For example,
-                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                      or `network:router_interface` (router interface).
-                  status:
-                    type: string
-                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                      and `ERROR`.
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Human-readable name of the resource.
+                network_id:
+                  type: string
+                  format: uuid
+                  description: The ID of the attached network.
+                admin_state_up:
+                  type:
+                    - string
+                    - boolean
+                  description: The administrative state of the resource, which is
+                    up (`true`) or down (`false`).
+                mac_address:
+                  type: string
+                  description: The MAC address of the port. If the port uses the `direct-physical`
+                    `vnic_type` then the value of this field is overwritten with the
+                    MAC address provided in the active binding:profile if any.
+                device_id:
+                  type: string
+                  description: The ID of the device that uses this port. For example,
+                    a server instance or a logical router.
+                device_owner:
+                  type: string
+                  description: The entity type that uses this port. For example, `compute:nova`
+                    (server instance), `network:dhcp` (DHCP agent) or `network:router_interface`
+                    (router interface).
+                status:
+                  type: string
+                  description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                    and `ERROR`.
               description: |-
                 The information of the port that this floating IP associates with.
                 In particular, if the floating IP is associated with a port, this field
@@ -12008,42 +12000,39 @@ components:
               description: |-
                 A valid DNS domain.
             port_details:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Human-readable name of the resource.
-                  network_id:
-                    type: string
-                    format: uuid
-                    description: The ID of the attached network.
-                  admin_state_up:
-                    type:
-                      - string
-                      - boolean
-                    description: The administrative state of the resource, which is
-                      up (`true`) or down (`false`).
-                  mac_address:
-                    type: string
-                    description: The MAC address of the port. If the port uses the
-                      `direct-physical` `vnic_type` then the value of this field is
-                      overwritten with the MAC address provided in the active binding:profile
-                      if any.
-                  device_id:
-                    type: string
-                    description: The ID of the device that uses this port. For example,
-                      a server instance or a logical router.
-                  device_owner:
-                    type: string
-                    description: The entity type that uses this port. For example,
-                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                      or `network:router_interface` (router interface).
-                  status:
-                    type: string
-                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                      and `ERROR`.
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Human-readable name of the resource.
+                network_id:
+                  type: string
+                  format: uuid
+                  description: The ID of the attached network.
+                admin_state_up:
+                  type:
+                    - string
+                    - boolean
+                  description: The administrative state of the resource, which is
+                    up (`true`) or down (`false`).
+                mac_address:
+                  type: string
+                  description: The MAC address of the port. If the port uses the `direct-physical`
+                    `vnic_type` then the value of this field is overwritten with the
+                    MAC address provided in the active binding:profile if any.
+                device_id:
+                  type: string
+                  description: The ID of the device that uses this port. For example,
+                    a server instance or a logical router.
+                device_owner:
+                  type: string
+                  description: The entity type that uses this port. For example, `compute:nova`
+                    (server instance), `network:dhcp` (DHCP agent) or `network:router_interface`
+                    (router interface).
+                status:
+                  type: string
+                  description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                    and `ERROR`.
               description: |-
                 The information of the port that this floating IP associates with.
                 In particular, if the floating IP is associated with a port, this field

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -11390,42 +11390,39 @@ components:
               description: |-
                 A valid DNS domain.
             port_details:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Human-readable name of the resource.
-                  network_id:
-                    type: string
-                    format: uuid
-                    description: The ID of the attached network.
-                  admin_state_up:
-                    type:
-                      - string
-                      - boolean
-                    description: The administrative state of the resource, which is
-                      up (`true`) or down (`false`).
-                  mac_address:
-                    type: string
-                    description: The MAC address of the port. If the port uses the
-                      `direct-physical` `vnic_type` then the value of this field is
-                      overwritten with the MAC address provided in the active binding:profile
-                      if any.
-                  device_id:
-                    type: string
-                    description: The ID of the device that uses this port. For example,
-                      a server instance or a logical router.
-                  device_owner:
-                    type: string
-                    description: The entity type that uses this port. For example,
-                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                      or `network:router_interface` (router interface).
-                  status:
-                    type: string
-                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                      and `ERROR`.
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Human-readable name of the resource.
+                network_id:
+                  type: string
+                  format: uuid
+                  description: The ID of the attached network.
+                admin_state_up:
+                  type:
+                    - string
+                    - boolean
+                  description: The administrative state of the resource, which is
+                    up (`true`) or down (`false`).
+                mac_address:
+                  type: string
+                  description: The MAC address of the port. If the port uses the `direct-physical`
+                    `vnic_type` then the value of this field is overwritten with the
+                    MAC address provided in the active binding:profile if any.
+                device_id:
+                  type: string
+                  description: The ID of the device that uses this port. For example,
+                    a server instance or a logical router.
+                device_owner:
+                  type: string
+                  description: The entity type that uses this port. For example, `compute:nova`
+                    (server instance), `network:dhcp` (DHCP agent) or `network:router_interface`
+                    (router interface).
+                status:
+                  type: string
+                  description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                    and `ERROR`.
               description: |-
                 The information of the port that this floating IP associates with.
                 In particular, if the floating IP is associated with a port, this field
@@ -11585,42 +11582,40 @@ components:
                 description: |-
                   A valid DNS domain.
               port_details:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                      description: Human-readable name of the resource.
-                    network_id:
-                      type: string
-                      format: uuid
-                      description: The ID of the attached network.
-                    admin_state_up:
-                      type:
-                        - string
-                        - boolean
-                      description: The administrative state of the resource, which
-                        is up (`true`) or down (`false`).
-                    mac_address:
-                      type: string
-                      description: The MAC address of the port. If the port uses the
-                        `direct-physical` `vnic_type` then the value of this field
-                        is overwritten with the MAC address provided in the active
-                        binding:profile if any.
-                    device_id:
-                      type: string
-                      description: The ID of the device that uses this port. For example,
-                        a server instance or a logical router.
-                    device_owner:
-                      type: string
-                      description: The entity type that uses this port. For example,
-                        `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                        or `network:router_interface` (router interface).
-                    status:
-                      type: string
-                      description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                        and `ERROR`.
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Human-readable name of the resource.
+                  network_id:
+                    type: string
+                    format: uuid
+                    description: The ID of the attached network.
+                  admin_state_up:
+                    type:
+#                      - string
+                      - boolean
+                    description: The administrative state of the resource, which is
+                      up (`true`) or down (`false`).
+                  mac_address:
+                    type: string
+                    description: The MAC address of the port. If the port uses the
+                      `direct-physical` `vnic_type` then the value of this field is
+                      overwritten with the MAC address provided in the active binding:profile
+                      if any.
+                  device_id:
+                    type: string
+                    description: The ID of the device that uses this port. For example,
+                      a server instance or a logical router.
+                  device_owner:
+                    type: string
+                    description: The entity type that uses this port. For example,
+                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
+                      or `network:router_interface` (router interface).
+                  status:
+                    type: string
+                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                      and `ERROR`.
                 description: |-
                   The information of the port that this floating IP associates with.
                   In particular, if the floating IP is associated with a port, this field
@@ -11815,42 +11810,39 @@ components:
               description: |-
                 A valid DNS domain.
             port_details:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Human-readable name of the resource.
-                  network_id:
-                    type: string
-                    format: uuid
-                    description: The ID of the attached network.
-                  admin_state_up:
-                    type:
-                      - string
-                      - boolean
-                    description: The administrative state of the resource, which is
-                      up (`true`) or down (`false`).
-                  mac_address:
-                    type: string
-                    description: The MAC address of the port. If the port uses the
-                      `direct-physical` `vnic_type` then the value of this field is
-                      overwritten with the MAC address provided in the active binding:profile
-                      if any.
-                  device_id:
-                    type: string
-                    description: The ID of the device that uses this port. For example,
-                      a server instance or a logical router.
-                  device_owner:
-                    type: string
-                    description: The entity type that uses this port. For example,
-                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                      or `network:router_interface` (router interface).
-                  status:
-                    type: string
-                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                      and `ERROR`.
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Human-readable name of the resource.
+                network_id:
+                  type: string
+                  format: uuid
+                  description: The ID of the attached network.
+                admin_state_up:
+                  type:
+                    - string
+                    - boolean
+                  description: The administrative state of the resource, which is
+                    up (`true`) or down (`false`).
+                mac_address:
+                  type: string
+                  description: The MAC address of the port. If the port uses the `direct-physical`
+                    `vnic_type` then the value of this field is overwritten with the
+                    MAC address provided in the active binding:profile if any.
+                device_id:
+                  type: string
+                  description: The ID of the device that uses this port. For example,
+                    a server instance or a logical router.
+                device_owner:
+                  type: string
+                  description: The entity type that uses this port. For example, `compute:nova`
+                    (server instance), `network:dhcp` (DHCP agent) or `network:router_interface`
+                    (router interface).
+                status:
+                  type: string
+                  description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                    and `ERROR`.
               description: |-
                 The information of the port that this floating IP associates with.
                 In particular, if the floating IP is associated with a port, this field
@@ -12008,42 +12000,39 @@ components:
               description: |-
                 A valid DNS domain.
             port_details:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    description: Human-readable name of the resource.
-                  network_id:
-                    type: string
-                    format: uuid
-                    description: The ID of the attached network.
-                  admin_state_up:
-                    type:
-                      - string
-                      - boolean
-                    description: The administrative state of the resource, which is
-                      up (`true`) or down (`false`).
-                  mac_address:
-                    type: string
-                    description: The MAC address of the port. If the port uses the
-                      `direct-physical` `vnic_type` then the value of this field is
-                      overwritten with the MAC address provided in the active binding:profile
-                      if any.
-                  device_id:
-                    type: string
-                    description: The ID of the device that uses this port. For example,
-                      a server instance or a logical router.
-                  device_owner:
-                    type: string
-                    description: The entity type that uses this port. For example,
-                      `compute:nova` (server instance), `network:dhcp` (DHCP agent)
-                      or `network:router_interface` (router interface).
-                  status:
-                    type: string
-                    description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
-                      and `ERROR`.
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Human-readable name of the resource.
+                network_id:
+                  type: string
+                  format: uuid
+                  description: The ID of the attached network.
+                admin_state_up:
+                  type:
+                    - string
+                    - boolean
+                  description: The administrative state of the resource, which is
+                    up (`true`) or down (`false`).
+                mac_address:
+                  type: string
+                  description: The MAC address of the port. If the port uses the `direct-physical`
+                    `vnic_type` then the value of this field is overwritten with the
+                    MAC address provided in the active binding:profile if any.
+                device_id:
+                  type: string
+                  description: The ID of the device that uses this port. For example,
+                    a server instance or a logical router.
+                device_owner:
+                  type: string
+                  description: The entity type that uses this port. For example, `compute:nova`
+                    (server instance), `network:dhcp` (DHCP agent) or `network:router_interface`
+                    (router interface).
+                status:
+                  type: string
+                  description: The port status. Values are `ACTIVE`, `DOWN`, `BUILD`
+                    and `ERROR`.
               description: |-
                 The information of the port that this floating IP associates with.
                 In particular, if the floating IP is associated with a port, this field

--- a/openstack_types/src/network/v2/floatingip/response/create.rs
+++ b/openstack_types/src/network/v2/floatingip/response/create.rs
@@ -69,7 +69,7 @@ pub struct FloatingipResponse {
     /// this field is `null`.
     #[serde(default)]
     #[structable(optional, serialize)]
-    pub port_details: Option<Vec<PortDetails>>,
+    pub port_details: Option<PortDetails>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -124,6 +124,12 @@ pub struct FloatingipResponse {
     pub updated_at: Option<String>,
 }
 
+/// The information of the port that this floating IP associates with. In
+/// particular, if the floating IP is associated with a port, this field
+/// contains some attributes of the associated port, including `name`,
+/// `network_id`, `mac_address`, `admin_state_up`, `status`, `device_id` and
+/// `device_owner`. If the floating IP is not associated with a port, this
+/// field is `null`.
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {

--- a/openstack_types/src/network/v2/floatingip/response/get.rs
+++ b/openstack_types/src/network/v2/floatingip/response/get.rs
@@ -69,7 +69,7 @@ pub struct FloatingipResponse {
     /// this field is `null`.
     #[serde(default)]
     #[structable(optional, serialize)]
-    pub port_details: Option<Vec<PortDetails>>,
+    pub port_details: Option<PortDetails>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -124,6 +124,12 @@ pub struct FloatingipResponse {
     pub updated_at: Option<String>,
 }
 
+/// The information of the port that this floating IP associates with. In
+/// particular, if the floating IP is associated with a port, this field
+/// contains some attributes of the associated port, including `name`,
+/// `network_id`, `mac_address`, `admin_state_up`, `status`, `device_id` and
+/// `device_owner`. If the floating IP is not associated with a port, this
+/// field is `null`.
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {

--- a/openstack_types/src/network/v2/floatingip/response/list.rs
+++ b/openstack_types/src/network/v2/floatingip/response/list.rs
@@ -69,7 +69,7 @@ pub struct FloatingipResponse {
     /// this field is `null`.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
-    pub port_details: Option<Vec<PortDetails>>,
+    pub port_details: Option<PortDetails>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -124,6 +124,12 @@ pub struct FloatingipResponse {
     pub updated_at: Option<String>,
 }
 
+/// The information of the port that this floating IP associates with. In
+/// particular, if the floating IP is associated with a port, this field
+/// contains some attributes of the associated port, including `name`,
+/// `network_id`, `mac_address`, `admin_state_up`, `status`, `device_id` and
+/// `device_owner`. If the floating IP is not associated with a port, this
+/// field is `null`.
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {

--- a/openstack_types/src/network/v2/floatingip/response/set.rs
+++ b/openstack_types/src/network/v2/floatingip/response/set.rs
@@ -69,7 +69,7 @@ pub struct FloatingipResponse {
     /// this field is `null`.
     #[serde(default)]
     #[structable(optional, serialize)]
-    pub port_details: Option<Vec<PortDetails>>,
+    pub port_details: Option<PortDetails>,
 
     /// The associated port forwarding resources for the floating IP. If the
     /// floating IP has multiple port forwarding resources, this field has
@@ -124,6 +124,12 @@ pub struct FloatingipResponse {
     pub updated_at: Option<String>,
 }
 
+/// The information of the port that this floating IP associates with. In
+/// particular, if the floating IP is associated with a port, this field
+/// contains some attributes of the associated port, including `name`,
+/// `network_id`, `mac_address`, `admin_state_up`, `status`, `device_id` and
+/// `device_owner`. If the floating IP is not associated with a port, this
+/// field is `null`.
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {

--- a/openstack_types/tests/mocked/main.rs
+++ b/openstack_types/tests/mocked/main.rs
@@ -53,6 +53,16 @@ pub fn get_client<S: AsRef<str>>(service: S) -> FakeOpenStackClient {
                 .expect("url must be valid uri"),
             );
         }
+        "network" => {
+            client.add_endpoint(
+                service.as_ref(),
+                Url::parse(
+                    &env::var("OPENSTACK_NETWORK_ENDPOINT")
+                        .expect("OPENSTACK_NETWORK_ENDPOINT environment variable must be present"),
+                )
+                .expect("url must be valid uri"),
+            );
+        }
         _ => {}
     };
     client.set_auth(Some(Auth::AuthToken(Box::new(AuthToken::from("fake")))));

--- a/openstack_types/tests/mocked/network/v2/floatingip/mod.rs
+++ b/openstack_types/tests/mocked/network/v2/floatingip/mod.rs
@@ -12,4 +12,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod v2;
+mod response;

--- a/openstack_types/tests/mocked/network/v2/floatingip/response/list.rs
+++ b/openstack_types/tests/mocked/network/v2/floatingip/response/list.rs
@@ -12,4 +12,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod v2;
+use openstack_sdk::api::network::v2::floatingip::list::Request;
+use openstack_sdk::api::{paged, Pagination, QueryAsync};
+use openstack_types::network::v2::floatingip::response::list::FloatingipResponse;
+
+use crate::get_client;
+
+#[tokio::test]
+async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
+    let client = get_client("network");
+
+    let _res: Vec<FloatingipResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
+        .query_async(&client)
+        .await?;
+
+    Ok(())
+}

--- a/openstack_types/tests/mocked/network/v2/floatingip/response/mod.rs
+++ b/openstack_types/tests/mocked/network/v2/floatingip/response/mod.rs
@@ -12,4 +12,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod v2;
+mod list;

--- a/openstack_types/tests/mocked/network/v2/mod.rs
+++ b/openstack_types/tests/mocked/network/v2/mod.rs
@@ -12,4 +12,4 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-mod v2;
+mod floatingip;


### PR DESCRIPTION
port_details is an object and not array of objects.

Add deserialization mock test

Change-Id: I4095e664d714222d1d1ef8fdac0422393e7c451b

Changes are triggered by https://review.opendev.org/949042
