### PR TITLE
fix: fix dns qp marker parameter name

### DIFF
--- a/openstack_cli/src/dns/v2/recordset/list.rs
+++ b/openstack_cli/src/dns/v2/recordset/list.rs
@@ -78,7 +78,7 @@ struct QueryParameters {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
-    market: Option<String>,
+    marker: Option<String>,
 
     /// Filter results to only show zones that have a name matching the filter
     #[arg(help_heading = "Query parameters", long)]
@@ -143,8 +143,8 @@ impl RecordsetsCommand {
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);
         }
-        if let Some(val) = &self.query.market {
-            ep_builder.market(val);
+        if let Some(val) = &self.query.marker {
+            ep_builder.marker(val);
         }
         if let Some(val) = &self.query.name {
             ep_builder.name(val);

--- a/openstack_cli/src/dns/v2/zone/list.rs
+++ b/openstack_cli/src/dns/v2/zone/list.rs
@@ -78,7 +78,7 @@ struct QueryParameters {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
-    market: Option<String>,
+    marker: Option<String>,
 
     /// Filter results to only show zones that have a name matching the filter
     #[arg(help_heading = "Query parameters", long)]
@@ -139,8 +139,8 @@ impl ZonesCommand {
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);
         }
-        if let Some(val) = &self.query.market {
-            ep_builder.market(val);
+        if let Some(val) = &self.query.marker {
+            ep_builder.marker(val);
         }
         if let Some(val) = &self.query.name {
             ep_builder.name(val);

--- a/openstack_cli/src/dns/v2/zone/recordset/list.rs
+++ b/openstack_cli/src/dns/v2/zone/recordset/list.rs
@@ -81,7 +81,7 @@ struct QueryParameters {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
-    market: Option<String>,
+    marker: Option<String>,
 
     /// Filter results to only show zones that have a name matching the filter
     #[arg(help_heading = "Query parameters", long)]
@@ -194,8 +194,8 @@ impl RecordsetsCommand {
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);
         }
-        if let Some(val) = &self.query.market {
-            ep_builder.market(val);
+        if let Some(val) = &self.query.marker {
+            ep_builder.marker(val);
         }
         if let Some(val) = &self.query.name {
             ep_builder.name(val);

--- a/openstack_cli/src/dns/v2/zone/share/list.rs
+++ b/openstack_cli/src/dns/v2/zone/share/list.rs
@@ -71,7 +71,7 @@ struct QueryParameters {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
-    market: Option<String>,
+    marker: Option<String>,
 
     /// Filter results to only show resources that have a matching
     /// target_project_id
@@ -154,8 +154,8 @@ impl SharesCommand {
         if let Some(val) = &self.query.limit {
             ep_builder.limit(*val);
         }
-        if let Some(val) = &self.query.market {
-            ep_builder.market(val);
+        if let Some(val) = &self.query.marker {
+            ep_builder.marker(val);
         }
         if let Some(val) = &self.query.target_project_id {
             ep_builder.target_project_id(val);

--- a/openstack_sdk/src/api/dns/v2/recordset/list.rs
+++ b/openstack_sdk/src/api/dns/v2/recordset/list.rs
@@ -53,7 +53,7 @@ pub struct Request<'a> {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[builder(default, setter(into))]
-    market: Option<Cow<'a, str>>,
+    marker: Option<Cow<'a, str>>,
 
     /// Filter results to only show zones that have a name matching the filter
     #[builder(default, setter(into))]
@@ -137,7 +137,7 @@ impl RestEndpoint for Request<'_> {
         params.push_opt("data", self.data.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("limit", self.limit);
-        params.push_opt("market", self.market.as_ref());
+        params.push_opt("marker", self.marker.as_ref());
         params.push_opt("name", self.name.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());

--- a/openstack_sdk/src/api/dns/v2/zone/list.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/list.rs
@@ -53,7 +53,7 @@ pub struct Request<'a> {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[builder(default, setter(into))]
-    market: Option<Cow<'a, str>>,
+    marker: Option<Cow<'a, str>>,
 
     /// Filter results to only show zones that have a name matching the filter
     #[builder(default, setter(into))]
@@ -133,7 +133,7 @@ impl RestEndpoint for Request<'_> {
         params.push_opt("description", self.description.as_ref());
         params.push_opt("email", self.email.as_ref());
         params.push_opt("limit", self.limit);
-        params.push_opt("market", self.market.as_ref());
+        params.push_opt("marker", self.marker.as_ref());
         params.push_opt("name", self.name.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());

--- a/openstack_sdk/src/api/dns/v2/zone/recordset/list.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/recordset/list.rs
@@ -53,7 +53,7 @@ pub struct Request<'a> {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[builder(default, setter(into))]
-    market: Option<Cow<'a, str>>,
+    marker: Option<Cow<'a, str>>,
 
     /// Filter results to only show zones that have a name matching the filter
     #[builder(default, setter(into))]
@@ -141,7 +141,7 @@ impl RestEndpoint for Request<'_> {
         params.push_opt("data", self.data.as_ref());
         params.push_opt("description", self.description.as_ref());
         params.push_opt("limit", self.limit);
-        params.push_opt("market", self.market.as_ref());
+        params.push_opt("marker", self.marker.as_ref());
         params.push_opt("name", self.name.as_ref());
         params.push_opt("sort_dir", self.sort_dir.as_ref());
         params.push_opt("sort_key", self.sort_key.as_ref());

--- a/openstack_sdk/src/api/dns/v2/zone/share/list.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/share/list.rs
@@ -41,7 +41,7 @@ pub struct Request<'a> {
     /// initial limited request and use the ID of the last-seen item from the
     /// response as the marker parameter value in a subsequent limited request.
     #[builder(default, setter(into))]
-    market: Option<Cow<'a, str>>,
+    marker: Option<Cow<'a, str>>,
 
     /// Filter results to only show resources that have a matching
     /// target_project_id
@@ -99,7 +99,7 @@ impl RestEndpoint for Request<'_> {
     fn parameters(&self) -> QueryParams {
         let mut params = QueryParams::default();
         params.push_opt("limit", self.limit);
-        params.push_opt("market", self.market.as_ref());
+        params.push_opt("marker", self.marker.as_ref());
         params.push_opt("target_project_id", self.target_project_id.as_ref());
 
         params

--- a/openstack_tui/src/cloud_worker/dns/v2/recordset/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/recordset/list.rs
@@ -40,7 +40,7 @@ pub struct DnsRecordsetList {
     #[builder(default)]
     pub limit: Option<i32>,
     #[builder(default)]
-    pub market: Option<String>,
+    pub marker: Option<String>,
     #[builder(default)]
     pub name: Option<String>,
     #[builder(default)]
@@ -87,8 +87,8 @@ impl TryFrom<&DnsRecordsetList> for RequestBuilder<'_> {
         if let Some(val) = &value.limit {
             ep_builder.limit(*val);
         }
-        if let Some(val) = &value.market {
-            ep_builder.market(val.clone());
+        if let Some(val) = &value.marker {
+            ep_builder.marker(val.clone());
         }
         if let Some(val) = &value.name {
             ep_builder.name(val.clone());

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/list.rs
@@ -40,7 +40,7 @@ pub struct DnsZoneList {
     #[builder(default)]
     pub limit: Option<i32>,
     #[builder(default)]
-    pub market: Option<String>,
+    pub marker: Option<String>,
     #[builder(default)]
     pub name: Option<String>,
     #[builder(default)]
@@ -73,8 +73,8 @@ impl TryFrom<&DnsZoneList> for RequestBuilder<'_> {
         if let Some(val) = &value.limit {
             ep_builder.limit(*val);
         }
-        if let Some(val) = &value.market {
-            ep_builder.market(val.clone());
+        if let Some(val) = &value.marker {
+            ep_builder.marker(val.clone());
         }
         if let Some(val) = &value.name {
             ep_builder.name(val.clone());

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/list.rs
@@ -40,7 +40,7 @@ pub struct DnsZoneRecordsetList {
     #[builder(default)]
     pub limit: Option<i32>,
     #[builder(default)]
-    pub market: Option<String>,
+    pub marker: Option<String>,
     #[builder(default)]
     pub name: Option<String>,
     #[builder(default)]
@@ -81,8 +81,8 @@ impl TryFrom<&DnsZoneRecordsetList> for RequestBuilder<'_> {
         if let Some(val) = &value.limit {
             ep_builder.limit(*val);
         }
-        if let Some(val) = &value.market {
-            ep_builder.market(val.clone());
+        if let Some(val) = &value.marker {
+            ep_builder.marker(val.clone());
         }
         if let Some(val) = &value.name {
             ep_builder.name(val.clone());

--- a/openstack_tui/src/components/dns/recordsets.rs
+++ b/openstack_tui/src/components/dns/recordsets.rs
@@ -49,7 +49,7 @@ impl From<DnsRecordsetList> for DnsZoneRecordsetList {
             data: value.data,
             description: value.description,
             limit: value.limit,
-            //market: value.market,
+            marker: value.marker,
             name: value.name,
             sort_dir: value.sort_dir,
             sort_key: value.sort_key,
@@ -57,7 +57,6 @@ impl From<DnsRecordsetList> for DnsZoneRecordsetList {
             ttl: value.ttl,
             zone_name: value.zone_name,
             zone_id: value.zone_id.unwrap_or_default(),
-            ..Default::default()
         }
     }
 }

--- a/openstack_types/data/dns/v2.1.yaml
+++ b/openstack_types/data/dns/v2.1.yaml
@@ -1231,7 +1231,7 @@ components:
         initial limited request and use the ID of the last-seen item from the response
         as the marker parameter value in a subsequent limited request.
       in: query
-      name: market
+      name: marker
       schema:
         format: uuid
         type: string

--- a/openstack_types/data/dns/v2.yaml
+++ b/openstack_types/data/dns/v2.yaml
@@ -1231,7 +1231,7 @@ components:
         initial limited request and use the ID of the last-seen item from the response
         as the marker parameter value in a subsequent limited request.
       in: query
-      name: market
+      name: marker
       schema:
         format: uuid
         type: string

--- a/openstack_types/data/identity/v3.14.yaml
+++ b/openstack_types/data/identity/v3.14.yaml
@@ -8915,7 +8915,7 @@ components:
         \  - gt: expiration time higher than the timestamp\n  - gte: expiration time
         higher than or equal to the timestamp\n  - eq: expiration time equal to the
         timestamp\n  - neq: expiration time not equal to the timestamp\n\nValid timestamps
-        are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n
+        are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n\
         The example would return a list of users whose password expired before the
         timestamp `(2016-12-08T22:02:00Z).`"
       in: query
@@ -8928,8 +8928,8 @@ components:
           than the timestamp\n  - lte: expiration time lower than or equal to the
           timestamp\n  - gt: expiration time higher than the timestamp\n  - gte: expiration
           time higher than or equal to the timestamp\n  - eq: expiration time equal
-          to the timestamp\n  - neq: expiration time not equal to the timestamp\n\n
-          Valid timestamps are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n
+          to the timestamp\n  - neq: expiration time not equal to the timestamp\n\n\
+          Valid timestamps are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n\
           The example would return a list of users whose password expired before the
           timestamp `(2016-12-08T22:02:00Z).`"
         type: string

--- a/openstack_types/data/identity/v3.yaml
+++ b/openstack_types/data/identity/v3.yaml
@@ -8915,7 +8915,7 @@ components:
         \  - gt: expiration time higher than the timestamp\n  - gte: expiration time
         higher than or equal to the timestamp\n  - eq: expiration time equal to the
         timestamp\n  - neq: expiration time not equal to the timestamp\n\nValid timestamps
-        are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n
+        are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n\
         The example would return a list of users whose password expired before the
         timestamp `(2016-12-08T22:02:00Z).`"
       in: query
@@ -8928,8 +8928,8 @@ components:
           than the timestamp\n  - lte: expiration time lower than or equal to the
           timestamp\n  - gt: expiration time higher than the timestamp\n  - gte: expiration
           time higher than or equal to the timestamp\n  - eq: expiration time equal
-          to the timestamp\n  - neq: expiration time not equal to the timestamp\n\n
-          Valid timestamps are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n
+          to the timestamp\n  - neq: expiration time not equal to the timestamp\n\n\
+          Valid timestamps are of the form: `YYYY-MM-DDTHH:mm:ssZ`.For example:`/v3/users?password_expires_at=lt:2016-12-08T22:02:00Z`\n\
           The example would return a list of users whose password expired before the
           timestamp `(2016-12-08T22:02:00Z).`"
         type: string

--- a/openstack_types/data/network/v2.26.yaml
+++ b/openstack_types/data/network/v2.26.yaml
@@ -23520,7 +23520,7 @@ components:
                       - ingress
                     type: string
                   ethertype:
-                    description: "Must be IPv4 or IPv6, and addresses represented\n
+                    description: "Must be IPv4 or IPv6, and addresses represented\n\
                       in CIDR must match the ingress or egress rules."
                     enum:
                       - IPv4
@@ -23537,8 +23537,8 @@ components:
                   port_range_max:
                     description: "The maximum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be greater than or equal to\n
-                      the `port_range_min` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be greater than or equal to\n\
+                      the `port_range_min` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP code."
                     type:
                       - integer
@@ -23546,8 +23546,8 @@ components:
                   port_range_min:
                     description: "The minimum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be less than or equal to\n
-                      the `port_range_max` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be less than or equal to\n\
+                      the `port_range_max` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP type."
                     type:
                       - integer
@@ -23698,7 +23698,7 @@ components:
                       - ingress
                     type: string
                   ethertype:
-                    description: "Must be IPv4 or IPv6, and addresses represented\n
+                    description: "Must be IPv4 or IPv6, and addresses represented\n\
                       in CIDR must match the ingress or egress rules."
                     enum:
                       - IPv4
@@ -23715,8 +23715,8 @@ components:
                   port_range_max:
                     description: "The maximum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be greater than or equal to\n
-                      the `port_range_min` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be greater than or equal to\n\
+                      the `port_range_min` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP code."
                     type:
                       - integer
@@ -23724,8 +23724,8 @@ components:
                   port_range_min:
                     description: "The minimum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be less than or equal to\n
-                      the `port_range_max` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be less than or equal to\n\
+                      the `port_range_max` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP type."
                     type:
                       - integer
@@ -24411,7 +24411,7 @@ components:
                       - ingress
                     type: string
                   ethertype:
-                    description: "Must be IPv4 or IPv6, and addresses represented\n
+                    description: "Must be IPv4 or IPv6, and addresses represented\n\
                       in CIDR must match the ingress or egress rules."
                     enum:
                       - IPv4
@@ -24428,8 +24428,8 @@ components:
                   port_range_max:
                     description: "The maximum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be greater than or equal to\n
-                      the `port_range_min` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be greater than or equal to\n\
+                      the `port_range_min` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP code."
                     type:
                       - integer
@@ -24437,8 +24437,8 @@ components:
                   port_range_min:
                     description: "The minimum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be less than or equal to\n
-                      the `port_range_max` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be less than or equal to\n\
+                      the `port_range_max` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP type."
                     type:
                       - integer
@@ -24559,14 +24559,14 @@ components:
                       maxLength: 255
                       type: string
                     direction:
-                      description: "Ingress or egress, which is the direction in\n
+                      description: "Ingress or egress, which is the direction in\n\
                         which the security group rule is applied."
                       enum:
                         - egress
                         - ingress
                       type: string
                     ethertype:
-                      description: "Must be IPv4 or IPv6, and addresses represented\n
+                      description: "Must be IPv4 or IPv6, and addresses represented\n\
                         in CIDR must match the ingress or egress rules."
                       enum:
                         - IPv4
@@ -24581,7 +24581,7 @@ components:
                         - 'null'
                         - string
                     port_range_max:
-                      description: "The maximum port number in the range that is\n
+                      description: "The maximum port number in the range that is\n\
                         matched by the security group rule. If the protocol is TCP,
                         UDP,\nDCCP, SCTP or UDP-Lite this value must be greater than
                         or equal to\nthe `port_range_min` attribute value. If the
@@ -24590,7 +24590,7 @@ components:
                         - integer
                         - 'null'
                     port_range_min:
-                      description: "The minimum port number in the range that is\n
+                      description: "The minimum port number in the range that is\n\
                         matched by the security group rule. If the protocol is TCP,
                         UDP,\nDCCP, SCTP or UDP-Lite this value must be less than
                         or equal to\nthe `port_range_max` attribute value. If the
@@ -24607,7 +24607,7 @@ components:
                         with this\nsecurity group rule."
                       type: string
                     remote_group_id:
-                      description: "The remote group UUID to associate with this\n
+                      description: "The remote group UUID to associate with this\n\
                         security group rule. You can specify either the\n`remote_group_id`
                         or `remote_ip_prefix` attribute in the\nrequest body."
                       type: string
@@ -24621,7 +24621,7 @@ components:
                       description: The revision number of the resource.
                       type: integer
                     security_group_id:
-                      description: "The security group ID to associate with this\n
+                      description: "The security group ID to associate with this\n\
                         security group rule."
                       maxLength: 36
                       type: string

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -23520,7 +23520,7 @@ components:
                       - ingress
                     type: string
                   ethertype:
-                    description: "Must be IPv4 or IPv6, and addresses represented\n
+                    description: "Must be IPv4 or IPv6, and addresses represented\n\
                       in CIDR must match the ingress or egress rules."
                     enum:
                       - IPv4
@@ -23537,8 +23537,8 @@ components:
                   port_range_max:
                     description: "The maximum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be greater than or equal to\n
-                      the `port_range_min` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be greater than or equal to\n\
+                      the `port_range_min` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP code."
                     type:
                       - integer
@@ -23546,8 +23546,8 @@ components:
                   port_range_min:
                     description: "The minimum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be less than or equal to\n
-                      the `port_range_max` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be less than or equal to\n\
+                      the `port_range_max` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP type."
                     type:
                       - integer
@@ -23698,7 +23698,7 @@ components:
                       - ingress
                     type: string
                   ethertype:
-                    description: "Must be IPv4 or IPv6, and addresses represented\n
+                    description: "Must be IPv4 or IPv6, and addresses represented\n\
                       in CIDR must match the ingress or egress rules."
                     enum:
                       - IPv4
@@ -23715,8 +23715,8 @@ components:
                   port_range_max:
                     description: "The maximum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be greater than or equal to\n
-                      the `port_range_min` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be greater than or equal to\n\
+                      the `port_range_min` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP code."
                     type:
                       - integer
@@ -23724,8 +23724,8 @@ components:
                   port_range_min:
                     description: "The minimum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be less than or equal to\n
-                      the `port_range_max` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be less than or equal to\n\
+                      the `port_range_max` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP type."
                     type:
                       - integer
@@ -24411,7 +24411,7 @@ components:
                       - ingress
                     type: string
                   ethertype:
-                    description: "Must be IPv4 or IPv6, and addresses represented\n
+                    description: "Must be IPv4 or IPv6, and addresses represented\n\
                       in CIDR must match the ingress or egress rules."
                     enum:
                       - IPv4
@@ -24428,8 +24428,8 @@ components:
                   port_range_max:
                     description: "The maximum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be greater than or equal to\n
-                      the `port_range_min` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be greater than or equal to\n\
+                      the `port_range_min` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP code."
                     type:
                       - integer
@@ -24437,8 +24437,8 @@ components:
                   port_range_min:
                     description: "The minimum port number in the range that is\nmatched
                       by the security group rule. If the protocol is TCP, UDP,\nDCCP,
-                      SCTP or UDP-Lite this value must be less than or equal to\n
-                      the `port_range_max` attribute value. If the protocol is ICMP,\n
+                      SCTP or UDP-Lite this value must be less than or equal to\n\
+                      the `port_range_max` attribute value. If the protocol is ICMP,\n\
                       this value must be an ICMP type."
                     type:
                       - integer
@@ -24559,14 +24559,14 @@ components:
                       maxLength: 255
                       type: string
                     direction:
-                      description: "Ingress or egress, which is the direction in\n
+                      description: "Ingress or egress, which is the direction in\n\
                         which the security group rule is applied."
                       enum:
                         - egress
                         - ingress
                       type: string
                     ethertype:
-                      description: "Must be IPv4 or IPv6, and addresses represented\n
+                      description: "Must be IPv4 or IPv6, and addresses represented\n\
                         in CIDR must match the ingress or egress rules."
                       enum:
                         - IPv4
@@ -24581,7 +24581,7 @@ components:
                         - 'null'
                         - string
                     port_range_max:
-                      description: "The maximum port number in the range that is\n
+                      description: "The maximum port number in the range that is\n\
                         matched by the security group rule. If the protocol is TCP,
                         UDP,\nDCCP, SCTP or UDP-Lite this value must be greater than
                         or equal to\nthe `port_range_min` attribute value. If the
@@ -24590,7 +24590,7 @@ components:
                         - integer
                         - 'null'
                     port_range_min:
-                      description: "The minimum port number in the range that is\n
+                      description: "The minimum port number in the range that is\n\
                         matched by the security group rule. If the protocol is TCP,
                         UDP,\nDCCP, SCTP or UDP-Lite this value must be less than
                         or equal to\nthe `port_range_max` attribute value. If the
@@ -24607,7 +24607,7 @@ components:
                         with this\nsecurity group rule."
                       type: string
                     remote_group_id:
-                      description: "The remote group UUID to associate with this\n
+                      description: "The remote group UUID to associate with this\n\
                         security group rule. You can specify either the\n`remote_group_id`
                         or `remote_ip_prefix` attribute in the\nrequest body."
                       type: string
@@ -24621,7 +24621,7 @@ components:
                       description: The revision number of the resource.
                       type: integer
                     security_group_id:
-                      description: "The security group ID to associate with this\n
+                      description: "The security group ID to associate with this\n\
                         security group rule."
                       maxLength: 36
                       type: string

--- a/openstack_types/data/placement/v1.39.yaml
+++ b/openstack_types/data/placement/v1.39.yaml
@@ -933,13 +933,13 @@ components:
         by a comma-separated list of strings representing aggregate uuids. The resource
         providers in the allocation request in the response must directly or via the
         root provider be associated with the aggregate or aggregates identified by
-        uuid:\n``member_of=5e08ea53-c4c6-448e-9334-ac4953de3cfa``, ``member_of=in:42896e0d-205d-4fe3-bd1e-100924931787,5e08ea53-c4c6-448e-9334-ac4953de3cfa``\n
+        uuid:\n``member_of=5e08ea53-c4c6-448e-9334-ac4953de3cfa``, ``member_of=in:42896e0d-205d-4fe3-bd1e-100924931787,5e08ea53-c4c6-448e-9334-ac4953de3cfa``\n\
         Starting from microversion 1.24 specifying multiple member_of query string
         parameters is possible. Multiple member_of parameters will result in filtering
         providers that are directly or via root provider associated with aggregates
         listed in all of the member_of query string values. For example, to get the
         providers that are associated with aggregate A as well as associated with
-        any of aggregates B or C, the user could issue the following query: ``member_of=AGGA_UUID&member_of=in:AGGB_UUID,AGGC_UUID``\n
+        any of aggregates B or C, the user could issue the following query: ``member_of=AGGA_UUID&member_of=in:AGGB_UUID,AGGC_UUID``\n\
         Starting from microversion 1.32 specifying forbidden aggregates is supported
         in the member_of query string parameter. Forbidden aggregates are prefixed
         with a !. This negative expression can also be used in multiple member_of
@@ -947,7 +947,7 @@ components:
         to “Candidate resource providers must be in AGGA and not in AGGB.” We do NOT
         support ! on the values within in:, but we support !in:. Both of the following
         two example queries return candidate resource providers that are NOT in AGGA,
-        AGGB, or AGGC: ``member_of=!in:AGGA_UUID,AGGB_UUID,AGGC_UUID``, ``member_of=!AGGA_UUID&member_of=!AGGB_UUID&member_of=!AGGC_UUID``\n
+        AGGB, or AGGC: ``member_of=!in:AGGA_UUID,AGGB_UUID,AGGC_UUID``, ``member_of=!AGGA_UUID&member_of=!AGGB_UUID&member_of=!AGGC_UUID``\n\
         We do not check if the same aggregate uuid is in both positive and negative
         expression to return 400 BadRequest. We still return 200 for such cases. For
         example: ``member_of=AGGA_UUID&member_of=!AGGA_UUID`` would return empty allocation_requests
@@ -980,17 +980,17 @@ components:
       x-openstack:
         resource_link: identity/v3/project.id
     required:
-      description: "A comma-separated list of traits that a provider must have:\n
-        ``required=HW_CPU_X86_AVX,HW_CPU_X86_SSE``\n Allocation requests in the response
-        will be for resource providers that have capacity for all requested resources
-        and the set of those resource providers will collectively contain all of the
-        required traits. These traits may be satisfied by any provider in the same
-        non-sharing tree or associated via aggregate as far as that provider also
-        contributes resource to the request. Starting from microversion 1.22 traits
-        which are forbidden from any resource provider contributing resources to the
-        request may be expressed by prefixing a trait with a `!`.\nStarting from microversion
-        1.39 the required query parameter can be repeated. The trait lists from the
-        repeated parameters are AND-ed together. So:\n``required=T1,!T2&required=T3``
+      description: "A comma-separated list of traits that a provider must have:\n\
+        \ ``required=HW_CPU_X86_AVX,HW_CPU_X86_SSE``\n Allocation requests in the
+        response will be for resource providers that have capacity for all requested
+        resources and the set of those resource providers will collectively contain
+        all of the required traits. These traits may be satisfied by any provider
+        in the same non-sharing tree or associated via aggregate as far as that provider
+        also contributes resource to the request. Starting from microversion 1.22
+        traits which are forbidden from any resource provider contributing resources
+        to the request may be expressed by prefixing a trait with a `!`.\nStarting
+        from microversion 1.39 the required query parameter can be repeated. The trait
+        lists from the repeated parameters are AND-ed together. So:\n``required=T1,!T2&required=T3``
         means T1 and not T2 and T3.\n Also starting from microversion 1.39 the required
         parameter supports the syntax:\n``required=in:T1,T2,T3`` which means T1 or
         T2 or T3.\nMixing forbidden traits into an in: prefixed value is not supported

--- a/openstack_types/data/placement/v1.yaml
+++ b/openstack_types/data/placement/v1.yaml
@@ -933,13 +933,13 @@ components:
         by a comma-separated list of strings representing aggregate uuids. The resource
         providers in the allocation request in the response must directly or via the
         root provider be associated with the aggregate or aggregates identified by
-        uuid:\n``member_of=5e08ea53-c4c6-448e-9334-ac4953de3cfa``, ``member_of=in:42896e0d-205d-4fe3-bd1e-100924931787,5e08ea53-c4c6-448e-9334-ac4953de3cfa``\n
+        uuid:\n``member_of=5e08ea53-c4c6-448e-9334-ac4953de3cfa``, ``member_of=in:42896e0d-205d-4fe3-bd1e-100924931787,5e08ea53-c4c6-448e-9334-ac4953de3cfa``\n\
         Starting from microversion 1.24 specifying multiple member_of query string
         parameters is possible. Multiple member_of parameters will result in filtering
         providers that are directly or via root provider associated with aggregates
         listed in all of the member_of query string values. For example, to get the
         providers that are associated with aggregate A as well as associated with
-        any of aggregates B or C, the user could issue the following query: ``member_of=AGGA_UUID&member_of=in:AGGB_UUID,AGGC_UUID``\n
+        any of aggregates B or C, the user could issue the following query: ``member_of=AGGA_UUID&member_of=in:AGGB_UUID,AGGC_UUID``\n\
         Starting from microversion 1.32 specifying forbidden aggregates is supported
         in the member_of query string parameter. Forbidden aggregates are prefixed
         with a !. This negative expression can also be used in multiple member_of
@@ -947,7 +947,7 @@ components:
         to “Candidate resource providers must be in AGGA and not in AGGB.” We do NOT
         support ! on the values within in:, but we support !in:. Both of the following
         two example queries return candidate resource providers that are NOT in AGGA,
-        AGGB, or AGGC: ``member_of=!in:AGGA_UUID,AGGB_UUID,AGGC_UUID``, ``member_of=!AGGA_UUID&member_of=!AGGB_UUID&member_of=!AGGC_UUID``\n
+        AGGB, or AGGC: ``member_of=!in:AGGA_UUID,AGGB_UUID,AGGC_UUID``, ``member_of=!AGGA_UUID&member_of=!AGGB_UUID&member_of=!AGGC_UUID``\n\
         We do not check if the same aggregate uuid is in both positive and negative
         expression to return 400 BadRequest. We still return 200 for such cases. For
         example: ``member_of=AGGA_UUID&member_of=!AGGA_UUID`` would return empty allocation_requests
@@ -980,17 +980,17 @@ components:
       x-openstack:
         resource_link: identity/v3/project.id
     required:
-      description: "A comma-separated list of traits that a provider must have:\n
-        ``required=HW_CPU_X86_AVX,HW_CPU_X86_SSE``\n Allocation requests in the response
-        will be for resource providers that have capacity for all requested resources
-        and the set of those resource providers will collectively contain all of the
-        required traits. These traits may be satisfied by any provider in the same
-        non-sharing tree or associated via aggregate as far as that provider also
-        contributes resource to the request. Starting from microversion 1.22 traits
-        which are forbidden from any resource provider contributing resources to the
-        request may be expressed by prefixing a trait with a `!`.\nStarting from microversion
-        1.39 the required query parameter can be repeated. The trait lists from the
-        repeated parameters are AND-ed together. So:\n``required=T1,!T2&required=T3``
+      description: "A comma-separated list of traits that a provider must have:\n\
+        \ ``required=HW_CPU_X86_AVX,HW_CPU_X86_SSE``\n Allocation requests in the
+        response will be for resource providers that have capacity for all requested
+        resources and the set of those resource providers will collectively contain
+        all of the required traits. These traits may be satisfied by any provider
+        in the same non-sharing tree or associated via aggregate as far as that provider
+        also contributes resource to the request. Starting from microversion 1.22
+        traits which are forbidden from any resource provider contributing resources
+        to the request may be expressed by prefixing a trait with a `!`.\nStarting
+        from microversion 1.39 the required query parameter can be repeated. The trait
+        lists from the repeated parameters are AND-ed together. So:\n``required=T1,!T2&required=T3``
         means T1 and not T2 and T3.\n Also starting from microversion 1.39 the required
         parameter supports the syntax:\n``required=in:T1,T2,T3`` which means T1 or
         T2 or T3.\nMixing forbidden traits into an in: prefixed value is not supported

--- a/openstack_types/data/shared-file-system/v2.89.yaml
+++ b/openstack_types/data/shared-file-system/v2.89.yaml
@@ -3799,7 +3799,7 @@ components:
       in: query
       name: resource_id
       schema:
-        description: "The ID of the resource that the locks pertain to to filter resource\n
+        description: "The ID of the resource that the locks pertain to to filter resource\n\
           locks by.\n"
         format: uuid
         type:
@@ -4887,7 +4887,7 @@ components:
             updated_at:
               description: "The date and time stamp when the resource was last updated
                 within the\nservice's database. If a resource was never updated after
-                it was\ncreated, the value of this parameter is set to ``null``.\n
+                it was\ncreated, the value of this parameter is set to ``null``.\n\
                 \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                 \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if included,
                 returns the time zone as an\noffset from UTC.\n\nFor example, ``2016-12-31T13:14:15-05:00``.\n"
@@ -5038,7 +5038,7 @@ components:
             updated_at:
               description: "The date and time stamp when the resource was last updated
                 within the\nservice's database. If a resource was never updated after
-                it was\ncreated, the value of this parameter is set to ``null``.\n
+                it was\ncreated, the value of this parameter is set to ``null``.\n\
                 \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                 \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if included,
                 returns the time zone as an\noffset from UTC.\n\nFor example, ``2016-12-31T13:14:15-05:00``.\n"
@@ -5246,7 +5246,7 @@ components:
             updated_at:
               description: "The date and time stamp when the resource was last updated
                 within the\nservice's database. If a resource was never updated after
-                it was\ncreated, the value of this parameter is set to ``null``.\n
+                it was\ncreated, the value of this parameter is set to ``null``.\n\
                 \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                 \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if included,
                 returns the time zone as an\noffset from UTC.\n\nFor example, ``2016-12-31T13:14:15-05:00``.\n"
@@ -5422,7 +5422,7 @@ components:
               updated_at:
                 description: "The date and time stamp when the resource was last updated
                   within the\nservice's database. If a resource was never updated
-                  after it was\ncreated, the value of this parameter is set to ``null``.\n
+                  after it was\ncreated, the value of this parameter is set to ``null``.\n\
                   \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                   \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if
                   included, returns the time zone as an\noffset from UTC.\n\nFor example,

--- a/openstack_types/data/shared-file-system/v2.yaml
+++ b/openstack_types/data/shared-file-system/v2.yaml
@@ -3799,7 +3799,7 @@ components:
       in: query
       name: resource_id
       schema:
-        description: "The ID of the resource that the locks pertain to to filter resource\n
+        description: "The ID of the resource that the locks pertain to to filter resource\n\
           locks by.\n"
         format: uuid
         type:
@@ -4887,7 +4887,7 @@ components:
             updated_at:
               description: "The date and time stamp when the resource was last updated
                 within the\nservice's database. If a resource was never updated after
-                it was\ncreated, the value of this parameter is set to ``null``.\n
+                it was\ncreated, the value of this parameter is set to ``null``.\n\
                 \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                 \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if included,
                 returns the time zone as an\noffset from UTC.\n\nFor example, ``2016-12-31T13:14:15-05:00``.\n"
@@ -5038,7 +5038,7 @@ components:
             updated_at:
               description: "The date and time stamp when the resource was last updated
                 within the\nservice's database. If a resource was never updated after
-                it was\ncreated, the value of this parameter is set to ``null``.\n
+                it was\ncreated, the value of this parameter is set to ``null``.\n\
                 \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                 \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if included,
                 returns the time zone as an\noffset from UTC.\n\nFor example, ``2016-12-31T13:14:15-05:00``.\n"
@@ -5246,7 +5246,7 @@ components:
             updated_at:
               description: "The date and time stamp when the resource was last updated
                 within the\nservice's database. If a resource was never updated after
-                it was\ncreated, the value of this parameter is set to ``null``.\n
+                it was\ncreated, the value of this parameter is set to ``null``.\n\
                 \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                 \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if included,
                 returns the time zone as an\noffset from UTC.\n\nFor example, ``2016-12-31T13:14:15-05:00``.\n"
@@ -5422,7 +5422,7 @@ components:
               updated_at:
                 description: "The date and time stamp when the resource was last updated
                   within the\nservice's database. If a resource was never updated
-                  after it was\ncreated, the value of this parameter is set to ``null``.\n
+                  after it was\ncreated, the value of this parameter is set to ``null``.\n\
                   \nThe date and time stamp format is `ISO 8601\n<https://en.wikipedia.org/wiki/ISO_8601>`_:\n\
                   \n::\n\n   CCYY-MM-DDThh:mm:ss±hh:mm\n\nThe ``±hh:mm`` value, if
                   included, returns the time zone as an\noffset from UTC.\n\nFor example,


### PR DESCRIPTION
Fix typo "market" where "marker" should be.

Change-Id: Ic9f94727b6abb33619bde96a610fedad7cc12398

Changes are triggered by https://review.opendev.org/950996
