### PR TITLE
fix: Address explicit nullable types in network

### DIFF
--- a/openstack_cli/src/network/v2/floatingip/create.rs
+++ b/openstack_cli/src/network/v2/floatingip/create.rs
@@ -167,7 +167,7 @@ impl FloatingipCommand {
         let args = &self.floatingip;
         let mut floatingip_builder = create::FloatingipBuilder::default();
         if let Some(val) = &args.floating_ip_address {
-            floatingip_builder.floating_ip_address(val);
+            floatingip_builder.floating_ip_address(Some(val.into()));
         }
 
         if let Some(val) = &args.subnet_id {
@@ -181,7 +181,7 @@ impl FloatingipCommand {
         }
 
         if let Some(val) = &args.fixed_ip_address {
-            floatingip_builder.fixed_ip_address(val);
+            floatingip_builder.fixed_ip_address(Some(val.into()));
         }
 
         if let Some(val) = &args.tenant_id {

--- a/openstack_cli/src/network/v2/floatingip/set.rs
+++ b/openstack_cli/src/network/v2/floatingip/set.rs
@@ -133,7 +133,7 @@ impl FloatingipCommand {
         }
 
         if let Some(val) = &args.fixed_ip_address {
-            floatingip_builder.fixed_ip_address(val);
+            floatingip_builder.fixed_ip_address(Some(val.into()));
         }
 
         if let Some(val) = &args.qos_policy_id {

--- a/openstack_cli/src/network/v2/local_ip/create.rs
+++ b/openstack_cli/src/network/v2/local_ip/create.rs
@@ -128,7 +128,7 @@ impl LocalIpCommand {
         }
 
         if let Some(val) = &args.local_ip_address {
-            local_ip_builder.local_ip_address(val);
+            local_ip_builder.local_ip_address(Some(val.into()));
         }
 
         if let Some(val) = &args.ip_mode {

--- a/openstack_cli/src/network/v2/local_ip/port_association/create.rs
+++ b/openstack_cli/src/network/v2/local_ip/port_association/create.rs
@@ -116,7 +116,7 @@ impl PortAssociationCommand {
         }
 
         if let Some(val) = &args.fixed_ip {
-            port_association_builder.fixed_ip(val);
+            port_association_builder.fixed_ip(Some(val.into()));
         }
 
         if let Some(val) = &args.project_id {

--- a/openstack_cli/src/network/v2/ndp_proxy/create.rs
+++ b/openstack_cli/src/network/v2/ndp_proxy/create.rs
@@ -113,7 +113,7 @@ impl NdpProxyCommand {
         }
 
         if let Some(val) = &args.ip_address {
-            ndp_proxy_builder.ip_address(val);
+            ndp_proxy_builder.ip_address(Some(val.into()));
         }
 
         if let Some(val) = &args.description {

--- a/openstack_cli/src/network/v2/subnet/create.rs
+++ b/openstack_cli/src/network/v2/subnet/create.rs
@@ -257,7 +257,7 @@ impl SubnetCommand {
         }
 
         if let Some(val) = &args.gateway_ip {
-            subnet_builder.gateway_ip(val);
+            subnet_builder.gateway_ip(Some(val.into()));
         }
 
         if let Some(val) = &args.allocation_pools {

--- a/openstack_cli/src/network/v2/subnet/set.rs
+++ b/openstack_cli/src/network/v2/subnet/set.rs
@@ -176,7 +176,7 @@ impl SubnetCommand {
         }
 
         if let Some(val) = &args.gateway_ip {
-            subnet_builder.gateway_ip(val);
+            subnet_builder.gateway_ip(Some(val.into()));
         }
 
         if let Some(val) = &args.allocation_pools {

--- a/openstack_sdk/src/api/network/v2/floatingip/create.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/create.rs
@@ -92,12 +92,12 @@ pub struct Floatingip<'a> {
     /// the `fixed_ip_address` parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) fixed_ip_address: Option<Cow<'a, str>>,
+    pub(crate) fixed_ip_address: Option<Option<Cow<'a, str>>>,
 
     /// The floating IP address.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) floating_ip_address: Option<Cow<'a, str>>,
+    pub(crate) floating_ip_address: Option<Option<Cow<'a, str>>>,
 
     /// The ID of the network associated with the floating IP.
     #[serde()]

--- a/openstack_sdk/src/api/network/v2/floatingip/set.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/set.rs
@@ -60,7 +60,7 @@ pub struct Floatingip<'a> {
     /// the `fixed_ip_address` parameter.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) fixed_ip_address: Option<Cow<'a, str>>,
+    pub(crate) fixed_ip_address: Option<Option<Cow<'a, str>>>,
 
     /// The ID of a port associated with the floating IP. To associate the
     /// floating IP with a fixed IP, you must specify the ID of the internal

--- a/openstack_sdk/src/api/network/v2/local_ip/create.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/create.rs
@@ -45,7 +45,7 @@ pub struct LocalIp<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) local_ip_address: Option<Cow<'a, str>>,
+    pub(crate) local_ip_address: Option<Option<Cow<'a, str>>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/local_ip/port_association/create.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/port_association/create.rs
@@ -40,7 +40,7 @@ pub struct PortAssociation<'a> {
     /// The requested IP of the port associated with the Local IP.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) fixed_ip: Option<Cow<'a, str>>,
+    pub(crate) fixed_ip: Option<Option<Cow<'a, str>>>,
 
     /// The requested ID of the port associated with the Local IP.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/network/v2/ndp_proxy/create.rs
+++ b/openstack_sdk/src/api/network/v2/ndp_proxy/create.rs
@@ -33,7 +33,7 @@ pub struct NdpProxy<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) ip_address: Option<Cow<'a, str>>,
+    pub(crate) ip_address: Option<Option<Cow<'a, str>>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/subnet/create.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/create.rs
@@ -153,7 +153,7 @@ pub struct Subnet<'a> {
     /// the gateway for the subnet by default.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) gateway_ip: Option<Cow<'a, str>>,
+    pub(crate) gateway_ip: Option<Option<Cow<'a, str>>>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.

--- a/openstack_sdk/src/api/network/v2/subnet/set.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/set.rs
@@ -99,7 +99,7 @@ pub struct Subnet<'a> {
     /// the gateway for the subnet by default.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) gateway_ip: Option<Cow<'a, str>>,
+    pub(crate) gateway_ip: Option<Option<Cow<'a, str>>>,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.

--- a/openstack_types/data/network/v2.26.yaml
+++ b/openstack_types/data/network/v2.26.yaml
@@ -11234,7 +11234,9 @@ components:
           type: object
           properties:
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             subnet_id:
@@ -11260,7 +11262,9 @@ components:
                 To associate the floating IP with a fixed IP at creation time,
                 you must specify the identifier of the internal port.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the floating IP.
                 If an internal port has multiple associated IP addresses,
@@ -11315,7 +11319,9 @@ components:
               description: |-
                 The ID of the floating IP address.
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             floating_network_id:
@@ -11339,7 +11345,9 @@ components:
               description: |-
                 The ID of a port associated with the floating IP.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the
                 floating IP address.
@@ -11505,7 +11513,9 @@ components:
                 description: |-
                   The ID of the floating IP address.
               floating_ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   The floating IP address.
               floating_network_id:
@@ -11529,7 +11539,9 @@ components:
                 description: |-
                   The ID of a port associated with the floating IP.
               fixed_ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   The fixed IP address that is associated with the
                   floating IP address.
@@ -11696,7 +11708,9 @@ components:
                 you must specify the ID of the internal port.
                 To disassociate the floating IP, `null` should be specified.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the floating IP.
                 If an internal port has multiple associated IP addresses,
@@ -11731,7 +11745,9 @@ components:
               description: |-
                 The ID of the floating IP address.
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             floating_network_id:
@@ -11755,7 +11771,9 @@ components:
               description: |-
                 The ID of a port associated with the floating IP.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the
                 floating IP address.
@@ -11919,7 +11937,9 @@ components:
               description: |-
                 The ID of the floating IP address.
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             floating_network_id:
@@ -11943,7 +11963,9 @@ components:
               description: |-
                 The ID of a port associated with the floating IP.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the
                 floating IP address.
@@ -12335,7 +12357,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12362,7 +12386,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12397,7 +12423,9 @@ components:
                 type: string
                 format: uuid
               ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
               description:
                 type: string
                 maxLength: 255
@@ -12443,7 +12471,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12476,7 +12506,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12670,7 +12702,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12702,7 +12736,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12742,7 +12778,9 @@ components:
                 type: string
                 format: uuid
               local_ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
               ip_mode:
                 type: string
                 enum:
@@ -12793,7 +12831,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12831,7 +12871,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12856,7 +12898,9 @@ components:
               description: |-
                 The requested ID of the port associated with the Local IP.
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The requested IP of the port associated with the Local IP.
             project_id:
@@ -12881,7 +12925,9 @@ components:
               description: |-
                 The ID of the port associated with the Local IP.
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The IP of the port associated with the Local IP.
             host:
@@ -12911,7 +12957,9 @@ components:
                 description: |-
                   The ID of the port associated with the Local IP.
               fixed_ip:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   The IP of the port associated with the Local IP.
               host:
@@ -12941,7 +12989,9 @@ components:
               type: string
               format: uuid
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
             host:
               type: string
     Local_IpsPort_AssociationShowResponse:
@@ -12960,7 +13010,9 @@ components:
               type: string
               format: uuid
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
             host:
               type: string
     LogLogsCreateRequest:
@@ -20801,7 +20853,9 @@ components:
                 description: |-
                   The CIDR of the subnet.
               gateway_ip:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   Gateway IP of this subnet. If the value is `null` that implies no
                   gateway is associated with the subnet.
@@ -20963,7 +21017,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet. If the gateway_ip is not
@@ -21120,7 +21176,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet.
@@ -21336,7 +21394,9 @@ components:
                 description: |-
                   Status of the underlying data plane of a port.
               extra_dhcp_opts:
-                type: array
+                type:
+                  - array
+                  - 'null'
                 items:
                   type: object
                   extraProperties: true
@@ -21638,7 +21698,9 @@ components:
                 A server connected to the port can send a packet with source address which
                 matches one of the specified allowed address pairs.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -21881,7 +21943,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -22608,7 +22672,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet.
@@ -22735,7 +22801,9 @@ components:
               description: |-
                 Human-readable name of the resource.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet. If the gateway_ip is not
@@ -22854,7 +22922,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet.
@@ -23068,7 +23138,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -23366,7 +23438,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -23592,7 +23666,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -26050,7 +26126,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26181,7 +26259,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26333,7 +26413,9 @@ components:
                   ID, or FQDN. Typically, this value matches the `peer_address`
                   value.
               peer_cidrs:
-                type: array
+                type:
+                  - array
+                  - 'null'
                 items:
                   type: string
                 description: |-
@@ -26471,7 +26553,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26587,7 +26671,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26737,7 +26823,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -27404,7 +27492,9 @@ components:
       name: floating_ip_address
       description: floating_ip_address query parameter for /v2.0/floatingips API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     floatingips_floating_network_id:
       in: query
       name: floating_network_id
@@ -27435,7 +27525,9 @@ components:
       name: fixed_ip_address
       description: fixed_ip_address query parameter for /v2.0/floatingips API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     floatingips_tenant_id:
       in: query
       name: tenant_id
@@ -27670,7 +27762,9 @@ components:
       name: local_ip_address
       description: local_ip_address query parameter for /v2.0/local-ips API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     local_ips_ip_mode:
       in: query
       name: ip_mode
@@ -27722,7 +27816,9 @@ components:
       description: fixed_ip query parameter for /v2.0/local_ips/{local_ip_id}/port_associations
         API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     port_associations_host:
       in: query
       name: host
@@ -29613,7 +29709,9 @@ components:
       name: gateway_ip
       description: gateway_ip query parameter for /v2.0/subnets API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     subnets_tenant_id:
       in: query
       name: tenant_id

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -11234,7 +11234,9 @@ components:
           type: object
           properties:
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             subnet_id:
@@ -11260,7 +11262,9 @@ components:
                 To associate the floating IP with a fixed IP at creation time,
                 you must specify the identifier of the internal port.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the floating IP.
                 If an internal port has multiple associated IP addresses,
@@ -11315,7 +11319,9 @@ components:
               description: |-
                 The ID of the floating IP address.
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             floating_network_id:
@@ -11339,7 +11345,9 @@ components:
               description: |-
                 The ID of a port associated with the floating IP.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the
                 floating IP address.
@@ -11505,7 +11513,9 @@ components:
                 description: |-
                   The ID of the floating IP address.
               floating_ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   The floating IP address.
               floating_network_id:
@@ -11529,7 +11539,9 @@ components:
                 description: |-
                   The ID of a port associated with the floating IP.
               fixed_ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   The fixed IP address that is associated with the
                   floating IP address.
@@ -11696,7 +11708,9 @@ components:
                 you must specify the ID of the internal port.
                 To disassociate the floating IP, `null` should be specified.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the floating IP.
                 If an internal port has multiple associated IP addresses,
@@ -11731,7 +11745,9 @@ components:
               description: |-
                 The ID of the floating IP address.
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             floating_network_id:
@@ -11755,7 +11771,9 @@ components:
               description: |-
                 The ID of a port associated with the floating IP.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the
                 floating IP address.
@@ -11919,7 +11937,9 @@ components:
               description: |-
                 The ID of the floating IP address.
             floating_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The floating IP address.
             floating_network_id:
@@ -11943,7 +11963,9 @@ components:
               description: |-
                 The ID of a port associated with the floating IP.
             fixed_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The fixed IP address that is associated with the
                 floating IP address.
@@ -12335,7 +12357,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12362,7 +12386,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12397,7 +12423,9 @@ components:
                 type: string
                 format: uuid
               ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
               description:
                 type: string
                 maxLength: 255
@@ -12443,7 +12471,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12476,7 +12506,9 @@ components:
               type: string
               format: uuid
             ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             description:
               type: string
               maxLength: 255
@@ -12670,7 +12702,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12702,7 +12736,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12742,7 +12778,9 @@ components:
                 type: string
                 format: uuid
               local_ip_address:
-                type: string
+                type:
+                  - string
+                  - 'null'
               ip_mode:
                 type: string
                 enum:
@@ -12793,7 +12831,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12831,7 +12871,9 @@ components:
               type: string
               format: uuid
             local_ip_address:
-              type: string
+              type:
+                - string
+                - 'null'
             ip_mode:
               type: string
               enum:
@@ -12856,7 +12898,9 @@ components:
               description: |-
                 The requested ID of the port associated with the Local IP.
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The requested IP of the port associated with the Local IP.
             project_id:
@@ -12881,7 +12925,9 @@ components:
               description: |-
                 The ID of the port associated with the Local IP.
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 The IP of the port associated with the Local IP.
             host:
@@ -12911,7 +12957,9 @@ components:
                 description: |-
                   The ID of the port associated with the Local IP.
               fixed_ip:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   The IP of the port associated with the Local IP.
               host:
@@ -12941,7 +12989,9 @@ components:
               type: string
               format: uuid
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
             host:
               type: string
     Local_IpsPort_AssociationShowResponse:
@@ -12960,7 +13010,9 @@ components:
               type: string
               format: uuid
             fixed_ip:
-              type: string
+              type:
+                - string
+                - 'null'
             host:
               type: string
     LogLogsCreateRequest:
@@ -20801,7 +20853,9 @@ components:
                 description: |-
                   The CIDR of the subnet.
               gateway_ip:
-                type: string
+                type:
+                  - string
+                  - 'null'
                 description: |-
                   Gateway IP of this subnet. If the value is `null` that implies no
                   gateway is associated with the subnet.
@@ -20963,7 +21017,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet. If the gateway_ip is not
@@ -21120,7 +21176,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet.
@@ -21336,7 +21394,9 @@ components:
                 description: |-
                   Status of the underlying data plane of a port.
               extra_dhcp_opts:
-                type: array
+                type:
+                  - array
+                  - 'null'
                 items:
                   type: object
                   extraProperties: true
@@ -21638,7 +21698,9 @@ components:
                 A server connected to the port can send a packet with source address which
                 matches one of the specified allowed address pairs.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -21881,7 +21943,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -22608,7 +22672,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet.
@@ -22735,7 +22801,9 @@ components:
               description: |-
                 Human-readable name of the resource.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet. If the gateway_ip is not
@@ -22854,7 +22922,9 @@ components:
               description: |-
                 The CIDR of the subnet.
             gateway_ip:
-              type: string
+              type:
+                - string
+                - 'null'
               description: |-
                 Gateway IP of this subnet. If the value is `null` that implies no
                 gateway is associated with the subnet.
@@ -23068,7 +23138,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -23366,7 +23438,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -23592,7 +23666,9 @@ components:
               description: |-
                 Status of the underlying data plane of a port.
             extra_dhcp_opts:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: object
                 extraProperties: true
@@ -26050,7 +26126,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26181,7 +26259,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26333,7 +26413,9 @@ components:
                   ID, or FQDN. Typically, this value matches the `peer_address`
                   value.
               peer_cidrs:
-                type: array
+                type:
+                  - array
+                  - 'null'
                 items:
                   type: string
                 description: |-
@@ -26471,7 +26553,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26587,7 +26671,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -26737,7 +26823,9 @@ components:
                 ID, or FQDN. Typically, this value matches the `peer_address`
                 value.
             peer_cidrs:
-              type: array
+              type:
+                - array
+                - 'null'
               items:
                 type: string
               description: |-
@@ -27404,7 +27492,9 @@ components:
       name: floating_ip_address
       description: floating_ip_address query parameter for /v2.0/floatingips API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     floatingips_floating_network_id:
       in: query
       name: floating_network_id
@@ -27435,7 +27525,9 @@ components:
       name: fixed_ip_address
       description: fixed_ip_address query parameter for /v2.0/floatingips API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     floatingips_tenant_id:
       in: query
       name: tenant_id
@@ -27670,7 +27762,9 @@ components:
       name: local_ip_address
       description: local_ip_address query parameter for /v2.0/local-ips API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     local_ips_ip_mode:
       in: query
       name: ip_mode
@@ -27722,7 +27816,9 @@ components:
       description: fixed_ip query parameter for /v2.0/local_ips/{local_ip_id}/port_associations
         API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     port_associations_host:
       in: query
       name: host
@@ -29613,7 +29709,9 @@ components:
       name: gateway_ip
       description: gateway_ip query parameter for /v2.0/subnets API
       schema:
-        type: string
+        type:
+          - string
+          - 'null'
     subnets_tenant_id:
       in: query
       name: tenant_id


### PR DESCRIPTION
Some conversion schemes missed explicit null support.

Change-Id: I01ed16f2690c78492a0d8673ad86f67de92c80ae

Changes are triggered by https://review.opendev.org/949561
