### PR TITLE
feat: Improve UX clarity of "limit" query parameter

### DIFF
--- a/openstack_cli/src/block_storage/v3/attachment/list.rs
+++ b/openstack_cli/src/block_storage/v3/attachment/list.rs
@@ -60,7 +60,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/backup/list.rs
+++ b/openstack_cli/src/block_storage/v3/backup/list.rs
@@ -60,7 +60,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/group/list.rs
+++ b/openstack_cli/src/block_storage/v3/group/list.rs
@@ -60,7 +60,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/group_snapshot/list.rs
+++ b/openstack_cli/src/block_storage/v3/group_snapshot/list.rs
@@ -60,7 +60,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/group_type/list.rs
+++ b/openstack_cli/src/block_storage/v3/group_type/list.rs
@@ -60,7 +60,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/manageable_snapshot/get.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_snapshot/get.rs
@@ -51,7 +51,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/manageable_snapshot/list.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_snapshot/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/manageable_volume/get.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_volume/get.rs
@@ -51,7 +51,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/manageable_volume/list.rs
+++ b/openstack_cli/src/block_storage/v3/manageable_volume/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/message/list.rs
+++ b/openstack_cli/src/block_storage/v3/message/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/qos_spec/list.rs
+++ b/openstack_cli/src/block_storage/v3/qos_spec/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/snapshot/list.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/list.rs
@@ -68,7 +68,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/volume/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume/list.rs
@@ -73,7 +73,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/block_storage/v3/volume_transfer/list.rs
+++ b/openstack_cli/src/block_storage/v3/volume_transfer/list.rs
@@ -64,7 +64,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/compute/v2/flavor/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/list.rs
@@ -60,9 +60,20 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     is_public: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 

--- a/openstack_cli/src/compute/v2/hypervisor/list.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/list.rs
@@ -64,9 +64,20 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     hypervisor_hostname_pattern: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 

--- a/openstack_cli/src/compute/v2/keypair/list.rs
+++ b/openstack_cli/src/compute/v2/keypair/list.rs
@@ -61,9 +61,20 @@ pub struct KeypairsCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 

--- a/openstack_cli/src/compute/v2/migration/get.rs
+++ b/openstack_cli/src/compute/v2/migration/get.rs
@@ -79,9 +79,20 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     instance_uuid: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 

--- a/openstack_cli/src/compute/v2/server/instance_action/list.rs
+++ b/openstack_cli/src/compute/v2/server/instance_action/list.rs
@@ -71,9 +71,20 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     changes_since: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 }

--- a/openstack_cli/src/compute/v2/server/list.rs
+++ b/openstack_cli/src/compute/v2/server/list.rs
@@ -149,7 +149,15 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     launched_at: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     #[arg(help_heading = "Query parameters", long)]
@@ -158,6 +166,9 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     locked_by: Option<String>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 

--- a/openstack_cli/src/compute/v2/server/volume_attachment/list.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/list.rs
@@ -57,7 +57,15 @@ pub struct VolumeAttachmentsCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/compute/v2/server_group/list.rs
+++ b/openstack_cli/src/compute/v2/server_group/list.rs
@@ -63,7 +63,15 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     all_projects: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/compute/v2/simple_tenant_usage/list.rs
+++ b/openstack_cli/src/compute/v2/simple_tenant_usage/list.rs
@@ -63,9 +63,20 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     end: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 

--- a/openstack_cli/src/compute/v2/simple_tenant_usage/show.rs
+++ b/openstack_cli/src/compute/v2/simple_tenant_usage/show.rs
@@ -55,9 +55,20 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     end: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
+    /// The ID of the last-seen item. Use the limit parameter to make an
+    /// initial limited request and use the ID of the last-seen item from the
+    /// response as the marker parameter value in a subsequent limited request.
     #[arg(help_heading = "Query parameters", long)]
     marker: Option<String>,
 

