### PR TITLE
chore: Do correct testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      
+
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            test_args: ""
+            rust_ver: 1.85
           # - target: x86_64-unknown-linux-musl
           #   os: ubuntu-latest
           # - target: x86_64-apple-darwin
@@ -48,8 +50,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
         with:
-          toolchain: stable
           targets: ${{ matrix.target }}
+          toolchain: ${{ matrix.rust_ver }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@f1390fd0d8205ae79e5e57b1d1e300dceeb4163e # v2.49.44
@@ -60,7 +62,7 @@ jobs:
         uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
 
       - name: Run tests
-        run: cargo nextest run
+        run: cargo nextest run ${{ matrix.test_args }}
 
       - name: Run Doc tests
         run: cargo test --doc

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -55,13 +55,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    strategy:
-      matrix:
-        include:
-          - rust_ver: 1.76
-            clippy_args: "-p openstack_sdk -p openstack_types"
-          - rust_ver: 1.85
-            clippy_args: "-p openstack_cli -p openstack_tui"
     steps:
 
       - name: Harden Runner
@@ -71,10 +64,10 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Install Rust ${{ matrix.rust_ver }}
+      - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
         with:
-          toolchain: ${{ matrix.rust_ver }}
+          toolchain: stable
           components: rustfmt, clippy
 
       - uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
@@ -91,7 +84,7 @@ jobs:
         run:
           cargo clippy
           --lib --tests
-          --all-features ${{ matrix.clippy_args }}
+          --all-features
           --message-format=json | ${CARGO_HOME}/bin/clippy-sarif | tee rust-clippy-results.sarif | ${CARGO_HOME}/bin/sarif-fmt
 
       - name: Upload analysis results to GitHub

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -6,7 +6,7 @@ src = "src"
 title = "OpenStack Client Tools"
 
 [rust]
-edition = "2024" 
+edition = "2024"
 
 [build]
 build-dir = "html"


### PR DESCRIPTION
It was intended to run tests with the MSRV and not the clippy. Since
clippy format changes between releases it is not correct to check if the
code formatted with newer clippy passed old clippy. It is relevant for
tests though.
