### PR TITLE
feat: Add support setting Null for nullable args

### DIFF
--- a/openstack_cli/src/block_storage/v3/backup/create_30.rs
+++ b/openstack_cli/src/block_storage/v3/backup/create_30.rs
@@ -62,9 +62,17 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     container: Option<String>,
 
+    /// Set explicit NULL for the container
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "container")]
+    no_container: bool,
+
     /// The backup description or null.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 
     /// Indicates whether to backup, even if the volume is attached. Default is
     /// `false`. See [valid boolean values](#valid-boolean-values)
@@ -80,9 +88,17 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The UUID of the source snapshot that you want to back up.
     #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
+
+    /// Set explicit NULL for the snapshot_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "snapshot_id")]
+    no_snapshot_id: bool,
 
     /// The UUID of the volume that you want to back up.
     #[arg(help_heading = "Body parameters", long)]
@@ -115,10 +131,14 @@ impl BackupCommand {
 
         if let Some(val) = &args.container {
             backup_builder.container(Some(val.into()));
+        } else if args.no_container {
+            backup_builder.container(None);
         }
 
         if let Some(val) = &args.description {
             backup_builder.description(Some(val.into()));
+        } else if args.no_description {
+            backup_builder.description(None);
         }
 
         if let Some(val) = &args.incremental {
@@ -131,10 +151,14 @@ impl BackupCommand {
 
         if let Some(val) = &args.name {
             backup_builder.name(Some(val.into()));
+        } else if args.no_name {
+            backup_builder.name(None);
         }
 
         if let Some(val) = &args.snapshot_id {
             backup_builder.snapshot_id(Some(val.into()));
+        } else if args.no_snapshot_id {
+            backup_builder.snapshot_id(None);
         }
 
         ep_builder.backup(backup_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/backup/create_343.rs
+++ b/openstack_cli/src/block_storage/v3/backup/create_343.rs
@@ -63,9 +63,17 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     container: Option<String>,
 
+    /// Set explicit NULL for the container
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "container")]
+    no_container: bool,
+
     /// The backup description or null.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 
     /// Indicates whether to backup, even if the volume is attached. Default is
     /// `false`. See [valid boolean values](#valid-boolean-values)
@@ -87,9 +95,17 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The UUID of the source snapshot that you want to back up.
     #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
+
+    /// Set explicit NULL for the snapshot_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "snapshot_id")]
+    no_snapshot_id: bool,
 
     /// The UUID of the volume that you want to back up.
     #[arg(help_heading = "Body parameters", long)]
@@ -122,10 +138,14 @@ impl BackupCommand {
 
         if let Some(val) = &args.container {
             backup_builder.container(Some(val.into()));
+        } else if args.no_container {
+            backup_builder.container(None);
         }
 
         if let Some(val) = &args.description {
             backup_builder.description(Some(val.into()));
+        } else if args.no_description {
+            backup_builder.description(None);
         }
 
         if let Some(val) = &args.incremental {
@@ -138,10 +158,14 @@ impl BackupCommand {
 
         if let Some(val) = &args.name {
             backup_builder.name(Some(val.into()));
+        } else if args.no_name {
+            backup_builder.name(None);
         }
 
         if let Some(val) = &args.snapshot_id {
             backup_builder.snapshot_id(Some(val.into()));
+        } else if args.no_snapshot_id {
+            backup_builder.snapshot_id(None);
         }
 
         if let Some(val) = &args.metadata {

--- a/openstack_cli/src/block_storage/v3/backup/create_351.rs
+++ b/openstack_cli/src/block_storage/v3/backup/create_351.rs
@@ -65,13 +65,25 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The container name or null.
     #[arg(help_heading = "Body parameters", long)]
     container: Option<String>,
 
+    /// Set explicit NULL for the container
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "container")]
+    no_container: bool,
+
     /// The backup description or null.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 
     /// Indicates whether to backup, even if the volume is attached. Default is
     /// `false`. See [valid boolean values](#valid-boolean-values)
@@ -93,9 +105,17 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The UUID of the source snapshot that you want to back up.
     #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
+
+    /// Set explicit NULL for the snapshot_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "snapshot_id")]
+    no_snapshot_id: bool,
 
     /// The UUID of the volume that you want to back up.
     #[arg(help_heading = "Body parameters", long)]
@@ -128,10 +148,14 @@ impl BackupCommand {
 
         if let Some(val) = &args.container {
             backup_builder.container(Some(val.into()));
+        } else if args.no_container {
+            backup_builder.container(None);
         }
 
         if let Some(val) = &args.description {
             backup_builder.description(Some(val.into()));
+        } else if args.no_description {
+            backup_builder.description(None);
         }
 
         if let Some(val) = &args.incremental {
@@ -144,10 +168,14 @@ impl BackupCommand {
 
         if let Some(val) = &args.name {
             backup_builder.name(Some(val.into()));
+        } else if args.no_name {
+            backup_builder.name(None);
         }
 
         if let Some(val) = &args.snapshot_id {
             backup_builder.snapshot_id(Some(val.into()));
+        } else if args.no_snapshot_id {
+            backup_builder.snapshot_id(None);
         }
 
         if let Some(val) = &args.metadata {
@@ -156,6 +184,8 @@ impl BackupCommand {
 
         if let Some(val) = &args.availability_zone {
             backup_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            backup_builder.availability_zone(None);
         }
 
         ep_builder.backup(backup_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/backup/restore/create.rs
+++ b/openstack_cli/src/block_storage/v3/backup/restore/create.rs
@@ -68,8 +68,16 @@ struct Restore {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     volume_id: Option<String>,
+
+    /// Set explicit NULL for the volume_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_id")]
+    no_volume_id: bool,
 }
 
 impl RestoreCommand {

--- a/openstack_cli/src/block_storage/v3/backup/set_343.rs
+++ b/openstack_cli/src/block_storage/v3/backup/set_343.rs
@@ -71,11 +71,19 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl BackupCommand {

--- a/openstack_cli/src/block_storage/v3/backup/set_39.rs
+++ b/openstack_cli/src/block_storage/v3/backup/set_39.rs
@@ -70,8 +70,16 @@ struct Backup {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl BackupCommand {

--- a/openstack_cli/src/block_storage/v3/group/create_313.rs
+++ b/openstack_cli/src/block_storage/v3/group/create_313.rs
@@ -62,9 +62,17 @@ struct Group {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The group description.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 
     /// The group type ID.
     #[arg(help_heading = "Body parameters", long)]
@@ -73,6 +81,10 @@ struct Group {
     /// The group name.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 
     /// The list of volume types. In an environment with multiple-storage back
     /// ends, the scheduler determines where to send the volume based on the
@@ -108,18 +120,24 @@ impl GroupCommand {
         let mut group_builder = create_313::GroupBuilder::default();
         if let Some(val) = &args.description {
             group_builder.description(Some(val.into()));
+        } else if args.no_description {
+            group_builder.description(None);
         }
 
         group_builder.group_type(&args.group_type);
 
         if let Some(val) = &args.name {
             group_builder.name(Some(val.into()));
+        } else if args.no_name {
+            group_builder.name(None);
         }
 
         group_builder.volume_types(args.volume_types.iter().map(Into::into).collect::<Vec<_>>());
 
         if let Some(val) = &args.availability_zone {
             group_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            group_builder.availability_zone(None);
         }
 
         ep_builder.group(group_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/group/create_from_src_314.rs
+++ b/openstack_cli/src/block_storage/v3/group/create_from_src_314.rs
@@ -59,11 +59,19 @@ struct CreateFromSrc {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     group_snapshot_id: Option<String>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 
     #[arg(help_heading = "Body parameters", long)]
     source_group_id: Option<String>,
@@ -92,10 +100,14 @@ impl GroupCommand {
         let mut create_from_src_builder = create_from_src_314::CreateFromSrcBuilder::default();
         if let Some(val) = &args.description {
             create_from_src_builder.description(Some(val.into()));
+        } else if args.no_description {
+            create_from_src_builder.description(None);
         }
 
         if let Some(val) = &args.name {
             create_from_src_builder.name(Some(val.into()));
+        } else if args.no_name {
+            create_from_src_builder.name(None);
         }
 
         if let Some(val) = &args.source_group_id {

--- a/openstack_cli/src/block_storage/v3/group/failover_replication_338.rs
+++ b/openstack_cli/src/block_storage/v3/group/failover_replication_338.rs
@@ -61,6 +61,10 @@ struct FailoverReplication {
 
     #[arg(help_heading = "Body parameters", long)]
     secondary_backend_id: Option<String>,
+
+    /// Set explicit NULL for the secondary_backend_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "secondary_backend_id")]
+    no_secondary_backend_id: bool,
 }
 
 impl GroupCommand {
@@ -91,6 +95,8 @@ impl GroupCommand {
 
         if let Some(val) = &args.secondary_backend_id {
             failover_replication_builder.secondary_backend_id(Some(val.into()));
+        } else if args.no_secondary_backend_id {
+            failover_replication_builder.secondary_backend_id(None);
         }
 
         ep_builder.failover_replication(failover_replication_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/group/set_313.rs
+++ b/openstack_cli/src/block_storage/v3/group/set_313.rs
@@ -86,14 +86,30 @@ struct Group {
     #[arg(help_heading = "Body parameters", long)]
     add_volumes: Option<String>,
 
+    /// Set explicit NULL for the add_volumes
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "add_volumes")]
+    no_add_volumes: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     remove_volumes: Option<String>,
+
+    /// Set explicit NULL for the remove_volumes
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "remove_volumes")]
+    no_remove_volumes: bool,
 }
 
 impl GroupCommand {
@@ -133,18 +149,26 @@ impl GroupCommand {
         let mut group_builder = set_313::GroupBuilder::default();
         if let Some(val) = &args.description {
             group_builder.description(Some(val.into()));
+        } else if args.no_description {
+            group_builder.description(None);
         }
 
         if let Some(val) = &args.name {
             group_builder.name(Some(val.into()));
+        } else if args.no_name {
+            group_builder.name(None);
         }
 
         if let Some(val) = &args.add_volumes {
             group_builder.add_volumes(Some(val.into()));
+        } else if args.no_add_volumes {
+            group_builder.add_volumes(None);
         }
 
         if let Some(val) = &args.remove_volumes {
             group_builder.remove_volumes(Some(val.into()));
+        } else if args.no_remove_volumes {
+            group_builder.remove_volumes(None);
         }
 
         ep_builder.group(group_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/group_snapshot/create_314.rs
+++ b/openstack_cli/src/block_storage/v3/group_snapshot/create_314.rs
@@ -62,6 +62,10 @@ struct GroupSnapshot {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The ID of the group.
     #[arg(help_heading = "Body parameters", long)]
     group_id: String,
@@ -69,6 +73,10 @@ struct GroupSnapshot {
     /// The group snapshot name.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl GroupSnapshotCommand {
@@ -100,10 +108,14 @@ impl GroupSnapshotCommand {
 
         if let Some(val) = &args.name {
             group_snapshot_builder.name(Some(val.into()));
+        } else if args.no_name {
+            group_snapshot_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             group_snapshot_builder.description(Some(val.into()));
+        } else if args.no_description {
+            group_snapshot_builder.description(None);
         }
 
         ep_builder.group_snapshot(group_snapshot_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/group_type/create_311.rs
+++ b/openstack_cli/src/block_storage/v3/group_type/create_311.rs
@@ -63,6 +63,10 @@ struct GroupType {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// A set of key and value pairs that contains the specifications for a
     /// group type.
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
@@ -105,6 +109,8 @@ impl GroupTypeCommand {
 
         if let Some(val) = &args.description {
             group_type_builder.description(Some(val.into()));
+        } else if args.no_description {
+            group_type_builder.description(None);
         }
 
         if let Some(val) = &args.is_public {

--- a/openstack_cli/src/block_storage/v3/group_type/set_311.rs
+++ b/openstack_cli/src/block_storage/v3/group_type/set_311.rs
@@ -70,11 +70,19 @@ struct GroupType {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     is_public: Option<bool>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl GroupTypeCommand {
@@ -115,10 +123,14 @@ impl GroupTypeCommand {
         let mut group_type_builder = set_311::GroupTypeBuilder::default();
         if let Some(val) = &args.name {
             group_type_builder.name(Some(val.into()));
+        } else if args.no_name {
+            group_type_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             group_type_builder.description(Some(val.into()));
+        } else if args.no_description {
+            group_type_builder.description(None);
         }
 
         if let Some(val) = &args.is_public {

--- a/openstack_cli/src/block_storage/v3/manageable_snapshot/create.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_snapshot/create.rs
@@ -108,6 +108,10 @@ struct Snapshot {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// One or more metadata key and value pairs for the snapshot.
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
@@ -115,6 +119,10 @@ struct Snapshot {
     /// The name of the snapshot. Default is `None`.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 
     /// A reference to the existing volume. The internal structure of this
     /// reference depends on the volume driver implementation. For details
@@ -153,6 +161,8 @@ impl ManageableSnapshotCommand {
         let mut snapshot_builder = create::SnapshotBuilder::default();
         if let Some(val) = &args.description {
             snapshot_builder.description(Some(val.into()));
+        } else if args.no_description {
+            snapshot_builder.description(None);
         }
 
         if let Some(val) = &args.metadata {
@@ -161,6 +171,8 @@ impl ManageableSnapshotCommand {
 
         if let Some(val) = &args.name {
             snapshot_builder.name(Some(val.into()));
+        } else if args.no_name {
+            snapshot_builder.name(None);
         }
 
         snapshot_builder.volume_id(&args.volume_id);

--- a/openstack_cli/src/block_storage/v3/manageable_volume/create.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_volume/create.rs
@@ -118,6 +118,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// Enables or disables the bootable attribute. You can boot an instance
     /// from a bootable volume. See
     /// [valid boolean values](#valid-boolean-values)
@@ -128,10 +132,18 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The OpenStack Block Storage host where the existing resource resides.
     /// Optional only if cluster field is provided.
     #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
+
+    /// Set explicit NULL for the host
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "host")]
+    no_host: bool,
 
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
@@ -141,6 +153,10 @@ struct Volume {
     /// The volume name.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 
     /// A reference to the existing volume. The internal structure of this
     /// reference depends on the volume driver implementation. For details
@@ -152,6 +168,10 @@ struct Volume {
     /// The volume name.
     #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
+
+    /// Set explicit NULL for the volume_type
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_type")]
+    no_volume_type: bool,
 }
 
 impl ManageableVolumeCommand {
@@ -179,10 +199,14 @@ impl ManageableVolumeCommand {
         let mut volume_builder = create::VolumeBuilder::default();
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.availability_zone {
             volume_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            volume_builder.availability_zone(None);
         }
 
         if let Some(val) = &args.bootable {
@@ -191,14 +215,20 @@ impl ManageableVolumeCommand {
 
         if let Some(val) = &args.volume_type {
             volume_builder.volume_type(Some(val.into()));
+        } else if args.no_volume_type {
+            volume_builder.volume_type(None);
         }
 
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.host {
             volume_builder.host(Some(val.into()));
+        } else if args.no_host {
+            volume_builder.host(None);
         }
 
         volume_builder._ref(args._ref.clone());

--- a/openstack_cli/src/block_storage/v3/os_volume_transfer/create.rs
+++ b/openstack_cli/src/block_storage/v3/os_volume_transfer/create.rs
@@ -62,6 +62,10 @@ struct Transfer {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The UUID of the volume.
     #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
@@ -95,6 +99,8 @@ impl OsVolumeTransferCommand {
 
         if let Some(val) = &args.name {
             transfer_builder.name(Some(val.into()));
+        } else if args.no_name {
+            transfer_builder.name(None);
         }
 
         ep_builder.transfer(transfer_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/snapshot/create.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/create.rs
@@ -63,9 +63,17 @@ struct Snapshot {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The name of the snapshot.
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
+
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
 
     /// Indicates whether to snapshot, even if the volume is attached. Default
     /// is `false`. See [valid boolean values](#valid-boolean-values)
@@ -79,6 +87,10 @@ struct Snapshot {
     /// The name of the snapshot.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 
     /// The UUID of the volume.
     #[arg(help_heading = "Body parameters", long)]
@@ -108,14 +120,20 @@ impl SnapshotCommand {
         let mut snapshot_builder = create::SnapshotBuilder::default();
         if let Some(val) = &args.name {
             snapshot_builder.name(Some(val.into()));
+        } else if args.no_name {
+            snapshot_builder.name(None);
         }
 
         if let Some(val) = &args.display_name {
             snapshot_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            snapshot_builder.display_name(None);
         }
 
         if let Some(val) = &args.description {
             snapshot_builder.description(Some(val.into()));
+        } else if args.no_description {
+            snapshot_builder.description(None);
         }
 
         snapshot_builder.volume_id(args.volume_id.clone());

--- a/openstack_cli/src/block_storage/v3/snapshot/set.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/set.rs
@@ -70,14 +70,30 @@ struct Snapshot {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
+
+    /// Set explicit NULL for the display_description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_description")]
+    no_display_description: bool,
 
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl SnapshotCommand {
@@ -116,18 +132,26 @@ impl SnapshotCommand {
         let mut snapshot_builder = set::SnapshotBuilder::default();
         if let Some(val) = &args.name {
             snapshot_builder.name(Some(val.into()));
+        } else if args.no_name {
+            snapshot_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             snapshot_builder.description(Some(val.into()));
+        } else if args.no_description {
+            snapshot_builder.description(None);
         }
 
         if let Some(val) = &args.display_name {
             snapshot_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            snapshot_builder.display_name(None);
         }
 
         if let Some(val) = &args.display_description {
             snapshot_builder.display_description(Some(val.into()));
+        } else if args.no_display_description {
+            snapshot_builder.display_description(None);
         }
 
         ep_builder.snapshot(snapshot_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/snapshot_manage/create.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot_manage/create.rs
@@ -106,11 +106,19 @@ struct Snapshot {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     _ref: Option<Value>,
@@ -144,6 +152,8 @@ impl SnapshotManageCommand {
         let mut snapshot_builder = create::SnapshotBuilder::default();
         if let Some(val) = &args.description {
             snapshot_builder.description(Some(val.into()));
+        } else if args.no_description {
+            snapshot_builder.description(None);
         }
 
         if let Some(val) = &args.metadata {
@@ -152,6 +162,8 @@ impl SnapshotManageCommand {
 
         if let Some(val) = &args.name {
             snapshot_builder.name(Some(val.into()));
+        } else if args.no_name {
+            snapshot_builder.name(None);
         }
 
         snapshot_builder.volume_id(&args.volume_id);

--- a/openstack_cli/src/block_storage/v3/type/create.rs
+++ b/openstack_cli/src/block_storage/v3/type/create.rs
@@ -69,6 +69,10 @@ struct VolumeType {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val_opt::<String, String>)]
     extra_specs: Option<Vec<(String, Option<String>)>>,
 
@@ -105,6 +109,8 @@ impl TypeCommand {
 
         if let Some(val) = &args.description {
             volume_type_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_type_builder.description(None);
         }
 
         if let Some(val) = &args.extra_specs {

--- a/openstack_cli/src/block_storage/v3/type/encryption/create.rs
+++ b/openstack_cli/src/block_storage/v3/type/encryption/create.rs
@@ -76,6 +76,10 @@ struct Encryption {
     #[arg(help_heading = "Body parameters", long)]
     cipher: Option<String>,
 
+    /// Set explicit NULL for the cipher
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "cipher")]
+    no_cipher: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     control_location: ControlLocation,
 
@@ -124,6 +128,8 @@ impl EncryptionCommand {
 
         if let Some(val) = &args.cipher {
             encryption_builder.cipher(Some(val.into()));
+        } else if args.no_cipher {
+            encryption_builder.cipher(None);
         }
 
         ep_builder.encryption(encryption_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/type/encryption/set.rs
+++ b/openstack_cli/src/block_storage/v3/type/encryption/set.rs
@@ -84,6 +84,10 @@ struct Encryption {
     #[arg(help_heading = "Body parameters", long)]
     cipher: Option<String>,
 
+    /// Set explicit NULL for the cipher
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "cipher")]
+    no_cipher: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     control_location: Option<ControlLocation>,
 
@@ -137,6 +141,8 @@ impl EncryptionCommand {
 
         if let Some(val) = &args.cipher {
             encryption_builder.cipher(Some(val.into()));
+        } else if args.no_cipher {
+            encryption_builder.cipher(None);
         }
 
         ep_builder.encryption(encryption_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/type/set.rs
+++ b/openstack_cli/src/block_storage/v3/type/set.rs
@@ -70,11 +70,19 @@ struct VolumeType {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     is_public: Option<bool>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl TypeCommand {
@@ -112,10 +120,14 @@ impl TypeCommand {
         let mut volume_type_builder = set::VolumeTypeBuilder::default();
         if let Some(val) = &args.name {
             volume_type_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_type_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             volume_type_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_type_builder.description(None);
         }
 
         if let Some(val) = &args.is_public {

--- a/openstack_cli/src/block_storage/v3/volume/create_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_30.rs
@@ -72,22 +72,46 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
+
+    /// Set explicit NULL for the consistencygroup_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "consistencygroup_id")]
+    no_consistencygroup_id: bool,
 
     /// The volume description.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
+
+    /// Set explicit NULL for the display_description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_description")]
+    no_display_description: bool,
 
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
+
+    /// Set explicit NULL for the image_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_id")]
+    no_image_id: bool,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
@@ -101,6 +125,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
+    /// Set explicit NULL for the image_ref
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_ref")]
+    no_image_ref: bool,
+
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
@@ -113,6 +141,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The size of the volume, in gibibytes (GiB).
     #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
@@ -121,9 +153,17 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
+    /// Set explicit NULL for the snapshot_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "snapshot_id")]
+    no_snapshot_id: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
+
+    /// Set explicit NULL for the source_volid
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "source_volid")]
+    no_source_volid: bool,
 
     /// The volume type (either name or ID). To create an environment with
     /// multiple-storage back ends, you must specify a volume type. Block
@@ -137,6 +177,10 @@ struct Volume {
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
+
+    /// Set explicit NULL for the volume_type
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_type")]
+    no_volume_type: bool,
 }
 
 impl VolumeCommand {
@@ -167,22 +211,32 @@ impl VolumeCommand {
         let mut volume_builder = create_30::VolumeBuilder::default();
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.display_name {
             volume_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            volume_builder.display_name(None);
         }
 
         if let Some(val) = &args.display_description {
             volume_builder.display_description(Some(val.into()));
+        } else if args.no_display_description {
+            volume_builder.display_description(None);
         }
 
         if let Some(val) = &args.volume_type {
             volume_builder.volume_type(Some(val.into()));
+        } else if args.no_volume_type {
+            volume_builder.volume_type(None);
         }
 
         if let Some(val) = &args.metadata {
@@ -191,14 +245,20 @@ impl VolumeCommand {
 
         if let Some(val) = &args.snapshot_id {
             volume_builder.snapshot_id(Some(val.into()));
+        } else if args.no_snapshot_id {
+            volume_builder.snapshot_id(None);
         }
 
         if let Some(val) = &args.source_volid {
             volume_builder.source_volid(Some(val.into()));
+        } else if args.no_source_volid {
+            volume_builder.source_volid(None);
         }
 
         if let Some(val) = &args.consistencygroup_id {
             volume_builder.consistencygroup_id(Some(val.into()));
+        } else if args.no_consistencygroup_id {
+            volume_builder.consistencygroup_id(None);
         }
 
         if let Some(val) = &args.size {
@@ -207,6 +267,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.availability_zone {
             volume_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            volume_builder.availability_zone(None);
         }
 
         if let Some(val) = &args.multiattach {
@@ -215,10 +277,14 @@ impl VolumeCommand {
 
         if let Some(val) = &args.image_id {
             volume_builder.image_id(Some(val.into()));
+        } else if args.no_image_id {
+            volume_builder.image_id(None);
         }
 
         if let Some(val) = &args.image_ref {
             volume_builder.image_ref(Some(val.into()));
+        } else if args.no_image_ref {
+            volume_builder.image_ref(None);
         }
 
         ep_builder.volume(volume_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume/create_313.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_313.rs
@@ -72,25 +72,53 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
+
+    /// Set explicit NULL for the consistencygroup_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "consistencygroup_id")]
+    no_consistencygroup_id: bool,
 
     /// The volume description.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
+
+    /// Set explicit NULL for the display_description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_description")]
+    no_display_description: bool,
 
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     group_id: Option<String>,
 
+    /// Set explicit NULL for the group_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "group_id")]
+    no_group_id: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
+
+    /// Set explicit NULL for the image_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_id")]
+    no_image_id: bool,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
@@ -104,6 +132,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
+    /// Set explicit NULL for the image_ref
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_ref")]
+    no_image_ref: bool,
+
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
@@ -116,6 +148,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The size of the volume, in gibibytes (GiB).
     #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
@@ -124,9 +160,17 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
+    /// Set explicit NULL for the snapshot_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "snapshot_id")]
+    no_snapshot_id: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
+
+    /// Set explicit NULL for the source_volid
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "source_volid")]
+    no_source_volid: bool,
 
     /// The volume type (either name or ID). To create an environment with
     /// multiple-storage back ends, you must specify a volume type. Block
@@ -140,6 +184,10 @@ struct Volume {
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
+
+    /// Set explicit NULL for the volume_type
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_type")]
+    no_volume_type: bool,
 }
 
 impl VolumeCommand {
@@ -170,22 +218,32 @@ impl VolumeCommand {
         let mut volume_builder = create_313::VolumeBuilder::default();
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.display_name {
             volume_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            volume_builder.display_name(None);
         }
 
         if let Some(val) = &args.display_description {
             volume_builder.display_description(Some(val.into()));
+        } else if args.no_display_description {
+            volume_builder.display_description(None);
         }
 
         if let Some(val) = &args.volume_type {
             volume_builder.volume_type(Some(val.into()));
+        } else if args.no_volume_type {
+            volume_builder.volume_type(None);
         }
 
         if let Some(val) = &args.metadata {
@@ -194,14 +252,20 @@ impl VolumeCommand {
 
         if let Some(val) = &args.snapshot_id {
             volume_builder.snapshot_id(Some(val.into()));
+        } else if args.no_snapshot_id {
+            volume_builder.snapshot_id(None);
         }
 
         if let Some(val) = &args.source_volid {
             volume_builder.source_volid(Some(val.into()));
+        } else if args.no_source_volid {
+            volume_builder.source_volid(None);
         }
 
         if let Some(val) = &args.consistencygroup_id {
             volume_builder.consistencygroup_id(Some(val.into()));
+        } else if args.no_consistencygroup_id {
+            volume_builder.consistencygroup_id(None);
         }
 
         if let Some(val) = &args.size {
@@ -210,6 +274,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.availability_zone {
             volume_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            volume_builder.availability_zone(None);
         }
 
         if let Some(val) = &args.multiattach {
@@ -218,14 +284,20 @@ impl VolumeCommand {
 
         if let Some(val) = &args.image_id {
             volume_builder.image_id(Some(val.into()));
+        } else if args.no_image_id {
+            volume_builder.image_id(None);
         }
 
         if let Some(val) = &args.image_ref {
             volume_builder.image_ref(Some(val.into()));
+        } else if args.no_image_ref {
+            volume_builder.image_ref(None);
         }
 
         if let Some(val) = &args.group_id {
             volume_builder.group_id(Some(val.into()));
+        } else if args.no_group_id {
+            volume_builder.group_id(None);
         }
 
         ep_builder.volume(volume_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume/create_347.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_347.rs
@@ -72,31 +72,63 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The UUID of the backup.
     ///
     /// **New in version 3.47**
     #[arg(help_heading = "Body parameters", long)]
     backup_id: Option<String>,
 
+    /// Set explicit NULL for the backup_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "backup_id")]
+    no_backup_id: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
+
+    /// Set explicit NULL for the consistencygroup_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "consistencygroup_id")]
+    no_consistencygroup_id: bool,
 
     /// The volume description.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
+
+    /// Set explicit NULL for the display_description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_description")]
+    no_display_description: bool,
 
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     group_id: Option<String>,
 
+    /// Set explicit NULL for the group_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "group_id")]
+    no_group_id: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
+
+    /// Set explicit NULL for the image_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_id")]
+    no_image_id: bool,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
@@ -110,6 +142,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
+    /// Set explicit NULL for the image_ref
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_ref")]
+    no_image_ref: bool,
+
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
@@ -122,6 +158,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The size of the volume, in gibibytes (GiB).
     #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
@@ -130,9 +170,17 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
+    /// Set explicit NULL for the snapshot_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "snapshot_id")]
+    no_snapshot_id: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
+
+    /// Set explicit NULL for the source_volid
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "source_volid")]
+    no_source_volid: bool,
 
     /// The volume type (either name or ID). To create an environment with
     /// multiple-storage back ends, you must specify a volume type. Block
@@ -146,6 +194,10 @@ struct Volume {
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
+
+    /// Set explicit NULL for the volume_type
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_type")]
+    no_volume_type: bool,
 }
 
 impl VolumeCommand {
@@ -176,22 +228,32 @@ impl VolumeCommand {
         let mut volume_builder = create_347::VolumeBuilder::default();
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.display_name {
             volume_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            volume_builder.display_name(None);
         }
 
         if let Some(val) = &args.display_description {
             volume_builder.display_description(Some(val.into()));
+        } else if args.no_display_description {
+            volume_builder.display_description(None);
         }
 
         if let Some(val) = &args.volume_type {
             volume_builder.volume_type(Some(val.into()));
+        } else if args.no_volume_type {
+            volume_builder.volume_type(None);
         }
 
         if let Some(val) = &args.metadata {
@@ -200,14 +262,20 @@ impl VolumeCommand {
 
         if let Some(val) = &args.snapshot_id {
             volume_builder.snapshot_id(Some(val.into()));
+        } else if args.no_snapshot_id {
+            volume_builder.snapshot_id(None);
         }
 
         if let Some(val) = &args.source_volid {
             volume_builder.source_volid(Some(val.into()));
+        } else if args.no_source_volid {
+            volume_builder.source_volid(None);
         }
 
         if let Some(val) = &args.consistencygroup_id {
             volume_builder.consistencygroup_id(Some(val.into()));
+        } else if args.no_consistencygroup_id {
+            volume_builder.consistencygroup_id(None);
         }
 
         if let Some(val) = &args.size {
@@ -216,6 +284,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.availability_zone {
             volume_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            volume_builder.availability_zone(None);
         }
 
         if let Some(val) = &args.multiattach {
@@ -224,18 +294,26 @@ impl VolumeCommand {
 
         if let Some(val) = &args.image_id {
             volume_builder.image_id(Some(val.into()));
+        } else if args.no_image_id {
+            volume_builder.image_id(None);
         }
 
         if let Some(val) = &args.image_ref {
             volume_builder.image_ref(Some(val.into()));
+        } else if args.no_image_ref {
+            volume_builder.image_ref(None);
         }
 
         if let Some(val) = &args.group_id {
             volume_builder.group_id(Some(val.into()));
+        } else if args.no_group_id {
+            volume_builder.group_id(None);
         }
 
         if let Some(val) = &args.backup_id {
             volume_builder.backup_id(Some(val.into()));
+        } else if args.no_backup_id {
+            volume_builder.backup_id(None);
         }
 
         ep_builder.volume(volume_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume/create_353.rs
+++ b/openstack_cli/src/block_storage/v3/volume/create_353.rs
@@ -72,31 +72,63 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The UUID of the backup.
     ///
     /// **New in version 3.47**
     #[arg(help_heading = "Body parameters", long)]
     backup_id: Option<String>,
 
+    /// Set explicit NULL for the backup_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "backup_id")]
+    no_backup_id: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     consistencygroup_id: Option<String>,
+
+    /// Set explicit NULL for the consistencygroup_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "consistencygroup_id")]
+    no_consistencygroup_id: bool,
 
     /// The volume description.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
+
+    /// Set explicit NULL for the display_description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_description")]
+    no_display_description: bool,
 
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
 
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     group_id: Option<String>,
 
+    /// Set explicit NULL for the group_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "group_id")]
+    no_group_id: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     image_id: Option<String>,
+
+    /// Set explicit NULL for the image_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_id")]
+    no_image_id: bool,
 
     /// The UUID of the image from which you want to create the volume.
     /// Required to create a bootable volume.
@@ -110,6 +142,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     image_ref: Option<String>,
 
+    /// Set explicit NULL for the image_ref
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "image_ref")]
+    no_image_ref: bool,
+
     /// One or more metadata key and value pairs to be associated with the new
     /// volume.
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
@@ -122,6 +158,10 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The size of the volume, in gibibytes (GiB).
     #[arg(help_heading = "Body parameters", long)]
     size: Option<Option<i32>>,
@@ -130,9 +170,17 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     snapshot_id: Option<String>,
 
+    /// Set explicit NULL for the snapshot_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "snapshot_id")]
+    no_snapshot_id: bool,
+
     /// The UUID of the consistency group.
     #[arg(help_heading = "Body parameters", long)]
     source_volid: Option<String>,
+
+    /// Set explicit NULL for the source_volid
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "source_volid")]
+    no_source_volid: bool,
 
     /// The volume type (either name or ID). To create an environment with
     /// multiple-storage back ends, you must specify a volume type. Block
@@ -146,6 +194,10 @@ struct Volume {
     /// [Configure multiple-storage back ends](https://docs.openstack.org/cinder/latest/admin/blockstorage-multi-backend.html).
     #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
+
+    /// Set explicit NULL for the volume_type
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_type")]
+    no_volume_type: bool,
 }
 
 impl VolumeCommand {
@@ -176,22 +228,32 @@ impl VolumeCommand {
         let mut volume_builder = create_353::VolumeBuilder::default();
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.display_name {
             volume_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            volume_builder.display_name(None);
         }
 
         if let Some(val) = &args.display_description {
             volume_builder.display_description(Some(val.into()));
+        } else if args.no_display_description {
+            volume_builder.display_description(None);
         }
 
         if let Some(val) = &args.volume_type {
             volume_builder.volume_type(Some(val.into()));
+        } else if args.no_volume_type {
+            volume_builder.volume_type(None);
         }
 
         if let Some(val) = &args.metadata {
@@ -200,14 +262,20 @@ impl VolumeCommand {
 
         if let Some(val) = &args.snapshot_id {
             volume_builder.snapshot_id(Some(val.into()));
+        } else if args.no_snapshot_id {
+            volume_builder.snapshot_id(None);
         }
 
         if let Some(val) = &args.source_volid {
             volume_builder.source_volid(Some(val.into()));
+        } else if args.no_source_volid {
+            volume_builder.source_volid(None);
         }
 
         if let Some(val) = &args.consistencygroup_id {
             volume_builder.consistencygroup_id(Some(val.into()));
+        } else if args.no_consistencygroup_id {
+            volume_builder.consistencygroup_id(None);
         }
 
         if let Some(val) = &args.size {
@@ -216,6 +284,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.availability_zone {
             volume_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            volume_builder.availability_zone(None);
         }
 
         if let Some(val) = &args.multiattach {
@@ -224,18 +294,26 @@ impl VolumeCommand {
 
         if let Some(val) = &args.image_id {
             volume_builder.image_id(Some(val.into()));
+        } else if args.no_image_id {
+            volume_builder.image_id(None);
         }
 
         if let Some(val) = &args.image_ref {
             volume_builder.image_ref(Some(val.into()));
+        } else if args.no_image_ref {
+            volume_builder.image_ref(None);
         }
 
         if let Some(val) = &args.group_id {
             volume_builder.group_id(Some(val.into()));
+        } else if args.no_group_id {
+            volume_builder.group_id(None);
         }
 
         if let Some(val) = &args.backup_id {
             volume_builder.backup_id(Some(val.into()));
+        } else if args.no_backup_id {
+            volume_builder.backup_id(None);
         }
 
         ep_builder.volume(volume_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume/os_detach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_detach.rs
@@ -66,6 +66,10 @@ struct PathParameters {
 struct OsDetach {
     #[arg(help_heading = "Body parameters", long)]
     attachment_id: Option<String>,
+
+    /// Set explicit NULL for the attachment_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "attachment_id")]
+    no_attachment_id: bool,
 }
 
 impl VolumeCommand {

--- a/openstack_cli/src/block_storage/v3/volume/os_force_detach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_force_detach.rs
@@ -68,6 +68,10 @@ struct OsForceDetach {
     #[arg(help_heading = "Body parameters", long)]
     attachment_id: Option<String>,
 
+    /// Set explicit NULL for the attachment_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "attachment_id")]
+    no_attachment_id: bool,
+
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     connector: Option<Option<Value>>,
 }
@@ -101,6 +105,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.attachment_id {
             os_force_detach_builder.attachment_id(Some(val.into()));
+        } else if args.no_attachment_id {
+            os_force_detach_builder.attachment_id(None);
         }
 
         ep_builder.os_force_detach(os_force_detach_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_316.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_316.rs
@@ -67,11 +67,19 @@ struct OsMigrateVolume {
     #[arg(help_heading = "Body parameters", long)]
     cluster: Option<String>,
 
+    /// Set explicit NULL for the cluster
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "cluster")]
+    no_cluster: bool,
+
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     force_host_copy: Option<bool>,
 
     #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
+
+    /// Set explicit NULL for the host
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "host")]
+    no_host: bool,
 
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     lock_volume: Option<bool>,
@@ -102,6 +110,8 @@ impl VolumeCommand {
             os_migrate_volume_316::OsMigrateVolumeBuilder::default();
         if let Some(val) = &args.host {
             os_migrate_volume_builder.host(Some(val.into()));
+        } else if args.no_host {
+            os_migrate_volume_builder.host(None);
         }
 
         if let Some(val) = &args.force_host_copy {
@@ -114,6 +124,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.cluster {
             os_migrate_volume_builder.cluster(Some(val.into()));
+        } else if args.no_cluster {
+            os_migrate_volume_builder.cluster(None);
         }
 
         ep_builder.os_migrate_volume(os_migrate_volume_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_30.rs
@@ -80,6 +80,10 @@ struct OsVolumeUploadImage {
     #[arg(help_heading = "Body parameters", long)]
     container_format: Option<String>,
 
+    /// Set explicit NULL for the container_format
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "container_format")]
+    no_container_format: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     disk_format: Option<DiskFormat>,
 
@@ -135,6 +139,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.container_format {
             os_volume_upload_image_builder.container_format(Some(val.into()));
+        } else if args.no_container_format {
+            os_volume_upload_image_builder.container_format(None);
         }
 
         ep_builder.os_volume_upload_image(os_volume_upload_image_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_31.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_31.rs
@@ -88,6 +88,10 @@ struct OsVolumeUploadImage {
     #[arg(help_heading = "Body parameters", long)]
     container_format: Option<String>,
 
+    /// Set explicit NULL for the container_format
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "container_format")]
+    no_container_format: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     disk_format: Option<DiskFormat>,
 
@@ -149,6 +153,8 @@ impl VolumeCommand {
 
         if let Some(val) = &args.container_format {
             os_volume_upload_image_builder.container_format(Some(val.into()));
+        } else if args.no_container_format {
+            os_volume_upload_image_builder.container_format(None);
         }
 
         if let Some(val) = &args.visibility {

--- a/openstack_cli/src/block_storage/v3/volume/set_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/set_30.rs
@@ -71,17 +71,33 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
+    /// Set explicit NULL for the display_description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_description")]
+    no_display_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
+
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
 
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl VolumeCommand {
@@ -121,18 +137,26 @@ impl VolumeCommand {
         let mut volume_builder = set_30::VolumeBuilder::default();
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.display_name {
             volume_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            volume_builder.display_name(None);
         }
 
         if let Some(val) = &args.display_description {
             volume_builder.display_description(Some(val.into()));
+        } else if args.no_display_description {
+            volume_builder.display_description(None);
         }
 
         if let Some(val) = &args.metadata {

--- a/openstack_cli/src/block_storage/v3/volume/set_353.rs
+++ b/openstack_cli/src/block_storage/v3/volume/set_353.rs
@@ -71,17 +71,33 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_description: Option<String>,
 
+    /// Set explicit NULL for the display_description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_description")]
+    no_display_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     display_name: Option<String>,
+
+    /// Set explicit NULL for the display_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "display_name")]
+    no_display_name: bool,
 
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl VolumeCommand {
@@ -121,18 +137,26 @@ impl VolumeCommand {
         let mut volume_builder = set_353::VolumeBuilder::default();
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.display_name {
             volume_builder.display_name(Some(val.into()));
+        } else if args.no_display_name {
+            volume_builder.display_name(None);
         }
 
         if let Some(val) = &args.display_description {
             volume_builder.display_description(Some(val.into()));
+        } else if args.no_display_description {
+            volume_builder.display_description(None);
         }
 
         if let Some(val) = &args.metadata {

--- a/openstack_cli/src/block_storage/v3/volume_manage/create_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume_manage/create_30.rs
@@ -116,14 +116,26 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     bootable: Option<bool>,
 
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
+
+    /// Set explicit NULL for the host
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "host")]
+    no_host: bool,
 
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
@@ -131,11 +143,19 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     _ref: Value,
 
     #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
+
+    /// Set explicit NULL for the volume_type
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_type")]
+    no_volume_type: bool,
 }
 
 impl VolumeManageCommand {
@@ -164,10 +184,14 @@ impl VolumeManageCommand {
         let mut volume_builder = create_30::VolumeBuilder::default();
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.availability_zone {
             volume_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            volume_builder.availability_zone(None);
         }
 
         if let Some(val) = &args.bootable {
@@ -176,14 +200,20 @@ impl VolumeManageCommand {
 
         if let Some(val) = &args.volume_type {
             volume_builder.volume_type(Some(val.into()));
+        } else if args.no_volume_type {
+            volume_builder.volume_type(None);
         }
 
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.host {
             volume_builder.host(Some(val.into()));
+        } else if args.no_host {
+            volume_builder.host(None);
         }
 
         volume_builder._ref(args._ref.clone());

--- a/openstack_cli/src/block_storage/v3/volume_manage/create_316.rs
+++ b/openstack_cli/src/block_storage/v3/volume_manage/create_316.rs
@@ -116,17 +116,33 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     bootable: Option<bool>,
 
     #[arg(help_heading = "Body parameters", long)]
     cluster: Option<String>,
 
+    /// Set explicit NULL for the cluster
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "cluster")]
+    no_cluster: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
+
+    /// Set explicit NULL for the host
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "host")]
+    no_host: bool,
 
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, String>)]
     metadata: Option<Vec<(String, String)>>,
@@ -134,11 +150,19 @@ struct Volume {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     _ref: Value,
 
     #[arg(help_heading = "Body parameters", long)]
     volume_type: Option<String>,
+
+    /// Set explicit NULL for the volume_type
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "volume_type")]
+    no_volume_type: bool,
 }
 
 impl VolumeManageCommand {
@@ -167,10 +191,14 @@ impl VolumeManageCommand {
         let mut volume_builder = create_316::VolumeBuilder::default();
         if let Some(val) = &args.description {
             volume_builder.description(Some(val.into()));
+        } else if args.no_description {
+            volume_builder.description(None);
         }
 
         if let Some(val) = &args.availability_zone {
             volume_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            volume_builder.availability_zone(None);
         }
 
         if let Some(val) = &args.bootable {
@@ -179,14 +207,20 @@ impl VolumeManageCommand {
 
         if let Some(val) = &args.volume_type {
             volume_builder.volume_type(Some(val.into()));
+        } else if args.no_volume_type {
+            volume_builder.volume_type(None);
         }
 
         if let Some(val) = &args.name {
             volume_builder.name(Some(val.into()));
+        } else if args.no_name {
+            volume_builder.name(None);
         }
 
         if let Some(val) = &args.host {
             volume_builder.host(Some(val.into()));
+        } else if args.no_host {
+            volume_builder.host(None);
         }
 
         volume_builder._ref(args._ref.clone());
@@ -197,6 +231,8 @@ impl VolumeManageCommand {
 
         if let Some(val) = &args.cluster {
             volume_builder.cluster(Some(val.into()));
+        } else if args.no_cluster {
+            volume_builder.cluster(None);
         }
 
         ep_builder.volume(volume_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume_transfer/create_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume_transfer/create_30.rs
@@ -62,6 +62,10 @@ struct Transfer {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The UUID of the volume.
     #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
@@ -96,6 +100,8 @@ impl VolumeTransferCommand {
 
         if let Some(val) = &args.name {
             transfer_builder.name(Some(val.into()));
+        } else if args.no_name {
+            transfer_builder.name(None);
         }
 
         ep_builder.transfer(transfer_builder.build().unwrap());

--- a/openstack_cli/src/block_storage/v3/volume_transfer/create_355.rs
+++ b/openstack_cli/src/block_storage/v3/volume_transfer/create_355.rs
@@ -62,6 +62,10 @@ struct Transfer {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// Transfer volume without snapshots. Defaults to False if not specified.
     ///
     /// **New in version 3.55**
@@ -102,6 +106,8 @@ impl VolumeTransferCommand {
 
         if let Some(val) = &args.name {
             transfer_builder.name(Some(val.into()));
+        } else if args.no_name {
+            transfer_builder.name(None);
         }
 
         if let Some(val) = &args.no_snapshots {

--- a/openstack_cli/src/compute/v2/aggregate/create_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_20.rs
@@ -73,6 +73,10 @@ struct Aggregate {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The name of the host aggregate.
     #[arg(help_heading = "Body parameters", long)]
     name: String,
@@ -104,6 +108,8 @@ impl AggregateCommand {
 
         if let Some(val) = &args.availability_zone {
             aggregate_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            aggregate_builder.availability_zone(None);
         }
 
         ep_builder.aggregate(aggregate_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/aggregate/create_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/create_21.rs
@@ -73,6 +73,10 @@ struct Aggregate {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The name of the host aggregate.
     #[arg(help_heading = "Body parameters", long)]
     name: String,
@@ -104,6 +108,8 @@ impl AggregateCommand {
 
         if let Some(val) = &args.availability_zone {
             aggregate_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            aggregate_builder.availability_zone(None);
         }
 
         ep_builder.aggregate(aggregate_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/aggregate/set_20.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_20.rs
@@ -89,6 +89,10 @@ struct Aggregate {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The name of the host aggregate.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
@@ -135,6 +139,8 @@ impl AggregateCommand {
 
         if let Some(val) = &args.availability_zone {
             aggregate_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            aggregate_builder.availability_zone(None);
         }
 
         ep_builder.aggregate(aggregate_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/aggregate/set_21.rs
+++ b/openstack_cli/src/compute/v2/aggregate/set_21.rs
@@ -89,6 +89,10 @@ struct Aggregate {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     /// The name of the host aggregate.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
@@ -135,6 +139,8 @@ impl AggregateCommand {
 
         if let Some(val) = &args.availability_zone {
             aggregate_builder.availability_zone(Some(val.into()));
+        } else if args.no_availability_zone {
+            aggregate_builder.availability_zone(None);
         }
 
         ep_builder.aggregate(aggregate_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/flavor/create_20.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_20.rs
@@ -79,6 +79,10 @@ struct Flavor {
     #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
+    /// Set explicit NULL for the id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "id")]
+    no_id: bool,
+
     /// The display name of a flavor.
     #[arg(help_heading = "Body parameters", long)]
     name: String,
@@ -139,6 +143,8 @@ impl FlavorCommand {
 
         if let Some(val) = &args.id {
             flavor_builder.id(Some(val.into()));
+        } else if args.no_id {
+            flavor_builder.id(None);
         }
 
         flavor_builder.ram(args.ram);

--- a/openstack_cli/src/compute/v2/flavor/create_21.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_21.rs
@@ -79,6 +79,10 @@ struct Flavor {
     #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
 
+    /// Set explicit NULL for the id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "id")]
+    no_id: bool,
+
     /// The display name of a flavor.
     #[arg(help_heading = "Body parameters", long)]
     name: String,
@@ -139,6 +143,8 @@ impl FlavorCommand {
 
         if let Some(val) = &args.id {
             flavor_builder.id(Some(val.into()));
+        } else if args.no_id {
+            flavor_builder.id(None);
         }
 
         flavor_builder.ram(args.ram);

--- a/openstack_cli/src/compute/v2/flavor/create_255.rs
+++ b/openstack_cli/src/compute/v2/flavor/create_255.rs
@@ -75,6 +75,10 @@ struct Flavor {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The size of a dedicated swap disk that will be allocated, in MiB. If 0
     /// (the default), no dedicated swap disk will be created.
     #[arg(help_heading = "Body parameters", long)]
@@ -85,6 +89,10 @@ struct Flavor {
     /// UUID will be assigned.
     #[arg(help_heading = "Body parameters", long)]
     id: Option<String>,
+
+    /// Set explicit NULL for the id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "id")]
+    no_id: bool,
 
     /// The display name of a flavor.
     #[arg(help_heading = "Body parameters", long)]
@@ -146,6 +154,8 @@ impl FlavorCommand {
 
         if let Some(val) = &args.id {
             flavor_builder.id(Some(val.into()));
+        } else if args.no_id {
+            flavor_builder.id(None);
         }
 
         flavor_builder.ram(args.ram);
@@ -172,6 +182,8 @@ impl FlavorCommand {
 
         if let Some(val) = &args.description {
             flavor_builder.description(Some(val.into()));
+        } else if args.no_description {
+            flavor_builder.description(None);
         }
 
         ep_builder.flavor(flavor_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/create_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_20.rs
@@ -330,6 +330,10 @@ struct Server {
     /// input validation, it isn’t allowed in Nova v2.1 API.
     #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
+
+    /// Set explicit NULL for the user_data
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "user_data")]
+    no_user_data: bool,
 }
 
 /// OsSchedulerHints Body data
@@ -564,6 +568,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.user_data {
             server_builder.user_data(Some(val.into()));
+        } else if args.no_user_data {
+            server_builder.user_data(None);
         }
 
         ep_builder.server(server_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/create_219.rs
+++ b/openstack_cli/src/compute/v2/server/create_219.rs
@@ -194,6 +194,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -568,6 +572,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         ep_builder.server(server_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/create_232.rs
+++ b/openstack_cli/src/compute/v2/server/create_232.rs
@@ -194,6 +194,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -568,6 +572,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         ep_builder.server(server_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/create_233.rs
+++ b/openstack_cli/src/compute/v2/server/create_233.rs
@@ -194,6 +194,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -568,6 +572,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         ep_builder.server(server_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/create_237.rs
+++ b/openstack_cli/src/compute/v2/server/create_237.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -598,6 +602,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         ep_builder.server(server_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/create_242.rs
+++ b/openstack_cli/src/compute/v2/server/create_242.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -598,6 +602,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         ep_builder.server(server_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/create_252.rs
+++ b/openstack_cli/src/compute/v2/server/create_252.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -614,6 +618,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/compute/v2/server/create_257.rs
+++ b/openstack_cli/src/compute/v2/server/create_257.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -595,6 +599,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/compute/v2/server/create_263.rs
+++ b/openstack_cli/src/compute/v2/server/create_263.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -607,6 +611,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/compute/v2/server/create_267.rs
+++ b/openstack_cli/src/compute/v2/server/create_267.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -607,6 +611,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/compute/v2/server/create_274.rs
+++ b/openstack_cli/src/compute/v2/server/create_274.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -623,6 +627,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/compute/v2/server/create_290.rs
+++ b/openstack_cli/src/compute/v2/server/create_290.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -638,6 +642,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/compute/v2/server/create_294.rs
+++ b/openstack_cli/src/compute/v2/server/create_294.rs
@@ -215,6 +215,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The flavor reference, as an ID (including a UUID) or full URL, for the
     /// flavor for your server instance.
     #[arg(help_heading = "Body parameters", long)]
@@ -638,6 +642,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/compute/v2/server/migrate_256.rs
+++ b/openstack_cli/src/compute/v2/server/migrate_256.rs
@@ -94,6 +94,10 @@ struct PathParameters {
 struct Migrate {
     #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
+
+    /// Set explicit NULL for the host
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "host")]
+    no_host: bool,
 }
 
 impl ServerCommand {

--- a/openstack_cli/src/compute/v2/server/rebuild_219.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_219.rs
@@ -96,6 +96,10 @@ struct Rebuild {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The UUID of the image to rebuild for your server instance. It must be a
     /// valid UUID otherwise API will return 400. To rebuild a volume-backed
     /// server with a new image, at least microversion 2.93 needs to be
@@ -225,6 +229,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             rebuild_builder.description(Some(val.into()));
+        } else if args.no_description {
+            rebuild_builder.description(None);
         }
 
         ep_builder.rebuild(rebuild_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/rebuild_254.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_254.rs
@@ -96,6 +96,10 @@ struct Rebuild {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The UUID of the image to rebuild for your server instance. It must be a
     /// valid UUID otherwise API will return 400. To rebuild a volume-backed
     /// server with a new image, at least microversion 2.93 needs to be
@@ -122,6 +126,10 @@ struct Rebuild {
     /// **New in version 2.54**
     #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
+
+    /// Set explicit NULL for the key_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "key_name")]
+    no_key_name: bool,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
@@ -240,10 +248,14 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             rebuild_builder.description(Some(val.into()));
+        } else if args.no_description {
+            rebuild_builder.description(None);
         }
 
         if let Some(val) = &args.key_name {
             rebuild_builder.key_name(Some(val.into()));
+        } else if args.no_key_name {
+            rebuild_builder.key_name(None);
         }
 
         ep_builder.rebuild(rebuild_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/rebuild_257.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_257.rs
@@ -95,6 +95,10 @@ struct Rebuild {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The UUID of the image to rebuild for your server instance. It must be a
     /// valid UUID otherwise API will return 400. To rebuild a volume-backed
     /// server with a new image, at least microversion 2.93 needs to be
@@ -121,6 +125,10 @@ struct Rebuild {
     /// **New in version 2.54**
     #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
+
+    /// Set explicit NULL for the key_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "key_name")]
+    no_key_name: bool,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
@@ -168,6 +176,10 @@ struct Rebuild {
     /// **New in version 2.57**
     #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
+
+    /// Set explicit NULL for the user_data
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "user_data")]
+    no_user_data: bool,
 }
 
 impl ServerCommand {
@@ -228,14 +240,20 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             rebuild_builder.description(Some(val.into()));
+        } else if args.no_description {
+            rebuild_builder.description(None);
         }
 
         if let Some(val) = &args.key_name {
             rebuild_builder.key_name(Some(val.into()));
+        } else if args.no_key_name {
+            rebuild_builder.key_name(None);
         }
 
         if let Some(val) = &args.user_data {
             rebuild_builder.user_data(Some(val.into()));
+        } else if args.no_user_data {
+            rebuild_builder.user_data(None);
         }
 
         ep_builder.rebuild(rebuild_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/rebuild_263.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_263.rs
@@ -95,6 +95,10 @@ struct Rebuild {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The UUID of the image to rebuild for your server instance. It must be a
     /// valid UUID otherwise API will return 400. To rebuild a volume-backed
     /// server with a new image, at least microversion 2.93 needs to be
@@ -121,6 +125,10 @@ struct Rebuild {
     /// **New in version 2.54**
     #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
+
+    /// Set explicit NULL for the key_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "key_name")]
+    no_key_name: bool,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
@@ -183,6 +191,10 @@ struct Rebuild {
     /// **New in version 2.57**
     #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
+
+    /// Set explicit NULL for the user_data
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "user_data")]
+    no_user_data: bool,
 }
 
 impl ServerCommand {
@@ -243,14 +255,20 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             rebuild_builder.description(Some(val.into()));
+        } else if args.no_description {
+            rebuild_builder.description(None);
         }
 
         if let Some(val) = &args.key_name {
             rebuild_builder.key_name(Some(val.into()));
+        } else if args.no_key_name {
+            rebuild_builder.key_name(None);
         }
 
         if let Some(val) = &args.user_data {
             rebuild_builder.user_data(Some(val.into()));
+        } else if args.no_user_data {
+            rebuild_builder.user_data(None);
         }
 
         if let Some(val) = &args.trusted_image_certificates {

--- a/openstack_cli/src/compute/v2/server/rebuild_290.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_290.rs
@@ -95,6 +95,10 @@ struct Rebuild {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The hostname to configure for the instance in the metadata service.
     ///
     /// Starting with microversion 2.94, this can be a Fully Qualified Domain
@@ -136,6 +140,10 @@ struct Rebuild {
     /// **New in version 2.54**
     #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
+
+    /// Set explicit NULL for the key_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "key_name")]
+    no_key_name: bool,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
@@ -198,6 +206,10 @@ struct Rebuild {
     /// **New in version 2.57**
     #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
+
+    /// Set explicit NULL for the user_data
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "user_data")]
+    no_user_data: bool,
 }
 
 impl ServerCommand {
@@ -258,14 +270,20 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             rebuild_builder.description(Some(val.into()));
+        } else if args.no_description {
+            rebuild_builder.description(None);
         }
 
         if let Some(val) = &args.key_name {
             rebuild_builder.key_name(Some(val.into()));
+        } else if args.no_key_name {
+            rebuild_builder.key_name(None);
         }
 
         if let Some(val) = &args.user_data {
             rebuild_builder.user_data(Some(val.into()));
+        } else if args.no_user_data {
+            rebuild_builder.user_data(None);
         }
 
         if let Some(val) = &args.trusted_image_certificates {

--- a/openstack_cli/src/compute/v2/server/rebuild_294.rs
+++ b/openstack_cli/src/compute/v2/server/rebuild_294.rs
@@ -95,6 +95,10 @@ struct Rebuild {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The hostname to configure for the instance in the metadata service.
     ///
     /// Starting with microversion 2.94, this can be a Fully Qualified Domain
@@ -136,6 +140,10 @@ struct Rebuild {
     /// **New in version 2.54**
     #[arg(help_heading = "Body parameters", long)]
     key_name: Option<String>,
+
+    /// Set explicit NULL for the key_name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "key_name")]
+    no_key_name: bool,
 
     /// Metadata key and value pairs. The maximum size of the metadata key and
     /// value is 255 bytes each.
@@ -198,6 +206,10 @@ struct Rebuild {
     /// **New in version 2.57**
     #[arg(help_heading = "Body parameters", long)]
     user_data: Option<String>,
+
+    /// Set explicit NULL for the user_data
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "user_data")]
+    no_user_data: bool,
 }
 
 impl ServerCommand {
@@ -258,14 +270,20 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             rebuild_builder.description(Some(val.into()));
+        } else if args.no_description {
+            rebuild_builder.description(None);
         }
 
         if let Some(val) = &args.key_name {
             rebuild_builder.key_name(Some(val.into()));
+        } else if args.no_key_name {
+            rebuild_builder.key_name(None);
         }
 
         if let Some(val) = &args.user_data {
             rebuild_builder.user_data(Some(val.into()));
+        } else if args.no_user_data {
+            rebuild_builder.user_data(None);
         }
 
         if let Some(val) = &args.trusted_image_certificates {

--- a/openstack_cli/src/compute/v2/server/set_219.rs
+++ b/openstack_cli/src/compute/v2/server/set_219.rs
@@ -97,6 +97,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The server name.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
@@ -178,6 +182,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         ep_builder.server(server_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/set_290.rs
+++ b/openstack_cli/src/compute/v2/server/set_290.rs
@@ -97,6 +97,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The hostname to configure for the instance in the metadata service.
     ///
     /// Starting with microversion 2.94, this can be a Fully Qualified Domain
@@ -193,6 +197,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.hostname {

--- a/openstack_cli/src/compute/v2/server/set_294.rs
+++ b/openstack_cli/src/compute/v2/server/set_294.rs
@@ -97,6 +97,10 @@ struct Server {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The hostname to configure for the instance in the metadata service.
     ///
     /// Starting with microversion 2.94, this can be a Fully Qualified Domain
@@ -193,6 +197,8 @@ impl ServerCommand {
 
         if let Some(val) = &args.description {
             server_builder.description(Some(val.into()));
+        } else if args.no_description {
+            server_builder.description(None);
         }
 
         if let Some(val) = &args.hostname {

--- a/openstack_cli/src/compute/v2/server/unshelve_291.rs
+++ b/openstack_cli/src/compute/v2/server/unshelve_291.rs
@@ -69,6 +69,10 @@ struct Unshelve {
     #[arg(help_heading = "Body parameters", long)]
     availability_zone: Option<String>,
 
+    /// Set explicit NULL for the availability_zone
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "availability_zone")]
+    no_availability_zone: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     host: Option<String>,
 }

--- a/openstack_cli/src/compute/v2/server/volume_attachment/create_20.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/create_20.rs
@@ -83,6 +83,10 @@ struct VolumeAttachment {
     #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
+    /// Set explicit NULL for the device
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "device")]
+    no_device: bool,
+
     /// The UUID of the volume to attach.
     #[arg(help_heading = "Body parameters", long)]
     volume_id: String,
@@ -118,6 +122,8 @@ impl VolumeAttachmentCommand {
 
         if let Some(val) = &args.device {
             volume_attachment_builder.device(Some(val.into()));
+        } else if args.no_device {
+            volume_attachment_builder.device(None);
         }
 
         ep_builder.volume_attachment(volume_attachment_builder.build().unwrap());

--- a/openstack_cli/src/compute/v2/server/volume_attachment/create_249.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/create_249.rs
@@ -83,6 +83,10 @@ struct VolumeAttachment {
     #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
+    /// Set explicit NULL for the device
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "device")]
+    no_device: bool,
+
     /// A device role tag that can be applied to a volume when attaching it to
     /// the VM. The guest OS of a server that has devices tagged in this manner
     /// can access hardware metadata about the tagged devices from the metadata
@@ -132,6 +136,8 @@ impl VolumeAttachmentCommand {
 
         if let Some(val) = &args.device {
             volume_attachment_builder.device(Some(val.into()));
+        } else if args.no_device {
+            volume_attachment_builder.device(None);
         }
 
         if let Some(val) = &args.tag {

--- a/openstack_cli/src/compute/v2/server/volume_attachment/create_279.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/create_279.rs
@@ -90,6 +90,10 @@ struct VolumeAttachment {
     #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
+    /// Set explicit NULL for the device
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "device")]
+    no_device: bool,
+
     /// A device role tag that can be applied to a volume when attaching it to
     /// the VM. The guest OS of a server that has devices tagged in this manner
     /// can access hardware metadata about the tagged devices from the metadata
@@ -139,6 +143,8 @@ impl VolumeAttachmentCommand {
 
         if let Some(val) = &args.device {
             volume_attachment_builder.device(Some(val.into()));
+        } else if args.no_device {
+            volume_attachment_builder.device(None);
         }
 
         if let Some(val) = &args.tag {

--- a/openstack_cli/src/compute/v2/server/volume_attachment/set_285.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/set_285.rs
@@ -107,6 +107,10 @@ struct VolumeAttachment {
     #[arg(help_heading = "Body parameters", long)]
     device: Option<String>,
 
+    /// Set explicit NULL for the device
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "device")]
+    no_device: bool,
+
     /// The UUID of the attachment.
     ///
     /// **New in version 2.85**
@@ -161,6 +165,8 @@ impl VolumeAttachmentCommand {
 
         if let Some(val) = &args.device {
             volume_attachment_builder.device(Some(val.into()));
+        } else if args.no_device {
+            volume_attachment_builder.device(None);
         }
 
         if let Some(val) = &args.tag {

--- a/openstack_cli/src/identity/v3/credential/create.rs
+++ b/openstack_cli/src/identity/v3/credential/create.rs
@@ -80,6 +80,10 @@ struct Credential {
     #[arg(help_heading = "Body parameters", long)]
     project_id: Option<String>,
 
+    /// Set explicit NULL for the project_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "project_id")]
+    no_project_id: bool,
+
     /// The credential type, such as `ec2` or `cert`. The implementation
     /// determines the list of supported types.
     #[arg(help_heading = "Body parameters", long)]
@@ -118,6 +122,8 @@ impl CredentialCommand {
 
         if let Some(val) = &args.project_id {
             credential_builder.project_id(Some(val.into()));
+        } else if args.no_project_id {
+            credential_builder.project_id(None);
         }
 
         credential_builder._type(&args._type);

--- a/openstack_cli/src/identity/v3/credential/set.rs
+++ b/openstack_cli/src/identity/v3/credential/set.rs
@@ -78,6 +78,10 @@ struct Credential {
     #[arg(help_heading = "Body parameters", long)]
     project_id: Option<String>,
 
+    /// Set explicit NULL for the project_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "project_id")]
+    no_project_id: bool,
+
     /// The credential type, such as `ec2` or `cert`. The implementation
     /// determines the list of supported types.
     #[arg(help_heading = "Body parameters", long)]
@@ -115,6 +119,8 @@ impl CredentialCommand {
 
         if let Some(val) = &args.project_id {
             credential_builder.project_id(Some(val.into()));
+        } else if args.no_project_id {
+            credential_builder.project_id(None);
         }
 
         if let Some(val) = &args._type {

--- a/openstack_cli/src/identity/v3/domain/create.rs
+++ b/openstack_cli/src/identity/v3/domain/create.rs
@@ -74,6 +74,10 @@ struct Domain {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// If set to `true`, domain is created enabled. If set to `false`, domain
     /// is created disabled. The default is `true`.
     ///
@@ -131,6 +135,8 @@ impl DomainCommand {
 
         if let Some(val) = &args.description {
             domain_builder.description(Some(val.into()));
+        } else if args.no_description {
+            domain_builder.description(None);
         }
 
         if let Some(val) = &args.enabled {

--- a/openstack_cli/src/identity/v3/domain/set.rs
+++ b/openstack_cli/src/identity/v3/domain/set.rs
@@ -84,6 +84,10 @@ struct Domain {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// If set to `true`, domain is enabled. If set to `false`, domain is
     /// disabled. The default is `true`.
     ///
@@ -145,6 +149,8 @@ impl DomainCommand {
         let mut domain_builder = set::DomainBuilder::default();
         if let Some(val) = &args.description {
             domain_builder.description(Some(val.into()));
+        } else if args.no_description {
+            domain_builder.description(None);
         }
 
         if let Some(val) = &args.enabled {

--- a/openstack_cli/src/identity/v3/endpoint/create.rs
+++ b/openstack_cli/src/identity/v3/endpoint/create.rs
@@ -75,6 +75,10 @@ struct Endpoint {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Defines whether the endpoint appears in the service catalog: - `false`.
     /// The endpoint does not appear in the service catalog. - `true`. The
     /// endpoint appears in the service catalog. Default is `true`.
@@ -101,9 +105,17 @@ struct Endpoint {
     #[arg(help_heading = "Body parameters", long)]
     region: Option<String>,
 
+    /// Set explicit NULL for the region
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "region")]
+    no_region: bool,
+
     /// (Since v3.2) The ID of the region that contains the service endpoint.
     #[arg(help_heading = "Body parameters", long)]
     region_id: Option<String>,
+
+    /// Set explicit NULL for the region_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "region_id")]
+    no_region_id: bool,
 
     /// The UUID of the service to which the endpoint belongs.
     #[arg(help_heading = "Body parameters", long)]
@@ -151,10 +163,14 @@ impl EndpointCommand {
 
         if let Some(val) = &args.region_id {
             endpoint_builder.region_id(Some(val.into()));
+        } else if args.no_region_id {
+            endpoint_builder.region_id(None);
         }
 
         if let Some(val) = &args.region {
             endpoint_builder.region(Some(val.into()));
+        } else if args.no_region {
+            endpoint_builder.region(None);
         }
 
         endpoint_builder.service_id(&args.service_id);
@@ -167,6 +183,8 @@ impl EndpointCommand {
 
         if let Some(val) = &args.description {
             endpoint_builder.description(Some(val.into()));
+        } else if args.no_description {
+            endpoint_builder.description(None);
         }
 
         ep_builder.endpoint(endpoint_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/endpoint/set.rs
+++ b/openstack_cli/src/identity/v3/endpoint/set.rs
@@ -83,6 +83,10 @@ struct Endpoint {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Indicates whether the endpoint appears in the service catalog -false.
     /// The endpoint does not appear in the service catalog. -true. The
     /// endpoint appears in the service catalog.
@@ -105,9 +109,17 @@ struct Endpoint {
     #[arg(help_heading = "Body parameters", long)]
     region: Option<String>,
 
+    /// Set explicit NULL for the region
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "region")]
+    no_region: bool,
+
     /// (Since v3.2) The ID of the region that contains the service endpoint.
     #[arg(help_heading = "Body parameters", long)]
     region_id: Option<String>,
+
+    /// Set explicit NULL for the region_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "region_id")]
+    no_region_id: bool,
 
     /// The UUID of the service to which the endpoint belongs.
     #[arg(help_heading = "Body parameters", long)]
@@ -154,10 +166,14 @@ impl EndpointCommand {
 
         if let Some(val) = &args.region_id {
             endpoint_builder.region_id(Some(val.into()));
+        } else if args.no_region_id {
+            endpoint_builder.region_id(None);
         }
 
         if let Some(val) = &args.region {
             endpoint_builder.region(Some(val.into()));
+        } else if args.no_region {
+            endpoint_builder.region(None);
         }
 
         if let Some(val) = &args.service_id {
@@ -174,6 +190,8 @@ impl EndpointCommand {
 
         if let Some(val) = &args.description {
             endpoint_builder.description(Some(val.into()));
+        } else if args.no_description {
+            endpoint_builder.description(None);
         }
 
         ep_builder.endpoint(endpoint_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/group/create.rs
+++ b/openstack_cli/src/identity/v3/group/create.rs
@@ -66,6 +66,10 @@ struct Group {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The ID of the domain of the group. If the domain ID is not provided in
     /// the request, the Identity service will attempt to pull the domain ID
     /// from the token used in the request. Note that this requires the use of
@@ -100,6 +104,8 @@ impl GroupCommand {
         let mut group_builder = create::GroupBuilder::default();
         if let Some(val) = &args.description {
             group_builder.description(Some(val.into()));
+        } else if args.no_description {
+            group_builder.description(None);
         }
 
         if let Some(val) = &args.domain_id {

--- a/openstack_cli/src/identity/v3/group/set.rs
+++ b/openstack_cli/src/identity/v3/group/set.rs
@@ -79,6 +79,10 @@ struct Group {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The new name of the group.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
@@ -119,6 +123,8 @@ impl GroupCommand {
         let mut group_builder = set::GroupBuilder::default();
         if let Some(val) = &args.description {
             group_builder.description(Some(val.into()));
+        } else if args.no_description {
+            group_builder.description(None);
         }
 
         if let Some(val) = &args.name {

--- a/openstack_cli/src/identity/v3/limit/set.rs
+++ b/openstack_cli/src/identity/v3/limit/set.rs
@@ -75,6 +75,10 @@ struct Limit {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The override limit.
     #[arg(help_heading = "Body parameters", long)]
     resource_limit: Option<i32>,
@@ -107,6 +111,8 @@ impl LimitCommand {
 
         if let Some(val) = &args.description {
             limit_builder.description(Some(val.into()));
+        } else if args.no_description {
+            limit_builder.description(None);
         }
 
         ep_builder.limit(limit_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/create.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/create.rs
@@ -99,6 +99,10 @@ struct EndpointGroup {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Describes the filtering performed by the endpoint group. The filter
     /// used must be an endpoint property, such as interface, service_id,
     /// region, and enabled. Note that if using interface as a filter, the only
@@ -136,6 +140,8 @@ impl EndpointGroupCommand {
         let mut endpoint_group_builder = create::EndpointGroupBuilder::default();
         if let Some(val) = &args.description {
             endpoint_group_builder.description(Some(val.into()));
+        } else if args.no_description {
+            endpoint_group_builder.description(None);
         }
 
         let mut filters_builder = create::FiltersBuilder::default();

--- a/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/set.rs
+++ b/openstack_cli/src/identity/v3/os_ep_filter/endpoint_group/set.rs
@@ -108,6 +108,10 @@ struct EndpointGroup {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Describes the filtering performed by the endpoint group. The filter
     /// used must be an endpoint property, such as interface, service_id,
     /// region, and enabled. Note that if using interface as a filter, the only
@@ -146,6 +150,8 @@ impl EndpointGroupCommand {
         let mut endpoint_group_builder = set::EndpointGroupBuilder::default();
         if let Some(val) = &args.description {
             endpoint_group_builder.description(Some(val.into()));
+        } else if args.no_description {
+            endpoint_group_builder.description(None);
         }
 
         if let Some(val) = &args.filters {

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
@@ -77,11 +77,19 @@ struct IdentityProvider {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The ID of a domain that is associated with the identity provider.
     /// Federated users that authenticate with the identity provider will be
     /// created under the domain specified.
     #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
+
+    /// Set explicit NULL for the domain_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "domain_id")]
+    no_domain_id: bool,
 
     /// Whether the identity provider is enabled or not
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
@@ -124,6 +132,8 @@ impl IdentityProviderCommand {
 
         if let Some(val) = &args.description {
             identity_provider_builder.description(Some(val.into()));
+        } else if args.no_description {
+            identity_provider_builder.description(None);
         }
 
         if let Some(val) = &args.authorization_ttl {
@@ -136,6 +146,8 @@ impl IdentityProviderCommand {
 
         if let Some(val) = &args.domain_id {
             identity_provider_builder.domain_id(Some(val.into()));
+        } else if args.no_domain_id {
+            identity_provider_builder.domain_id(None);
         }
 
         ep_builder.identity_provider(identity_provider_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/create.rs
@@ -83,6 +83,10 @@ struct Protocol {
 
     #[arg(help_heading = "Body parameters", long)]
     remote_id_attribute: Option<String>,
+
+    /// Set explicit NULL for the remote_id_attribute
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "remote_id_attribute")]
+    no_remote_id_attribute: bool,
 }
 
 impl ProtocolCommand {
@@ -115,6 +119,8 @@ impl ProtocolCommand {
 
         if let Some(val) = &args.remote_id_attribute {
             protocol_builder.remote_id_attribute(Some(val.into()));
+        } else if args.no_remote_id_attribute {
+            protocol_builder.remote_id_attribute(None);
         }
 
         ep_builder.protocol(protocol_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/protocol/set.rs
@@ -83,6 +83,10 @@ struct Protocol {
 
     #[arg(help_heading = "Body parameters", long)]
     remote_id_attribute: Option<String>,
+
+    /// Set explicit NULL for the remote_id_attribute
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "remote_id_attribute")]
+    no_remote_id_attribute: bool,
 }
 
 impl ProtocolCommand {
@@ -115,6 +119,8 @@ impl ProtocolCommand {
 
         if let Some(val) = &args.remote_id_attribute {
             protocol_builder.remote_id_attribute(Some(val.into()));
+        } else if args.no_remote_id_attribute {
+            protocol_builder.remote_id_attribute(None);
         }
 
         ep_builder.protocol(protocol_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
@@ -75,6 +75,10 @@ struct IdentityProvider {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Whether the identity provider is enabled or not
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
@@ -116,6 +120,8 @@ impl IdentityProviderCommand {
 
         if let Some(val) = &args.description {
             identity_provider_builder.description(Some(val.into()));
+        } else if args.no_description {
+            identity_provider_builder.description(None);
         }
 
         if let Some(val) = &args.authorization_ttl {

--- a/openstack_cli/src/identity/v3/os_federation/service_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/service_provider/create.rs
@@ -76,6 +76,10 @@ struct ServiceProvider {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Whether the service provider is enabled or not
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
@@ -83,6 +87,10 @@ struct ServiceProvider {
     /// The prefix of the RelayState SAML attribute
     #[arg(help_heading = "Body parameters", long)]
     relay_state_prefix: Option<String>,
+
+    /// Set explicit NULL for the relay_state_prefix
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "relay_state_prefix")]
+    no_relay_state_prefix: bool,
 
     /// The service provider's URL
     #[arg(help_heading = "Body parameters", long)]
@@ -120,6 +128,8 @@ impl ServiceProviderCommand {
 
         if let Some(val) = &args.description {
             service_provider_builder.description(Some(val.into()));
+        } else if args.no_description {
+            service_provider_builder.description(None);
         }
 
         if let Some(val) = &args.enabled {
@@ -128,6 +138,8 @@ impl ServiceProviderCommand {
 
         if let Some(val) = &args.relay_state_prefix {
             service_provider_builder.relay_state_prefix(Some(val.into()));
+        } else if args.no_relay_state_prefix {
+            service_provider_builder.relay_state_prefix(None);
         }
 
         ep_builder.service_provider(service_provider_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/os_federation/service_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/service_provider/set.rs
@@ -76,6 +76,10 @@ struct ServiceProvider {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Whether the service provider is enabled or not
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<bool>,
@@ -83,6 +87,10 @@ struct ServiceProvider {
     /// The prefix of the RelayState SAML attribute
     #[arg(help_heading = "Body parameters", long)]
     relay_state_prefix: Option<String>,
+
+    /// Set explicit NULL for the relay_state_prefix
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "relay_state_prefix")]
+    no_relay_state_prefix: bool,
 
     /// The service provider's URL
     #[arg(help_heading = "Body parameters", long)]
@@ -123,6 +131,8 @@ impl ServiceProviderCommand {
 
         if let Some(val) = &args.description {
             service_provider_builder.description(Some(val.into()));
+        } else if args.no_description {
+            service_provider_builder.description(None);
         }
 
         if let Some(val) = &args.enabled {
@@ -131,6 +141,8 @@ impl ServiceProviderCommand {
 
         if let Some(val) = &args.relay_state_prefix {
             service_provider_builder.relay_state_prefix(Some(val.into()));
+        } else if args.no_relay_state_prefix {
+            service_provider_builder.relay_state_prefix(None);
         }
 
         ep_builder.service_provider(service_provider_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/os_trust/trust/create.rs
+++ b/openstack_cli/src/identity/v3/os_trust/trust/create.rs
@@ -78,6 +78,10 @@ struct Trust {
     #[arg(help_heading = "Body parameters", long)]
     expires_at: Option<String>,
 
+    /// Set explicit NULL for the expires_at
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "expires_at")]
+    no_expires_at: bool,
+
     /// If set to true, then the user attribute of tokens generated based on
     /// the trust will represent that of the trustor rather than the trustee,
     /// thus allowing the trustee to impersonate the trustor. If impersonation
@@ -91,10 +95,18 @@ struct Trust {
     #[arg(help_heading = "Body parameters", long)]
     project_id: Option<String>,
 
+    /// Set explicit NULL for the project_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "project_id")]
+    no_project_id: bool,
+
     /// Returned with redelegated trust provides information about the
     /// predecessor in the trust chain.
     #[arg(help_heading = "Body parameters", long)]
     redelegated_trust_id: Option<String>,
+
+    /// Set explicit NULL for the redelegated_trust_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "redelegated_trust_id")]
+    no_redelegated_trust_id: bool,
 
     /// Specifies the maximum remaining depth of the redelegated trust chain.
     /// Each subsequent trust has this field decremented by 1 automatically.
@@ -170,6 +182,8 @@ impl TrustCommand {
 
         if let Some(val) = &args.project_id {
             trust_builder.project_id(Some(val.into()));
+        } else if args.no_project_id {
+            trust_builder.project_id(None);
         }
 
         if let Some(val) = &args.remaining_uses {
@@ -178,6 +192,8 @@ impl TrustCommand {
 
         if let Some(val) = &args.expires_at {
             trust_builder.expires_at(Some(val.into()));
+        } else if args.no_expires_at {
+            trust_builder.expires_at(None);
         }
 
         if let Some(val) = &args.allow_redelegation {
@@ -190,6 +206,8 @@ impl TrustCommand {
 
         if let Some(val) = &args.redelegated_trust_id {
             trust_builder.redelegated_trust_id(Some(val.into()));
+        } else if args.no_redelegated_trust_id {
+            trust_builder.redelegated_trust_id(None);
         }
 
         if let Some(val) = &args.roles {

--- a/openstack_cli/src/identity/v3/project/create.rs
+++ b/openstack_cli/src/identity/v3/project/create.rs
@@ -74,6 +74,10 @@ struct Project {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The ID of the domain for the project.
     ///
     /// For projects acting as a domain, the `domain_id` must not be specified,
@@ -88,6 +92,10 @@ struct Project {
     /// `Bad Request (400)` will be returned.
     #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
+
+    /// Set explicit NULL for the domain_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "domain_id")]
+    no_domain_id: bool,
 
     /// If set to `true`, project is enabled. If set to `false`, project is
     /// disabled. The default is `true`.
@@ -126,6 +134,10 @@ struct Project {
     #[arg(help_heading = "Body parameters", long)]
     parent_id: Option<String>,
 
+    /// Set explicit NULL for the parent_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "parent_id")]
+    no_parent_id: bool,
+
     /// A list of simple strings assigned to a project. Tags can be used to
     /// classify projects into groups.
     ///
@@ -156,10 +168,14 @@ impl ProjectCommand {
         let mut project_builder = create::ProjectBuilder::default();
         if let Some(val) = &args.description {
             project_builder.description(Some(val.into()));
+        } else if args.no_description {
+            project_builder.description(None);
         }
 
         if let Some(val) = &args.domain_id {
             project_builder.domain_id(Some(val.into()));
+        } else if args.no_domain_id {
+            project_builder.domain_id(None);
         }
 
         if let Some(val) = &args.enabled {
@@ -172,6 +188,8 @@ impl ProjectCommand {
 
         if let Some(val) = &args.parent_id {
             project_builder.parent_id(Some(val.into()));
+        } else if args.no_parent_id {
+            project_builder.parent_id(None);
         }
 
         project_builder.name(&args.name);

--- a/openstack_cli/src/identity/v3/project/set.rs
+++ b/openstack_cli/src/identity/v3/project/set.rs
@@ -84,6 +84,10 @@ struct Project {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// If set to `true`, project is enabled. If set to `false`, project is
     /// disabled.
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
@@ -142,6 +146,8 @@ impl ProjectCommand {
         let mut project_builder = set::ProjectBuilder::default();
         if let Some(val) = &args.description {
             project_builder.description(Some(val.into()));
+        } else if args.no_description {
+            project_builder.description(None);
         }
 
         if let Some(val) = &args.enabled {

--- a/openstack_cli/src/identity/v3/registered_limit/set.rs
+++ b/openstack_cli/src/identity/v3/registered_limit/set.rs
@@ -79,11 +79,19 @@ struct RegisteredLimit {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The ID of the region that contains the service endpoint. Either
     /// service_id, resource_name, or region_id must be different than existing
     /// value otherwise it will raise 409.
     #[arg(help_heading = "Body parameters", long)]
     region_id: Option<String>,
+
+    /// Set explicit NULL for the region_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "region_id")]
+    no_region_id: bool,
 
     /// The resource name. Either service_id, resource_name or region_id must
     /// be different than existing value otherwise it will raise 409.
@@ -125,6 +133,8 @@ impl RegisteredLimitCommand {
 
         if let Some(val) = &args.region_id {
             registered_limit_builder.region_id(Some(val.into()));
+        } else if args.no_region_id {
+            registered_limit_builder.region_id(None);
         }
 
         if let Some(val) = &args.resource_name {
@@ -137,6 +147,8 @@ impl RegisteredLimitCommand {
 
         if let Some(val) = &args.description {
             registered_limit_builder.description(Some(val.into()));
+        } else if args.no_description {
+            registered_limit_builder.description(None);
         }
 
         ep_builder.registered_limit(registered_limit_builder.build().unwrap());

--- a/openstack_cli/src/identity/v3/role/create.rs
+++ b/openstack_cli/src/identity/v3/role/create.rs
@@ -74,9 +74,17 @@ struct Role {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The ID of the domain of the role.
     #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
+
+    /// Set explicit NULL for the domain_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "domain_id")]
+    no_domain_id: bool,
 
     /// The role name.
     #[arg(help_heading = "Body parameters", long)]
@@ -113,10 +121,14 @@ impl RoleCommand {
 
         if let Some(val) = &args.description {
             role_builder.description(Some(val.into()));
+        } else if args.no_description {
+            role_builder.description(None);
         }
 
         if let Some(val) = &args.domain_id {
             role_builder.domain_id(Some(val.into()));
+        } else if args.no_domain_id {
+            role_builder.domain_id(None);
         }
 
         if let Some(val) = &args.options {

--- a/openstack_cli/src/identity/v3/role/set.rs
+++ b/openstack_cli/src/identity/v3/role/set.rs
@@ -84,9 +84,17 @@ struct Role {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// The ID of the domain.
     #[arg(help_heading = "Body parameters", long)]
     domain_id: Option<String>,
+
+    /// Set explicit NULL for the domain_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "domain_id")]
+    no_domain_id: bool,
 
     /// The new role name.
     #[arg(help_heading = "Body parameters", long)]
@@ -137,10 +145,14 @@ impl RoleCommand {
 
         if let Some(val) = &args.description {
             role_builder.description(Some(val.into()));
+        } else if args.no_description {
+            role_builder.description(None);
         }
 
         if let Some(val) = &args.domain_id {
             role_builder.domain_id(Some(val.into()));
+        } else if args.no_domain_id {
+            role_builder.domain_id(None);
         }
 
         if let Some(val) = &args.options {

--- a/openstack_cli/src/identity/v3/user/application_credential/create.rs
+++ b/openstack_cli/src/identity/v3/user/application_credential/create.rs
@@ -97,10 +97,18 @@ struct ApplicationCredential {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// An optional expiry time for the application credential. If unset, the
     /// application credential does not expire.
     #[arg(help_heading = "Body parameters", long)]
     expires_at: Option<String>,
+
+    /// Set explicit NULL for the expires_at
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "expires_at")]
+    no_expires_at: bool,
 
     /// The UUID for the credential.
     #[arg(help_heading = "Body parameters", long)]
@@ -130,8 +138,16 @@ struct ApplicationCredential {
     #[arg(help_heading = "Body parameters", long)]
     secret: Option<String>,
 
+    /// Set explicit NULL for the secret
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "secret")]
+    no_secret: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     system: Option<String>,
+
+    /// Set explicit NULL for the system
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "system")]
+    no_system: bool,
 
     /// An optional flag to restrict whether the application credential may be
     /// used for the creation or destruction of other application credentials
@@ -214,16 +230,22 @@ impl ApplicationCredentialCommand {
 
         if let Some(val) = &args.secret {
             application_credential_builder.secret(Some(val.into()));
+        } else if args.no_secret {
+            application_credential_builder.secret(None);
         }
 
         application_credential_builder.name(&args.name);
 
         if let Some(val) = &args.description {
             application_credential_builder.description(Some(val.into()));
+        } else if args.no_description {
+            application_credential_builder.description(None);
         }
 
         if let Some(val) = &args.expires_at {
             application_credential_builder.expires_at(Some(val.into()));
+        } else if args.no_expires_at {
+            application_credential_builder.expires_at(None);
         }
 
         if let Some(val) = &args.project_id {
@@ -244,6 +266,8 @@ impl ApplicationCredentialCommand {
 
         if let Some(val) = &args.system {
             application_credential_builder.system(Some(val.into()));
+        } else if args.no_system {
+            application_credential_builder.system(None);
         }
 
         if let Some(val) = &args.roles {

--- a/openstack_cli/src/identity/v3/user/create.rs
+++ b/openstack_cli/src/identity/v3/user/create.rs
@@ -101,9 +101,17 @@ struct User {
     #[arg(help_heading = "Body parameters", long)]
     default_project_id: Option<String>,
 
+    /// Set explicit NULL for the default_project_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "default_project_id")]
+    no_default_project_id: bool,
+
     /// The resource description.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 
     /// The ID of the domain of the user. If the domain ID is not provided in
     /// the request, the Identity service will attempt to pull the domain ID
@@ -153,6 +161,10 @@ struct User {
     /// The password for the user.
     #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
+
+    /// Set explicit NULL for the password
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "password")]
+    no_password: bool,
 }
 
 impl UserCommand {
@@ -177,14 +189,20 @@ impl UserCommand {
         let mut user_builder = create::UserBuilder::default();
         if let Some(val) = &args.password {
             user_builder.password(Some(val.into()));
+        } else if args.no_password {
+            user_builder.password(None);
         }
 
         if let Some(val) = &args.default_project_id {
             user_builder.default_project_id(Some(val.into()));
+        } else if args.no_default_project_id {
+            user_builder.default_project_id(None);
         }
 
         if let Some(val) = &args.description {
             user_builder.description(Some(val.into()));
+        } else if args.no_description {
+            user_builder.description(None);
         }
 
         if let Some(val) = &args.domain_id {

--- a/openstack_cli/src/identity/v3/user/set.rs
+++ b/openstack_cli/src/identity/v3/user/set.rs
@@ -107,9 +107,17 @@ struct User {
     #[arg(help_heading = "Body parameters", long)]
     default_project_id: Option<String>,
 
+    /// Set explicit NULL for the default_project_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "default_project_id")]
+    no_default_project_id: bool,
+
     /// The resource description.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 
     /// Enables or disables the user. An enabled user can authenticate and
     /// receive authorization. A disabled user cannot authenticate or receive
@@ -156,6 +164,10 @@ struct User {
     /// The new password for the user.
     #[arg(help_heading = "Body parameters", long)]
     password: Option<String>,
+
+    /// Set explicit NULL for the password
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "password")]
+    no_password: bool,
 }
 
 impl UserCommand {
@@ -193,14 +205,20 @@ impl UserCommand {
         let mut user_builder = set::UserBuilder::default();
         if let Some(val) = &args.password {
             user_builder.password(Some(val.into()));
+        } else if args.no_password {
+            user_builder.password(None);
         }
 
         if let Some(val) = &args.default_project_id {
             user_builder.default_project_id(Some(val.into()));
+        } else if args.no_default_project_id {
+            user_builder.default_project_id(None);
         }
 
         if let Some(val) = &args.description {
             user_builder.description(Some(val.into()));
+        } else if args.no_description {
+            user_builder.description(None);
         }
 
         if let Some(val) = &args.enabled {

--- a/openstack_cli/src/network/v2/agent/set.rs
+++ b/openstack_cli/src/network/v2/agent/set.rs
@@ -79,6 +79,10 @@ struct Agent {
     /// string.
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
+
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
 }
 
 impl AgentCommand {
@@ -108,6 +112,8 @@ impl AgentCommand {
 
         if let Some(val) = &args.description {
             agent_builder.description(Some(val.into()));
+        } else if args.no_description {
+            agent_builder.description(None);
         }
 
         ep_builder.agent(agent_builder.build().unwrap());

--- a/openstack_cli/src/network/v2/flavor/create.rs
+++ b/openstack_cli/src/network/v2/flavor/create.rs
@@ -89,6 +89,10 @@ struct Flavor {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Indicates whether the flavor is enabled or not. Default is true.
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<Option<bool>>,
@@ -132,6 +136,8 @@ impl FlavorCommand {
 
         if let Some(val) = &args.description {
             flavor_builder.description(Some(val.into()));
+        } else if args.no_description {
+            flavor_builder.description(None);
         }
 
         if let Some(val) = &args.service_type {

--- a/openstack_cli/src/network/v2/flavor/set.rs
+++ b/openstack_cli/src/network/v2/flavor/set.rs
@@ -80,6 +80,10 @@ struct Flavor {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Indicates whether the flavor is enabled or not. Default is true.
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     enabled: Option<Option<bool>>,
@@ -132,6 +136,8 @@ impl FlavorCommand {
 
         if let Some(val) = &args.description {
             flavor_builder.description(Some(val.into()));
+        } else if args.no_description {
+            flavor_builder.description(None);
         }
 
         if let Some(val) = &args.service_profiles {

--- a/openstack_cli/src/network/v2/floatingip/create.rs
+++ b/openstack_cli/src/network/v2/floatingip/create.rs
@@ -119,9 +119,17 @@ struct Floatingip {
     #[arg(help_heading = "Body parameters", long)]
     fixed_ip_address: Option<String>,
 
+    /// Set explicit NULL for the fixed_ip_address
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "fixed_ip_address")]
+    no_fixed_ip_address: bool,
+
     /// The floating IP address.
     #[arg(help_heading = "Body parameters", long)]
     floating_ip_address: Option<String>,
+
+    /// Set explicit NULL for the floating_ip_address
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "floating_ip_address")]
+    no_floating_ip_address: bool,
 
     /// The ID of the network associated with the floating IP.
     #[arg(help_heading = "Body parameters", long)]
@@ -133,13 +141,25 @@ struct Floatingip {
     #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 
+    /// Set explicit NULL for the port_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "port_id")]
+    no_port_id: bool,
+
     /// The ID of the QoS policy associated with the floating IP.
     #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
+    /// Set explicit NULL for the qos_policy_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "qos_policy_id")]
+    no_qos_policy_id: bool,
+
     /// The subnet ID on which you want to create the floating IP.
     #[arg(help_heading = "Body parameters", long)]
     subnet_id: Option<String>,
+
+    /// Set explicit NULL for the subnet_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "subnet_id")]
+    no_subnet_id: bool,
 
     /// The ID of the project.
     #[arg(help_heading = "Body parameters", long)]
@@ -168,20 +188,28 @@ impl FloatingipCommand {
         let mut floatingip_builder = create::FloatingipBuilder::default();
         if let Some(val) = &args.floating_ip_address {
             floatingip_builder.floating_ip_address(Some(val.into()));
+        } else if args.no_floating_ip_address {
+            floatingip_builder.floating_ip_address(None);
         }
 
         if let Some(val) = &args.subnet_id {
             floatingip_builder.subnet_id(Some(val.into()));
+        } else if args.no_subnet_id {
+            floatingip_builder.subnet_id(None);
         }
 
         floatingip_builder.floating_network_id(&args.floating_network_id);
 
         if let Some(val) = &args.port_id {
             floatingip_builder.port_id(Some(val.into()));
+        } else if args.no_port_id {
+            floatingip_builder.port_id(None);
         }
 
         if let Some(val) = &args.fixed_ip_address {
             floatingip_builder.fixed_ip_address(Some(val.into()));
+        } else if args.no_fixed_ip_address {
+            floatingip_builder.fixed_ip_address(None);
         }
 
         if let Some(val) = &args.tenant_id {
@@ -190,6 +218,8 @@ impl FloatingipCommand {
 
         if let Some(val) = &args.qos_policy_id {
             floatingip_builder.qos_policy_id(Some(val.into()));
+        } else if args.no_qos_policy_id {
+            floatingip_builder.qos_policy_id(None);
         }
 
         if let Some(val) = &args.dns_name {

--- a/openstack_cli/src/network/v2/floatingip/set.rs
+++ b/openstack_cli/src/network/v2/floatingip/set.rs
@@ -97,14 +97,26 @@ struct Floatingip {
     #[arg(help_heading = "Body parameters", long)]
     fixed_ip_address: Option<String>,
 
+    /// Set explicit NULL for the fixed_ip_address
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "fixed_ip_address")]
+    no_fixed_ip_address: bool,
+
     /// The ID of a port associated with the floating IP. To associate the
     /// floating IP with a fixed IP, you must specify the ID of the internal
     /// port. To disassociate the floating IP, `null` should be specified.
     #[arg(help_heading = "Body parameters", long)]
     port_id: Option<String>,
 
+    /// Set explicit NULL for the port_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "port_id")]
+    no_port_id: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
+
+    /// Set explicit NULL for the qos_policy_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "qos_policy_id")]
+    no_qos_policy_id: bool,
 }
 
 impl FloatingipCommand {
@@ -130,14 +142,20 @@ impl FloatingipCommand {
         let mut floatingip_builder = set::FloatingipBuilder::default();
         if let Some(val) = &args.port_id {
             floatingip_builder.port_id(Some(val.into()));
+        } else if args.no_port_id {
+            floatingip_builder.port_id(None);
         }
 
         if let Some(val) = &args.fixed_ip_address {
             floatingip_builder.fixed_ip_address(Some(val.into()));
+        } else if args.no_fixed_ip_address {
+            floatingip_builder.fixed_ip_address(None);
         }
 
         if let Some(val) = &args.qos_policy_id {
             floatingip_builder.qos_policy_id(Some(val.into()));
+        } else if args.no_qos_policy_id {
+            floatingip_builder.qos_policy_id(None);
         }
 
         if let Some(val) = &args.description {

--- a/openstack_cli/src/network/v2/local_ip/create.rs
+++ b/openstack_cli/src/network/v2/local_ip/create.rs
@@ -74,6 +74,10 @@ struct LocalIp {
     #[arg(help_heading = "Body parameters", long)]
     local_ip_address: Option<String>,
 
+    /// Set explicit NULL for the local_ip_address
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "local_ip_address")]
+    no_local_ip_address: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     local_port_id: Option<String>,
 
@@ -129,6 +133,8 @@ impl LocalIpCommand {
 
         if let Some(val) = &args.local_ip_address {
             local_ip_builder.local_ip_address(Some(val.into()));
+        } else if args.no_local_ip_address {
+            local_ip_builder.local_ip_address(None);
         }
 
         if let Some(val) = &args.ip_mode {

--- a/openstack_cli/src/network/v2/local_ip/port_association/create.rs
+++ b/openstack_cli/src/network/v2/local_ip/port_association/create.rs
@@ -79,6 +79,10 @@ struct PortAssociation {
     #[arg(help_heading = "Body parameters", long)]
     fixed_ip: Option<String>,
 
+    /// Set explicit NULL for the fixed_ip
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "fixed_ip")]
+    no_fixed_ip: bool,
+
     /// The requested ID of the port associated with the Local IP.
     #[arg(help_heading = "Body parameters", long)]
     fixed_port_id: Option<String>,
@@ -117,6 +121,8 @@ impl PortAssociationCommand {
 
         if let Some(val) = &args.fixed_ip {
             port_association_builder.fixed_ip(Some(val.into()));
+        } else if args.no_fixed_ip {
+            port_association_builder.fixed_ip(None);
         }
 
         if let Some(val) = &args.project_id {

--- a/openstack_cli/src/network/v2/log/log/create.rs
+++ b/openstack_cli/src/network/v2/log/log/create.rs
@@ -111,6 +111,10 @@ struct Log {
     #[arg(help_heading = "Body parameters", long)]
     resource_id: Option<String>,
 
+    /// Set explicit NULL for the resource_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "resource_id")]
+    no_resource_id: bool,
+
     /// The resource log type such as ‘security_group’.
     #[arg(help_heading = "Body parameters", long)]
     resource_type: Option<String>,
@@ -118,6 +122,10 @@ struct Log {
     /// The ID of resource target log such as port ID.
     #[arg(help_heading = "Body parameters", long)]
     target_id: Option<String>,
+
+    /// Set explicit NULL for the target_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "target_id")]
+    no_target_id: bool,
 }
 
 impl LogCommand {
@@ -154,6 +162,8 @@ impl LogCommand {
 
         if let Some(val) = &args.resource_id {
             log_builder.resource_id(Some(val.into()));
+        } else if args.no_resource_id {
+            log_builder.resource_id(None);
         }
 
         if let Some(val) = &args.event {
@@ -167,6 +177,8 @@ impl LogCommand {
 
         if let Some(val) = &args.target_id {
             log_builder.target_id(Some(val.into()));
+        } else if args.no_target_id {
+            log_builder.target_id(None);
         }
 
         if let Some(val) = &args.enabled {

--- a/openstack_cli/src/network/v2/ndp_proxy/create.rs
+++ b/openstack_cli/src/network/v2/ndp_proxy/create.rs
@@ -63,6 +63,10 @@ struct NdpProxy {
     #[arg(help_heading = "Body parameters", long)]
     ip_address: Option<String>,
 
+    /// Set explicit NULL for the ip_address
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "ip_address")]
+    no_ip_address: bool,
+
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
@@ -114,6 +118,8 @@ impl NdpProxyCommand {
 
         if let Some(val) = &args.ip_address {
             ndp_proxy_builder.ip_address(Some(val.into()));
+        } else if args.no_ip_address {
+            ndp_proxy_builder.ip_address(None);
         }
 
         if let Some(val) = &args.description {

--- a/openstack_cli/src/network/v2/network/create.rs
+++ b/openstack_cli/src/network/v2/network/create.rs
@@ -123,6 +123,10 @@ struct Network {
     #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
+    /// Set explicit NULL for the qos_policy_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "qos_policy_id")]
+    no_qos_policy_id: bool,
+
     /// Indicates whether the network has an external routing facility that’s
     /// not managed by the networking service.
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
@@ -224,6 +228,8 @@ impl NetworkCommand {
 
         if let Some(val) = &args.qos_policy_id {
             network_builder.qos_policy_id(Some(val.into()));
+        } else if args.no_qos_policy_id {
+            network_builder.qos_policy_id(None);
         }
 
         if let Some(val) = &args.is_default {

--- a/openstack_cli/src/network/v2/network/set.rs
+++ b/openstack_cli/src/network/v2/network/set.rs
@@ -120,6 +120,10 @@ struct Network {
     #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
+    /// Set explicit NULL for the qos_policy_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "qos_policy_id")]
+    no_qos_policy_id: bool,
+
     /// Indicates whether the network has an external routing facility that’s
     /// not managed by the networking service.
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
@@ -216,6 +220,8 @@ impl NetworkCommand {
 
         if let Some(val) = &args.qos_policy_id {
             network_builder.qos_policy_id(Some(val.into()));
+        } else if args.no_qos_policy_id {
+            network_builder.qos_policy_id(None);
         }
 
         if let Some(val) = &args.is_default {

--- a/openstack_cli/src/network/v2/port/create.rs
+++ b/openstack_cli/src/network/v2/port/create.rs
@@ -162,6 +162,10 @@ struct Port {
     #[arg(help_heading = "Body parameters", long)]
     device_profile: Option<String>,
 
+    /// Set explicit NULL for the device_profile
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "device_profile")]
+    no_device_profile: bool,
+
     /// A valid DNS domain.
     #[arg(help_heading = "Body parameters", long)]
     dns_domain: Option<String>,
@@ -240,6 +244,10 @@ struct Port {
     /// QoS policy associated with the port.
     #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
+
+    /// Set explicit NULL for the qos_policy_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "qos_policy_id")]
+    no_qos_policy_id: bool,
 
     /// The IDs of security groups applied to the port.
     ///
@@ -339,6 +347,8 @@ impl PortCommand {
 
         if let Some(val) = &args.device_profile {
             port_builder.device_profile(Some(val.into()));
+        } else if args.no_device_profile {
+            port_builder.device_profile(None);
         }
 
         if let Some(val) = &args.hints {
@@ -388,6 +398,8 @@ impl PortCommand {
 
         if let Some(val) = &args.qos_policy_id {
             port_builder.qos_policy_id(Some(val.into()));
+        } else if args.no_qos_policy_id {
+            port_builder.qos_policy_id(None);
         }
 
         if let Some(val) = &args.tags {

--- a/openstack_cli/src/network/v2/port/set.rs
+++ b/openstack_cli/src/network/v2/port/set.rs
@@ -274,6 +274,10 @@ struct Port {
     #[arg(help_heading = "Body parameters", long)]
     qos_policy_id: Option<String>,
 
+    /// Set explicit NULL for the qos_policy_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "qos_policy_id")]
+    no_qos_policy_id: bool,
+
     /// The IDs of security groups applied to the port.
     ///
     /// Parameter is an array, may be provided multiple times.
@@ -420,6 +424,8 @@ impl PortCommand {
 
         if let Some(val) = &args.qos_policy_id {
             port_builder.qos_policy_id(Some(val.into()));
+        } else if args.no_qos_policy_id {
+            port_builder.qos_policy_id(None);
         }
 
         if let Some(val) = &args.dns_name {

--- a/openstack_cli/src/network/v2/segment/create.rs
+++ b/openstack_cli/src/network/v2/segment/create.rs
@@ -71,6 +71,10 @@ struct Segment {
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
 
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
+
     /// The ID of the attached network.
     #[arg(help_heading = "Body parameters", long)]
     network_id: Option<String>,
@@ -138,6 +142,8 @@ impl SegmentCommand {
 
         if let Some(val) = &args.name {
             segment_builder.name(Some(val.into()));
+        } else if args.no_name {
+            segment_builder.name(None);
         }
 
         if let Some(val) = &args.description {

--- a/openstack_cli/src/network/v2/segment/set.rs
+++ b/openstack_cli/src/network/v2/segment/set.rs
@@ -80,6 +80,10 @@ struct Segment {
     /// Human-readable name of the segment.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
+
+    /// Set explicit NULL for the name
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
+    no_name: bool,
 }
 
 impl SegmentCommand {
@@ -117,6 +121,8 @@ impl SegmentCommand {
         let mut segment_builder = set::SegmentBuilder::default();
         if let Some(val) = &args.name {
             segment_builder.name(Some(val.into()));
+        } else if args.no_name {
+            segment_builder.name(None);
         }
 
         if let Some(val) = &args.description {

--- a/openstack_cli/src/network/v2/service_profile/create.rs
+++ b/openstack_cli/src/network/v2/service_profile/create.rs
@@ -85,6 +85,10 @@ struct ServiceProfile {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Provider driver to use for this profile.
     #[arg(help_heading = "Body parameters", long)]
     driver: Option<String>,
@@ -122,6 +126,8 @@ impl ServiceProfileCommand {
         let mut service_profile_builder = create::ServiceProfileBuilder::default();
         if let Some(val) = &args.description {
             service_profile_builder.description(Some(val.into()));
+        } else if args.no_description {
+            service_profile_builder.description(None);
         }
 
         if let Some(val) = &args.driver {

--- a/openstack_cli/src/network/v2/service_profile/set.rs
+++ b/openstack_cli/src/network/v2/service_profile/set.rs
@@ -75,6 +75,10 @@ struct ServiceProfile {
     #[arg(help_heading = "Body parameters", long)]
     description: Option<String>,
 
+    /// Set explicit NULL for the description
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "description")]
+    no_description: bool,
+
     /// Provider driver to use for this profile.
     #[arg(help_heading = "Body parameters", long)]
     driver: Option<String>,
@@ -113,6 +117,8 @@ impl ServiceProfileCommand {
         let mut service_profile_builder = set::ServiceProfileBuilder::default();
         if let Some(val) = &args.description {
             service_profile_builder.description(Some(val.into()));
+        } else if args.no_description {
+            service_profile_builder.description(None);
         }
 
         if let Some(val) = &args.driver {

--- a/openstack_cli/src/network/v2/subnet/create.rs
+++ b/openstack_cli/src/network/v2/subnet/create.rs
@@ -125,6 +125,10 @@ struct Subnet {
     #[arg(help_heading = "Body parameters", long)]
     cidr: Option<String>,
 
+    /// Set explicit NULL for the cidr
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "cidr")]
+    no_cidr: bool,
+
     /// A human-readable description for the resource. Default is an empty
     /// string.
     #[arg(help_heading = "Body parameters", long)]
@@ -153,6 +157,10 @@ struct Subnet {
     /// the gateway for the subnet by default.
     #[arg(help_heading = "Body parameters", long)]
     gateway_ip: Option<String>,
+
+    /// Set explicit NULL for the gateway_ip
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "gateway_ip")]
+    no_gateway_ip: bool,
 
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.
@@ -195,6 +203,10 @@ struct Subnet {
     #[arg(help_heading = "Body parameters", long)]
     segment_id: Option<String>,
 
+    /// Set explicit NULL for the segment_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "segment_id")]
+    no_segment_id: bool,
+
     /// The service types associated with the subnet.
     ///
     /// Parameter is an array, may be provided multiple times.
@@ -204,6 +216,10 @@ struct Subnet {
     /// The ID of the subnet pool associated with the subnet.
     #[arg(help_heading = "Body parameters", long)]
     subnetpool_id: Option<String>,
+
+    /// Set explicit NULL for the subnetpool_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "subnetpool_id")]
+    no_subnetpool_id: bool,
 
     /// The ID of the project that owns the resource. Only administrative and
     /// users with advsvc role can specify a project ID other than their own.
@@ -246,6 +262,8 @@ impl SubnetCommand {
 
         if let Some(val) = &args.subnetpool_id {
             subnet_builder.subnetpool_id(Some(val.into()));
+        } else if args.no_subnetpool_id {
+            subnet_builder.subnetpool_id(None);
         }
 
         if let Some(val) = &args.prefixlen {
@@ -254,10 +272,14 @@ impl SubnetCommand {
 
         if let Some(val) = &args.cidr {
             subnet_builder.cidr(Some(val.into()));
+        } else if args.no_cidr {
+            subnet_builder.cidr(None);
         }
 
         if let Some(val) = &args.gateway_ip {
             subnet_builder.gateway_ip(Some(val.into()));
+        } else if args.no_gateway_ip {
+            subnet_builder.gateway_ip(None);
         }
 
         if let Some(val) = &args.allocation_pools {
@@ -324,6 +346,8 @@ impl SubnetCommand {
 
         if let Some(val) = &args.segment_id {
             subnet_builder.segment_id(Some(val.into()));
+        } else if args.no_segment_id {
+            subnet_builder.segment_id(None);
         }
 
         ep_builder.subnet(subnet_builder.build().unwrap());

--- a/openstack_cli/src/network/v2/subnet/set.rs
+++ b/openstack_cli/src/network/v2/subnet/set.rs
@@ -115,6 +115,10 @@ struct Subnet {
     #[arg(help_heading = "Body parameters", long)]
     gateway_ip: Option<String>,
 
+    /// Set explicit NULL for the gateway_ip
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "gateway_ip")]
+    no_gateway_ip: bool,
+
     /// Additional routes for the subnet. A list of dictionaries with
     /// `destination` and `nexthop` parameters. Default value is an empty list.
     ///
@@ -130,6 +134,10 @@ struct Subnet {
     /// available when `segment` extension is enabled.
     #[arg(help_heading = "Body parameters", long)]
     segment_id: Option<String>,
+
+    /// Set explicit NULL for the segment_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "segment_id")]
+    no_segment_id: bool,
 
     /// The service types associated with the subnet.
     ///
@@ -177,6 +185,8 @@ impl SubnetCommand {
 
         if let Some(val) = &args.gateway_ip {
             subnet_builder.gateway_ip(Some(val.into()));
+        } else if args.no_gateway_ip {
+            subnet_builder.gateway_ip(None);
         }
 
         if let Some(val) = &args.allocation_pools {
@@ -217,6 +227,8 @@ impl SubnetCommand {
 
         if let Some(val) = &args.segment_id {
             subnet_builder.segment_id(Some(val.into()));
+        } else if args.no_segment_id {
+            subnet_builder.segment_id(None);
         }
 
         ep_builder.subnet(subnet_builder.build().unwrap());

--- a/openstack_cli/src/network/v2/subnetpool/create.rs
+++ b/openstack_cli/src/network/v2/subnetpool/create.rs
@@ -67,6 +67,10 @@ struct Subnetpool {
     #[arg(help_heading = "Body parameters", long)]
     address_scope_id: Option<String>,
 
+    /// Set explicit NULL for the address_scope_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "address_scope_id")]
+    no_address_scope_id: bool,
+
     /// The size of the prefix to allocate when the `cidr` or `prefixlen`
     /// attributes are omitted when you create the subnet. Default is
     /// `min_prefixlen`.
@@ -183,6 +187,8 @@ impl SubnetpoolCommand {
 
         if let Some(val) = &args.address_scope_id {
             subnetpool_builder.address_scope_id(Some(val.into()));
+        } else if args.no_address_scope_id {
+            subnetpool_builder.address_scope_id(None);
         }
 
         if let Some(val) = &args.description {

--- a/openstack_cli/src/network/v2/subnetpool/set.rs
+++ b/openstack_cli/src/network/v2/subnetpool/set.rs
@@ -77,6 +77,10 @@ struct Subnetpool {
     #[arg(help_heading = "Body parameters", long)]
     address_scope_id: Option<String>,
 
+    /// Set explicit NULL for the address_scope_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "address_scope_id")]
+    no_address_scope_id: bool,
+
     /// The size of the prefix to allocate when the `cidr` or `prefixlen`
     /// attributes are omitted when you create the subnet. Default is
     /// `min_prefixlen`.
@@ -189,6 +193,8 @@ impl SubnetpoolCommand {
 
         if let Some(val) = &args.address_scope_id {
             subnetpool_builder.address_scope_id(Some(val.into()));
+        } else if args.no_address_scope_id {
+            subnetpool_builder.address_scope_id(None);
         }
 
         if let Some(val) = &args.description {

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
@@ -106,6 +106,10 @@ struct IpsecSiteConnection {
     #[arg(help_heading = "Body parameters", long)]
     local_ep_group_id: Option<String>,
 
+    /// Set explicit NULL for the local_ep_group_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "local_ep_group_id")]
+    no_local_ep_group_id: bool,
+
     /// An ID to be used instead of the external IP address for a virtual
     /// router used in traffic between instances on different networks in
     /// east-west traffic. Most often, local ID would be domain name, email
@@ -141,6 +145,10 @@ struct IpsecSiteConnection {
     /// a `subnet_id` for the VPN service.
     #[arg(help_heading = "Body parameters", long)]
     peer_ep_group_id: Option<String>,
+
+    /// Set explicit NULL for the peer_ep_group_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "peer_ep_group_id")]
+    no_peer_ep_group_id: bool,
 
     /// The peer router identity for authentication. A valid value is an IPv4
     /// address, IPv6 address, e-mail address, key ID, or FQDN. Typically, this
@@ -215,10 +223,14 @@ impl IpsecSiteConnectionCommand {
 
         if let Some(val) = &args.local_ep_group_id {
             ipsec_site_connection_builder.local_ep_group_id(Some(val.into()));
+        } else if args.no_local_ep_group_id {
+            ipsec_site_connection_builder.local_ep_group_id(None);
         }
 
         if let Some(val) = &args.peer_ep_group_id {
             ipsec_site_connection_builder.peer_ep_group_id(Some(val.into()));
+        } else if args.no_peer_ep_group_id {
+            ipsec_site_connection_builder.peer_ep_group_id(None);
         }
 
         if let Some(val) = &args.mtu {

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
@@ -108,6 +108,10 @@ struct IpsecSiteConnection {
     #[arg(help_heading = "Body parameters", long)]
     local_ep_group_id: Option<String>,
 
+    /// Set explicit NULL for the local_ep_group_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "local_ep_group_id")]
+    no_local_ep_group_id: bool,
+
     /// An ID to be used instead of the external IP address for a virtual
     /// router used in traffic between instances on different networks in
     /// east-west traffic. Most often, local ID would be domain name, email
@@ -143,6 +147,10 @@ struct IpsecSiteConnection {
     /// a `subnet_id` for the VPN service.
     #[arg(help_heading = "Body parameters", long)]
     peer_ep_group_id: Option<String>,
+
+    /// Set explicit NULL for the peer_ep_group_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "peer_ep_group_id")]
+    no_peer_ep_group_id: bool,
 
     /// The peer router identity for authentication. A valid value is an IPv4
     /// address, IPv6 address, e-mail address, key ID, or FQDN. Typically, this
@@ -218,10 +226,14 @@ impl IpsecSiteConnectionCommand {
 
         if let Some(val) = &args.local_ep_group_id {
             ipsec_site_connection_builder.local_ep_group_id(Some(val.into()));
+        } else if args.no_local_ep_group_id {
+            ipsec_site_connection_builder.local_ep_group_id(None);
         }
 
         if let Some(val) = &args.peer_ep_group_id {
             ipsec_site_connection_builder.peer_ep_group_id(Some(val.into()));
+        } else if args.no_peer_ep_group_id {
+            ipsec_site_connection_builder.peer_ep_group_id(None);
         }
 
         if let Some(val) = &args.mtu {

--- a/openstack_cli/src/network/v2/vpn/vpnservice/create.rs
+++ b/openstack_cli/src/network/v2/vpn/vpnservice/create.rs
@@ -86,6 +86,10 @@ struct Vpnservice {
     #[arg(help_heading = "Body parameters", long)]
     flavor_id: Option<String>,
 
+    /// Set explicit NULL for the flavor_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "flavor_id")]
+    no_flavor_id: bool,
+
     /// Human-readable name of the resource. Default is an empty string.
     #[arg(help_heading = "Body parameters", long)]
     name: Option<String>,
@@ -99,6 +103,10 @@ struct Vpnservice {
     /// address to the port.
     #[arg(help_heading = "Body parameters", long)]
     subnet_id: Option<String>,
+
+    /// Set explicit NULL for the subnet_id
+    #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "subnet_id")]
+    no_subnet_id: bool,
 
     /// The ID of the project.
     #[arg(help_heading = "Body parameters", long)]
@@ -140,6 +148,8 @@ impl VpnserviceCommand {
 
         if let Some(val) = &args.subnet_id {
             vpnservice_builder.subnet_id(Some(val.into()));
+        } else if args.no_subnet_id {
+            vpnservice_builder.subnet_id(None);
         }
 
         if let Some(val) = &args.router_id {
@@ -152,6 +162,8 @@ impl VpnserviceCommand {
 
         if let Some(val) = &args.flavor_id {
             vpnservice_builder.flavor_id(Some(val.into()));
+        } else if args.no_flavor_id {
+            vpnservice_builder.flavor_id(None);
         }
 
         ep_builder.vpnservice(vpnservice_builder.build().unwrap());


### PR DESCRIPTION
For primitive types (not arrays and not dicts or similar) when resource
attribute can be explicitly nullable (while also being optional) it is
necessary to allow CLI user to set it to null. The only practical way
found till now is to add additional argument: `device_id / no_device_id`
which can be used to set explicit null. Neither relying on specific
value ("", "null") nor using default value when no value is sustainable
looking at the variations of APIs.

Change-Id: I6d549ffcc5c51a9c3ed849c590777b5ba4f6d721

Changes are triggered by https://review.opendev.org/949618
