### PR TITLE
feat: Implement json pointer extractor for the column

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,6 +2157,7 @@ dependencies = [
  "file_diff",
  "http 1.3.1",
  "indicatif",
+ "itertools 0.14.0",
  "json-patch",
  "openstack_sdk",
  "openstack_types",
@@ -3149,9 +3150,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structable"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6257306fe544bd6250d9c80e8e6bf50ef0b8a5abc7160e5601585a0f1e87b17"
+checksum = "70a88c38bf1204c0cc19c0e3cf7ca1a24b9a7e2bdd58a451a8e86552c9236cff"
 dependencies = [
  "serde",
  "structable_derive",
@@ -3159,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "structable_derive"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176879d4996065044b70719be709732de4f3d56b1a65b38fd88abb22646903bd"
+checksum = "ea361fca038f366f332dbb6a491430b085d2376f2b9b2ebd57793e6aaee38829"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/doc/src/cli/config.md
+++ b/doc/src/cli/config.md
@@ -2,9 +2,9 @@
 
 It is possible to configure different aspects of the OpenStackClient (not the
 clouds connection credentials) using the configuration file
-(`$XDG_CONFIG_DIR/osc/config.yaml`). This enables user to configurate which
-columns should be returned when no corresponding run time arguments on a
-resource base.
+([$XDG_CONFIG_DIR](https://docs.rs/dirs/latest/dirs/fn.config_dir.html)`/osc/config.yaml`).
+This enables user to configurate which columns should be returned when no
+corresponding run time arguments on a resource base.
 
 ```yaml
 views:
@@ -34,3 +34,31 @@ The key of the `views` map is a resource key shared among all
 [Codegenerator
 metadata](https://opendev.org/openstack/codegenerator/src/branch/master/metadata)
 for known resource keys.
+
+## Resource view options
+
+- **default_fields** (*list[str]*)
+
+  A list of fields to be displayed by default (in not wide mode). If not
+  specified, only certain fields determined internally are displayed. Output
+  columns are sorted in the order given in the list.
+
+- **wide** (*bool*)
+
+  If set to true, display all fields. If set to false, display only the
+  default_fields.
+
+- **fields** (*list[obj]*)
+
+  A list of column configuration. Consists of:
+
+  - **name** (*str*) - field name (resource attribute name)
+
+  - **width** (*int*) - column width in characters
+
+  - **min_width** (*int*) - minimum column width in characters
+
+  - **max_width** (*int*) - maximum column width in characters
+
+  - **json_pointer** (*str*) - JSON pointer to the extract from the resource
+    field. This is only applied in the list and not `wide` mode.

--- a/openstack_cli/.config/config.yaml
+++ b/openstack_cli/.config/config.yaml
@@ -1,6 +1,15 @@
 ---
 views:
   # block storage
+  block-storage.attachment:
+    default_fields: [id, instance, volume_id, status, attach_mode, attached_at]
+    fields:
+      - name: id
+        width: 38
+      - name: instance
+        width: 38
+      - name: volume_id
+        width: 38
   block-storage.backup:
     default_fields: [id, name, availability_zone, description, fail_reason, is_incremental, metadata, object_count, size, snapshot_id, status, volume_id, created_at]
     fields:
@@ -32,10 +41,10 @@ views:
   compute.aggregate:
     default_fields: [name, uuid, az, updated_at]
     fields:
-      - name: id
+      - name: uuid
         width: 38
   compute.flavor:
-    default_fields: [id, name, vcpus, ram, disk]
+    default_fields: [id, name, vcpus, ram, disk, swap, description]
     fields:
       - name: id
         width: 38
@@ -67,6 +76,10 @@ views:
         width: 7
       - name: status
         width: 8
+      - name: flavor
+        json_pointer: "/original_name"
+      - name: image
+        json_pointer: "/id"
   # dns
   dns.recordset:
     default_fields: [id, name, description, records, status, type, zone_id, zone_name, created_at, updated_at]
@@ -96,25 +109,47 @@ views:
       - name: project_id
         width: 34
   # identity
+  identity.domain:
+    default_fields: [id, name, enabled, description, options, tags]
+    fields:
+      - name: id
+        width: 34
   identity.group:
     default_fields: [id, name, domain_id, description]
     fields:
       - name: id
         width: 34
+      - name: domain_id
+        width: 34
   identity.project:
-    default_fields: [id, name, domain_id, enabled, parent_id]
+    default_fields: [id, name, domain_id, enabled, parent_id, description, options, tags]
     fields:
       - name: id
         width: 34
+      - name: domain_id
+        width: 34
+      - name: parent_id
+        width: 34
   identity.user/application_credential:
-    default_fields: [id, name, expires_at, project_id, roles, unrestricted]
+    default_fields: [id, name, description, project_id, expires_at, roles, unrestricted]
+    fields:
+      - name: id
+        width: 34
+      - name: project_id
+        width: 34
+  identity.user/access_rule:
+    default_fields: [id, service, path, method]
     fields:
       - name: id
         width: 34
   identity.user:
-    default_fields: [id, name, domain_id, description, enabled, password_expires_at]
+    default_fields: [id, name, domain_id, enabled, description, password_expires_at]
     fields:
       - name: id
+        width: 34
+      - name: domain_id
+        width: 34
+      - name: default_project_id
         width: 34
   # image
   image.image:
@@ -131,25 +166,51 @@ views:
       - name: id
         width: 38
   load-balancer.listener:
-    default_fields: [id, name, description, admin_state_up, default_pool_id, l7policies, loadbalancers, operating_status, protocol, protocol_port, provisioning_status, protocol, port, tags]
+    default_fields: [id, name, description, admin_state_up, default_pool_id, l7policies, loadbalancers, operating_status, protocol, protocol_port, provisioning_status, port, tags]
     fields:
       - name: id
+        width: 38
+      - name: default_pool_id
         width: 38
   load-balancer.loadbalancer:
     default_fields: [id, name, admin_state_up, description, listeners, operating_status, pools, provisioning_status, status, vip_address, tags]
     fields:
       - name: id
         width: 38
+      - name: vip_network_id
+        width: 38
+      - name: vip_subnet_id
+        width: 38
+      - name: vip_port_id
+        width: 38
+      - name: tenant_id
+        width: 34
+      - name: project_id
+        width: 34
   load-balancer.pool/member:
     default_fields: [id, name, address, admin_state_up, backup, monitor_address, monitor_port, operating_status, protocol_port, provisioning_status, subnet_id, weight, tags]
     fields:
       - name: id
         width: 38
+      - name: subnet_id
+        width: 38
+      - name: tenant_id
+        width: 34
+      - name: project_id
+        width: 34
   load-balancer.pool:
     default_fields: [id, name, admin_state_up, description, healthmonitor_id, lb_algorithm, listeners, loadbalancers, members, operating_status, protocol, provisioning_status, tls_enabled, tags]
     fields:
       - name: id
         width: 38
+      - name: healthmonitor_id
+        width: 38
+      - name: admin_state_up
+        min_width: 5
+      - name: tenant_id
+        width: 34
+      - name: project_id
+        width: 34
   # network
   network.network:
     default_fields: [id, name, admin_state_up, dns_domain, provider:network_type, router:external, shared, status, subnets, created_at, tags]
@@ -182,7 +243,12 @@ views:
       - name: tenant_id
         width: 34
   network.router:
-    default_fields: [id, name, admin_stateu_up, description, external_gateway_info, status, created_at, tags]
+    default_fields: [id, name, admin_state_up, description, external_gateway_info, status, created_at, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: tenant_id
+        width: 34
   network.subnet:
     default_fields: [id, name, allocation_pools, cidr, created_at, description, dns_nameservers, gateway_ip, ip_version, tags]
     fields:

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -83,6 +83,7 @@ tracing-subscriber = { workspace = true }
 url = { workspace = true }
 config.workspace = true
 dirs.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 assert_cmd = "^2.0"

--- a/openstack_cli/src/config.rs
+++ b/openstack_cli/src/config.rs
@@ -118,6 +118,10 @@ pub struct FieldConfig {
     /// Max width of the column
     #[serde(default)]
     pub max_width: Option<usize>,
+    /// [JSON pointer](https://datatracker.ietf.org/doc/html/rfc6901) to extract data from the
+    /// field
+    #[serde(default)]
+    pub json_pointer: Option<String>,
 }
 
 /// OpenStackClient configuration


### PR DESCRIPTION
Add possibility to specify `json_path` as the column configuration in
the configuration file to output only the data under the path. This is
helpful i.e. when listing servers not to show the whole flavor
information, but only show the flavor name using the `/original_name`
json path expression. It is inly applied in the listing operations and
no `-o wide` specified.
