### PR TITLE
chore: Add global clippy config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ debug = 0
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[workspace.lints.clippy]
+result_large_err = "allow"

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -94,3 +94,6 @@ tempfile = { workspace = true }
 name = "functional"
 path = "tests/main.rs"
 test = false
+
+[lints]
+workspace = true

--- a/openstack_cli/src/image/v2/metadef.rs
+++ b/openstack_cli/src/image/v2/metadef.rs
@@ -61,8 +61,8 @@ pub struct MetadefCommand {
 #[allow(missing_docs)]
 #[derive(Subcommand)]
 pub enum MetadefCommands {
-    Namespace(namespace::NamespaceCommand),
-    ResourceType(resource_type::ResourceTypeCommand),
+    Namespace(Box<namespace::NamespaceCommand>),
+    ResourceType(Box<resource_type::ResourceTypeCommand>),
 }
 
 impl MetadefCommand {

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -100,3 +100,6 @@ required-features = ["async", "compute"]
 [[example]]
 name = "ignore"
 required-features = ["async", "compute"]
+
+[lints]
+workspace = true

--- a/openstack_tui/Cargo.toml
+++ b/openstack_tui/Cargo.toml
@@ -51,3 +51,6 @@ tracing = { workspace = true }
 tracing-error = { workspace = true }
 tracing-subscriber = { workspace = true }
 url.workspace = true
+
+[lints]
+workspace = true

--- a/openstack_types/Cargo.toml
+++ b/openstack_types/Cargo.toml
@@ -53,3 +53,6 @@ url.workspace = true
 name = "mocked"
 path = "tests/mocked/main.rs"
 test = false
+
+[lints]
+workspace = true


### PR DESCRIPTION
We can't easily box all errors. For now silence the warning introducing
global lint confguration.