--- a/openstack_cli/src/dns/v2/recordset/list.rs
+++ b/openstack_cli/src/dns/v2/recordset/list.rs
@@ -71,7 +71,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/dns/v2/zone/list.rs
+++ b/openstack_cli/src/dns/v2/zone/list.rs
@@ -71,7 +71,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/dns/v2/zone/recordset/list.rs
+++ b/openstack_cli/src/dns/v2/zone/recordset/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/dns/v2/zone/share/list.rs
+++ b/openstack_cli/src/dns/v2/zone/share/list.rs
@@ -64,7 +64,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/identity/v3/domain/list.rs
+++ b/openstack_cli/src/identity/v3/domain/list.rs
@@ -62,7 +62,15 @@ struct QueryParameters {
     #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     enabled: Option<bool>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last fetched entry

--- a/openstack_cli/src/identity/v3/group/list.rs
+++ b/openstack_cli/src/identity/v3/group/list.rs
@@ -64,7 +64,15 @@ struct QueryParameters {
     #[command(flatten)]
     domain: DomainInput,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last fetched entry

--- a/openstack_cli/src/identity/v3/project/list.rs
+++ b/openstack_cli/src/identity/v3/project/list.rs
@@ -70,7 +70,15 @@ struct QueryParameters {
     #[arg(action=clap::ArgAction::Set, help_heading = "Query parameters", long)]
     is_domain: Option<bool>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last fetched entry

--- a/openstack_cli/src/identity/v3/user/list.rs
+++ b/openstack_cli/src/identity/v3/user/list.rs
@@ -72,7 +72,15 @@ struct QueryParameters {
     #[arg(help_heading = "Query parameters", long)]
     idp_id: Option<String>,
 
-    #[arg(help_heading = "Query parameters", long)]
+    /// Requests a page size of items. Returns a number of items up to a limit
+    /// value. Use the limit parameter to make an initial limited request and
+    /// use the ID of the last-seen item from the response as the marker
+    /// parameter value in a subsequent limited request.
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last fetched entry

--- a/openstack_cli/src/image/v2/image/list.rs
+++ b/openstack_cli/src/image/v2/image/list.rs
@@ -161,7 +161,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/load_balancer/v2/amphorae/list.rs
+++ b/openstack_cli/src/load_balancer/v2/amphorae/list.rs
@@ -97,7 +97,11 @@ struct QueryParameters {
     lb_network_ip: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/load_balancer/v2/availability_zone/list.rs
+++ b/openstack_cli/src/load_balancer/v2/availability_zone/list.rs
@@ -59,7 +59,11 @@ struct QueryParameters {
     description: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/availability_zone_profile/list.rs
+++ b/openstack_cli/src/load_balancer/v2/availability_zone_profile/list.rs
@@ -59,7 +59,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/flavor/list.rs
+++ b/openstack_cli/src/load_balancer/v2/flavor/list.rs
@@ -65,7 +65,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/flavor_profile/list.rs
+++ b/openstack_cli/src/load_balancer/v2/flavor_profile/list.rs
@@ -59,7 +59,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/healthmonitor/list.rs
+++ b/openstack_cli/src/load_balancer/v2/healthmonitor/list.rs
@@ -101,7 +101,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/l7policy/list.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/list.rs
@@ -77,7 +77,11 @@ struct QueryParameters {
     description: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/load_balancer/v2/l7policy/rule/list.rs
+++ b/openstack_cli/src/load_balancer/v2/l7policy/rule/list.rs
@@ -86,7 +86,11 @@ struct QueryParameters {
     key: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/listener/list.rs
+++ b/openstack_cli/src/load_balancer/v2/listener/list.rs
@@ -113,7 +113,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// Load balancer ID

--- a/openstack_cli/src/load_balancer/v2/loadbalancer/list.rs
+++ b/openstack_cli/src/load_balancer/v2/loadbalancer/list.rs
@@ -88,7 +88,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/pool/list.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/list.rs
@@ -88,7 +88,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the load balancer for the pool.

--- a/openstack_cli/src/load_balancer/v2/pool/member/list.rs
+++ b/openstack_cli/src/load_balancer/v2/pool/member/list.rs
@@ -92,7 +92,11 @@ struct QueryParameters {
     id: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/load_balancer/v2/provider/list.rs
+++ b/openstack_cli/src/load_balancer/v2/provider/list.rs
@@ -62,7 +62,11 @@ struct QueryParameters {
     description: Option<String>,
 
     /// Page size
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// ID of the last item in the previous list

--- a/openstack_cli/src/network/v2/address_group/list.rs
+++ b/openstack_cli/src/network/v2/address_group/list.rs
@@ -86,7 +86,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/address_scope/list.rs
+++ b/openstack_cli/src/network/v2/address_scope/list.rs
@@ -86,7 +86,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/agent/dhcp_network/list.rs
+++ b/openstack_cli/src/network/v2/agent/dhcp_network/list.rs
@@ -73,7 +73,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/agent/l3_router/list.rs
+++ b/openstack_cli/src/network/v2/agent/l3_router/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/agent/list.rs
+++ b/openstack_cli/src/network/v2/agent/list.rs
@@ -106,7 +106,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/auto_allocated_topology/list.rs
+++ b/openstack_cli/src/network/v2/auto_allocated_topology/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/availability_zone/list.rs
+++ b/openstack_cli/src/network/v2/availability_zone/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/default_security_group_rule/list.rs
+++ b/openstack_cli/src/network/v2/default_security_group_rule/list.rs
@@ -93,7 +93,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/flavor/list.rs
+++ b/openstack_cli/src/network/v2/flavor/list.rs
@@ -88,7 +88,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/flavor/next_provider/list.rs
+++ b/openstack_cli/src/network/v2/flavor/next_provider/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/flavor/service_profile/list.rs
+++ b/openstack_cli/src/network/v2/flavor/service_profile/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/floatingip/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/list.rs
@@ -99,7 +99,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
@@ -103,7 +103,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/floatingip/tag/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/floatingip_pool/list.rs
+++ b/openstack_cli/src/network/v2/floatingip_pool/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/local_ip/list.rs
+++ b/openstack_cli/src/network/v2/local_ip/list.rs
@@ -68,7 +68,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// local_ip_address query parameter for /v2.0/local-ips API

--- a/openstack_cli/src/network/v2/local_ip/port_association/list.rs
+++ b/openstack_cli/src/network/v2/local_ip/port_association/list.rs
@@ -89,7 +89,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// local_ip_address query parameter for

--- a/openstack_cli/src/network/v2/log/log/list.rs
+++ b/openstack_cli/src/network/v2/log/log/list.rs
@@ -92,7 +92,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/log/loggable_resource/list.rs
+++ b/openstack_cli/src/network/v2/log/loggable_resource/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/metering/metering_label/list.rs
+++ b/openstack_cli/src/network/v2/metering/metering_label/list.rs
@@ -84,7 +84,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/metering/metering_label_rule/list.rs
+++ b/openstack_cli/src/network/v2/metering/metering_label_rule/list.rs
@@ -99,7 +99,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/ndp_proxy/list.rs
+++ b/openstack_cli/src/network/v2/ndp_proxy/list.rs
@@ -60,7 +60,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
@@ -73,7 +73,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/network/list.rs
+++ b/openstack_cli/src/network/v2/network/list.rs
@@ -99,7 +99,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/network/tag/list.rs
+++ b/openstack_cli/src/network/v2/network/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/network_ip_availability/list.rs
+++ b/openstack_cli/src/network/v2/network_ip_availability/list.rs
@@ -81,7 +81,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/network_segment_range/list.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/list.rs
@@ -64,7 +64,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/network_segment_range/tag/list.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -66,7 +66,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/policy/tag/list.rs
+++ b/openstack_cli/src/network/v2/policy/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/port/binding/list.rs
+++ b/openstack_cli/src/network/v2/port/binding/list.rs
@@ -66,7 +66,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/port/list.rs
+++ b/openstack_cli/src/network/v2/port/list.rs
@@ -116,7 +116,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// mac_address query parameter for /v2.0/ports API

--- a/openstack_cli/src/network/v2/port/tag/list.rs
+++ b/openstack_cli/src/network/v2/port/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -64,7 +64,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/alias_dscp_marking_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_dscp_marking_rule/list.rs
@@ -64,7 +64,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -65,7 +65,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -65,7 +65,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -81,7 +81,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/policy/dscp_marking_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/dscp_marking_rule/list.rs
@@ -86,7 +86,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/policy/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/list.rs
@@ -89,7 +89,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -86,7 +86,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -66,7 +66,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/qos/rule_type/list.rs
+++ b/openstack_cli/src/network/v2/qos/rule_type/list.rs
@@ -82,7 +82,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/quota/list.rs
+++ b/openstack_cli/src/network/v2/quota/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/rbac_policy/list.rs
+++ b/openstack_cli/src/network/v2/rbac_policy/list.rs
@@ -82,7 +82,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
@@ -83,7 +83,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/router/l3_agent/list.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/list.rs
@@ -73,7 +73,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/router/list.rs
+++ b/openstack_cli/src/network/v2/router/list.rs
@@ -94,7 +94,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/router/tag/list.rs
+++ b/openstack_cli/src/network/v2/router/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/security_group/list.rs
+++ b/openstack_cli/src/network/v2/security_group/list.rs
@@ -85,7 +85,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/security_group/tag/list.rs
+++ b/openstack_cli/src/network/v2/security_group/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/security_group_rule/list.rs
+++ b/openstack_cli/src/network/v2/security_group_rule/list.rs
@@ -98,7 +98,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/segment/list.rs
+++ b/openstack_cli/src/network/v2/segment/list.rs
@@ -82,7 +82,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/service_profile/list.rs
+++ b/openstack_cli/src/network/v2/service_profile/list.rs
@@ -92,7 +92,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/service_provider/list.rs
+++ b/openstack_cli/src/network/v2/service_provider/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/subnet/list.rs
+++ b/openstack_cli/src/network/v2/subnet/list.rs
@@ -111,7 +111,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/subnet/tag/list.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/subnetpool/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/list.rs
@@ -106,7 +106,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/subnetpool/tag/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/trunk/tag/list.rs
+++ b/openstack_cli/src/network/v2/trunk/tag/list.rs
@@ -56,7 +56,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/vpn/endpoint_group/list.rs
+++ b/openstack_cli/src/network/v2/vpn/endpoint_group/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/vpn/ikepolicy/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ikepolicy/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/vpn/ipsecpolicy/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsecpolicy/list.rs
@@ -74,7 +74,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/network/v2/vpn/vpnservice/list.rs
+++ b/openstack_cli/src/network/v2/vpn/vpnservice/list.rs
@@ -76,7 +76,11 @@ struct QueryParameters {
     /// value. Use the limit parameter to make an initial limited request and
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an

--- a/openstack_cli/src/placement/v1/allocation_candidate/list.rs
+++ b/openstack_cli/src/placement/v1/allocation_candidate/list.rs
@@ -83,7 +83,11 @@ struct QueryParameters {
 
     /// A positive integer used to limit the maximum number of allocation
     /// candidates returned in the response.
-    #[arg(help_heading = "Query parameters", long)]
+    #[arg(
+        help_heading = "Query parameters",
+        long("page-size"),
+        visible_alias("limit")
+    )]
     limit: Option<i32>,
 
     /// A string representing an aggregate uuid; or the prefix in: followed by

--- a/openstack_types/data/compute/v2.100.yaml
+++ b/openstack_types/data/compute/v2.100.yaml
@@ -2612,7 +2612,7 @@ paths:
         - os-keypairs
       x-openstack:
         max-ver: '2.9'
-        min-ver: '2.1'
+        min-ver: '2.0'
     get:
       deprecated: true
       description: |-
@@ -10494,7 +10494,20 @@ components:
       description: Response of the images:get operation
       type: object
     ImagesMetadataCreateResponse:
-      description: Response of the images/image_id/metadata:post operation
+      additionalProperties: false
+      properties:
+        metadata:
+          additionalProperties: false
+          description: |-
+            Metadata key and value pairs. The maximum size for each metadata key and value
+            pair is 255 bytes.
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - metadata
       type: object
     ImagesMetadataCreate_21:
       additionalProperties: false
@@ -10516,13 +10529,54 @@ components:
         max-ver: '2.38'
         min-ver: '2.1'
     ImagesMetadataListResponse:
-      description: Response of the images/image_id/metadata:get operation
+      additionalProperties: false
+      properties:
+        metadata:
+          additionalProperties: false
+          description: |-
+            Metadata key and value pairs. The maximum size for each metadata key and value
+            pair is 255 bytes.
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - metadata
       type: object
     ImagesMetadataShowResponse:
-      description: Response of the images/image_id/metadata/id:get operation
+      additionalProperties: false
+      properties:
+        meta:
+          additionalProperties: false
+          description: |-
+            The object of detailed key metadata items.
+          maxProperties: 1
+          minProperties: 1
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - meta
       type: object
     ImagesMetadataUpdateResponse:
-      description: Response of the images/image_id/metadata/id:put operation
+      additionalProperties: false
+      properties:
+        meta:
+          additionalProperties: false
+          description: |-
+            The object of detailed key metadata items.
+          maxProperties: 1
+          minProperties: 1
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - meta
       type: object
     ImagesMetadataUpdate_21:
       additionalProperties: false
@@ -10545,7 +10599,20 @@ components:
         max-ver: '2.38'
         min-ver: '2.1'
     ImagesMetadataUpdate_AllResponse:
-      description: Response of the images/image_id/metadata:put operation
+      additionalProperties: false
+      properties:
+        metadata:
+          additionalProperties: false
+          description: |-
+            Metadata key and value pairs. The maximum size for each metadata key and value
+            pair is 255 bytes.
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - metadata
       type: object
     ImagesMetadataUpdate_All_21:
       additionalProperties: false
@@ -17723,8 +17790,25 @@ components:
       x-openstack:
         action-name: os-getRDPConsole
     Os_Volumes_BootActionOs-GetrdpconsoleResponse:
-      description: Response of the 
-        os-volumes_boot/id/action:post:os-getRDPConsole action
+      additionalProperties: false
+      properties:
+        console:
+          additionalProperties: false
+          properties:
+            type:
+              const: rdp
+              description: ''
+              type: string
+            url:
+              description: ''
+              format: uri
+              type: string
+          required:
+            - type
+            - url
+          type: object
+      required:
+        - console
       type: object
       x-openstack:
         action-name: os-getRDPConsole
@@ -17735,9 +17819,8 @@ components:
           additionalProperties: false
           properties:
             type:
+              const: serial
               description: ''
-              enum:
-                - serial
               type: string
             url:
               description: ''
@@ -17759,9 +17842,8 @@ components:
           additionalProperties: false
           properties:
             type:
+              const: spice-html5
               description: ''
-              enum:
-                - spice-html5
               type: string
             url:
               description: ''
@@ -17771,8 +17853,6 @@ components:
             - type
             - url
           type: object
-      required:
-        - console
       type: object
       x-openstack:
         action-name: os-getSPICEConsole

--- a/openstack_types/data/compute/v2.yaml
+++ b/openstack_types/data/compute/v2.yaml
@@ -2612,7 +2612,7 @@ paths:
         - os-keypairs
       x-openstack:
         max-ver: '2.9'
-        min-ver: '2.1'
+        min-ver: '2.0'
     get:
       deprecated: true
       description: |-
@@ -10494,7 +10494,20 @@ components:
       description: Response of the images:get operation
       type: object
     ImagesMetadataCreateResponse:
-      description: Response of the images/image_id/metadata:post operation
+      additionalProperties: false
+      properties:
+        metadata:
+          additionalProperties: false
+          description: |-
+            Metadata key and value pairs. The maximum size for each metadata key and value
+            pair is 255 bytes.
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - metadata
       type: object
     ImagesMetadataCreate_21:
       additionalProperties: false
@@ -10516,13 +10529,54 @@ components:
         max-ver: '2.38'
         min-ver: '2.1'
     ImagesMetadataListResponse:
-      description: Response of the images/image_id/metadata:get operation
+      additionalProperties: false
+      properties:
+        metadata:
+          additionalProperties: false
+          description: |-
+            Metadata key and value pairs. The maximum size for each metadata key and value
+            pair is 255 bytes.
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - metadata
       type: object
     ImagesMetadataShowResponse:
-      description: Response of the images/image_id/metadata/id:get operation
+      additionalProperties: false
+      properties:
+        meta:
+          additionalProperties: false
+          description: |-
+            The object of detailed key metadata items.
+          maxProperties: 1
+          minProperties: 1
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - meta
       type: object
     ImagesMetadataUpdateResponse:
-      description: Response of the images/image_id/metadata/id:put operation
+      additionalProperties: false
+      properties:
+        meta:
+          additionalProperties: false
+          description: |-
+            The object of detailed key metadata items.
+          maxProperties: 1
+          minProperties: 1
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - meta
       type: object
     ImagesMetadataUpdate_21:
       additionalProperties: false
@@ -10545,7 +10599,20 @@ components:
         max-ver: '2.38'
         min-ver: '2.1'
     ImagesMetadataUpdate_AllResponse:
-      description: Response of the images/image_id/metadata:put operation
+      additionalProperties: false
+      properties:
+        metadata:
+          additionalProperties: false
+          description: |-
+            Metadata key and value pairs. The maximum size for each metadata key and value
+            pair is 255 bytes.
+          patternProperties:
+            ^[a-zA-Z0-9-_:. ]{1,255}$:
+              maxLength: 255
+              type: string
+          type: object
+      required:
+        - metadata
       type: object
     ImagesMetadataUpdate_All_21:
       additionalProperties: false
@@ -17723,8 +17790,25 @@ components:
       x-openstack:
         action-name: os-getRDPConsole
     Os_Volumes_BootActionOs-GetrdpconsoleResponse:
-      description: Response of the 
-        os-volumes_boot/id/action:post:os-getRDPConsole action
+      additionalProperties: false
+      properties:
+        console:
+          additionalProperties: false
+          properties:
+            type:
+              const: rdp
+              description: ''
+              type: string
+            url:
+              description: ''
+              format: uri
+              type: string
+          required:
+            - type
+            - url
+          type: object
+      required:
+        - console
       type: object
       x-openstack:
         action-name: os-getRDPConsole
@@ -17735,9 +17819,8 @@ components:
           additionalProperties: false
           properties:
             type:
+              const: serial
               description: ''
-              enum:
-                - serial
               type: string
             url:
               description: ''
@@ -17759,9 +17842,8 @@ components:
           additionalProperties: false
           properties:
             type:
+              const: spice-html5
               description: ''
-              enum:
-                - spice-html5
               type: string
             url:
               description: ''
@@ -17771,8 +17853,6 @@ components:
             - type
             - url
           type: object
-      required:
-        - console
       type: object
       x-openstack:
         action-name: os-getSPICEConsole


### PR DESCRIPTION
Rename "limit" query parameter of the list operations to "page-size" for
giving precise meaning (keep alias "limit"). This is necessary to
finally resolve the conflict that we have in the python-openstackclient
where "limit" means a page size and all entries are fetched unless you
also specify the marker (which is not something anybody can really
understand why).

Change-Id: I9a6ddcbe30d92c4d190229ac77a10c28eb0015fb
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/952998
