### PR TITLE
fix: add missed serde macros in types

### DIFF
--- a/openstack_types/src/block_storage/v3/availability_zone/response/list.rs
+++ b/openstack_types/src/block_storage/v3/availability_zone/response/list.rs
@@ -35,5 +35,6 @@ pub struct AvailabilityZoneResponse {
 /// `ZoneState` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ZoneState {
+    #[serde(default)]
     pub available: Option<bool>,
 }

--- a/openstack_types/src/block_storage/v3/backup/import_record/response/create.rs
+++ b/openstack_types/src/block_storage/v3/backup/import_record/response/create.rs
@@ -42,6 +42,8 @@ pub struct ImportRecordResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/backup/response/create.rs
+++ b/openstack_types/src/block_storage/v3/backup/response/create.rs
@@ -126,6 +126,8 @@ pub struct BackupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/backup/response/get.rs
+++ b/openstack_types/src/block_storage/v3/backup/response/get.rs
@@ -126,6 +126,8 @@ pub struct BackupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/backup/response/list.rs
+++ b/openstack_types/src/block_storage/v3/backup/response/list.rs
@@ -37,6 +37,8 @@ pub struct BackupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/backup/response/list_detailed.rs
+++ b/openstack_types/src/block_storage/v3/backup/response/list_detailed.rs
@@ -148,6 +148,8 @@ pub struct BackupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/backup/response/set.rs
+++ b/openstack_types/src/block_storage/v3/backup/response/set.rs
@@ -126,6 +126,8 @@ pub struct BackupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/limit/response/list.rs
+++ b/openstack_types/src/block_storage/v3/limit/response/list.rs
@@ -36,14 +36,24 @@ pub struct LimitResponse {
 /// `Absolute` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Absolute {
+    #[serde(rename = "maxTotalBackupGigabytes")]
     pub max_total_backup_gigabytes: i64,
+    #[serde(rename = "maxTotalBackups")]
     pub max_total_backups: i32,
+    #[serde(rename = "maxTotalSnapshots")]
     pub max_total_snapshots: i32,
+    #[serde(rename = "maxTotalVolumeGigabytes")]
     pub max_total_volume_gigabytes: i64,
+    #[serde(rename = "maxTotalVolumes")]
     pub max_total_volumes: i32,
+    #[serde(rename = "totalBackupGigabytesUsed")]
     pub total_backup_gigabytes_used: i64,
+    #[serde(rename = "totalBackupsUsed")]
     pub total_backups_used: i32,
+    #[serde(rename = "totalGigabytesUsed")]
     pub total_gigabytes_used: i64,
+    #[serde(rename = "totalSnapshotsUsed")]
     pub total_snapshots_used: i32,
+    #[serde(rename = "totalVolumesUsed")]
     pub total_volumes_used: i32,
 }

--- a/openstack_types/src/block_storage/v3/manageable_snapshot/response/get.rs
+++ b/openstack_types/src/block_storage/v3/manageable_snapshot/response/get.rs
@@ -32,6 +32,7 @@ pub struct ManageableSnapshotResponse {
 /// `Reference` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Reference {
+    #[serde(default, rename = "source-name")]
     pub source_name: Option<String>,
 }
 
@@ -39,6 +40,7 @@ pub struct Reference {
 /// `SourceReference` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SourceReference {
+    #[serde(default, rename = "source-name")]
     pub source_name: Option<String>,
 }
 

--- a/openstack_types/src/block_storage/v3/manageable_snapshot/response/list_detailed.rs
+++ b/openstack_types/src/block_storage/v3/manageable_snapshot/response/list_detailed.rs
@@ -32,6 +32,7 @@ pub struct ManageableSnapshotResponse {
 /// `Reference` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Reference {
+    #[serde(default, rename = "source-name")]
     pub source_name: Option<String>,
 }
 
@@ -39,17 +40,25 @@ pub struct Reference {
 /// `SourceReference` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SourceReference {
+    #[serde(default, rename = "source-name")]
     pub source_name: Option<String>,
 }
 
 /// `ManageableSnapshots` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ManageableSnapshots {
+    #[serde(default)]
     pub cinder_id: Option<String>,
+    #[serde(default)]
     pub extra_info: Option<String>,
+    #[serde(default)]
     pub reason_not_safe: Option<String>,
+    #[serde(default)]
     pub reference: Option<Reference>,
+    #[serde(default)]
     pub safe_to_manage: Option<bool>,
+    #[serde(default)]
     pub size: Option<i64>,
+    #[serde(default)]
     pub source_reference: Option<SourceReference>,
 }

