### PR TITLE
fix: Make catalog more permissive

### DIFF
--- a/openstack_cli/src/catalog/show.rs
+++ b/openstack_cli/src/catalog/show.rs
@@ -67,7 +67,9 @@ impl ShowCommand {
             .filter(|x| x.service_type == self.service_type)
             .flat_map(|x| {
                 let mut eps = x.endpoints;
-                eps.sort_by_key(|x| format!("{}{}", x.region, x.interface));
+                eps.sort_by_key(|x| {
+                    format!("{}{}", x.region.as_deref().unwrap_or_default(), x.interface)
+                });
                 eps
             })
             .map(|x| serde_json::to_value(x).unwrap())

--- a/openstack_sdk/src/catalog.rs
+++ b/openstack_sdk/src/catalog.rs
@@ -144,7 +144,7 @@ impl Catalog {
                     self.register_catalog_endpoint(
                         &srv.service_type,
                         &ep.url,
-                        Some(&ep.region),
+                        ep.region.clone(),
                         Some(&ep.interface),
                     )?;
                 }

--- a/openstack_sdk/src/types/identity/v3.rs
+++ b/openstack_sdk/src/types/identity/v3.rs
@@ -53,7 +53,7 @@ pub struct ServiceEndpoints {
 pub struct CatalogEndpoint {
     pub id: String,
     pub interface: String,
-    pub region: String,
+    pub region: Option<String>,
     pub url: String,
 }
 


### PR DESCRIPTION
Technically it is possible that the service name in the catalog is
empty as well as region_id of the endpoint. Make it this way so that we
do not fail (should never happen on real clouds but present in dev
situations).
