### PR TITLE
fix: Fix role_assignments command

### DIFF
--- a/openstack_cli/src/identity/v3/limit/list.rs
+++ b/openstack_cli/src/identity/v3/limit/list.rs
@@ -228,8 +228,8 @@ impl LimitsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<LimitResponse>(data)?;
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+        op.output_list::<LimitResponse>(data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/registered_limit/list.rs
+++ b/openstack_cli/src/identity/v3/registered_limit/list.rs
@@ -100,8 +100,8 @@ impl RegisteredLimitsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<RegisteredLimitResponse>(data)?;
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+        op.output_list::<RegisteredLimitResponse>(data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/role_assignment/list.rs
+++ b/openstack_cli/src/identity/v3/role_assignment/list.rs
@@ -208,8 +208,8 @@ impl RoleAssignmentsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<RoleAssignmentResponse>(data)?;
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+        op.output_list::<RoleAssignmentResponse>(data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/system/group/role/list.rs
+++ b/openstack_cli/src/identity/v3/system/group/role/list.rs
@@ -88,8 +88,8 @@ impl RolesCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<RoleResponse>(data)?;
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+        op.output_list::<RoleResponse>(data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/identity/v3/system/user/role/list.rs
+++ b/openstack_cli/src/identity/v3/system/user/role/list.rs
@@ -148,8 +148,8 @@ impl RolesCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<RoleResponse>(data)?;
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+        op.output_list::<RoleResponse>(data)?;
         Ok(())
     }
 }

--- a/openstack_cli/src/image/v2/task/list.rs
+++ b/openstack_cli/src/image/v2/task/list.rs
@@ -79,8 +79,8 @@ impl TasksCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let data = ep.query_async(client).await?;
-        op.output_single::<TaskResponse>(data)?;
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+        op.output_list::<TaskResponse>(data)?;
         Ok(())
     }
 }


### PR DESCRIPTION
In the cli generation it was assumed that the first element in the
response schema is the object itself. That is used to check whether the
response is list or not. Now the role_assignment schema return `links`
object first breaking that assumption. Extend the check to first look at
the `response_key` that we identified previously.

Change-Id: Ib2cf6e394486ebd0a475ed3d9bba97feefcd5205

Changes are triggered by https://review.opendev.org/950250
