### PR TITLE
fix: Ensure swift bytes are positive integers

### DIFF
--- a/openstack_types/data/object-store/v1.yaml
+++ b/openstack_types/data/object-store/v1.yaml
@@ -1355,11 +1355,13 @@ components:
           description: The number of objects in the container.
           type: integer
           format: int64
+          minimum: 0
         bytes:
           description: |
             The total number of bytes that are stored in Object Storage for the account.
           type: integer
           format: int64
+          minimum: 0
         name:
           description: The name of the container.
           type: string
@@ -1385,6 +1387,7 @@ components:
             The total number of bytes that are stored in Object Storage for the container.
           type: integer
           format: int64
+          minimum: 0
         hash:
           description: The MD5 checksum value of the object content.
           type: string


### PR DESCRIPTION
In swift we service return few integer attributes which can only be
positive. Ensure this is incorporated in the schema.

Change-Id: I23509ca116f607a2b26fa1c01387dbd4f4df705a
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/950669
