### PR TITLE
fix: Fix type conversion of const bool

### DIFF
--- a/openstack_types/src/identity/v3/role_assignment/response/list.rs
+++ b/openstack_types/src/identity/v3/role_assignment/response/list.rs
@@ -96,7 +96,7 @@ pub struct Project {
 /// `System` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct System {
-    pub all: i32,
+    pub all: bool,
 }
 
 /// `Scope` type


### PR DESCRIPTION
`prop: {const: True}` should be converted to bool and not to integer.

Change-Id: Ic3775a36c138d451dbad7615bc0e446528d8b0be
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/950754