--- a/openstack_types/src/block_storage/v3/manageable_volume/response/create.rs
+++ b/openstack_types/src/block_storage/v3/manageable_volume/response/create.rs
@@ -220,6 +220,7 @@ pub struct ManageableVolumeResponse {
 /// `Attachments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Attachments {
+    #[serde(default)]
     pub attached_at: Option<String>,
     pub attachment_id: String,
     pub device: Option<String>,
@@ -235,6 +236,8 @@ pub struct Attachments {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/manageable_volume/response/get.rs
+++ b/openstack_types/src/block_storage/v3/manageable_volume/response/get.rs
@@ -32,6 +32,7 @@ pub struct ManageableVolumeResponse {
 /// `Reference` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Reference {
+    #[serde(default, rename = "source-name")]
     pub source_name: Option<String>,
 }
 
@@ -39,7 +40,10 @@ pub struct Reference {
 /// `ManageableVolumes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ManageableVolumes {
+    #[serde(default)]
     pub reference: Option<Reference>,
+    #[serde(default)]
     pub safe_to_manage: Option<bool>,
+    #[serde(default)]
     pub size: Option<i64>,
 }

--- a/openstack_types/src/block_storage/v3/manageable_volume/response/list_detailed.rs
+++ b/openstack_types/src/block_storage/v3/manageable_volume/response/list_detailed.rs
@@ -32,6 +32,7 @@ pub struct ManageableVolumeResponse {
 /// `Reference` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Reference {
+    #[serde(default, rename = "source-name")]
     pub source_name: Option<String>,
 }
 
@@ -39,10 +40,16 @@ pub struct Reference {
 /// `ManageableVolumes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ManageableVolumes {
+    #[serde(default)]
     pub cinder_id: Option<String>,
+    #[serde(default)]
     pub extra_info: Option<String>,
+    #[serde(default)]
     pub reason_not_safe: Option<String>,
+    #[serde(default)]
     pub reference: Option<Reference>,
+    #[serde(default)]
     pub safe_to_manage: Option<bool>,
+    #[serde(default)]
     pub size: Option<i64>,
 }

--- a/openstack_types/src/block_storage/v3/message/response/get.rs
+++ b/openstack_types/src/block_storage/v3/message/response/get.rs
@@ -89,6 +89,8 @@ pub struct MessageResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/message/response/list.rs
+++ b/openstack_types/src/block_storage/v3/message/response/list.rs
@@ -84,6 +84,8 @@ pub struct MessageResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/os_volume_transfer/response/accept.rs
+++ b/openstack_types/src/block_storage/v3/os_volume_transfer/response/accept.rs
@@ -67,6 +67,8 @@ pub struct OsVolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/os_volume_transfer/response/create.rs
+++ b/openstack_types/src/block_storage/v3/os_volume_transfer/response/create.rs
@@ -67,6 +67,8 @@ pub struct OsVolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/os_volume_transfer/response/get.rs
+++ b/openstack_types/src/block_storage/v3/os_volume_transfer/response/get.rs
@@ -67,6 +67,8 @@ pub struct OsVolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/os_volume_transfer/response/list.rs
+++ b/openstack_types/src/block_storage/v3/os_volume_transfer/response/list.rs
@@ -44,6 +44,8 @@ pub struct OsVolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/os_volume_transfer/response/list_detailed.rs
+++ b/openstack_types/src/block_storage/v3/os_volume_transfer/response/list_detailed.rs
@@ -62,6 +62,8 @@ pub struct OsVolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume/response/create.rs
+++ b/openstack_types/src/block_storage/v3/volume/response/create.rs
@@ -234,6 +234,7 @@ pub struct VolumeResponse {
 /// `Attachments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Attachments {
+    #[serde(default)]
     pub attached_at: Option<String>,
     pub attachment_id: String,
     pub device: Option<String>,
@@ -249,6 +250,8 @@ pub struct Attachments {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume/response/get.rs
+++ b/openstack_types/src/block_storage/v3/volume/response/get.rs
@@ -234,6 +234,7 @@ pub struct VolumeResponse {
 /// `Attachments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Attachments {
+    #[serde(default)]
     pub attached_at: Option<String>,
     pub attachment_id: String,
     pub device: Option<String>,
@@ -249,6 +250,8 @@ pub struct Attachments {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume/response/list.rs
+++ b/openstack_types/src/block_storage/v3/volume/response/list.rs
@@ -37,6 +37,8 @@ pub struct VolumeResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume/response/list_detailed.rs
+++ b/openstack_types/src/block_storage/v3/volume/response/list_detailed.rs
@@ -229,6 +229,7 @@ pub struct VolumeResponse {
 /// `Attachments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Attachments {
+    #[serde(default)]
     pub attached_at: Option<String>,
     pub attachment_id: String,
     pub device: Option<String>,
@@ -244,6 +245,8 @@ pub struct Attachments {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume/response/set.rs
+++ b/openstack_types/src/block_storage/v3/volume/response/set.rs
@@ -234,6 +234,7 @@ pub struct VolumeResponse {
 /// `Attachments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Attachments {
+    #[serde(default)]
     pub attached_at: Option<String>,
     pub attachment_id: String,
     pub device: Option<String>,
@@ -249,6 +250,8 @@ pub struct Attachments {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume_transfer/response/accept.rs
+++ b/openstack_types/src/block_storage/v3/volume_transfer/response/accept.rs
@@ -95,6 +95,8 @@ pub struct VolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume_transfer/response/create.rs
+++ b/openstack_types/src/block_storage/v3/volume_transfer/response/create.rs
@@ -95,6 +95,8 @@ pub struct VolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume_transfer/response/get.rs
+++ b/openstack_types/src/block_storage/v3/volume_transfer/response/get.rs
@@ -95,6 +95,8 @@ pub struct VolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume_transfer/response/list.rs
+++ b/openstack_types/src/block_storage/v3/volume_transfer/response/list.rs
@@ -44,6 +44,8 @@ pub struct VolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/block_storage/v3/volume_transfer/response/list_detailed.rs
+++ b/openstack_types/src/block_storage/v3/volume_transfer/response/list_detailed.rs
@@ -90,6 +90,8 @@ pub struct VolumeTransferResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/compute/v2/availability_zone/response/list.rs
+++ b/openstack_types/src/compute/v2/availability_zone/response/list.rs
@@ -43,5 +43,6 @@ pub struct AvailabilityZoneResponse {
 /// `ZoneState` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ZoneState {
+    #[serde(default)]
     pub available: Option<bool>,
 }

--- a/openstack_types/src/compute/v2/availability_zone/response/list_detail.rs
+++ b/openstack_types/src/compute/v2/availability_zone/response/list_detail.rs
@@ -47,5 +47,6 @@ pub struct AvailabilityZoneResponse {
 /// `ZoneState` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ZoneState {
+    #[serde(default)]
     pub available: Option<bool>,
 }

--- a/openstack_types/src/compute/v2/extension/response/get.rs
+++ b/openstack_types/src/compute/v2/extension/response/get.rs
@@ -68,6 +68,8 @@ pub struct ExtensionResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/compute/v2/extension/response/list.rs
+++ b/openstack_types/src/compute/v2/extension/response/list.rs
@@ -62,6 +62,8 @@ pub struct ExtensionResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/compute/v2/hypervisor/response/get.rs
+++ b/openstack_types/src/compute/v2/hypervisor/response/get.rs
@@ -201,8 +201,11 @@ pub struct Servers {
 /// `Service` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Service {
+    #[serde(default)]
     pub disabled_reason: Option<String>,
+    #[serde(default)]
     pub host: Option<String>,
+    #[serde(default, deserialize_with = "crate::common::deser_num_str_opt")]
     pub id: Option<i64>,
 }
 

--- a/openstack_types/src/compute/v2/hypervisor/response/list_detailed.rs
+++ b/openstack_types/src/compute/v2/hypervisor/response/list_detailed.rs
@@ -201,8 +201,11 @@ pub struct Servers {
 /// `Service` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Service {
+    #[serde(default)]
     pub disabled_reason: Option<String>,
+    #[serde(default)]
     pub host: Option<String>,
+    #[serde(default, deserialize_with = "crate::common::deser_num_str_opt")]
     pub id: Option<i64>,
 }
 

--- a/openstack_types/src/compute/v2/limit/response/list.rs
+++ b/openstack_types/src/compute/v2/limit/response/list.rs
@@ -33,15 +33,26 @@ pub struct LimitResponse {
 /// `Absolute` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Absolute {
+    #[serde(default, rename = "maxServerGroupMembers")]
     pub max_server_group_members: Option<i32>,
+    #[serde(default, rename = "maxServerGroups")]
     pub max_server_groups: Option<i32>,
+    #[serde(default, rename = "maxServerMetamaxServerMeta")]
     pub max_server_metamax_server_meta: Option<i32>,
+    #[serde(default, rename = "maxTotalCores")]
     pub max_total_cores: Option<i32>,
+    #[serde(default, rename = "maxTotalInstances")]
     pub max_total_instances: Option<i32>,
+    #[serde(default, rename = "maxTotalKeypairs")]
     pub max_total_keypairs: Option<i32>,
+    #[serde(default, rename = "maxTotalRAMSize")]
     pub max_total_ramsize: Option<i32>,
+    #[serde(default, rename = "totalCoresUsed")]
     pub total_cores_used: Option<i32>,
+    #[serde(default, rename = "totalInstancesUsed")]
     pub total_instances_used: Option<i32>,
+    #[serde(default, rename = "totalRAMUsed")]
     pub total_ramused: Option<i32>,
+    #[serde(default, rename = "totalServerGroupsUsed")]
     pub total_server_groups_used: Option<i32>,
 }

--- a/openstack_types/src/compute/v2/quota_set/response/details.rs
+++ b/openstack_types/src/compute/v2/quota_set/response/details.rs
@@ -139,8 +139,11 @@ pub struct QuotaSetResponse {
 /// `Cores` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Cores {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -151,8 +154,11 @@ pub struct Cores {
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -163,8 +169,11 @@ pub struct FixedIps {
 /// `FloatingIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FloatingIps {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -175,8 +184,11 @@ pub struct FloatingIps {
 /// `InjectedFiles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InjectedFiles {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -185,8 +197,11 @@ pub struct InjectedFiles {
 /// `InjectedFilesContentBytes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InjectedFilesContentBytes {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -195,8 +210,11 @@ pub struct InjectedFilesContentBytes {
 /// `InjectedFilesPathBytes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InjectedFilesPathBytes {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -205,8 +223,11 @@ pub struct InjectedFilesPathBytes {
 /// `Instances` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Instances {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -221,8 +242,11 @@ pub struct Instances {
 /// `KeyPairs` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KeyPairs {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -231,8 +255,11 @@ pub struct KeyPairs {
 /// `MetadataItems` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MetadataItems {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -242,8 +269,11 @@ pub struct MetadataItems {
 /// `Networks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Networks {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -252,8 +282,11 @@ pub struct Networks {
 /// `Ram` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Ram {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -264,8 +297,11 @@ pub struct Ram {
 /// `SecurityGroupRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroupRules {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -276,8 +312,11 @@ pub struct SecurityGroupRules {
 /// `SecurityGroups` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroups {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -286,8 +325,11 @@ pub struct SecurityGroups {
 /// `ServerGroupMembers` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ServerGroupMembers {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }
 
@@ -296,7 +338,10 @@ pub struct ServerGroupMembers {
 /// `ServerGroups` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ServerGroups {
+    #[serde(default)]
     pub in_use: Option<i32>,
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
 }

--- a/openstack_types/src/compute/v2/server/diagnostic/response/get.rs
+++ b/openstack_types/src/compute/v2/server/diagnostic/response/get.rs
@@ -208,16 +208,27 @@ impl std::str::FromStr for Driver {
 /// `NicDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NicDetails {
+    #[serde(default)]
     pub mac_address: Option<String>,
+    #[serde(default)]
     pub rx_drop: Option<i32>,
+    #[serde(default)]
     pub rx_errors: Option<i32>,
+    #[serde(default)]
     pub rx_octets: Option<i32>,
+    #[serde(default)]
     pub rx_packets: Option<i32>,
+    #[serde(default)]
     pub rx_rate: Option<i32>,
+    #[serde(default)]
     pub tx_drop: Option<i32>,
+    #[serde(default)]
     pub tx_errors: Option<i32>,
+    #[serde(default)]
     pub tx_octets: Option<i32>,
+    #[serde(default)]
     pub tx_packets: Option<i32>,
+    #[serde(default)]
     pub tx_rate: Option<i32>,
 }
 

--- a/openstack_types/src/compute/v2/server/instance_action/response/get.rs
+++ b/openstack_types/src/compute/v2/server/instance_action/response/get.rs
@@ -97,12 +97,19 @@ pub struct InstanceActionResponse {
 /// `Events` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Events {
+    #[serde(default)]
     pub details: Option<String>,
     pub event: String,
+    #[serde(default)]
     pub finish_time: Option<String>,
+    #[serde(default)]
     pub host: Option<String>,
+    #[serde(default, rename = "hostId")]
     pub host_id: Option<String>,
+    #[serde(default)]
     pub result: Option<String>,
+    #[serde(default)]
     pub start_time: Option<String>,
+    #[serde(default)]
     pub traceback: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/interface/response/create.rs
+++ b/openstack_types/src/compute/v2/server/interface/response/create.rs
@@ -57,6 +57,8 @@ pub struct InterfaceResponse {
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/interface/response/get.rs
+++ b/openstack_types/src/compute/v2/server/interface/response/get.rs
@@ -57,6 +57,8 @@ pub struct InterfaceResponse {
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/interface/response/list.rs
+++ b/openstack_types/src/compute/v2/server/interface/response/list.rs
@@ -31,7 +31,9 @@ pub struct InterfaceResponse {
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -40,9 +42,14 @@ pub struct FixedIps {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InterfaceAttachments {
     pub fixed_ips: Vec<FixedIps>,
+    #[serde(default)]
     pub mac_addr: Option<String>,
+    #[serde(default)]
     pub net_id: Option<String>,
+    #[serde(default)]
     pub port_id: Option<String>,
+    #[serde(default)]
     pub port_state: Option<String>,
+    #[serde(default)]
     pub tag: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/response/create.rs
+++ b/openstack_types/src/compute/v2/server/response/create.rs
@@ -88,12 +88,15 @@ impl std::str::FromStr for OsDcfDiskConfig {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }
 
 /// `SecurityGroups` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroups {
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/response/get.rs
+++ b/openstack_types/src/compute/v2/server/response/get.rs
@@ -443,7 +443,9 @@ impl std::str::FromStr for OsDcfDiskConfig {
 /// `Addresses` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Addresses {
+    #[serde(default)]
     pub addr: Option<String>,
+    #[serde(default)]
     pub version: Option<i32>,
 }
 
@@ -452,9 +454,13 @@ pub struct Addresses {
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
+    #[serde(default)]
     pub code: Option<i32>,
+    #[serde(default)]
     pub created: Option<String>,
+    #[serde(default)]
     pub details: Option<String>,
+    #[serde(default)]
     pub message: Option<String>,
 }
 
@@ -464,7 +470,9 @@ pub struct Fault {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }
 
@@ -478,14 +486,23 @@ pub struct Links {
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
+    #[serde(default)]
     pub disk: Option<i32>,
+    #[serde(default)]
     pub ephemeral: Option<i32>,
+    #[serde(default)]
     pub extra_specs: Option<BTreeMap<String, String>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Vec<Links>>,
+    #[serde(default)]
     pub original_name: Option<String>,
+    #[serde(default)]
     pub ram: Option<i32>,
+    #[serde(default)]
     pub swap: Option<i32>,
+    #[serde(default)]
     pub vcpus: Option<i32>,
 }
 
@@ -536,7 +553,9 @@ impl std::str::FromStr for HostStatus {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {
     pub id: String,
+    #[serde(default)]
     pub links: Option<Vec<Links>>,
+    #[serde(default)]
     pub properties: Option<BTreeMap<String, Value>>,
 }
 
@@ -569,5 +588,6 @@ pub enum ImageEnum {
 /// `SecurityGroups` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroups {
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/response/list_detailed.rs
+++ b/openstack_types/src/compute/v2/server/response/list_detailed.rs
@@ -413,7 +413,9 @@ impl std::str::FromStr for OsDcfDiskConfig {
 /// `Addresses` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Addresses {
+    #[serde(default)]
     pub addr: Option<String>,
+    #[serde(default)]
     pub version: Option<i32>,
 }
 
@@ -422,9 +424,13 @@ pub struct Addresses {
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
+    #[serde(default)]
     pub code: Option<i32>,
+    #[serde(default)]
     pub created: Option<String>,
+    #[serde(default)]
     pub details: Option<String>,
+    #[serde(default)]
     pub message: Option<String>,
 }
 
@@ -434,7 +440,9 @@ pub struct Fault {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }
 
@@ -448,14 +456,23 @@ pub struct Links {
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
+    #[serde(default)]
     pub disk: Option<i32>,
+    #[serde(default)]
     pub ephemeral: Option<i32>,
+    #[serde(default)]
     pub extra_specs: Option<BTreeMap<String, String>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Vec<Links>>,
+    #[serde(default)]
     pub original_name: Option<String>,
+    #[serde(default)]
     pub ram: Option<i32>,
+    #[serde(default)]
     pub swap: Option<i32>,
+    #[serde(default)]
     pub vcpus: Option<i32>,
 }
 
@@ -506,7 +523,9 @@ impl std::str::FromStr for HostStatus {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {
     pub id: String,
+    #[serde(default)]
     pub links: Option<Vec<Links>>,
+    #[serde(default)]
     pub properties: Option<BTreeMap<String, Value>>,
 }
 
@@ -539,5 +558,6 @@ pub enum ImageEnum {
 /// `SecurityGroups` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroups {
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/response/set.rs
+++ b/openstack_types/src/compute/v2/server/response/set.rs
@@ -443,7 +443,9 @@ impl std::str::FromStr for OsDcfDiskConfig {
 /// `Addresses` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Addresses {
+    #[serde(default)]
     pub addr: Option<String>,
+    #[serde(default)]
     pub version: Option<i32>,
 }
 
@@ -452,9 +454,13 @@ pub struct Addresses {
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
+    #[serde(default)]
     pub code: Option<i32>,
+    #[serde(default)]
     pub created: Option<String>,
+    #[serde(default)]
     pub details: Option<String>,
+    #[serde(default)]
     pub message: Option<String>,
 }
 
@@ -464,7 +470,9 @@ pub struct Fault {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }
 
@@ -478,14 +486,23 @@ pub struct Links {
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
+    #[serde(default)]
     pub disk: Option<i32>,
+    #[serde(default)]
     pub ephemeral: Option<i32>,
+    #[serde(default)]
     pub extra_specs: Option<BTreeMap<String, String>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Vec<Links>>,
+    #[serde(default)]
     pub original_name: Option<String>,
+    #[serde(default)]
     pub ram: Option<i32>,
+    #[serde(default)]
     pub swap: Option<i32>,
+    #[serde(default)]
     pub vcpus: Option<i32>,
 }
 
@@ -536,7 +553,9 @@ impl std::str::FromStr for HostStatus {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {
     pub id: String,
+    #[serde(default)]
     pub links: Option<Vec<Links>>,
+    #[serde(default)]
     pub properties: Option<BTreeMap<String, Value>>,
 }
 
@@ -569,5 +588,6 @@ pub enum ImageEnum {
 /// `SecurityGroups` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroups {
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server/security_group/response/list.rs
+++ b/openstack_types/src/compute/v2/server/security_group/response/list.rs
@@ -51,17 +51,25 @@ pub struct SecurityGroupResponse {
 /// `Group` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Group {
+    #[serde(default)]
     pub name: Option<String>,
 }
 
 /// `Rules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Rules {
+    #[serde(default)]
     pub from_port: Option<i32>,
+    #[serde(default)]
     pub group: Option<Group>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub ip_protocol: Option<String>,
+    #[serde(default)]
     pub ip_range: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub parent_group_id: Option<String>,
+    #[serde(default)]
     pub to_port: Option<i32>,
 }

--- a/openstack_types/src/compute/v2/server_external_event/response/create.rs
+++ b/openstack_types/src/compute/v2/server_external_event/response/create.rs
@@ -107,5 +107,6 @@ pub struct Events {
     pub name: Name,
     pub server_uuid: String,
     pub status: Status,
+    #[serde(default)]
     pub tag: Option<String>,
 }

--- a/openstack_types/src/compute/v2/server_group/response/create.rs
+++ b/openstack_types/src/compute/v2/server_group/response/create.rs
@@ -184,5 +184,6 @@ impl std::str::FromStr for Policy {
 /// `Rules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Rules {
+    #[serde(default, deserialize_with = "crate::common::deser_num_str_opt")]
     pub max_server_per_host: Option<i64>,
 }

--- a/openstack_types/src/compute/v2/server_group/response/get.rs
+++ b/openstack_types/src/compute/v2/server_group/response/get.rs
@@ -184,5 +184,6 @@ impl std::str::FromStr for Policy {
 /// `Rules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Rules {
+    #[serde(default, deserialize_with = "crate::common::deser_num_str_opt")]
     pub max_server_per_host: Option<i64>,
 }

--- a/openstack_types/src/compute/v2/server_group/response/list.rs
+++ b/openstack_types/src/compute/v2/server_group/response/list.rs
@@ -184,5 +184,6 @@ impl std::str::FromStr for Policy {
 /// `Rules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Rules {
+    #[serde(default, deserialize_with = "crate::common::deser_num_str_opt")]
     pub max_server_per_host: Option<i64>,
 }

--- a/openstack_types/src/compute/v2/simple_tenant_usage/response/get.rs
+++ b/openstack_types/src/compute/v2/simple_tenant_usage/response/get.rs
@@ -40,30 +40,50 @@ pub struct SimpleTenantUsageResponse {
 /// `ServerUsages` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ServerUsages {
+    #[serde(default)]
     pub ended_at: Option<String>,
+    #[serde(default)]
     pub flavor: Option<String>,
+    #[serde(default)]
     pub hours: Option<f32>,
+    #[serde(default)]
     pub instance_id: Option<String>,
+    #[serde(default)]
     pub local_gb: Option<i32>,
+    #[serde(default)]
     pub memory_mb: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub started_at: Option<String>,
+    #[serde(default)]
     pub state: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub uptime: Option<i32>,
+    #[serde(default)]
     pub vcpus: Option<i32>,
 }
 
 /// `TenantUsages` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TenantUsages {
+    #[serde(default)]
     pub server_usages: Option<Vec<ServerUsages>>,
+    #[serde(default)]
     pub start: Option<String>,
+    #[serde(default)]
     pub stop: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub total_hours: Option<f32>,
+    #[serde(default)]
     pub total_local_gb_usage: Option<f32>,
+    #[serde(default)]
     pub total_memory_mb_usage: Option<f32>,
+    #[serde(default)]
     pub total_vcpus_usage: Option<f32>,
 }
 
@@ -73,6 +93,8 @@ pub struct TenantUsages {
 /// `TenantUsagesLinks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TenantUsagesLinks {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/compute/v2/simple_tenant_usage/response/list.rs
+++ b/openstack_types/src/compute/v2/simple_tenant_usage/response/list.rs
@@ -40,30 +40,50 @@ pub struct SimpleTenantUsageResponse {
 /// `ServerUsages` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ServerUsages {
+    #[serde(default)]
     pub ended_at: Option<String>,
+    #[serde(default)]
     pub flavor: Option<String>,
+    #[serde(default)]
     pub hours: Option<f32>,
+    #[serde(default)]
     pub instance_id: Option<String>,
+    #[serde(default)]
     pub local_gb: Option<i32>,
+    #[serde(default)]
     pub memory_mb: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub started_at: Option<String>,
+    #[serde(default)]
     pub state: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub uptime: Option<i32>,
+    #[serde(default)]
     pub vcpus: Option<i32>,
 }
 
 /// `TenantUsages` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TenantUsages {
+    #[serde(default)]
     pub server_usages: Option<Vec<ServerUsages>>,
+    #[serde(default)]
     pub start: Option<String>,
+    #[serde(default)]
     pub stop: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub total_hours: Option<f32>,
+    #[serde(default)]
     pub total_local_gb_usage: Option<f32>,
+    #[serde(default)]
     pub total_memory_mb_usage: Option<f32>,
+    #[serde(default)]
     pub total_vcpus_usage: Option<f32>,
 }
 
@@ -73,6 +93,8 @@ pub struct TenantUsages {
 /// `TenantUsagesLinks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TenantUsagesLinks {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/compute/v2/version/response/get.rs
+++ b/openstack_types/src/compute/v2/version/response/get.rs
@@ -72,6 +72,7 @@ pub struct VersionResponse {
 pub struct Links {
     pub href: String,
     pub rel: String,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
@@ -79,6 +80,7 @@ pub struct Links {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MediaTypes {
     pub base: String,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/certificate/response/create.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/certificate/response/create.rs
@@ -55,9 +55,14 @@ pub struct CertificateResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/container_infrastructure_management/v1/certificate/response/get.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/certificate/response/get.rs
@@ -58,9 +58,14 @@ pub struct CertificateResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/create.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/create.rs
@@ -132,10 +132,15 @@ pub struct NodegroupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/get.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/get.rs
@@ -132,10 +132,15 @@ pub struct NodegroupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/list.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/list.rs
@@ -128,10 +128,15 @@ pub struct NodegroupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/set.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/cluster/nodegroup/response/set.rs
@@ -132,10 +132,15 @@ pub struct NodegroupResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/cluster/response/get.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/cluster/response/get.rs
@@ -251,10 +251,15 @@ impl std::str::FromStr for HealthStatus {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/cluster/response/list.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/cluster/response/list.rs
@@ -214,10 +214,15 @@ impl std::str::FromStr for HealthStatus {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/clustertemplate/response/create.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/clustertemplate/response/create.rs
@@ -287,10 +287,15 @@ impl std::str::FromStr for Coe {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/clustertemplate/response/get.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/clustertemplate/response/get.rs
@@ -287,10 +287,15 @@ impl std::str::FromStr for Coe {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/clustertemplate/response/list.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/clustertemplate/response/list.rs
@@ -282,10 +282,15 @@ impl std::str::FromStr for Coe {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/federation/response/get.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/federation/response/get.rs
@@ -68,10 +68,15 @@ pub struct FederationResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/federation/response/list.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/federation/response/list.rs
@@ -64,10 +64,15 @@ pub struct FederationResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 

--- a/openstack_types/src/container_infrastructure_management/v1/version/response/get.rs
+++ b/openstack_types/src/container_infrastructure_management/v1/version/response/get.rs
@@ -79,10 +79,15 @@ pub struct VersionResponse {
 /// `Certificates` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Certificates {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -90,10 +95,15 @@ pub struct Certificates {
 /// `Clusters` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Clusters {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -101,10 +111,15 @@ pub struct Clusters {
 /// `Clustertemplates` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Clustertemplates {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -112,10 +127,15 @@ pub struct Clustertemplates {
 /// `Federations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Federations {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -123,10 +143,15 @@ pub struct Federations {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -134,9 +159,13 @@ pub struct Links {
 /// `MediaTypes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MediaTypes {
+    #[serde(default)]
     pub base: Option<String>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -144,10 +173,15 @@ pub struct MediaTypes {
 /// `Mservices` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Mservices {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -155,10 +189,15 @@ pub struct Mservices {
 /// `Nodegroups` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Nodegroups {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -166,10 +205,15 @@ pub struct Nodegroups {
 /// `Quotas` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Quotas {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -177,9 +221,14 @@ pub struct Quotas {
 /// `Stats` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Stats {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/dns/v2/recordset/response/list.rs
+++ b/openstack_types/src/dns/v2/recordset/response/list.rs
@@ -134,6 +134,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/reverse/floatingip/response/get.rs
+++ b/openstack_types/src/dns/v2/reverse/floatingip/response/get.rs
@@ -98,6 +98,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/reverse/floatingip/response/list.rs
+++ b/openstack_types/src/dns/v2/reverse/floatingip/response/list.rs
@@ -91,6 +91,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/reverse/floatingip/response/set.rs
+++ b/openstack_types/src/dns/v2/reverse/floatingip/response/set.rs
@@ -98,6 +98,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/nameserver/response/list.rs
+++ b/openstack_types/src/dns/v2/zone/nameserver/response/list.rs
@@ -38,5 +38,6 @@ pub struct NameserverResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/dns/v2/zone/recordset/response/create.rs
+++ b/openstack_types/src/dns/v2/zone/recordset/response/create.rs
@@ -141,6 +141,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/recordset/response/get.rs
+++ b/openstack_types/src/dns/v2/zone/recordset/response/get.rs
@@ -141,6 +141,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/recordset/response/list.rs
+++ b/openstack_types/src/dns/v2/zone/recordset/response/list.rs
@@ -134,6 +134,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/recordset/response/set.rs
+++ b/openstack_types/src/dns/v2/zone/recordset/response/set.rs
@@ -141,6 +141,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/response/create.rs
+++ b/openstack_types/src/dns/v2/zone/response/create.rs
@@ -166,6 +166,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/response/get.rs
+++ b/openstack_types/src/dns/v2/zone/response/get.rs
@@ -166,6 +166,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/response/list.rs
+++ b/openstack_types/src/dns/v2/zone/response/list.rs
@@ -159,6 +159,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/response/set.rs
+++ b/openstack_types/src/dns/v2/zone/response/set.rs
@@ -166,6 +166,7 @@ impl std::str::FromStr for Action {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/dns/v2/zone/share/response/create.rs
+++ b/openstack_types/src/dns/v2/zone/share/response/create.rs
@@ -63,6 +63,8 @@ pub struct ShareResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
+    #[serde(default)]
     pub zone: Option<String>,
 }

--- a/openstack_types/src/dns/v2/zone/share/response/get.rs
+++ b/openstack_types/src/dns/v2/zone/share/response/get.rs
@@ -63,6 +63,8 @@ pub struct ShareResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
+    #[serde(default)]
     pub zone: Option<String>,
 }

--- a/openstack_types/src/dns/v2/zone/share/response/list.rs
+++ b/openstack_types/src/dns/v2/zone/share/response/list.rs
@@ -30,6 +30,7 @@ pub struct ShareResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -39,7 +40,9 @@ pub struct Links {
 /// `SharedZonesLinks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SharedZonesLinks {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
+    #[serde(default)]
     pub zone: Option<String>,
 }
 
@@ -47,10 +50,16 @@ pub struct SharedZonesLinks {
 /// `SharedZones` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SharedZones {
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<SharedZonesLinks>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub target_project_id: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/catalog/response/list.rs
+++ b/openstack_types/src/identity/v3/auth/catalog/response/list.rs
@@ -74,8 +74,12 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/domain/response/list.rs
+++ b/openstack_types/src/identity/v3/auth/domain/response/list.rs
@@ -50,6 +50,8 @@ pub struct DomainResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/response/create.rs
+++ b/openstack_types/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/response/create.rs
@@ -102,25 +102,35 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -128,9 +138,14 @@ pub struct Domain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/response/get.rs
+++ b/openstack_types/src/identity/v3/auth/os_federation/identity_provider/protocol/websso/response/get.rs
@@ -102,25 +102,35 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -128,9 +138,14 @@ pub struct Domain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/os_federation/websso/response/create.rs
+++ b/openstack_types/src/identity/v3/auth/os_federation/websso/response/create.rs
@@ -102,25 +102,35 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -128,9 +138,14 @@ pub struct Domain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/os_federation/websso/response/get.rs
+++ b/openstack_types/src/identity/v3/auth/os_federation/websso/response/get.rs
@@ -102,25 +102,35 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -128,9 +138,14 @@ pub struct Domain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/project/response/list.rs
+++ b/openstack_types/src/identity/v3/auth/project/response/list.rs
@@ -50,6 +50,8 @@ pub struct ProjectResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/token/response/create.rs
+++ b/openstack_types/src/identity/v3/auth/token/response/create.rs
@@ -146,18 +146,26 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
@@ -166,7 +174,9 @@ pub struct Catalog {
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -176,14 +186,18 @@ pub struct Domain {
 /// `Project` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Project {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -193,7 +207,9 @@ pub struct Roles {
 /// `UserDomain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UserDomain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -201,9 +217,14 @@ pub struct UserDomain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<UserDomain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/auth/token/response/get.rs
+++ b/openstack_types/src/identity/v3/auth/token/response/get.rs
@@ -146,18 +146,26 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
@@ -166,7 +174,9 @@ pub struct Catalog {
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -176,14 +186,18 @@ pub struct Domain {
 /// `Project` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Project {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -193,7 +207,9 @@ pub struct Roles {
 /// `UserDomain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UserDomain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -201,9 +217,14 @@ pub struct UserDomain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<UserDomain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/credential/response/create.rs
+++ b/openstack_types/src/identity/v3/credential/response/create.rs
@@ -58,5 +58,6 @@ pub struct CredentialResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/credential/response/get.rs
+++ b/openstack_types/src/identity/v3/credential/response/get.rs
@@ -58,5 +58,6 @@ pub struct CredentialResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/credential/response/list.rs
+++ b/openstack_types/src/identity/v3/credential/response/list.rs
@@ -53,5 +53,6 @@ pub struct CredentialResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/credential/response/set.rs
+++ b/openstack_types/src/identity/v3/credential/response/set.rs
@@ -58,5 +58,6 @@ pub struct CredentialResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/domain/group/role/response/list.rs
+++ b/openstack_types/src/identity/v3/domain/group/role/response/list.rs
@@ -42,5 +42,6 @@ pub struct RoleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/domain/response/create.rs
+++ b/openstack_types/src/identity/v3/domain/response/create.rs
@@ -64,6 +64,7 @@ pub struct DomainResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -72,5 +73,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/domain/response/get.rs
+++ b/openstack_types/src/identity/v3/domain/response/get.rs
@@ -64,6 +64,7 @@ pub struct DomainResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -72,5 +73,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/domain/response/list.rs
+++ b/openstack_types/src/identity/v3/domain/response/list.rs
@@ -59,6 +59,7 @@ pub struct DomainResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -67,5 +68,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/domain/response/set.rs
+++ b/openstack_types/src/identity/v3/domain/response/set.rs
@@ -64,6 +64,7 @@ pub struct DomainResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -72,5 +73,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/domain/user/role/response/list.rs
+++ b/openstack_types/src/identity/v3/domain/user/role/response/list.rs
@@ -42,5 +42,6 @@ pub struct RoleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/group/user/response/list.rs
+++ b/openstack_types/src/identity/v3/group/user/response/list.rs
@@ -111,8 +111,11 @@ pub struct Federated {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
@@ -124,11 +127,18 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub ignore_change_password_upon_first_use: Option<bool>,
+    #[serde(default)]
     pub ignore_lockout_failure_attempts: Option<bool>,
+    #[serde(default)]
     pub ignore_password_expiry: Option<bool>,
+    #[serde(default)]
     pub ignore_user_inactivity: Option<bool>,
+    #[serde(default)]
     pub lock_password: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_enabled: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }

--- a/openstack_types/src/identity/v3/limit/response/create.rs
+++ b/openstack_types/src/identity/v3/limit/response/create.rs
@@ -73,5 +73,6 @@ pub struct LimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/limit/response/get.rs
+++ b/openstack_types/src/identity/v3/limit/response/get.rs
@@ -73,5 +73,6 @@ pub struct LimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/limit/response/list.rs
+++ b/openstack_types/src/identity/v3/limit/response/list.rs
@@ -68,5 +68,6 @@ pub struct LimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/limit/response/set.rs
+++ b/openstack_types/src/identity/v3/limit/response/set.rs
@@ -73,5 +73,6 @@ pub struct LimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/create.rs
+++ b/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/create.rs
@@ -85,9 +85,13 @@ impl std::str::FromStr for Interface {
 /// `Filters` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Filters {
+    #[serde(default)]
     pub enabled: Option<bool>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region_id: Option<String>,
+    #[serde(default)]
     pub service_id: Option<String>,
 }
 
@@ -95,5 +99,6 @@ pub struct Filters {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/get.rs
+++ b/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/get.rs
@@ -85,9 +85,13 @@ impl std::str::FromStr for Interface {
 /// `Filters` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Filters {
+    #[serde(default)]
     pub enabled: Option<bool>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region_id: Option<String>,
+    #[serde(default)]
     pub service_id: Option<String>,
 }
 
@@ -95,5 +99,6 @@ pub struct Filters {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/list.rs
+++ b/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/list.rs
@@ -80,9 +80,13 @@ impl std::str::FromStr for Interface {
 /// `Filters` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Filters {
+    #[serde(default)]
     pub enabled: Option<bool>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region_id: Option<String>,
+    #[serde(default)]
     pub service_id: Option<String>,
 }
 
@@ -90,5 +94,6 @@ pub struct Filters {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/set.rs
+++ b/openstack_types/src/identity/v3/os_ep_filter/endpoint_group/response/set.rs
@@ -85,9 +85,13 @@ impl std::str::FromStr for Interface {
 /// `Filters` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Filters {
+    #[serde(default)]
     pub enabled: Option<bool>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region_id: Option<String>,
+    #[serde(default)]
     pub service_id: Option<String>,
 }
 
@@ -95,5 +99,6 @@ pub struct Filters {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/domain/response/list.rs
+++ b/openstack_types/src/identity/v3/os_federation/domain/response/list.rs
@@ -50,6 +50,8 @@ pub struct DomainResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/identity_provider/protocol/auth/response/create.rs
+++ b/openstack_types/src/identity/v3/os_federation/identity_provider/protocol/auth/response/create.rs
@@ -102,25 +102,35 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -128,9 +138,14 @@ pub struct Domain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/identity_provider/protocol/auth/response/get.rs
+++ b/openstack_types/src/identity/v3/os_federation/identity_provider/protocol/auth/response/get.rs
@@ -102,25 +102,35 @@ impl std::str::FromStr for Interface {
 /// `Endpoints` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Endpoints {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub interface: Option<Interface>,
+    #[serde(default)]
     pub region: Option<String>,
+    #[serde(default)]
     pub url: Option<String>,
 }
 
 /// `Catalog` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(default)]
     pub endpoints: Option<Vec<Endpoints>>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -128,9 +138,14 @@ pub struct Domain {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "OS-FEDERATION")]
     pub os_federation: Option<BTreeMap<String, Value>>,
+    #[serde(default)]
     pub password_expires_at: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/mapping/response/create.rs
+++ b/openstack_types/src/identity/v3/os_federation/mapping/response/create.rs
@@ -40,7 +40,9 @@ pub struct MappingResponse {
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -75,6 +77,7 @@ pub struct Roles {
 /// `Projects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Projects {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub name: String,
     pub roles: Vec<Roles>,
@@ -105,21 +108,32 @@ impl std::str::FromStr for Type {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub email: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Local` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Local {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub group: Option<LocalGroup>,
+    #[serde(default)]
     pub group_ids: Option<String>,
+    #[serde(default)]
     pub groups: Option<String>,
+    #[serde(default)]
     pub projects: Option<Vec<Projects>>,
+    #[serde(default)]
     pub user: Option<User>,
 }
 
@@ -127,7 +141,9 @@ pub struct Local {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteAnyOneOfRegexType {
     pub any_one_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -135,7 +151,9 @@ pub struct RemoteAnyOneOfRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteBlacklistRegexType {
     pub blacklist: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -143,14 +161,18 @@ pub struct RemoteBlacklistRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteNotAnyOfRegexType {
     pub not_any_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
 /// `RemoteRegexTypeWhitelist` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteRegexTypeWhitelist {
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
     pub whitelist: Vec<String>,
 }
@@ -158,6 +180,7 @@ pub struct RemoteRegexTypeWhitelist {
 /// `RemoteType` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteType {
+    #[serde(rename = "type")]
     pub _type: String,
 }
 

--- a/openstack_types/src/identity/v3/os_federation/mapping/response/get.rs
+++ b/openstack_types/src/identity/v3/os_federation/mapping/response/get.rs
@@ -40,7 +40,9 @@ pub struct MappingResponse {
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -75,6 +77,7 @@ pub struct Roles {
 /// `Projects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Projects {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub name: String,
     pub roles: Vec<Roles>,
@@ -105,21 +108,32 @@ impl std::str::FromStr for Type {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub email: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Local` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Local {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub group: Option<LocalGroup>,
+    #[serde(default)]
     pub group_ids: Option<String>,
+    #[serde(default)]
     pub groups: Option<String>,
+    #[serde(default)]
     pub projects: Option<Vec<Projects>>,
+    #[serde(default)]
     pub user: Option<User>,
 }
 
@@ -127,7 +141,9 @@ pub struct Local {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteAnyOneOfRegexType {
     pub any_one_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -135,7 +151,9 @@ pub struct RemoteAnyOneOfRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteBlacklistRegexType {
     pub blacklist: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -143,14 +161,18 @@ pub struct RemoteBlacklistRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteNotAnyOfRegexType {
     pub not_any_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
 /// `RemoteRegexTypeWhitelist` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteRegexTypeWhitelist {
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
     pub whitelist: Vec<String>,
 }
@@ -158,6 +180,7 @@ pub struct RemoteRegexTypeWhitelist {
 /// `RemoteType` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteType {
+    #[serde(rename = "type")]
     pub _type: String,
 }
 

--- a/openstack_types/src/identity/v3/os_federation/mapping/response/list.rs
+++ b/openstack_types/src/identity/v3/os_federation/mapping/response/list.rs
@@ -40,7 +40,9 @@ pub struct MappingResponse {
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -75,6 +77,7 @@ pub struct Roles {
 /// `Projects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Projects {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub name: String,
     pub roles: Vec<Roles>,
@@ -105,21 +108,32 @@ impl std::str::FromStr for Type {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub email: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Local` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Local {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub group: Option<LocalGroup>,
+    #[serde(default)]
     pub group_ids: Option<String>,
+    #[serde(default)]
     pub groups: Option<String>,
+    #[serde(default)]
     pub projects: Option<Vec<Projects>>,
+    #[serde(default)]
     pub user: Option<User>,
 }
 
@@ -127,7 +141,9 @@ pub struct Local {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteAnyOneOfRegexType {
     pub any_one_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -135,7 +151,9 @@ pub struct RemoteAnyOneOfRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteBlacklistRegexType {
     pub blacklist: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -143,14 +161,18 @@ pub struct RemoteBlacklistRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteNotAnyOfRegexType {
     pub not_any_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
 /// `RemoteRegexTypeWhitelist` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteRegexTypeWhitelist {
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
     pub whitelist: Vec<String>,
 }
@@ -158,6 +180,7 @@ pub struct RemoteRegexTypeWhitelist {
 /// `RemoteType` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteType {
+    #[serde(rename = "type")]
     pub _type: String,
 }
 

--- a/openstack_types/src/identity/v3/os_federation/mapping/response/set.rs
+++ b/openstack_types/src/identity/v3/os_federation/mapping/response/set.rs
@@ -40,7 +40,9 @@ pub struct MappingResponse {
 /// `Domain` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -75,6 +77,7 @@ pub struct Roles {
 /// `Projects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Projects {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub name: String,
     pub roles: Vec<Roles>,
@@ -105,21 +108,32 @@ impl std::str::FromStr for Type {
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub email: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Local` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Local {
+    #[serde(default)]
     pub domain: Option<Domain>,
+    #[serde(default)]
     pub group: Option<LocalGroup>,
+    #[serde(default)]
     pub group_ids: Option<String>,
+    #[serde(default)]
     pub groups: Option<String>,
+    #[serde(default)]
     pub projects: Option<Vec<Projects>>,
+    #[serde(default)]
     pub user: Option<User>,
 }
 
@@ -127,7 +141,9 @@ pub struct Local {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteAnyOneOfRegexType {
     pub any_one_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -135,7 +151,9 @@ pub struct RemoteAnyOneOfRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteBlacklistRegexType {
     pub blacklist: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
@@ -143,14 +161,18 @@ pub struct RemoteBlacklistRegexType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteNotAnyOfRegexType {
     pub not_any_of: Vec<String>,
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
 }
 
 /// `RemoteRegexTypeWhitelist` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteRegexTypeWhitelist {
+    #[serde(default)]
     pub regex: Option<bool>,
+    #[serde(rename = "type")]
     pub _type: String,
     pub whitelist: Vec<String>,
 }
@@ -158,6 +180,7 @@ pub struct RemoteRegexTypeWhitelist {
 /// `RemoteType` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RemoteType {
+    #[serde(rename = "type")]
     pub _type: String,
 }
 

--- a/openstack_types/src/identity/v3/os_federation/project/response/list.rs
+++ b/openstack_types/src/identity/v3/os_federation/project/response/list.rs
@@ -50,6 +50,8 @@ pub struct ProjectResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/service_provider/response/create.rs
+++ b/openstack_types/src/identity/v3/os_federation/service_provider/response/create.rs
@@ -62,5 +62,6 @@ pub struct ServiceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/service_provider/response/get.rs
+++ b/openstack_types/src/identity/v3/os_federation/service_provider/response/get.rs
@@ -62,5 +62,6 @@ pub struct ServiceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/service_provider/response/list.rs
+++ b/openstack_types/src/identity/v3/os_federation/service_provider/response/list.rs
@@ -57,5 +57,6 @@ pub struct ServiceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_federation/service_provider/response/set.rs
+++ b/openstack_types/src/identity/v3/os_federation/service_provider/response/set.rs
@@ -62,5 +62,6 @@ pub struct ServiceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/os_trust/trust/response/create.rs
+++ b/openstack_types/src/identity/v3/os_trust/trust/response/create.rs
@@ -131,25 +131,35 @@ pub struct TrustResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub domain_id: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub options: Option<Options>,
 }
 
@@ -157,7 +167,10 @@ pub struct Roles {
 /// `RolesLinks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RolesLinks {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }

--- a/openstack_types/src/identity/v3/os_trust/trust/response/get.rs
+++ b/openstack_types/src/identity/v3/os_trust/trust/response/get.rs
@@ -131,25 +131,35 @@ pub struct TrustResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub domain_id: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub options: Option<Options>,
 }
 
@@ -157,7 +167,10 @@ pub struct Roles {
 /// `RolesLinks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RolesLinks {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }

--- a/openstack_types/src/identity/v3/os_trust/trust/response/list.rs
+++ b/openstack_types/src/identity/v3/os_trust/trust/response/list.rs
@@ -126,25 +126,35 @@ pub struct TrustResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub domain_id: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub options: Option<Options>,
 }
 
@@ -152,7 +162,10 @@ pub struct Roles {
 /// `RolesLinks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RolesLinks {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }

--- a/openstack_types/src/identity/v3/project/group/role/response/list.rs
+++ b/openstack_types/src/identity/v3/project/group/role/response/list.rs
@@ -42,5 +42,6 @@ pub struct RoleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/project/response/create.rs
+++ b/openstack_types/src/identity/v3/project/response/create.rs
@@ -82,6 +82,7 @@ pub struct ProjectResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -90,5 +91,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/project/response/get.rs
+++ b/openstack_types/src/identity/v3/project/response/get.rs
@@ -82,6 +82,7 @@ pub struct ProjectResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -90,5 +91,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/project/response/list.rs
+++ b/openstack_types/src/identity/v3/project/response/list.rs
@@ -77,6 +77,7 @@ pub struct ProjectResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -85,5 +86,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/project/response/set.rs
+++ b/openstack_types/src/identity/v3/project/response/set.rs
@@ -82,6 +82,7 @@ pub struct ProjectResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -90,5 +91,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/project/user/role/response/list.rs
+++ b/openstack_types/src/identity/v3/project/user/role/response/list.rs
@@ -42,5 +42,6 @@ pub struct RoleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/registered_limit/response/create.rs
+++ b/openstack_types/src/identity/v3/registered_limit/response/create.rs
@@ -63,5 +63,6 @@ pub struct RegisteredLimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/registered_limit/response/get.rs
+++ b/openstack_types/src/identity/v3/registered_limit/response/get.rs
@@ -63,5 +63,6 @@ pub struct RegisteredLimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/registered_limit/response/list.rs
+++ b/openstack_types/src/identity/v3/registered_limit/response/list.rs
@@ -58,5 +58,6 @@ pub struct RegisteredLimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/registered_limit/response/set.rs
+++ b/openstack_types/src/identity/v3/registered_limit/response/set.rs
@@ -63,5 +63,6 @@ pub struct RegisteredLimitResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }

--- a/openstack_types/src/identity/v3/role/imply/response/get.rs
+++ b/openstack_types/src/identity/v3/role/imply/response/get.rs
@@ -37,6 +37,7 @@ pub struct ImplyResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -44,9 +45,13 @@ pub struct Links {
 /// `Implies` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Implies {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -54,8 +59,12 @@ pub struct Implies {
 /// `PriorRole` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PriorRole {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/role/imply/response/list.rs
+++ b/openstack_types/src/identity/v3/role/imply/response/list.rs
@@ -37,6 +37,7 @@ pub struct ImplyResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -44,9 +45,13 @@ pub struct Links {
 /// `Implies` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Implies {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -54,8 +59,12 @@ pub struct Implies {
 /// `PriorRole` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PriorRole {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/role/imply/response/set.rs
+++ b/openstack_types/src/identity/v3/role/imply/response/set.rs
@@ -37,6 +37,7 @@ pub struct ImplyResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -44,9 +45,13 @@ pub struct Links {
 /// `Implies` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Implies {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -54,8 +59,12 @@ pub struct Implies {
 /// `PriorRole` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PriorRole {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/role/response/create.rs
+++ b/openstack_types/src/identity/v3/role/response/create.rs
@@ -60,5 +60,6 @@ pub struct RoleResponse {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/role/response/get.rs
+++ b/openstack_types/src/identity/v3/role/response/get.rs
@@ -60,5 +60,6 @@ pub struct RoleResponse {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/role/response/list.rs
+++ b/openstack_types/src/identity/v3/role/response/list.rs
@@ -54,5 +54,6 @@ pub struct RoleResponse {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/role/response/set.rs
+++ b/openstack_types/src/identity/v3/role/response/set.rs
@@ -60,5 +60,6 @@ pub struct RoleResponse {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/role_assignment/response/list.rs
+++ b/openstack_types/src/identity/v3/role_assignment/response/list.rs
@@ -41,14 +41,17 @@ pub struct RoleAssignmentResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Domain {
     pub id: String,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
 /// `Group` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Group {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub id: String,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -56,15 +59,19 @@ pub struct Group {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
     pub assignment: String,
+    #[serde(default)]
     pub membership: Option<String>,
+    #[serde(default)]
     pub prior_role: Option<String>,
 }
 
 /// `Role` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Role {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub id: String,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -72,14 +79,17 @@ pub struct Role {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScopeDomain {
     pub id: String,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
 /// `Project` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Project {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub id: String,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -92,16 +102,22 @@ pub struct System {
 /// `Scope` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Scope {
+    #[serde(default)]
     pub domain: Option<ScopeDomain>,
+    #[serde(default, rename = "OS-INHERIT:inherited_to")]
     pub os_inherit_inherited_to: Option<String>,
+    #[serde(default)]
     pub project: Option<Project>,
+    #[serde(default)]
     pub system: Option<System>,
 }
 
 /// `User` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct User {
+    #[serde(default)]
     pub domain: Option<Domain>,
     pub id: String,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/role_inference/response/list.rs
+++ b/openstack_types/src/identity/v3/role_inference/response/list.rs
@@ -37,6 +37,7 @@ pub struct RoleInferenceResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -44,9 +45,13 @@ pub struct Links {
 /// `Implies` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Implies {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }
 
@@ -54,8 +59,12 @@ pub struct Implies {
 /// `PriorRole` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PriorRole {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub links: Option<Links>,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/system/group/role/response/list.rs
+++ b/openstack_types/src/identity/v3/system/group/role/response/list.rs
@@ -53,6 +53,7 @@ pub struct RoleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -61,5 +62,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/system/user/role/response/list.rs
+++ b/openstack_types/src/identity/v3/system/user/role/response/list.rs
@@ -53,6 +53,7 @@ pub struct RoleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 
@@ -61,5 +62,6 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub immutable: Option<bool>,
 }

--- a/openstack_types/src/identity/v3/user/access_rule/response/get.rs
+++ b/openstack_types/src/identity/v3/user/access_rule/response/get.rs
@@ -55,6 +55,7 @@ pub struct AccessRuleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/identity/v3/user/access_rule/response/list.rs
+++ b/openstack_types/src/identity/v3/user/access_rule/response/list.rs
@@ -50,6 +50,7 @@ pub struct AccessRuleResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default, rename = "self")]
     pub _self: Option<String>,
 }
 

--- a/openstack_types/src/identity/v3/user/application_credential/response/create.rs
+++ b/openstack_types/src/identity/v3/user/application_credential/response/create.rs
@@ -80,15 +80,21 @@ pub struct ApplicationCredentialResponse {
 /// `AccessRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AccessRules {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub method: Option<String>,
+    #[serde(default)]
     pub path: Option<String>,
+    #[serde(default)]
     pub service: Option<String>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/user/application_credential/response/get.rs
+++ b/openstack_types/src/identity/v3/user/application_credential/response/get.rs
@@ -72,15 +72,21 @@ pub struct ApplicationCredentialResponse {
 /// `AccessRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AccessRules {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub method: Option<String>,
+    #[serde(default)]
     pub path: Option<String>,
+    #[serde(default)]
     pub service: Option<String>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/user/application_credential/response/list.rs
+++ b/openstack_types/src/identity/v3/user/application_credential/response/list.rs
@@ -72,15 +72,21 @@ pub struct ApplicationCredentialResponse {
 /// `AccessRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AccessRules {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub method: Option<String>,
+    #[serde(default)]
     pub path: Option<String>,
+    #[serde(default)]
     pub service: Option<String>,
 }
 
 /// `Roles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Roles {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
 }

--- a/openstack_types/src/identity/v3/user/response/create.rs
+++ b/openstack_types/src/identity/v3/user/response/create.rs
@@ -119,8 +119,11 @@ pub struct Federated {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
@@ -132,11 +135,18 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub ignore_change_password_upon_first_use: Option<bool>,
+    #[serde(default)]
     pub ignore_lockout_failure_attempts: Option<bool>,
+    #[serde(default)]
     pub ignore_password_expiry: Option<bool>,
+    #[serde(default)]
     pub ignore_user_inactivity: Option<bool>,
+    #[serde(default)]
     pub lock_password: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_enabled: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }

--- a/openstack_types/src/identity/v3/user/response/get.rs
+++ b/openstack_types/src/identity/v3/user/response/get.rs
@@ -116,8 +116,11 @@ pub struct Federated {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
@@ -129,11 +132,18 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub ignore_change_password_upon_first_use: Option<bool>,
+    #[serde(default)]
     pub ignore_lockout_failure_attempts: Option<bool>,
+    #[serde(default)]
     pub ignore_password_expiry: Option<bool>,
+    #[serde(default)]
     pub ignore_user_inactivity: Option<bool>,
+    #[serde(default)]
     pub lock_password: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_enabled: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }

--- a/openstack_types/src/identity/v3/user/response/list.rs
+++ b/openstack_types/src/identity/v3/user/response/list.rs
@@ -111,8 +111,11 @@ pub struct Federated {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
@@ -124,11 +127,18 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub ignore_change_password_upon_first_use: Option<bool>,
+    #[serde(default)]
     pub ignore_lockout_failure_attempts: Option<bool>,
+    #[serde(default)]
     pub ignore_password_expiry: Option<bool>,
+    #[serde(default)]
     pub ignore_user_inactivity: Option<bool>,
+    #[serde(default)]
     pub lock_password: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_enabled: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }

--- a/openstack_types/src/identity/v3/user/response/set.rs
+++ b/openstack_types/src/identity/v3/user/response/set.rs
@@ -116,8 +116,11 @@ pub struct Federated {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub next: Option<String>,
+    #[serde(default)]
     pub previous: Option<String>,
+    #[serde(rename = "self")]
     pub _self: String,
 }
 
@@ -129,11 +132,18 @@ pub struct Links {
 /// `Options` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Options {
+    #[serde(default)]
     pub ignore_change_password_upon_first_use: Option<bool>,
+    #[serde(default)]
     pub ignore_lockout_failure_attempts: Option<bool>,
+    #[serde(default)]
     pub ignore_password_expiry: Option<bool>,
+    #[serde(default)]
     pub ignore_user_inactivity: Option<bool>,
+    #[serde(default)]
     pub lock_password: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_enabled: Option<bool>,
+    #[serde(default)]
     pub multi_factor_auth_rules: Option<Vec<Vec<String>>>,
 }

--- a/openstack_types/src/image/v2/image/location/response/create.rs
+++ b/openstack_types/src/image/v2/image/location/response/create.rs
@@ -44,6 +44,7 @@ pub struct LocationResponse {
 /// `ValidationData` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ValidationData {
+    #[serde(default)]
     pub checksum: Option<String>,
     pub os_hash_algo: String,
     pub os_hash_value: String,

--- a/openstack_types/src/image/v2/image/location/response/list.rs
+++ b/openstack_types/src/image/v2/image/location/response/list.rs
@@ -44,6 +44,7 @@ pub struct LocationResponse {
 /// `ValidationData` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ValidationData {
+    #[serde(default)]
     pub checksum: Option<String>,
     pub os_hash_algo: String,
     pub os_hash_value: String,

--- a/openstack_types/src/image/v2/image/response/create.rs
+++ b/openstack_types/src/image/v2/image/response/create.rs
@@ -265,6 +265,7 @@ pub struct ImageResponse {
 /// `ValidationData` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ValidationData {
+    #[serde(default)]
     pub checksum: Option<String>,
     pub os_hash_algo: String,
     pub os_hash_value: String,
@@ -275,6 +276,7 @@ pub struct ValidationData {
 pub struct Locations {
     pub metadata: BTreeMap<String, Value>,
     pub url: String,
+    #[serde(default)]
     pub validation_data: Option<ValidationData>,
 }
 

--- a/openstack_types/src/image/v2/image/response/get.rs
+++ b/openstack_types/src/image/v2/image/response/get.rs
@@ -265,6 +265,7 @@ pub struct ImageResponse {
 /// `ValidationData` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ValidationData {
+    #[serde(default)]
     pub checksum: Option<String>,
     pub os_hash_algo: String,
     pub os_hash_value: String,
@@ -275,6 +276,7 @@ pub struct ValidationData {
 pub struct Locations {
     pub metadata: BTreeMap<String, Value>,
     pub url: String,
+    #[serde(default)]
     pub validation_data: Option<ValidationData>,
 }
 

--- a/openstack_types/src/image/v2/image/response/list.rs
+++ b/openstack_types/src/image/v2/image/response/list.rs
@@ -284,6 +284,7 @@ impl std::str::FromStr for DiskFormatStringEnum {
 /// `ValidationData` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ValidationData {
+    #[serde(default)]
     pub checksum: Option<String>,
     pub os_hash_algo: String,
     pub os_hash_value: String,
@@ -294,6 +295,7 @@ pub struct ValidationData {
 pub struct Locations {
     pub metadata: BTreeMap<String, Value>,
     pub url: String,
+    #[serde(default)]
     pub validation_data: Option<ValidationData>,
 }
 

--- a/openstack_types/src/image/v2/image/response/patch.rs
+++ b/openstack_types/src/image/v2/image/response/patch.rs
@@ -264,6 +264,7 @@ pub struct ImageResponse {
 /// `ValidationData` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ValidationData {
+    #[serde(default)]
     pub checksum: Option<String>,
     pub os_hash_algo: String,
     pub os_hash_value: String,
@@ -274,6 +275,7 @@ pub struct ValidationData {
 pub struct Locations {
     pub metadata: BTreeMap<String, Value>,
     pub url: String,
+    #[serde(default)]
     pub validation_data: Option<ValidationData>,
 }
 

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/create.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/create.rs
@@ -103,30 +103,50 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/get.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/get.rs
@@ -103,30 +103,50 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/list.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/list.rs
@@ -103,30 +103,50 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/set.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/set.rs
@@ -103,30 +103,50 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/create.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/create.rs
@@ -143,6 +143,8 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/get.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/get.rs
@@ -143,6 +143,8 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/set.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/set.rs
@@ -143,6 +143,8 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }

--- a/openstack_types/src/image/v2/metadef/namespace/response/create.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/create.rs
@@ -133,54 +133,82 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }
 
 /// `Objects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Objects {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub properties: Option<BTreeMap<String, Properties>>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
 }
 
 /// `ResourceTypeAssociations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResourceTypeAssociations {
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub prefix: Option<String>,
+    #[serde(default)]
     pub properties_target: Option<String>,
 }
 
 /// `Tags` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Tags {
+    #[serde(default)]
     pub name: Option<String>,
 }
 

--- a/openstack_types/src/image/v2/metadef/namespace/response/get.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/get.rs
@@ -133,54 +133,82 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }
 
 /// `Objects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Objects {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub properties: Option<BTreeMap<String, Properties>>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
 }
 
 /// `ResourceTypeAssociations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResourceTypeAssociations {
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub prefix: Option<String>,
+    #[serde(default)]
     pub properties_target: Option<String>,
 }
 
 /// `Tags` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Tags {
+    #[serde(default)]
     pub name: Option<String>,
 }
 

--- a/openstack_types/src/image/v2/metadef/namespace/response/list.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/list.rs
@@ -133,54 +133,82 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }
 
 /// `Objects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Objects {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub properties: Option<BTreeMap<String, Properties>>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
 }
 
 /// `ResourceTypeAssociations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResourceTypeAssociations {
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub prefix: Option<String>,
+    #[serde(default)]
     pub properties_target: Option<String>,
 }
 
 /// `Tags` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Tags {
+    #[serde(default)]
     pub name: Option<String>,
 }
 

--- a/openstack_types/src/image/v2/metadef/namespace/response/set.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/set.rs
@@ -133,54 +133,82 @@ impl std::str::FromStr for Type {
 /// `Items` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Items {
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default, rename = "type")]
     pub _type: Option<Type>,
 }
 
 /// `Properties` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
+    #[serde(default, rename = "additionalItems")]
     pub additional_items: Option<bool>,
+    #[serde(default, rename = "default")]
     pub _default: Option<Value>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default, rename = "enum")]
     pub _enum: Option<Vec<String>>,
+    #[serde(default)]
     pub items: Option<Items>,
+    #[serde(default)]
     pub maximum: Option<f32>,
+    #[serde(default, rename = "maxItems")]
     pub max_items: Option<i32>,
+    #[serde(default, rename = "maxLength")]
     pub max_length: Option<i32>,
+    #[serde(default)]
     pub minimum: Option<f32>,
+    #[serde(default, rename = "minItems")]
     pub min_items: Option<i32>,
+    #[serde(default, rename = "minLength")]
     pub min_length: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operators: Option<Vec<String>>,
+    #[serde(default)]
     pub pattern: Option<String>,
+    #[serde(default)]
     pub readonly: Option<bool>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
     pub title: String,
+    #[serde(rename = "type")]
     pub _type: Type,
+    #[serde(default, rename = "uniqueItems")]
     pub unique_items: Option<bool>,
 }
 
 /// `Objects` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Objects {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub properties: Option<BTreeMap<String, Properties>>,
+    #[serde(default)]
     pub required: Option<Vec<String>>,
 }
 
 /// `ResourceTypeAssociations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResourceTypeAssociations {
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub prefix: Option<String>,
+    #[serde(default)]
     pub properties_target: Option<String>,
 }
 
 /// `Tags` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Tags {
+    #[serde(default)]
     pub name: Option<String>,
 }
 

--- a/openstack_types/src/load_balancer/v2/amphorae/response/stats.rs
+++ b/openstack_types/src/load_balancer/v2/amphorae/response/stats.rs
@@ -33,12 +33,20 @@ pub struct AmphoraeResponse {
 /// `AmphoraStats` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AmphoraStats {
+    #[serde(default)]
     pub active_connections: Option<i32>,
+    #[serde(default)]
     pub bytes_in: Option<i32>,
+    #[serde(default)]
     pub bytes_out: Option<i32>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub listener_id: Option<String>,
+    #[serde(default)]
     pub loadbalancer_id: Option<String>,
+    #[serde(default)]
     pub request_errors: Option<i32>,
+    #[serde(default)]
     pub total_connections: Option<i32>,
 }

--- a/openstack_types/src/load_balancer/v2/flavor_profile/response/list.rs
+++ b/openstack_types/src/load_balancer/v2/flavor_profile/response/list.rs
@@ -35,7 +35,9 @@ pub struct FlavorProfileResponse {
 /// `FlavorprofileLinks` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FlavorprofileLinks {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }
 
@@ -43,8 +45,12 @@ pub struct FlavorprofileLinks {
 /// `Flavorprofiles` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavorprofiles {
+    #[serde(default)]
     pub flavor_data: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub provider_name: Option<String>,
 }

--- a/openstack_types/src/load_balancer/v2/loadbalancer/response/create.rs
+++ b/openstack_types/src/load_balancer/v2/loadbalancer/response/create.rs
@@ -149,6 +149,7 @@ pub struct LoadbalancerResponse {
 /// `AdditionalVips` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AdditionalVips {
+    #[serde(default)]
     pub ip_address: Option<String>,
     pub subnet_id: String,
 }
@@ -157,19 +158,33 @@ pub struct AdditionalVips {
 /// `Rules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Rules {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub compare_type: Option<String>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub invert: Option<bool>,
+    #[serde(default)]
     pub key: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
+    #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
+    #[serde(default)]
     pub value: Option<String>,
 }
 
@@ -177,24 +192,43 @@ pub struct Rules {
 /// `L7policies` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct L7policies {
+    #[serde(default)]
     pub action: Option<String>,
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub listener_id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub position: Option<i32>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
+    #[serde(default)]
     pub redirect_http_code: Option<i32>,
+    #[serde(default)]
     pub redirect_pool_id: Option<String>,
+    #[serde(default)]
     pub redirect_prefix: Option<String>,
+    #[serde(default)]
     pub redirect_url: Option<String>,
+    #[serde(default)]
     pub rules: Option<Vec<Rules>>,
+    #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -209,39 +243,73 @@ pub struct Loadbalancers {
 /// `Listeners` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Listeners {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub allowed_cidrs: Option<Vec<String>>,
+    #[serde(default)]
     pub alpn_protocols: Option<Vec<String>>,
+    #[serde(default)]
     pub client_authentication: Option<String>,
+    #[serde(default)]
     pub client_ca_tls_container_ref: Option<String>,
+    #[serde(default)]
     pub client_crl_container_ref: Option<String>,
+    #[serde(default)]
     pub connection_limit: Option<i32>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub default_pool_id: Option<String>,
+    #[serde(default)]
     pub default_tls_container_ref: Option<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub hsts_include_subdomains: Option<bool>,
+    #[serde(default)]
     pub hsts_max_age: Option<i32>,
+    #[serde(default)]
     pub hsts_preload: Option<bool>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub insert_headers: Option<BTreeMap<String, String>>,
+    #[serde(default)]
     pub l7policies: Option<Vec<L7policies>>,
+    #[serde(default)]
     pub loadbalancers: Option<Vec<Loadbalancers>>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub protocol: Option<String>,
+    #[serde(default)]
     pub protocol_port: Option<i32>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
+    #[serde(default)]
     pub sni_container_refs: Option<Vec<String>>,
+    #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub timeout_client_data: Option<i32>,
+    #[serde(default)]
     pub timeout_member_connect: Option<i32>,
+    #[serde(default)]
     pub timeout_member_data: Option<i32>,
+    #[serde(default)]
     pub timeout_tcp_inspect: Option<i32>,
+    #[serde(default)]
     pub tls_ciphers: Option<String>,
+    #[serde(default)]
     pub tls_versions: Option<Vec<String>>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }
 
@@ -256,26 +324,47 @@ pub struct HealthmonitorPools {
 /// `Healthmonitor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Healthmonitor {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub delay: Option<i32>,
+    #[serde(default)]
     pub domain_name: Option<String>,
+    #[serde(default)]
     pub expected_codes: Option<String>,
+    #[serde(default)]
     pub http_method: Option<String>,
+    #[serde(default)]
     pub http_version: Option<f32>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub max_retries: Option<i32>,
+    #[serde(default)]
     pub max_retries_down: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub pools: Option<Vec<HealthmonitorPools>>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
+    #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub timeout: Option<i32>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
+    #[serde(default)]
     pub url_path: Option<String>,
 }
 
@@ -290,23 +379,41 @@ pub struct PoolsListeners {
 /// `Members` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Members {
+    #[serde(default)]
     pub address: Option<String>,
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub backup: Option<bool>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub monitor_address: Option<String>,
+    #[serde(default)]
     pub monitor_port: Option<i32>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub protocol_port: Option<i32>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
+    #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
+    #[serde(default)]
     pub vnic_type: Option<String>,
+    #[serde(default)]
     pub weight: Option<i32>,
 }
 
@@ -314,9 +421,13 @@ pub struct Members {
 /// `SessionPersistence` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SessionPersistence {
+    #[serde(default)]
     pub cookie_name: Option<String>,
+    #[serde(default)]
     pub persistence_granularity: Option<String>,
+    #[serde(default)]
     pub persistence_timeout: Option<i32>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
@@ -324,30 +435,56 @@ pub struct SessionPersistence {
 /// `PoolsStructResponse` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PoolsStructResponse {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub alpn_protocols: Option<Vec<String>>,
+    #[serde(default)]
     pub ca_tls_container_ref: Option<String>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub crl_container_ref: Option<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub healthmonitor: Option<Healthmonitor>,
+    #[serde(default)]
     pub healthmonitor_id: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub lb_algorithm: Option<String>,
+    #[serde(default)]
     pub listeners: Option<Vec<PoolsListeners>>,
+    #[serde(default)]
     pub loadbalancers: Option<Vec<Loadbalancers>>,
+    #[serde(default)]
     pub members: Option<Vec<Members>>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub protocol: Option<String>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
+    #[serde(default)]
     pub session_persistence: Option<SessionPersistence>,
+    #[serde(default)]
     pub tags: Option<Vec<String>>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub tls_ciphers: Option<String>,
+    #[serde(default)]
     pub tls_container_ref: Option<String>,
+    #[serde(default)]
     pub tls_enabled: Option<bool>,
+    #[serde(default)]
     pub tls_versions: Option<Vec<String>>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/load_balancer/v2/loadbalancer/response/get.rs
+++ b/openstack_types/src/load_balancer/v2/loadbalancer/response/get.rs
@@ -163,6 +163,7 @@ pub struct LoadbalancerResponse {
 /// `AdditionalVips` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AdditionalVips {
+    #[serde(default)]
     pub ip_address: Option<String>,
     pub subnet_id: String,
 }

--- a/openstack_types/src/load_balancer/v2/loadbalancer/response/list.rs
+++ b/openstack_types/src/load_balancer/v2/loadbalancer/response/list.rs
@@ -163,6 +163,7 @@ pub struct LoadbalancerResponse {
 /// `AdditionalVips` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AdditionalVips {
+    #[serde(default)]
     pub ip_address: Option<String>,
     pub subnet_id: String,
 }

--- a/openstack_types/src/load_balancer/v2/loadbalancer/response/set.rs
+++ b/openstack_types/src/load_balancer/v2/loadbalancer/response/set.rs
@@ -162,6 +162,7 @@ pub struct LoadbalancerResponse {
 /// `AdditionalVips` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AdditionalVips {
+    #[serde(default)]
     pub ip_address: Option<String>,
     pub subnet_id: String,
 }

--- a/openstack_types/src/load_balancer/v2/loadbalancer/response/status.rs
+++ b/openstack_types/src/load_balancer/v2/loadbalancer/response/status.rs
@@ -31,10 +31,15 @@ pub struct LoadbalancerResponse {
 /// `HealthMonitor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HealthMonitor {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }
 
@@ -42,11 +47,17 @@ pub struct HealthMonitor {
 /// `Members` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Members {
+    #[serde(default)]
     pub address: Option<String>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub protocol_port: Option<i32>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
 }
 
@@ -54,11 +65,17 @@ pub struct Members {
 /// `Pools` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Pools {
+    #[serde(default)]
     pub health_monitor: Option<HealthMonitor>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub members: Option<Vec<Members>>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
 }
 
@@ -66,10 +83,15 @@ pub struct Pools {
 /// `Listeners` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Listeners {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub pools: Option<Vec<Pools>>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
 }
 
@@ -77,9 +99,14 @@ pub struct Listeners {
 /// `Loadbalancer` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Loadbalancer {
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub listeners: Option<Vec<Listeners>>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub operating_status: Option<String>,
+    #[serde(default)]
     pub provisioning_status: Option<String>,
 }

--- a/openstack_types/src/load_balancer/v2/pool/response/create.rs
+++ b/openstack_types/src/load_balancer/v2/pool/response/create.rs
@@ -208,8 +208,12 @@ pub struct Members {
 /// `SessionPersistence` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SessionPersistence {
+    #[serde(default)]
     pub cookie_name: Option<String>,
+    #[serde(default)]
     pub persistence_granularity: Option<String>,
+    #[serde(default)]
     pub persistence_timeout: Option<i32>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }

--- a/openstack_types/src/load_balancer/v2/pool/response/get.rs
+++ b/openstack_types/src/load_balancer/v2/pool/response/get.rs
@@ -208,8 +208,12 @@ pub struct Members {
 /// `SessionPersistence` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SessionPersistence {
+    #[serde(default)]
     pub cookie_name: Option<String>,
+    #[serde(default)]
     pub persistence_granularity: Option<String>,
+    #[serde(default)]
     pub persistence_timeout: Option<i32>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }

--- a/openstack_types/src/load_balancer/v2/pool/response/list.rs
+++ b/openstack_types/src/load_balancer/v2/pool/response/list.rs
@@ -208,8 +208,12 @@ pub struct Members {
 /// `SessionPersistence` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SessionPersistence {
+    #[serde(default)]
     pub cookie_name: Option<String>,
+    #[serde(default)]
     pub persistence_granularity: Option<String>,
+    #[serde(default)]
     pub persistence_timeout: Option<i32>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }

--- a/openstack_types/src/load_balancer/v2/pool/response/set.rs
+++ b/openstack_types/src/load_balancer/v2/pool/response/set.rs
@@ -208,8 +208,12 @@ pub struct Members {
 /// `SessionPersistence` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SessionPersistence {
+    #[serde(default)]
     pub cookie_name: Option<String>,
+    #[serde(default)]
     pub persistence_granularity: Option<String>,
+    #[serde(default)]
     pub persistence_timeout: Option<i32>,
+    #[serde(default, rename = "type")]
     pub _type: Option<String>,
 }

--- a/openstack_types/src/network/v2/agent/l3_router/response/list.rs
+++ b/openstack_types/src/network/v2/agent/l3_router/response/list.rs
@@ -30,7 +30,9 @@ pub struct L3RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -41,35 +43,56 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default)]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
+    #[serde(default)]
     pub network_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub next_hop: Option<String>,
 }
 
 /// `Routers` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routers {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub availability_zone_hints: Option<Vec<String>>,
+    #[serde(default)]
     pub availability_zones: Option<Vec<String>>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub distributed: Option<bool>,
+    #[serde(default)]
     pub external_gateway_info: Option<ExternalGatewayInfo>,
+    #[serde(default)]
     pub flavor_id: Option<String>,
+    #[serde(default)]
     pub ha: Option<bool>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub project_id: Option<String>,
+    #[serde(default)]
     pub revision_number: Option<i32>,
+    #[serde(default)]
     pub routes: Option<Vec<Routes>>,
+    #[serde(default)]
     pub service_type_id: Option<String>,
+    #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
 }

--- a/openstack_types/src/network/v2/floatingip/response/create.rs
+++ b/openstack_types/src/network/v2/floatingip/response/create.rs
@@ -133,25 +133,41 @@ pub struct FloatingipResponse {
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub device_id: Option<String>,
+    #[serde(default)]
     pub device_owner: Option<String>,
+    #[serde(default)]
     pub mac_address: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub network_id: Option<String>,
+    #[serde(default)]
     pub status: Option<String>,
 }
 
 /// `PortForwardings` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortForwardings {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub external_port: Option<f32>,
+    #[serde(default)]
     pub external_port_range: Option<f32>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub internal_ip_address: Option<String>,
+    #[serde(default)]
     pub internal_port: Option<f32>,
+    #[serde(default)]
     pub internal_port_id: Option<String>,
+    #[serde(default)]
     pub internal_port_range: Option<f32>,
+    #[serde(default)]
     pub protocol: Option<String>,
 }

--- a/openstack_types/src/network/v2/floatingip/response/get.rs
+++ b/openstack_types/src/network/v2/floatingip/response/get.rs
@@ -133,25 +133,41 @@ pub struct FloatingipResponse {
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub device_id: Option<String>,
+    #[serde(default)]
     pub device_owner: Option<String>,
+    #[serde(default)]
     pub mac_address: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub network_id: Option<String>,
+    #[serde(default)]
     pub status: Option<String>,
 }
 
 /// `PortForwardings` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortForwardings {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub external_port: Option<f32>,
+    #[serde(default)]
     pub external_port_range: Option<f32>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub internal_ip_address: Option<String>,
+    #[serde(default)]
     pub internal_port: Option<f32>,
+    #[serde(default)]
     pub internal_port_id: Option<String>,
+    #[serde(default)]
     pub internal_port_range: Option<f32>,
+    #[serde(default)]
     pub protocol: Option<String>,
 }

--- a/openstack_types/src/network/v2/floatingip/response/list.rs
+++ b/openstack_types/src/network/v2/floatingip/response/list.rs
@@ -133,25 +133,41 @@ pub struct FloatingipResponse {
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub device_id: Option<String>,
+    #[serde(default)]
     pub device_owner: Option<String>,
+    #[serde(default)]
     pub mac_address: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub network_id: Option<String>,
+    #[serde(default)]
     pub status: Option<String>,
 }
 
 /// `PortForwardings` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortForwardings {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub external_port: Option<f32>,
+    #[serde(default)]
     pub external_port_range: Option<f32>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub internal_ip_address: Option<String>,
+    #[serde(default)]
     pub internal_port: Option<f32>,
+    #[serde(default)]
     pub internal_port_id: Option<String>,
+    #[serde(default)]
     pub internal_port_range: Option<f32>,
+    #[serde(default)]
     pub protocol: Option<String>,
 }

--- a/openstack_types/src/network/v2/floatingip/response/set.rs
+++ b/openstack_types/src/network/v2/floatingip/response/set.rs
@@ -133,25 +133,41 @@ pub struct FloatingipResponse {
 /// `PortDetails` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortDetails {
+    #[serde(default)]
     pub admin_state_up: Option<bool>,
+    #[serde(default)]
     pub device_id: Option<String>,
+    #[serde(default)]
     pub device_owner: Option<String>,
+    #[serde(default)]
     pub mac_address: Option<String>,
+    #[serde(default)]
     pub name: Option<String>,
+    #[serde(default)]
     pub network_id: Option<String>,
+    #[serde(default)]
     pub status: Option<String>,
 }
 
 /// `PortForwardings` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PortForwardings {
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub external_port: Option<f32>,
+    #[serde(default)]
     pub external_port_range: Option<f32>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub internal_ip_address: Option<String>,
+    #[serde(default)]
     pub internal_port: Option<f32>,
+    #[serde(default)]
     pub internal_port_id: Option<String>,
+    #[serde(default)]
     pub internal_port_range: Option<f32>,
+    #[serde(default)]
     pub protocol: Option<String>,
 }

--- a/openstack_types/src/network/v2/network/response/create.rs
+++ b/openstack_types/src/network/v2/network/response/create.rs
@@ -186,7 +186,10 @@ pub struct NetworkResponse {
 /// `Segments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Segments {
+    #[serde(default, rename = "provider:network_type")]
     pub provider_network_type: Option<String>,
+    #[serde(default, rename = "provider:physical_network")]
     pub provider_physical_network: Option<String>,
+    #[serde(default, rename = "provider:segmentation_id")]
     pub provider_segmentation_id: Option<i32>,
 }

--- a/openstack_types/src/network/v2/network/response/get.rs
+++ b/openstack_types/src/network/v2/network/response/get.rs
@@ -186,7 +186,10 @@ pub struct NetworkResponse {
 /// `Segments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Segments {
+    #[serde(default, rename = "provider:network_type")]
     pub provider_network_type: Option<String>,
+    #[serde(default, rename = "provider:physical_network")]
     pub provider_physical_network: Option<String>,
+    #[serde(default, rename = "provider:segmentation_id")]
     pub provider_segmentation_id: Option<i32>,
 }

--- a/openstack_types/src/network/v2/network/response/list.rs
+++ b/openstack_types/src/network/v2/network/response/list.rs
@@ -186,7 +186,10 @@ pub struct NetworkResponse {
 /// `Segments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Segments {
+    #[serde(default, rename = "provider:network_type")]
     pub provider_network_type: Option<String>,
+    #[serde(default, rename = "provider:physical_network")]
     pub provider_physical_network: Option<String>,
+    #[serde(default, rename = "provider:segmentation_id")]
     pub provider_segmentation_id: Option<i32>,
 }

--- a/openstack_types/src/network/v2/network/response/set.rs
+++ b/openstack_types/src/network/v2/network/response/set.rs
@@ -186,7 +186,10 @@ pub struct NetworkResponse {
 /// `Segments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Segments {
+    #[serde(default, rename = "provider:network_type")]
     pub provider_network_type: Option<String>,
+    #[serde(default, rename = "provider:physical_network")]
     pub provider_physical_network: Option<String>,
+    #[serde(default, rename = "provider:segmentation_id")]
     pub provider_segmentation_id: Option<i32>,
 }

--- a/openstack_types/src/network/v2/port/response/create.rs
+++ b/openstack_types/src/network/v2/port/response/create.rs
@@ -267,7 +267,9 @@ pub struct PortResponse {
 /// `AllowedAddressPairs` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllowedAddressPairs {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub max_address: Option<String>,
 }
 
@@ -363,15 +365,20 @@ impl std::str::FromStr for DataPlaneStatus {
 /// `DnsAssignment` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DnsAssignment {
+    #[serde(default)]
     pub fqdn: Option<String>,
+    #[serde(default)]
     pub hostname: Option<String>,
+    #[serde(default)]
     pub ip_address: Option<String>,
 }
 
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 

--- a/openstack_types/src/network/v2/port/response/get.rs
+++ b/openstack_types/src/network/v2/port/response/get.rs
@@ -267,7 +267,9 @@ pub struct PortResponse {
 /// `AllowedAddressPairs` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllowedAddressPairs {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub max_address: Option<String>,
 }
 
@@ -363,15 +365,20 @@ impl std::str::FromStr for DataPlaneStatus {
 /// `DnsAssignment` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DnsAssignment {
+    #[serde(default)]
     pub fqdn: Option<String>,
+    #[serde(default)]
     pub hostname: Option<String>,
+    #[serde(default)]
     pub ip_address: Option<String>,
 }
 
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 

--- a/openstack_types/src/network/v2/port/response/list.rs
+++ b/openstack_types/src/network/v2/port/response/list.rs
@@ -267,7 +267,9 @@ pub struct PortResponse {
 /// `AllowedAddressPairs` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllowedAddressPairs {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub max_address: Option<String>,
 }
 
@@ -363,15 +365,20 @@ impl std::str::FromStr for DataPlaneStatus {
 /// `DnsAssignment` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DnsAssignment {
+    #[serde(default)]
     pub fqdn: Option<String>,
+    #[serde(default)]
     pub hostname: Option<String>,
+    #[serde(default)]
     pub ip_address: Option<String>,
 }
 
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 

--- a/openstack_types/src/network/v2/port/response/set.rs
+++ b/openstack_types/src/network/v2/port/response/set.rs
@@ -267,7 +267,9 @@ pub struct PortResponse {
 /// `AllowedAddressPairs` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllowedAddressPairs {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub max_address: Option<String>,
 }
 
@@ -363,15 +365,20 @@ impl std::str::FromStr for DataPlaneStatus {
 /// `DnsAssignment` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DnsAssignment {
+    #[serde(default)]
     pub fqdn: Option<String>,
+    #[serde(default)]
     pub hostname: Option<String>,
+    #[serde(default)]
     pub ip_address: Option<String>,
 }
 
 /// `FixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 

--- a/openstack_types/src/network/v2/quota/response/details.rs
+++ b/openstack_types/src/network/v2/quota/response/details.rs
@@ -73,8 +73,11 @@ pub struct QuotaResponse {
 /// `Floatingip` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Floatingip {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -82,8 +85,11 @@ pub struct Floatingip {
 /// `Network` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Network {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -91,8 +97,11 @@ pub struct Network {
 /// `Port` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Port {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -100,8 +109,11 @@ pub struct Port {
 /// `RbacPolicy` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RbacPolicy {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -109,8 +121,11 @@ pub struct RbacPolicy {
 /// `Router` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Router {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -118,8 +133,11 @@ pub struct Router {
 /// `SecurityGroup` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroup {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -127,8 +145,11 @@ pub struct SecurityGroup {
 /// `SecurityGroupRule` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroupRule {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -136,8 +157,11 @@ pub struct SecurityGroupRule {
 /// `Subnet` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Subnet {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
@@ -145,7 +169,10 @@ pub struct Subnet {
 /// `Subnetpool` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Subnetpool {
+    #[serde(default)]
     pub limit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }

--- a/openstack_types/src/network/v2/router/response/add_external_gateways.rs
+++ b/openstack_types/src/network/v2/router/response/add_external_gateways.rs
@@ -140,7 +140,9 @@ pub struct RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -151,15 +153,20 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
     pub network_id: String,
+    #[serde(default)]
     pub qos_policy_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/add_extraroutes.rs
+++ b/openstack_types/src/network/v2/router/response/add_extraroutes.rs
@@ -43,6 +43,8 @@ pub struct RouterResponse {
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/create.rs
+++ b/openstack_types/src/network/v2/router/response/create.rs
@@ -140,7 +140,9 @@ pub struct RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -151,15 +153,20 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
     pub network_id: String,
+    #[serde(default)]
     pub qos_policy_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/get.rs
+++ b/openstack_types/src/network/v2/router/response/get.rs
@@ -140,7 +140,9 @@ pub struct RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -151,15 +153,20 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
     pub network_id: String,
+    #[serde(default)]
     pub qos_policy_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/list.rs
+++ b/openstack_types/src/network/v2/router/response/list.rs
@@ -140,7 +140,9 @@ pub struct RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -151,15 +153,20 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
     pub network_id: String,
+    #[serde(default)]
     pub qos_policy_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/remove_external_gateways.rs
+++ b/openstack_types/src/network/v2/router/response/remove_external_gateways.rs
@@ -140,7 +140,9 @@ pub struct RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -151,15 +153,20 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
     pub network_id: String,
+    #[serde(default)]
     pub qos_policy_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/remove_extraroutes.rs
+++ b/openstack_types/src/network/v2/router/response/remove_extraroutes.rs
@@ -43,6 +43,8 @@ pub struct RouterResponse {
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/set.rs
+++ b/openstack_types/src/network/v2/router/response/set.rs
@@ -140,7 +140,9 @@ pub struct RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -151,15 +153,20 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
     pub network_id: String,
+    #[serde(default)]
     pub qos_policy_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/router/response/update_external_gateways.rs
+++ b/openstack_types/src/network/v2/router/response/update_external_gateways.rs
@@ -140,7 +140,9 @@ pub struct RouterResponse {
 /// `ExternalFixedIps` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalFixedIps {
+    #[serde(default)]
     pub ip_address: Option<String>,
+    #[serde(default)]
     pub subnet_id: Option<String>,
 }
 
@@ -151,15 +153,20 @@ pub struct ExternalFixedIps {
 /// `ExternalGatewayInfo` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExternalGatewayInfo {
+    #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
     pub enable_snat: Option<bool>,
+    #[serde(default)]
     pub external_fixed_ips: Option<Vec<ExternalFixedIps>>,
     pub network_id: String,
+    #[serde(default)]
     pub qos_policy_id: Option<String>,
 }
 
 /// `Routes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Routes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }

--- a/openstack_types/src/network/v2/security_group/response/create.rs
+++ b/openstack_types/src/network/v2/security_group/response/create.rs
@@ -125,21 +125,38 @@ impl std::str::FromStr for Ethertype {
 /// `SecurityGroupRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroupRules {
+    #[serde(default)]
     pub belongs_to_default_sg: Option<bool>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub direction: Option<Direction>,
+    #[serde(default)]
     pub ethertype: Option<Ethertype>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub normalized_cidr: Option<String>,
+    #[serde(default)]
     pub port_range_max: Option<i32>,
+    #[serde(default)]
     pub port_range_min: Option<i32>,
+    #[serde(default)]
     pub protocol: Option<String>,
+    #[serde(default)]
     pub remote_address_group_id: Option<String>,
+    #[serde(default)]
     pub remote_group_id: Option<String>,
+    #[serde(default)]
     pub remote_ip_prefix: Option<String>,
+    #[serde(default)]
     pub revision_number: Option<i32>,
+    #[serde(default)]
     pub security_group_id: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/network/v2/security_group/response/get.rs
+++ b/openstack_types/src/network/v2/security_group/response/get.rs
@@ -125,21 +125,38 @@ impl std::str::FromStr for Ethertype {
 /// `SecurityGroupRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroupRules {
+    #[serde(default)]
     pub belongs_to_default_sg: Option<bool>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub direction: Option<Direction>,
+    #[serde(default)]
     pub ethertype: Option<Ethertype>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub normalized_cidr: Option<String>,
+    #[serde(default)]
     pub port_range_max: Option<i32>,
+    #[serde(default)]
     pub port_range_min: Option<i32>,
+    #[serde(default)]
     pub protocol: Option<String>,
+    #[serde(default)]
     pub remote_address_group_id: Option<String>,
+    #[serde(default)]
     pub remote_group_id: Option<String>,
+    #[serde(default)]
     pub remote_ip_prefix: Option<String>,
+    #[serde(default)]
     pub revision_number: Option<i32>,
+    #[serde(default)]
     pub security_group_id: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/network/v2/security_group/response/list.rs
+++ b/openstack_types/src/network/v2/security_group/response/list.rs
@@ -125,21 +125,38 @@ impl std::str::FromStr for Ethertype {
 /// `SecurityGroupRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroupRules {
+    #[serde(default)]
     pub belongs_to_default_sg: Option<bool>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub direction: Option<Direction>,
+    #[serde(default)]
     pub ethertype: Option<Ethertype>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub normalized_cidr: Option<String>,
+    #[serde(default)]
     pub port_range_max: Option<i32>,
+    #[serde(default)]
     pub port_range_min: Option<i32>,
+    #[serde(default)]
     pub protocol: Option<String>,
+    #[serde(default)]
     pub remote_address_group_id: Option<String>,
+    #[serde(default)]
     pub remote_group_id: Option<String>,
+    #[serde(default)]
     pub remote_ip_prefix: Option<String>,
+    #[serde(default)]
     pub revision_number: Option<i32>,
+    #[serde(default)]
     pub security_group_id: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/network/v2/security_group/response/set.rs
+++ b/openstack_types/src/network/v2/security_group/response/set.rs
@@ -125,21 +125,38 @@ impl std::str::FromStr for Ethertype {
 /// `SecurityGroupRules` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SecurityGroupRules {
+    #[serde(default)]
     pub belongs_to_default_sg: Option<bool>,
+    #[serde(default)]
     pub created_at: Option<String>,
+    #[serde(default)]
     pub description: Option<String>,
+    #[serde(default)]
     pub direction: Option<Direction>,
+    #[serde(default)]
     pub ethertype: Option<Ethertype>,
+    #[serde(default)]
     pub id: Option<String>,
+    #[serde(default)]
     pub normalized_cidr: Option<String>,
+    #[serde(default)]
     pub port_range_max: Option<i32>,
+    #[serde(default)]
     pub port_range_min: Option<i32>,
+    #[serde(default)]
     pub protocol: Option<String>,
+    #[serde(default)]
     pub remote_address_group_id: Option<String>,
+    #[serde(default)]
     pub remote_group_id: Option<String>,
+    #[serde(default)]
     pub remote_ip_prefix: Option<String>,
+    #[serde(default)]
     pub revision_number: Option<i32>,
+    #[serde(default)]
     pub security_group_id: Option<String>,
+    #[serde(default)]
     pub tenant_id: Option<String>,
+    #[serde(default)]
     pub updated_at: Option<String>,
 }

--- a/openstack_types/src/network/v2/subnet/response/create.rs
+++ b/openstack_types/src/network/v2/subnet/response/create.rs
@@ -150,14 +150,18 @@ pub struct SubnetResponse {
 /// `AllocationPools` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllocationPools {
+    #[serde(default)]
     pub end: Option<String>,
+    #[serde(default)]
     pub start: Option<String>,
 }
 
 /// `HostRoutes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HostRoutes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }
 

--- a/openstack_types/src/network/v2/subnet/response/get.rs
+++ b/openstack_types/src/network/v2/subnet/response/get.rs
@@ -150,14 +150,18 @@ pub struct SubnetResponse {
 /// `AllocationPools` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllocationPools {
+    #[serde(default)]
     pub end: Option<String>,
+    #[serde(default)]
     pub start: Option<String>,
 }
 
 /// `HostRoutes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HostRoutes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }
 

--- a/openstack_types/src/network/v2/subnet/response/list.rs
+++ b/openstack_types/src/network/v2/subnet/response/list.rs
@@ -150,14 +150,18 @@ pub struct SubnetResponse {
 /// `AllocationPools` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllocationPools {
+    #[serde(default)]
     pub end: Option<String>,
+    #[serde(default)]
     pub start: Option<String>,
 }
 
 /// `HostRoutes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HostRoutes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }
 

--- a/openstack_types/src/network/v2/subnet/response/set.rs
+++ b/openstack_types/src/network/v2/subnet/response/set.rs
@@ -150,14 +150,18 @@ pub struct SubnetResponse {
 /// `AllocationPools` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllocationPools {
+    #[serde(default)]
     pub end: Option<String>,
+    #[serde(default)]
     pub start: Option<String>,
 }
 
 /// `HostRoutes` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HostRoutes {
+    #[serde(default)]
     pub destination: Option<String>,
+    #[serde(default)]
     pub nexthop: Option<String>,
 }
 

--- a/openstack_types/src/placement/v1/allocation/response/get.rs
+++ b/openstack_types/src/placement/v1/allocation/response/get.rs
@@ -71,6 +71,7 @@ pub struct AllocationResponse {
 /// `AllocationsItem` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllocationsItem {
+    #[serde(default)]
     pub generation: Option<i32>,
     pub resources: BTreeMap<String, i32>,
 }

--- a/openstack_types/src/placement/v1/allocation_candidate/response/list.rs
+++ b/openstack_types/src/placement/v1/allocation_candidate/response/list.rs
@@ -38,6 +38,7 @@ pub struct AllocationCandidateResponse {
 /// `AllocationsItem` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllocationsItem {
+    #[serde(default)]
     pub resources: Option<BTreeMap<String, i32>>,
 }
 
@@ -45,21 +46,27 @@ pub struct AllocationsItem {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AllocationRequests {
     pub allocations: BTreeMap<String, AllocationsItem>,
+    #[serde(default)]
     pub mappings: Option<BTreeMap<String, Vec<String>>>,
 }
 
 /// `ResourcesItem` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResourcesItem {
+    #[serde(default)]
     pub capacity: Option<i32>,
+    #[serde(default)]
     pub used: Option<i32>,
 }
 
 /// `ProviderSummariesItem` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ProviderSummariesItem {
+    #[serde(default)]
     pub parent_provider_uuid: Option<String>,
     pub resources: BTreeMap<String, ResourcesItem>,
+    #[serde(default)]
     pub root_provider_uuid: Option<String>,
+    #[serde(default)]
     pub traits: Option<Vec<String>>,
 }

--- a/openstack_types/src/placement/v1/resource_class/response/create.rs
+++ b/openstack_types/src/placement/v1/resource_class/response/create.rs
@@ -36,6 +36,8 @@ pub struct ResourceClassResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/placement/v1/resource_class/response/get.rs
+++ b/openstack_types/src/placement/v1/resource_class/response/get.rs
@@ -36,6 +36,8 @@ pub struct ResourceClassResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/placement/v1/resource_class/response/list.rs
+++ b/openstack_types/src/placement/v1/resource_class/response/list.rs
@@ -31,6 +31,8 @@ pub struct ResourceClassResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/placement/v1/resource_class/response/set.rs
+++ b/openstack_types/src/placement/v1/resource_class/response/set.rs
@@ -36,6 +36,8 @@ pub struct ResourceClassResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/create.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/create.rs
@@ -36,10 +36,15 @@ pub struct InventoryResponse {
 /// `InventoriesItem` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InventoriesItem {
+    #[serde(default)]
     pub allocation_ratio: Option<f32>,
+    #[serde(default)]
     pub max_unit: Option<i32>,
+    #[serde(default)]
     pub min_unit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub step_size: Option<i32>,
     pub total: i32,
 }

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/list.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/list.rs
@@ -36,10 +36,15 @@ pub struct InventoryResponse {
 /// `InventoriesItem` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InventoriesItem {
+    #[serde(default)]
     pub allocation_ratio: Option<f32>,
+    #[serde(default)]
     pub max_unit: Option<i32>,
+    #[serde(default)]
     pub min_unit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub step_size: Option<i32>,
     pub total: i32,
 }

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/replace.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/replace.rs
@@ -36,10 +36,15 @@ pub struct InventoryResponse {
 /// `InventoriesItem` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InventoriesItem {
+    #[serde(default)]
     pub allocation_ratio: Option<f32>,
+    #[serde(default)]
     pub max_unit: Option<i32>,
+    #[serde(default)]
     pub min_unit: Option<i32>,
+    #[serde(default)]
     pub reserved: Option<i32>,
+    #[serde(default)]
     pub step_size: Option<i32>,
     pub total: i32,
 }

--- a/openstack_types/src/placement/v1/resource_provider/response/create.rs
+++ b/openstack_types/src/placement/v1/resource_provider/response/create.rs
@@ -63,6 +63,8 @@ pub struct ResourceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/placement/v1/resource_provider/response/get.rs
+++ b/openstack_types/src/placement/v1/resource_provider/response/get.rs
@@ -63,6 +63,8 @@ pub struct ResourceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/placement/v1/resource_provider/response/list.rs
+++ b/openstack_types/src/placement/v1/resource_provider/response/list.rs
@@ -53,6 +53,8 @@ pub struct ResourceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }

--- a/openstack_types/src/placement/v1/resource_provider/response/set.rs
+++ b/openstack_types/src/placement/v1/resource_provider/response/set.rs
@@ -63,6 +63,8 @@ pub struct ResourceProviderResponse {
 /// `Links` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Links {
+    #[serde(default)]
     pub href: Option<String>,
+    #[serde(default)]
     pub rel: Option<String>,
 }


### PR DESCRIPTION
When attribute is being locally renamed we miss the serde macros causing
deserialization to fail.

Change-Id: Ia8d8298c938ea088d1db62bf97df6defc41d93bc

Changes are triggered by https://review.opendev.org/950567
