### PR TITLE
feat: Allow starting tui with custom clouds.yaml

### DIFF
--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -17,7 +17,7 @@ use clap::builder::{
     Styles,
     styling::{AnsiColor, Effects},
 };
-use clap::{Args, Parser, ValueEnum};
+use clap::{Args, Parser, ValueEnum, ValueHint};
 use clap_complete::Shell;
 
 use openstack_sdk::AsyncOpenStack;
@@ -156,6 +156,7 @@ pub struct GlobalOpts {
         long,
         env = "OS_CLIENT_CONFIG_FILE",
         global = true,
+        value_hint = ValueHint::FilePath,
         display_order = 905
     )]
     pub os_client_config_file: Option<String>,
@@ -165,6 +166,7 @@ pub struct GlobalOpts {
         long,
         env = "OS_CLIENT_SECURE_FILE",
         global = true,
+        value_hint = ValueHint::FilePath,
         display_order = 905
     )]
     pub os_client_secure_file: Option<String>,

--- a/openstack_tui/src/bin/ostui.rs
+++ b/openstack_tui/src/bin/ostui.rs
@@ -28,7 +28,7 @@ async fn tokio_main() -> Result<()> {
 
     let args = Cli::parse();
 
-    let mut app = App::new(args.tick_rate, args.frame_rate, args.os_cloud)?;
+    let mut app = App::new(&args)?;
     app.run().await?;
 
     Ok(())

--- a/openstack_tui/src/cli.rs
+++ b/openstack_tui/src/cli.rs
@@ -11,31 +11,34 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-
-use clap::Parser;
+//! TUI Cli parameters
+use clap::{Parser, ValueHint};
+use std::path::PathBuf;
 
 use crate::utils::version;
 
+/// TUI Cli parameters
 #[derive(Parser, Debug)]
 #[command(author, version = version(), about)]
 pub struct Cli {
-    #[arg(
-        short,
-        long,
-        value_name = "FLOAT",
-        help = "Tick rate, i.e. number of ticks per second",
-        default_value_t = 0.2
-    )]
+    /// Number of ticks per second. May be used by certain views to trigger certain actions, but
+    /// most likely not used.
+    #[arg(short, long, value_name = "FLOAT", default_value_t = 0.2)]
     pub tick_rate: f64,
 
-    #[arg(
-        short,
-        long,
-        value_name = "FLOAT",
-        help = "Frame rate, i.e. number of frames per second",
-        default_value_t = 1.0
-    )]
+    /// Refresh frame rate (number of frames per second)
+    #[arg(short, long, value_name = "FLOAT", default_value_t = 1.0)]
     pub frame_rate: f64,
-    #[arg(long)]
+
+    /// Cloud name to connect to after the start
+    #[arg(long, env = "OS_CLOUD")]
     pub os_cloud: Option<String>,
+
+    /// Custom path to the `clouds.yaml` config file
+    #[arg(long, env = "OS_CLIENT_CONFIG_FILE", value_hint = ValueHint::FilePath)]
+    pub os_client_config_file: Option<PathBuf>,
+
+    /// Custom path to the `secure.yaml` config file
+    #[arg(long, env = "OS_CLIENT_SECURE_FILE", value_hint = ValueHint::FilePath)]
+    pub os_client_secure_file: Option<PathBuf>,
 }

--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -11,12 +11,17 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+//! Cloud worker module.
+//!
+//! Handle communication with the cloud including connection, re-connection (when auth expires) and
+//! all the API requests.
 
 use chrono::TimeDelta;
 use eyre::{Report, Result, eyre};
 use openstack_sdk::{
     AsyncOpenStack, auth::AuthState, config::ConfigFile, types::identity::v3::AuthResponse,
 };
+use std::path::PathBuf;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::debug;
 
@@ -44,8 +49,16 @@ pub(crate) struct Cloud {
 }
 
 impl Cloud {
-    pub fn new() -> Self {
-        let cfg = ConfigFile::new().unwrap();
+    pub fn new(
+        client_config_config_file: Option<PathBuf>,
+        client_secure_config_file: Option<PathBuf>,
+    ) -> Self {
+        let cfg = ConfigFile::new_with_user_specified_configs(
+            client_config_config_file.as_deref(),
+            client_secure_config_file.as_deref(),
+        )
+        .expect("unable to load config files");
+
         Self {
             cloud_configs: cfg,
             cloud: None,


### PR DESCRIPTION
Add support for `os_client_config_file` and `os_client_secure_file` to
the TUI in the same way it is done for OSC.
