### PR TITLE
feat: Rename operation_name with action_name in the metadata

### DIFF
--- a/openstack_cli/src/block_storage/v3/attachment/os_complete.rs
+++ b/openstack_cli/src/block_storage/v3/attachment/os_complete.rs
@@ -71,7 +71,7 @@ impl AttachmentCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.attachment"),
-            Some("os-complete"),
+            Some("os_complete"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/backup/os_force_delete.rs
+++ b/openstack_cli/src/block_storage/v3/backup/os_force_delete.rs
@@ -71,7 +71,7 @@ impl BackupCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.backup"),
-            Some("os-force_delete"),
+            Some("os_force_delete"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/backup/os_reset_status.rs
+++ b/openstack_cli/src/block_storage/v3/backup/os_reset_status.rs
@@ -80,7 +80,7 @@ impl BackupCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.backup"),
-            Some("os-reset_status"),
+            Some("os_reset_status"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/group/create_from_src_314.rs
+++ b/openstack_cli/src/block_storage/v3/group/create_from_src_314.rs
@@ -89,7 +89,7 @@ impl GroupCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.group"),
-            Some("create-from-src"),
+            Some("create_from_src"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/limit/list.rs
+++ b/openstack_cli/src/block_storage/v3/limit/list.rs
@@ -61,7 +61,7 @@ impl LimitCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show Limit");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("block-storage.limit"), Some("show"));
+        let op = OutputProcessor::from_args(parsed_args, Some("block-storage.limit"), Some("list"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = list::Request::builder();

--- a/openstack_cli/src/block_storage/v3/os_volume_transfer/accept.rs
+++ b/openstack_cli/src/block_storage/v3/os_volume_transfer/accept.rs
@@ -81,7 +81,7 @@ impl OsVolumeTransferCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.os_volume_transfer"),
-            Some("action"),
+            Some("accept"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/qos_spec/associate.rs
+++ b/openstack_cli/src/block_storage/v3/qos_spec/associate.rs
@@ -68,8 +68,11 @@ impl QosSpecCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Get QosSpec");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("block-storage.qos_spec"), Some("get"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("block-storage.qos_spec"),
+            Some("associate"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = associate::Request::builder();

--- a/openstack_cli/src/block_storage/v3/qos_spec/delete_keys.rs
+++ b/openstack_cli/src/block_storage/v3/qos_spec/delete_keys.rs
@@ -73,8 +73,11 @@ impl QosSpecCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action QosSpec");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("block-storage.qos_spec"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("block-storage.qos_spec"),
+            Some("delete_keys"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_keys::Request::builder();

--- a/openstack_cli/src/block_storage/v3/qos_spec/disassociate.rs
+++ b/openstack_cli/src/block_storage/v3/qos_spec/disassociate.rs
@@ -68,8 +68,11 @@ impl QosSpecCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Get QosSpec");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("block-storage.qos_spec"), Some("get"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("block-storage.qos_spec"),
+            Some("disassociate"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = disassociate::Request::builder();

--- a/openstack_cli/src/block_storage/v3/qos_spec/disassociate_all.rs
+++ b/openstack_cli/src/block_storage/v3/qos_spec/disassociate_all.rs
@@ -68,8 +68,11 @@ impl QosSpecCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Get QosSpec");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("block-storage.qos_spec"), Some("get"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("block-storage.qos_spec"),
+            Some("disassociate_all"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = disassociate_all::Request::builder();

--- a/openstack_cli/src/block_storage/v3/quota_set/defaults.rs
+++ b/openstack_cli/src/block_storage/v3/quota_set/defaults.rs
@@ -69,8 +69,11 @@ impl QuotaSetCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show QuotaSet");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("block-storage.quota_set"), Some("show"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("block-storage.quota_set"),
+            Some("defaults"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = defaults::Request::builder();

--- a/openstack_cli/src/block_storage/v3/snapshot/metadata/replace.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/metadata/replace.rs
@@ -77,7 +77,7 @@ impl MetadataCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.snapshot/metadata"),
-            Some("set"),
+            Some("replace"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/snapshot/os_force_delete.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/os_force_delete.rs
@@ -71,7 +71,7 @@ impl SnapshotCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.snapshot"),
-            Some("os-force_delete"),
+            Some("os_force_delete"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/snapshot/os_reset_status.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/os_reset_status.rs
@@ -71,7 +71,7 @@ impl SnapshotCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.snapshot"),
-            Some("os-reset_status"),
+            Some("os_reset_status"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/snapshot/os_unmanage.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/os_unmanage.rs
@@ -71,7 +71,7 @@ impl SnapshotCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.snapshot"),
-            Some("os-unmanage"),
+            Some("os_unmanage"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/snapshot/os_update_snapshot_status.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/os_update_snapshot_status.rs
@@ -83,7 +83,7 @@ impl SnapshotCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.snapshot"),
-            Some("os-update_snapshot_status"),
+            Some("os_update_snapshot_status"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/type/add_project_access.rs
+++ b/openstack_cli/src/block_storage/v3/type/add_project_access.rs
@@ -80,7 +80,7 @@ impl TypeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.type"),
-            Some("addprojectaccess"),
+            Some("add_project_access"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/type/remove_project_access.rs
+++ b/openstack_cli/src/block_storage/v3/type/remove_project_access.rs
@@ -80,7 +80,7 @@ impl TypeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.type"),
-            Some("removeprojectaccess"),
+            Some("remove_project_access"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/metadata/replace.rs
+++ b/openstack_cli/src/block_storage/v3/volume/metadata/replace.rs
@@ -78,7 +78,7 @@ impl MetadataCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume/metadata"),
-            Some("set"),
+            Some("replace"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_attach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_attach.rs
@@ -97,7 +97,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-attach"),
+            Some("os_attach"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_begin_detaching.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_begin_detaching.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-begin_detaching"),
+            Some("os_begin_detaching"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_detach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_detach.rs
@@ -84,7 +84,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-detach"),
+            Some("os_detach"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_extend.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_extend.rs
@@ -80,7 +80,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-extend"),
+            Some("os_extend"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_extend_volume_completion.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_extend_volume_completion.rs
@@ -81,7 +81,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-extend_volume_completion"),
+            Some("os_extend_volume_completion"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_force_delete.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_force_delete.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-force_delete"),
+            Some("os_force_delete"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_force_detach.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_force_detach.rs
@@ -88,7 +88,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-force_detach"),
+            Some("os_force_detach"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_initialize_connection.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_initialize_connection.rs
@@ -81,7 +81,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-initialize_connection"),
+            Some("os_initialize_connection"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_30.rs
@@ -86,7 +86,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-migrate_volume"),
+            Some("os_migrate_volume"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_316.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_316.rs
@@ -97,7 +97,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-migrate_volume"),
+            Some("os_migrate_volume"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_completion.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_migrate_volume_completion.rs
@@ -83,7 +83,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-migrate_volume_completion"),
+            Some("os_migrate_volume_completion"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_reimage_368.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_reimage_368.rs
@@ -83,7 +83,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-reimage"),
+            Some("os_reimage"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_reserve.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_reserve.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-reserve"),
+            Some("os_reserve"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_reset_status.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_reset_status.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-reset_status"),
+            Some("os_reset_status"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_retype.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_retype.rs
@@ -91,7 +91,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-retype"),
+            Some("os_retype"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_roll_detaching.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_roll_detaching.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-roll_detaching"),
+            Some("os_roll_detaching"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_set_bootable.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_set_bootable.rs
@@ -80,7 +80,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-set_bootable"),
+            Some("os_set_bootable"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_set_image_metadata.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_set_image_metadata.rs
@@ -81,7 +81,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-set_image_metadata"),
+            Some("os_set_image_metadata"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_show_image_metadata.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_show_image_metadata.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-show_image_metadata"),
+            Some("os_show_image_metadata"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_terminate_connection.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_terminate_connection.rs
@@ -81,7 +81,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-terminate_connection"),
+            Some("os_terminate_connection"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_unmanage.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unmanage.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-unmanage"),
+            Some("os_unmanage"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_unreserve.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unreserve.rs
@@ -71,7 +71,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-unreserve"),
+            Some("os_unreserve"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_unset_image_metadata.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unset_image_metadata.rs
@@ -80,7 +80,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-unset_image_metadata"),
+            Some("os_unset_image_metadata"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_update_readonly_flag.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_update_readonly_flag.rs
@@ -80,7 +80,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-update_readonly_flag"),
+            Some("os_update_readonly_flag"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_30.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_30.rs
@@ -106,7 +106,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-volume_upload_image"),
+            Some("os_volume_upload_image"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_31.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_volume_upload_image_31.rs
@@ -120,7 +120,7 @@ impl VolumeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume"),
-            Some("os-volume_upload_image"),
+            Some("os_volume_upload_image"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/block_storage/v3/volume_transfer/accept.rs
+++ b/openstack_cli/src/block_storage/v3/volume_transfer/accept.rs
@@ -81,7 +81,7 @@ impl VolumeTransferCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("block-storage.volume_transfer"),
-            Some("action"),
+            Some("accept"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/flavor/add_tenant_access.rs
+++ b/openstack_cli/src/compute/v2/flavor/add_tenant_access.rs
@@ -91,7 +91,7 @@ impl FlavorCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.flavor"),
-            Some("addtenantaccess"),
+            Some("add_tenant_access"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/flavor/remove_tenant_access.rs
+++ b/openstack_cli/src/compute/v2/flavor/remove_tenant_access.rs
@@ -92,7 +92,7 @@ impl FlavorCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.flavor"),
-            Some("removetenantaccess"),
+            Some("remove_tenant_access"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/limit/list.rs
+++ b/openstack_cli/src/compute/v2/limit/list.rs
@@ -69,7 +69,7 @@ impl LimitCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show Limit");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("compute.limit"), Some("show"));
+        let op = OutputProcessor::from_args(parsed_args, Some("compute.limit"), Some("list"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = list::Request::builder();

--- a/openstack_cli/src/compute/v2/quota_set/defaults.rs
+++ b/openstack_cli/src/compute/v2/quota_set/defaults.rs
@@ -74,7 +74,8 @@ impl QuotaSetCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show QuotaSet");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("compute.quota_set"), Some("show"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("compute.quota_set"), Some("defaults"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = defaults::Request::builder();

--- a/openstack_cli/src/compute/v2/quota_set/details.rs
+++ b/openstack_cli/src/compute/v2/quota_set/details.rs
@@ -100,7 +100,8 @@ impl QuotaSetCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show QuotaSet");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("compute.quota_set"), Some("show"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("compute.quota_set"), Some("details"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = details::Request::builder();

--- a/openstack_cli/src/compute/v2/server/add_fixed_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/add_fixed_ip_21.rs
@@ -94,7 +94,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("addfixedip"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("add_fixed_ip"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_fixed_ip_21::Request::builder();

--- a/openstack_cli/src/compute/v2/server/add_floating_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/add_floating_ip_21.rs
@@ -114,8 +114,11 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("addfloatingip"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server"),
+            Some("add_floating_ip"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_floating_ip_21::Request::builder();

--- a/openstack_cli/src/compute/v2/server/add_security_group.rs
+++ b/openstack_cli/src/compute/v2/server/add_security_group.rs
@@ -96,7 +96,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("addsecuritygroup"),
+            Some("add_security_group"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/change_password.rs
+++ b/openstack_cli/src/compute/v2/server/change_password.rs
@@ -91,8 +91,11 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("changepassword"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server"),
+            Some("change_password"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = change_password::Request::builder();

--- a/openstack_cli/src/compute/v2/server/confirm_resize.rs
+++ b/openstack_cli/src/compute/v2/server/confirm_resize.rs
@@ -106,7 +106,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("confirmresize"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("confirm_resize"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = confirm_resize::Request::builder();

--- a/openstack_cli/src/compute/v2/server/create_backup_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_20.rs
@@ -97,7 +97,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("createbackup"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("create_backup"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = create_backup_20::Request::builder();

--- a/openstack_cli/src/compute/v2/server/create_backup_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_21.rs
@@ -97,7 +97,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("createbackup"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("create_backup"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = create_backup_21::Request::builder();

--- a/openstack_cli/src/compute/v2/server/create_image_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_image_20.rs
@@ -89,7 +89,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("createimage"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("create_image"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = create_image_20::Request::builder();

--- a/openstack_cli/src/compute/v2/server/create_image_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_image_21.rs
@@ -89,7 +89,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("createimage"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("create_image"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = create_image_21::Request::builder();

--- a/openstack_cli/src/compute/v2/server/force_delete.rs
+++ b/openstack_cli/src/compute/v2/server/force_delete.rs
@@ -85,7 +85,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("forcedelete"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("force_delete"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = force_delete::Request::builder();

--- a/openstack_cli/src/compute/v2/server/inject_network_info.rs
+++ b/openstack_cli/src/compute/v2/server/inject_network_info.rs
@@ -87,7 +87,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("injectnetworkinfo"),
+            Some("inject_network_info"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/metadata/replace.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/replace.rs
@@ -89,8 +89,11 @@ impl MetadataCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Metadata");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server/metadata"), Some("set"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server/metadata"),
+            Some("replace"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/compute/v2/server/os_get_console_output.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_console_output.rs
@@ -102,7 +102,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("os-getconsoleoutput"),
+            Some("os_get_console_output"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/os_get_rdpconsole.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_rdpconsole.rs
@@ -84,7 +84,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("os-getrdpconsole"),
+            Some("os_get_rdpconsole"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/os_get_serial_console_21.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_serial_console_21.rs
@@ -103,7 +103,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("os-getserialconsole"),
+            Some("os_get_serial_console"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/os_get_spiceconsole_21.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_spiceconsole_21.rs
@@ -103,7 +103,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("os-getspiceconsole"),
+            Some("os_get_spiceconsole"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/os_get_vncconsole_21.rs
+++ b/openstack_cli/src/compute/v2/server/os_get_vncconsole_21.rs
@@ -99,7 +99,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("os-getvncconsole"),
+            Some("os_get_vncconsole"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_20.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_20.rs
@@ -106,8 +106,11 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os-migratelive"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server"),
+            Some("os_migrate_live"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = os_migrate_live_20::Request::builder();

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_225.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_225.rs
@@ -102,8 +102,11 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os-migratelive"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server"),
+            Some("os_migrate_live"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = os_migrate_live_225::Request::builder();

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_230.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_230.rs
@@ -118,8 +118,11 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os-migratelive"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server"),
+            Some("os_migrate_live"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = os_migrate_live_230::Request::builder();

--- a/openstack_cli/src/compute/v2/server/os_migrate_live_268.rs
+++ b/openstack_cli/src/compute/v2/server/os_migrate_live_268.rs
@@ -102,8 +102,11 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os-migratelive"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server"),
+            Some("os_migrate_live"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = os_migrate_live_268::Request::builder();

--- a/openstack_cli/src/compute/v2/server/os_reset_state.rs
+++ b/openstack_cli/src/compute/v2/server/os_reset_state.rs
@@ -99,7 +99,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os-resetstate"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os_reset_state"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = os_reset_state::Request::builder();

--- a/openstack_cli/src/compute/v2/server/os_start.rs
+++ b/openstack_cli/src/compute/v2/server/os_start.rs
@@ -98,7 +98,7 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os-start"));
+        let op = OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os_start"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = os_start::Request::builder();

--- a/openstack_cli/src/compute/v2/server/os_stop.rs
+++ b/openstack_cli/src/compute/v2/server/os_stop.rs
@@ -93,7 +93,7 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os-stop"));
+        let op = OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("os_stop"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = os_stop::Request::builder();

--- a/openstack_cli/src/compute/v2/server/remove_fixed_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/remove_fixed_ip_21.rs
@@ -93,8 +93,11 @@ impl ServerCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Server");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("removefixedip"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("compute.server"),
+            Some("remove_fixed_ip"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = remove_fixed_ip_21::Request::builder();

--- a/openstack_cli/src/compute/v2/server/remove_floating_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/remove_floating_ip_21.rs
@@ -98,7 +98,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("removefloatingip"),
+            Some("remove_floating_ip"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/remove_security_group.rs
+++ b/openstack_cli/src/compute/v2/server/remove_security_group.rs
@@ -96,7 +96,7 @@ impl ServerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("compute.server"),
-            Some("removesecuritygroup"),
+            Some("remove_security_group"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/compute/v2/server/reset_network.rs
+++ b/openstack_cli/src/compute/v2/server/reset_network.rs
@@ -81,7 +81,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("resetnetwork"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("reset_network"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = reset_network::Request::builder();

--- a/openstack_cli/src/compute/v2/server/revert_resize.rs
+++ b/openstack_cli/src/compute/v2/server/revert_resize.rs
@@ -107,7 +107,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("revertresize"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("revert_resize"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = revert_resize::Request::builder();

--- a/openstack_cli/src/compute/v2/server/shelve_offload.rs
+++ b/openstack_cli/src/compute/v2/server/shelve_offload.rs
@@ -108,7 +108,7 @@ impl ServerCommand {
         info!("Action Server");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("shelveoffload"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server"), Some("shelve_offload"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = shelve_offload::Request::builder();

--- a/openstack_cli/src/compute/v2/server/tag/delete_all.rs
+++ b/openstack_cli/src/compute/v2/server/tag/delete_all.rs
@@ -74,7 +74,7 @@ impl TagCommand {
         info!("Delete Tag");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("compute.server/tag"), Some("delete"));
+            OutputProcessor::from_args(parsed_args, Some("compute.server/tag"), Some("delete_all"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/compute/v2/server/tag/replace_226.rs
+++ b/openstack_cli/src/compute/v2/server/tag/replace_226.rs
@@ -81,7 +81,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("compute.server/tag"), Some("set"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("compute.server/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace_226::Request::builder();

--- a/openstack_cli/src/container_infrastructure_management/v1/cluster/nodegroup/delete_all.rs
+++ b/openstack_cli/src/container_infrastructure_management/v1/cluster/nodegroup/delete_all.rs
@@ -66,7 +66,7 @@ impl NodegroupCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("container-infrastructure-management.cluster/nodegroup"),
-            Some("delete"),
+            Some("delete_all"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/dns/v2/zone/task/abandon.rs
+++ b/openstack_cli/src/dns/v2/zone/task/abandon.rs
@@ -89,7 +89,7 @@ impl TaskCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Task");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("dns.zone/task"), Some("action"));
+        let op = OutputProcessor::from_args(parsed_args, Some("dns.zone/task"), Some("abandon"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = abandon::Request::builder();

--- a/openstack_cli/src/dns/v2/zone/task/pool_move.rs
+++ b/openstack_cli/src/dns/v2/zone/task/pool_move.rs
@@ -89,7 +89,7 @@ impl TaskCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Task");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("dns.zone/task"), Some("action"));
+        let op = OutputProcessor::from_args(parsed_args, Some("dns.zone/task"), Some("pool_move"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = pool_move::Request::builder();

--- a/openstack_cli/src/dns/v2/zone/task/xfr.rs
+++ b/openstack_cli/src/dns/v2/zone/task/xfr.rs
@@ -89,7 +89,7 @@ impl TaskCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Task");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("dns.zone/task"), Some("action"));
+        let op = OutputProcessor::from_args(parsed_args, Some("dns.zone/task"), Some("xfr"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = xfr::Request::builder();

--- a/openstack_cli/src/identity/v3/domain/config/default.rs
+++ b/openstack_cli/src/identity/v3/domain/config/default.rs
@@ -66,8 +66,11 @@ impl ConfigCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show Config");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("identity.domain/config"), Some("show"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("identity.domain/config"),
+            Some("default"),
+        );
         op.validate_args(parsed_args)?;
 
         let ep_builder = default::Request::builder();

--- a/openstack_cli/src/identity/v3/domain/config/delete_all.rs
+++ b/openstack_cli/src/identity/v3/domain/config/delete_all.rs
@@ -88,8 +88,11 @@ impl ConfigCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Config");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("identity.domain/config"), Some("delete"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("identity.domain/config"),
+            Some("delete_all"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/identity/v3/domain/config/group/default.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/default.rs
@@ -78,7 +78,7 @@ impl GroupCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("identity.domain/config/group"),
-            Some("show"),
+            Some("default"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/identity/v3/domain/config/group/option/default.rs
+++ b/openstack_cli/src/identity/v3/domain/config/group/option/default.rs
@@ -88,7 +88,7 @@ impl OptionCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("identity.domain/config/group/option"),
-            Some("show"),
+            Some("default"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/identity/v3/domain/config/replace.rs
+++ b/openstack_cli/src/identity/v3/domain/config/replace.rs
@@ -96,8 +96,11 @@ impl ConfigCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Config");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("identity.domain/config"), Some("set"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("identity.domain/config"),
+            Some("replace"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/group/role/inherited_to_project/inherited_to_projects.rs
@@ -117,7 +117,7 @@ impl InheritedToProjectCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("identity.OS_INHERIT/domain/group/role/inherited_to_project"),
-            Some("action"),
+            Some("inherited_to_projects"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/domain/user/role/inherited_to_project/inherited_to_projects.rs
@@ -127,7 +127,7 @@ impl InheritedToProjectCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("identity.OS_INHERIT/domain/user/role/inherited_to_project"),
-            Some("action"),
+            Some("inherited_to_projects"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/identity/v3/os_inherit/project/group/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/group/role/inherited_to_project/inherited_to_projects.rs
@@ -117,7 +117,7 @@ impl InheritedToProjectCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("identity.OS_INHERIT/project/group/role/inherited_to_project"),
-            Some("action"),
+            Some("inherited_to_projects"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
+++ b/openstack_cli/src/identity/v3/os_inherit/project/user/role/inherited_to_project/inherited_to_projects.rs
@@ -127,7 +127,7 @@ impl InheritedToProjectCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("identity.OS_INHERIT/project/user/role/inherited_to_project"),
-            Some("action"),
+            Some("inherited_to_projects"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/identity/v3/os_oauth2/token/token.rs
+++ b/openstack_cli/src/identity/v3/os_oauth2/token/token.rs
@@ -70,7 +70,7 @@ impl TokenCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("identity.OS_OAUTH2/token"),
-            Some("action"),
+            Some("token"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/identity/v3/project/tag/delete_all.rs
+++ b/openstack_cli/src/identity/v3/project/tag/delete_all.rs
@@ -88,8 +88,11 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Tag");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("identity.project/tag"), Some("delete"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("identity.project/tag"),
+            Some("delete_all"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/identity/v3/project/tag/replace.rs
+++ b/openstack_cli/src/identity/v3/project/tag/replace.rs
@@ -96,7 +96,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("identity.project/tag"), Some("set"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("identity.project/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/image/v2/cache/delete_all.rs
+++ b/openstack_cli/src/image/v2/cache/delete_all.rs
@@ -65,7 +65,7 @@ impl CacheCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Cache");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.cache"), Some("delete"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.cache"), Some("delete_all"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/image/v2/image/deactivate.rs
+++ b/openstack_cli/src/image/v2/image/deactivate.rs
@@ -76,7 +76,7 @@ impl ImageCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Image");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.image"), Some("action"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.image"), Some("deactivate"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = deactivate::Request::builder();

--- a/openstack_cli/src/image/v2/image/patch.rs
+++ b/openstack_cli/src/image/v2/image/patch.rs
@@ -208,7 +208,7 @@ impl ImageCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Image");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.image"), Some("set"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.image"), Some("patch"));
         op.validate_args(parsed_args)?;
 
         let mut find_builder = find::Request::builder();

--- a/openstack_cli/src/image/v2/image/reactivate.rs
+++ b/openstack_cli/src/image/v2/image/reactivate.rs
@@ -76,7 +76,7 @@ impl ImageCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Image");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.image"), Some("action"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.image"), Some("reactivate"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = reactivate::Request::builder();

--- a/openstack_cli/src/image/v2/image/stage/stage.rs
+++ b/openstack_cli/src/image/v2/image/stage/stage.rs
@@ -76,7 +76,7 @@ impl StageCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Stage");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.image/stage"), Some("action"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.image/stage"), Some("stage"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = stage::Request::builder();

--- a/openstack_cli/src/image/v2/metadef/namespace/object/delete_all.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/object/delete_all.rs
@@ -72,7 +72,7 @@ impl ObjectCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.metadef/namespace/object"),
-            Some("delete"),
+            Some("delete_all"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/metadef/namespace/property/delete_all.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/delete_all.rs
@@ -72,7 +72,7 @@ impl PropertyCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.metadef/namespace/property"),
-            Some("delete"),
+            Some("delete_all"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/metadef/namespace/property/list.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/list.rs
@@ -73,7 +73,7 @@ impl PropertyCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.metadef/namespace/property"),
-            Some("list_from_struct"),
+            Some("list"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/metadef/namespace/tag/delete_all.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/tag/delete_all.rs
@@ -72,7 +72,7 @@ impl TagCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.metadef/namespace/tag"),
-            Some("delete"),
+            Some("delete_all"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/image/get.rs
+++ b/openstack_cli/src/image/v2/schema/image/get.rs
@@ -70,7 +70,7 @@ impl ImageCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Json Image");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/image"), Some("json"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/image"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/image/v2/schema/images/get.rs
+++ b/openstack_cli/src/image/v2/schema/images/get.rs
@@ -72,7 +72,7 @@ impl ImagesCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Json Images");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/images"), Some("json"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/images"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/image/v2/schema/member/get.rs
+++ b/openstack_cli/src/image/v2/schema/member/get.rs
@@ -70,7 +70,7 @@ impl MemberCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Json Member");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/member"), Some("json"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/member"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/image/v2/schema/members/get.rs
+++ b/openstack_cli/src/image/v2/schema/members/get.rs
@@ -72,8 +72,7 @@ impl MembersCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Json Members");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("image.schema/members"), Some("json"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/members"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/image/v2/schema/metadef/namespace/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/namespace/get.rs
@@ -63,7 +63,7 @@ impl NamespaceCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/namespace"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/namespaces/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/namespaces/get.rs
@@ -63,7 +63,7 @@ impl NamespacesCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/namespaces"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/object/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/object/get.rs
@@ -63,7 +63,7 @@ impl ObjectCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/object"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/objects/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/objects/get.rs
@@ -63,7 +63,7 @@ impl ObjectsCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/objects"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/properties/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/properties/get.rs
@@ -63,7 +63,7 @@ impl PropertiesCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/properties"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/property/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/property/get.rs
@@ -63,7 +63,7 @@ impl PropertyCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/property"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/resource_type/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/resource_type/get.rs
@@ -63,7 +63,7 @@ impl ResourceTypeCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/resource_type"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/resource_types/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/resource_types/get.rs
@@ -63,7 +63,7 @@ impl ResourceTypesCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("image.schema/metadef/resource_types"),
-            Some("json"),
+            Some("get"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/image/v2/schema/metadef/tag/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/tag/get.rs
@@ -61,7 +61,7 @@ impl TagCommand {
         info!("Json Tag");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("image.schema/metadef/tag"), Some("json"));
+            OutputProcessor::from_args(parsed_args, Some("image.schema/metadef/tag"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/image/v2/schema/metadef/tags/get.rs
+++ b/openstack_cli/src/image/v2/schema/metadef/tags/get.rs
@@ -60,11 +60,8 @@ impl TagsCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Json Tags");
 
-        let op = OutputProcessor::from_args(
-            parsed_args,
-            Some("image.schema/metadef/tags"),
-            Some("json"),
-        );
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("image.schema/metadef/tags"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/image/v2/schema/task/get.rs
+++ b/openstack_cli/src/image/v2/schema/task/get.rs
@@ -71,7 +71,7 @@ impl TaskCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Json Task");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/task"), Some("json"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/task"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/image/v2/schema/tasks/get.rs
+++ b/openstack_cli/src/image/v2/schema/tasks/get.rs
@@ -74,7 +74,7 @@ impl TasksCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Json Tasks");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/tasks"), Some("json"));
+        let op = OutputProcessor::from_args(parsed_args, Some("image.schema/tasks"), Some("get"));
         op.validate_args(parsed_args)?;
 
         let ep_builder = get::Request::builder();

--- a/openstack_cli/src/load_balancer/v2/amphorae/config.rs
+++ b/openstack_cli/src/load_balancer/v2/amphorae/config.rs
@@ -77,7 +77,7 @@ impl AmphoraeCommand {
         info!("Action Amphorae");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("load-balancer.amphorae"), Some("action"));
+            OutputProcessor::from_args(parsed_args, Some("load-balancer.amphorae"), Some("config"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = config::Request::builder();

--- a/openstack_cli/src/load_balancer/v2/amphorae/failover.rs
+++ b/openstack_cli/src/load_balancer/v2/amphorae/failover.rs
@@ -75,8 +75,11 @@ impl AmphoraeCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Amphorae");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("load-balancer.amphorae"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("load-balancer.amphorae"),
+            Some("failover"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = failover::Request::builder();

--- a/openstack_cli/src/load_balancer/v2/amphorae/stats.rs
+++ b/openstack_cli/src/load_balancer/v2/amphorae/stats.rs
@@ -79,7 +79,7 @@ impl AmphoraeCommand {
         info!("Get Amphorae");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("load-balancer.amphorae"), Some("get"));
+            OutputProcessor::from_args(parsed_args, Some("load-balancer.amphorae"), Some("stats"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = stats::Request::builder();

--- a/openstack_cli/src/load_balancer/v2/listener/stats.rs
+++ b/openstack_cli/src/load_balancer/v2/listener/stats.rs
@@ -80,7 +80,7 @@ impl ListenerCommand {
         info!("Get Listener");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("load-balancer.listener"), Some("get"));
+            OutputProcessor::from_args(parsed_args, Some("load-balancer.listener"), Some("stats"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = stats::Request::builder();

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/failover.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/failover.rs
@@ -77,7 +77,7 @@ impl LoadbalancerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("load-balancer.loadbalancer"),
-            Some("action"),
+            Some("failover"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/stats.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/stats.rs
@@ -83,7 +83,7 @@ impl LoadbalancerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("load-balancer.loadbalancer"),
-            Some("get"),
+            Some("stats"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/status.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/status.rs
@@ -92,7 +92,7 @@ impl LoadbalancerCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("load-balancer.loadbalancer"),
-            Some("get"),
+            Some("status"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/load_balancer/v2/pool/member/replace.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/member/replace.rs
@@ -103,8 +103,11 @@ impl MemberCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Member");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("load-balancer.pool/member"), Some("set"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("load-balancer.pool/member"),
+            Some("replace"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut find_builder = find::Request::builder();

--- a/openstack_cli/src/network/v2/address_group/add_addresses.rs
+++ b/openstack_cli/src/network/v2/address_group/add_addresses.rs
@@ -81,8 +81,11 @@ impl AddressGroupCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action AddressGroup");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.address_group"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.address_group"),
+            Some("add_addresses"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_addresses::Request::builder();

--- a/openstack_cli/src/network/v2/address_group/remove_addresses.rs
+++ b/openstack_cli/src/network/v2/address_group/remove_addresses.rs
@@ -81,8 +81,11 @@ impl AddressGroupCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action AddressGroup");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.address_group"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.address_group"),
+            Some("remove_addresses"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = remove_addresses::Request::builder();

--- a/openstack_cli/src/network/v2/floatingip/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/delete_all.rs
@@ -69,8 +69,11 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Tag");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.floatingip/tag"), Some("delete"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.floatingip/tag"),
+            Some("delete_all"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/floatingip/tag/replace.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/replace.rs
@@ -74,8 +74,11 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.floatingip/tag"), Some("set"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.floatingip/tag"),
+            Some("replace"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/network/v2/network/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/network/tag/delete_all.rs
@@ -68,8 +68,11 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Tag");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.network/tag"), Some("delete"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.network/tag"),
+            Some("delete_all"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/network/tag/replace.rs
+++ b/openstack_cli/src/network/v2/network/tag/replace.rs
@@ -73,7 +73,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.network/tag"), Some("set"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("network.network/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/network/v2/network_segment_range/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/tag/delete_all.rs
@@ -72,7 +72,7 @@ impl TagCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("network.network_segment_range/tag"),
-            Some("delete"),
+            Some("delete_all"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/network/v2/network_segment_range/tag/replace.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/tag/replace.rs
@@ -77,7 +77,7 @@ impl TagCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("network.network_segment_range/tag"),
-            Some("set"),
+            Some("replace"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/network/v2/policy/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/policy/tag/delete_all.rs
@@ -69,7 +69,7 @@ impl TagCommand {
         info!("Delete Tag");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("network.policy/tag"), Some("delete"));
+            OutputProcessor::from_args(parsed_args, Some("network.policy/tag"), Some("delete_all"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/policy/tag/replace.rs
+++ b/openstack_cli/src/network/v2/policy/tag/replace.rs
@@ -73,7 +73,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.policy/tag"), Some("set"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("network.policy/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/network/v2/port/add_allowed_address_pairs.rs
+++ b/openstack_cli/src/network/v2/port/add_allowed_address_pairs.rs
@@ -77,7 +77,11 @@ impl PortCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Port");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.port"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.port"),
+            Some("add_allowed_address_pairs"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_allowed_address_pairs::Request::builder();

--- a/openstack_cli/src/network/v2/port/binding/activate.rs
+++ b/openstack_cli/src/network/v2/port/binding/activate.rs
@@ -85,7 +85,7 @@ impl BindingCommand {
         info!("Action Binding");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("network.port/binding"), Some("action"));
+            OutputProcessor::from_args(parsed_args, Some("network.port/binding"), Some("activate"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = activate::Request::builder();

--- a/openstack_cli/src/network/v2/port/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/port/tag/delete_all.rs
@@ -68,7 +68,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.port/tag"), Some("delete"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("network.port/tag"), Some("delete_all"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/port/tag/replace.rs
+++ b/openstack_cli/src/network/v2/port/tag/replace.rs
@@ -73,7 +73,7 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.port/tag"), Some("set"));
+        let op = OutputProcessor::from_args(parsed_args, Some("network.port/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/network/v2/quota/defaults.rs
+++ b/openstack_cli/src/network/v2/quota/defaults.rs
@@ -87,7 +87,7 @@ impl QuotaCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show Quota");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.quota"), Some("show"));
+        let op = OutputProcessor::from_args(parsed_args, Some("network.quota"), Some("defaults"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = defaults::Request::builder();

--- a/openstack_cli/src/network/v2/quota/details.rs
+++ b/openstack_cli/src/network/v2/quota/details.rs
@@ -69,7 +69,7 @@ impl QuotaCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Show Quota");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.quota"), Some("show"));
+        let op = OutputProcessor::from_args(parsed_args, Some("network.quota"), Some("details"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = details::Request::builder();

--- a/openstack_cli/src/network/v2/router/add_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/add_external_gateways.rs
@@ -83,7 +83,11 @@ impl RouterCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Router");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.router"),
+            Some("add_external_gateways"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_external_gateways::Request::builder();

--- a/openstack_cli/src/network/v2/router/add_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/add_extraroutes.rs
@@ -85,7 +85,11 @@ impl RouterCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Router");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.router"),
+            Some("add_extraroutes"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_extraroutes::Request::builder();

--- a/openstack_cli/src/network/v2/router/add_router_interface.rs
+++ b/openstack_cli/src/network/v2/router/add_router_interface.rs
@@ -78,7 +78,11 @@ impl RouterCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Router");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.router"),
+            Some("add_router_interface"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_router_interface::Request::builder();

--- a/openstack_cli/src/network/v2/router/remove_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/remove_external_gateways.rs
@@ -83,7 +83,11 @@ impl RouterCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Router");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.router"),
+            Some("remove_external_gateways"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = remove_external_gateways::Request::builder();

--- a/openstack_cli/src/network/v2/router/remove_extraroutes.rs
+++ b/openstack_cli/src/network/v2/router/remove_extraroutes.rs
@@ -85,7 +85,11 @@ impl RouterCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Router");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.router"),
+            Some("remove_extraroutes"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = remove_extraroutes::Request::builder();

--- a/openstack_cli/src/network/v2/router/remove_router_interface.rs
+++ b/openstack_cli/src/network/v2/router/remove_router_interface.rs
@@ -78,7 +78,11 @@ impl RouterCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Router");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.router"),
+            Some("remove_router_interface"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = remove_router_interface::Request::builder();

--- a/openstack_cli/src/network/v2/router/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/router/tag/delete_all.rs
@@ -69,7 +69,7 @@ impl TagCommand {
         info!("Delete Tag");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("network.router/tag"), Some("delete"));
+            OutputProcessor::from_args(parsed_args, Some("network.router/tag"), Some("delete_all"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/router/tag/replace.rs
+++ b/openstack_cli/src/network/v2/router/tag/replace.rs
@@ -73,7 +73,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router/tag"), Some("set"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("network.router/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/network/v2/router/update_external_gateways.rs
+++ b/openstack_cli/src/network/v2/router/update_external_gateways.rs
@@ -83,7 +83,11 @@ impl RouterCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Router");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.router"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.router"),
+            Some("update_external_gateways"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = update_external_gateways::Request::builder();

--- a/openstack_cli/src/network/v2/security_group/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/security_group/tag/delete_all.rs
@@ -72,7 +72,7 @@ impl TagCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("network.security_group/tag"),
-            Some("delete"),
+            Some("delete_all"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/network/v2/security_group/tag/replace.rs
+++ b/openstack_cli/src/network/v2/security_group/tag/replace.rs
@@ -77,7 +77,7 @@ impl TagCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("network.security_group/tag"),
-            Some("set"),
+            Some("replace"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/network/v2/subnet/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/delete_all.rs
@@ -69,7 +69,7 @@ impl TagCommand {
         info!("Delete Tag");
 
         let op =
-            OutputProcessor::from_args(parsed_args, Some("network.subnet/tag"), Some("delete"));
+            OutputProcessor::from_args(parsed_args, Some("network.subnet/tag"), Some("delete_all"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/subnet/tag/replace.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/replace.rs
@@ -73,7 +73,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.subnet/tag"), Some("set"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("network.subnet/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/network/v2/subnetpool/add_prefixes.rs
+++ b/openstack_cli/src/network/v2/subnetpool/add_prefixes.rs
@@ -76,8 +76,11 @@ impl SubnetpoolCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Subnetpool");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.subnetpool"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.subnetpool"),
+            Some("add_prefixes"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = add_prefixes::Request::builder();

--- a/openstack_cli/src/network/v2/subnetpool/onboard_network_subnet/onboard_network_subnets.rs
+++ b/openstack_cli/src/network/v2/subnetpool/onboard_network_subnet/onboard_network_subnets.rs
@@ -79,7 +79,7 @@ impl OnboardNetworkSubnetCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("network.subnetpool/onboard_network_subnet"),
-            Some("action"),
+            Some("onboard_network_subnets"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/network/v2/subnetpool/remove_prefixes.rs
+++ b/openstack_cli/src/network/v2/subnetpool/remove_prefixes.rs
@@ -76,8 +76,11 @@ impl SubnetpoolCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Action Subnetpool");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.subnetpool"), Some("action"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.subnetpool"),
+            Some("remove_prefixes"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = remove_prefixes::Request::builder();

--- a/openstack_cli/src/network/v2/subnetpool/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/subnetpool/tag/delete_all.rs
@@ -69,8 +69,11 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Tag");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.subnetpool/tag"), Some("delete"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.subnetpool/tag"),
+            Some("delete_all"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/subnetpool/tag/replace.rs
+++ b/openstack_cli/src/network/v2/subnetpool/tag/replace.rs
@@ -74,8 +74,11 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op =
-            OutputProcessor::from_args(parsed_args, Some("network.subnetpool/tag"), Some("set"));
+        let op = OutputProcessor::from_args(
+            parsed_args,
+            Some("network.subnetpool/tag"),
+            Some("replace"),
+        );
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/network/v2/trunk/tag/delete_all.rs
+++ b/openstack_cli/src/network/v2/trunk/tag/delete_all.rs
@@ -68,7 +68,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Delete Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.trunk/tag"), Some("delete"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("network.trunk/tag"), Some("delete_all"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = delete_all::Request::builder();

--- a/openstack_cli/src/network/v2/trunk/tag/replace.rs
+++ b/openstack_cli/src/network/v2/trunk/tag/replace.rs
@@ -73,7 +73,8 @@ impl TagCommand {
     ) -> Result<(), OpenStackCliError> {
         info!("Set Tag");
 
-        let op = OutputProcessor::from_args(parsed_args, Some("network.trunk/tag"), Some("set"));
+        let op =
+            OutputProcessor::from_args(parsed_args, Some("network.trunk/tag"), Some("replace"));
         op.validate_args(parsed_args)?;
 
         let mut ep_builder = replace::Request::builder();

--- a/openstack_cli/src/placement/v1/allocation_candidate/list.rs
+++ b/openstack_cli/src/placement/v1/allocation_candidate/list.rs
@@ -189,7 +189,7 @@ impl AllocationCandidateCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("placement.allocation_candidate"),
-            Some("show"),
+            Some("list"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/placement/v1/resource_provider/aggregate/list.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/aggregate/list.rs
@@ -80,7 +80,7 @@ impl AggregateCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("placement.resource_provider/aggregate"),
-            Some("show"),
+            Some("list"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/placement/v1/resource_provider/allocation/list.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/allocation/list.rs
@@ -79,7 +79,7 @@ impl AllocationCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("placement.resource_provider/allocation"),
-            Some("show"),
+            Some("list"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/placement/v1/resource_provider/inventory/delete_all.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/inventory/delete_all.rs
@@ -84,7 +84,7 @@ impl InventoryCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("placement.resource_provider/inventory"),
-            Some("delete"),
+            Some("delete_all"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/placement/v1/resource_provider/inventory/replace.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/inventory/replace.rs
@@ -90,7 +90,7 @@ impl InventoryCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("placement.resource_provider/inventory"),
-            Some("set"),
+            Some("replace"),
         );
         op.validate_args(parsed_args)?;
 

--- a/openstack_cli/src/placement/v1/resource_provider/trait/list.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/trait/list.rs
@@ -77,7 +77,7 @@ impl TraitCommand {
         let op = OutputProcessor::from_args(
             parsed_args,
             Some("placement.resource_provider/trait"),
-            Some("show"),
+            Some("list"),
         );
         op.validate_args(parsed_args)?;
 


### PR DESCRIPTION
Currently we comment the operation_name attribute in the metadata that
it is used as an action name. This only creates confusion especially if
we want to use something different as the operation_name (i.e.
operation_name or opertaion_type for neutron router results in
"action"). So in addition to the renaming of the metadata attribute
explicitly pass the metadata operation key as operation_name parameters
into the generator (when unset).

Change-Id: Ic04eafe5b6dea012ca18b9835cd5c86fefa87055
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/951833
