### PR TITLE
feat: Make image.locations.metadata not required

### DIFF
--- a/openstack_cli/src/compute/v2/server/remote_console/create_26.rs
+++ b/openstack_cli/src/compute/v2/server/remote_console/create_26.rs
@@ -77,6 +77,7 @@ struct PathParameters {
 
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
 enum Protocol {
+    Rdp,
     Serial,
     Spice,
     Vnc,
@@ -85,6 +86,7 @@ enum Protocol {
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
 enum Type {
     Novnc,
+    RdpHtml5,
     Serial,
     SpiceHtml5,
     Xvpvnc,
@@ -94,15 +96,17 @@ enum Type {
 #[derive(Args, Clone)]
 struct RemoteConsole {
     /// The protocol of remote console. The valid values are `vnc`, `spice`,
-    /// `serial` and `mks`. The protocol `mks` is added since Microversion
-    /// `2.8`.
+    /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
+    /// Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+    /// which was removed in the 29.0.0 (Caracal) release.
     #[arg(help_heading = "Body parameters", long)]
     protocol: Protocol,
 
-    /// The type of remote console. The valid values are `novnc`,
+    /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-    /// `webmks` was added in Microversion `2.8`, and the type `spice-direct`
-    /// was added in Microversion `2.99`.
+    /// `webmks` was added in Microversion `2.8` and the type `spice-direct`
+    /// was added in Microversion `2.99`. The type `rdp-html5` requires the
+    /// Hyper-V driver which was removed in the 29.0.0 (Caracal) release.
     #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
@@ -135,6 +139,7 @@ impl RemoteConsoleCommand {
         let mut remote_console_builder = create_26::RemoteConsoleBuilder::default();
 
         let tmp = match &args.protocol {
+            Protocol::Rdp => create_26::Protocol::Rdp,
             Protocol::Serial => create_26::Protocol::Serial,
             Protocol::Spice => create_26::Protocol::Spice,
             Protocol::Vnc => create_26::Protocol::Vnc,
@@ -143,6 +148,7 @@ impl RemoteConsoleCommand {
 
         let tmp = match &args._type {
             Type::Novnc => create_26::Type::Novnc,
+            Type::RdpHtml5 => create_26::Type::RdpHtml5,
             Type::Serial => create_26::Type::Serial,
             Type::SpiceHtml5 => create_26::Type::SpiceHtml5,
             Type::Xvpvnc => create_26::Type::Xvpvnc,

--- a/openstack_cli/src/compute/v2/server/remote_console/create_28.rs
+++ b/openstack_cli/src/compute/v2/server/remote_console/create_28.rs
@@ -78,6 +78,7 @@ struct PathParameters {
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
 enum Protocol {
     Mks,
+    Rdp,
     Serial,
     Spice,
     Vnc,
@@ -86,6 +87,7 @@ enum Protocol {
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
 enum Type {
     Novnc,
+    RdpHtml5,
     Serial,
     SpiceHtml5,
     Webmks,
@@ -96,15 +98,17 @@ enum Type {
 #[derive(Args, Clone)]
 struct RemoteConsole {
     /// The protocol of remote console. The valid values are `vnc`, `spice`,
-    /// `serial` and `mks`. The protocol `mks` is added since Microversion
-    /// `2.8`.
+    /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
+    /// Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+    /// which was removed in the 29.0.0 (Caracal) release.
     #[arg(help_heading = "Body parameters", long)]
     protocol: Protocol,
 
-    /// The type of remote console. The valid values are `novnc`,
+    /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-    /// `webmks` was added in Microversion `2.8`, and the type `spice-direct`
-    /// was added in Microversion `2.99`.
+    /// `webmks` was added in Microversion `2.8` and the type `spice-direct`
+    /// was added in Microversion `2.99`. The type `rdp-html5` requires the
+    /// Hyper-V driver which was removed in the 29.0.0 (Caracal) release.
     #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
@@ -138,6 +142,7 @@ impl RemoteConsoleCommand {
 
         let tmp = match &args.protocol {
             Protocol::Mks => create_28::Protocol::Mks,
+            Protocol::Rdp => create_28::Protocol::Rdp,
             Protocol::Serial => create_28::Protocol::Serial,
             Protocol::Spice => create_28::Protocol::Spice,
             Protocol::Vnc => create_28::Protocol::Vnc,
@@ -146,6 +151,7 @@ impl RemoteConsoleCommand {
 
         let tmp = match &args._type {
             Type::Novnc => create_28::Type::Novnc,
+            Type::RdpHtml5 => create_28::Type::RdpHtml5,
             Type::Serial => create_28::Type::Serial,
             Type::SpiceHtml5 => create_28::Type::SpiceHtml5,
             Type::Webmks => create_28::Type::Webmks,

--- a/openstack_cli/src/compute/v2/server/remote_console/create_299.rs
+++ b/openstack_cli/src/compute/v2/server/remote_console/create_299.rs
@@ -87,6 +87,7 @@ enum Protocol {
 #[derive(Clone, Eq, Ord, PartialEq, PartialOrd, ValueEnum)]
 enum Type {
     Novnc,
+    RdpHtml5,
     Serial,
     SpiceDirect,
     SpiceHtml5,
@@ -98,15 +99,17 @@ enum Type {
 #[derive(Args, Clone)]
 struct RemoteConsole {
     /// The protocol of remote console. The valid values are `vnc`, `spice`,
-    /// `serial` and `mks`. The protocol `mks` is added since Microversion
-    /// `2.8`.
+    /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
+    /// Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+    /// which was removed in the 29.0.0 (Caracal) release.
     #[arg(help_heading = "Body parameters", long)]
     protocol: Protocol,
 
-    /// The type of remote console. The valid values are `novnc`,
+    /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-    /// `webmks` was added in Microversion `2.8`, and the type `spice-direct`
-    /// was added in Microversion `2.99`.
+    /// `webmks` was added in Microversion `2.8` and the type `spice-direct`
+    /// was added in Microversion `2.99`. The type `rdp-html5` requires the
+    /// Hyper-V driver which was removed in the 29.0.0 (Caracal) release.
     #[arg(help_heading = "Body parameters", long)]
     _type: Type,
 }
@@ -149,6 +152,7 @@ impl RemoteConsoleCommand {
 
         let tmp = match &args._type {
             Type::Novnc => create_299::Type::Novnc,
+            Type::RdpHtml5 => create_299::Type::RdpHtml5,
             Type::Serial => create_299::Type::Serial,
             Type::SpiceDirect => create_299::Type::SpiceDirect,
             Type::SpiceHtml5 => create_299::Type::SpiceHtml5,

--- a/openstack_cli/src/image/v2/image/location/create.rs
+++ b/openstack_cli/src/image/v2/image/location/create.rs
@@ -63,7 +63,7 @@ pub struct LocationCommand {
     path: PathParameters,
 
     #[arg(help_heading = "Body parameters", long, value_name="key=value", value_parser=parse_key_val::<String, Value>)]
-    metadata: Vec<(String, Value)>,
+    metadata: Option<Vec<(String, Value)>>,
 
     /// The URL of the new location to be added in the image.
     #[arg(help_heading = "Body parameters", long)]
@@ -126,8 +126,9 @@ impl LocationCommand {
         // Set query parameters
         // Set body parameters
         // Set Request.metadata data
-
-        ep_builder.metadata(self.metadata.iter().cloned());
+        if let Some(arg) = &self.metadata {
+            ep_builder.metadata(arg.iter().cloned());
+        }
 
         // Set Request.url data
         ep_builder.url(&self.url);

--- a/openstack_sdk/src/api/compute/v2/server/remote_console/create_26.rs
+++ b/openstack_sdk/src/api/compute/v2/server/remote_console/create_26.rs
@@ -37,6 +37,8 @@ use std::borrow::Cow;
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub enum Protocol {
+    #[serde(rename = "rdp")]
+    Rdp,
     #[serde(rename = "serial")]
     Serial,
     #[serde(rename = "spice")]
@@ -49,6 +51,8 @@ pub enum Protocol {
 pub enum Type {
     #[serde(rename = "novnc")]
     Novnc,
+    #[serde(rename = "rdp-html5")]
+    RdpHtml5,
     #[serde(rename = "serial")]
     Serial,
     #[serde(rename = "spice-html5")]
@@ -62,16 +66,18 @@ pub enum Type {
 #[builder(setter(strip_option))]
 pub struct RemoteConsole {
     /// The protocol of remote console. The valid values are `vnc`, `spice`,
-    /// `serial` and `mks`. The protocol `mks` is added since Microversion
-    /// `2.8`.
+    /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
+    /// Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+    /// which was removed in the 29.0.0 (Caracal) release.
     #[serde()]
     #[builder()]
     pub(crate) protocol: Protocol,
 
-    /// The type of remote console. The valid values are `novnc`,
+    /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-    /// `webmks` was added in Microversion `2.8`, and the type `spice-direct`
-    /// was added in Microversion `2.99`.
+    /// `webmks` was added in Microversion `2.8` and the type `spice-direct`
+    /// was added in Microversion `2.99`. The type `rdp-html5` requires the
+    /// Hyper-V driver which was removed in the 29.0.0 (Caracal) release.
     #[serde(rename = "type")]
     #[builder()]
     pub(crate) _type: Type,
@@ -188,7 +194,7 @@ mod tests {
                 .remote_console(
                     RemoteConsoleBuilder::default()
                         ._type(Type::Novnc)
-                        .protocol(Protocol::Serial)
+                        .protocol(Protocol::Rdp)
                         .build()
                         .unwrap()
                 )
@@ -206,7 +212,7 @@ mod tests {
                 .remote_console(
                     RemoteConsoleBuilder::default()
                         ._type(Type::Novnc)
-                        .protocol(Protocol::Serial)
+                        .protocol(Protocol::Rdp)
                         .build()
                         .unwrap()
                 )
@@ -239,7 +245,7 @@ mod tests {
             .remote_console(
                 RemoteConsoleBuilder::default()
                     ._type(Type::Novnc)
-                    .protocol(Protocol::Serial)
+                    .protocol(Protocol::Rdp)
                     .build()
                     .unwrap(),
             )
@@ -272,7 +278,7 @@ mod tests {
             .remote_console(
                 RemoteConsoleBuilder::default()
                     ._type(Type::Novnc)
-                    .protocol(Protocol::Serial)
+                    .protocol(Protocol::Rdp)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/server/remote_console/create_28.rs
+++ b/openstack_sdk/src/api/compute/v2/server/remote_console/create_28.rs
@@ -39,6 +39,8 @@ use std::borrow::Cow;
 pub enum Protocol {
     #[serde(rename = "mks")]
     Mks,
+    #[serde(rename = "rdp")]
+    Rdp,
     #[serde(rename = "serial")]
     Serial,
     #[serde(rename = "spice")]
@@ -51,6 +53,8 @@ pub enum Protocol {
 pub enum Type {
     #[serde(rename = "novnc")]
     Novnc,
+    #[serde(rename = "rdp-html5")]
+    RdpHtml5,
     #[serde(rename = "serial")]
     Serial,
     #[serde(rename = "spice-html5")]
@@ -66,16 +70,18 @@ pub enum Type {
 #[builder(setter(strip_option))]
 pub struct RemoteConsole {
     /// The protocol of remote console. The valid values are `vnc`, `spice`,
-    /// `serial` and `mks`. The protocol `mks` is added since Microversion
-    /// `2.8`.
+    /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
+    /// Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+    /// which was removed in the 29.0.0 (Caracal) release.
     #[serde()]
     #[builder()]
     pub(crate) protocol: Protocol,
 
-    /// The type of remote console. The valid values are `novnc`,
+    /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-    /// `webmks` was added in Microversion `2.8`, and the type `spice-direct`
-    /// was added in Microversion `2.99`.
+    /// `webmks` was added in Microversion `2.8` and the type `spice-direct`
+    /// was added in Microversion `2.99`. The type `rdp-html5` requires the
+    /// Hyper-V driver which was removed in the 29.0.0 (Caracal) release.
     #[serde(rename = "type")]
     #[builder()]
     pub(crate) _type: Type,

--- a/openstack_sdk/src/api/compute/v2/server/remote_console/create_299.rs
+++ b/openstack_sdk/src/api/compute/v2/server/remote_console/create_299.rs
@@ -53,6 +53,8 @@ pub enum Protocol {
 pub enum Type {
     #[serde(rename = "novnc")]
     Novnc,
+    #[serde(rename = "rdp-html5")]
+    RdpHtml5,
     #[serde(rename = "serial")]
     Serial,
     #[serde(rename = "spice-direct")]
@@ -70,16 +72,18 @@ pub enum Type {
 #[builder(setter(strip_option))]
 pub struct RemoteConsole {
     /// The protocol of remote console. The valid values are `vnc`, `spice`,
-    /// `serial` and `mks`. The protocol `mks` is added since Microversion
-    /// `2.8`.
+    /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
+    /// Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+    /// which was removed in the 29.0.0 (Caracal) release.
     #[serde()]
     #[builder()]
     pub(crate) protocol: Protocol,
 
-    /// The type of remote console. The valid values are `novnc`,
+    /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-    /// `webmks` was added in Microversion `2.8`, and the type `spice-direct`
-    /// was added in Microversion `2.99`.
+    /// `webmks` was added in Microversion `2.8` and the type `spice-direct`
+    /// was added in Microversion `2.99`. The type `rdp-html5` requires the
+    /// Hyper-V driver which was removed in the 29.0.0 (Caracal) release.
     #[serde(rename = "type")]
     #[builder()]
     pub(crate) _type: Type,

--- a/openstack_sdk/src/api/image/v2/image/create.rs
+++ b/openstack_sdk/src/api/image/v2/image/create.rs
@@ -113,9 +113,9 @@ pub struct ValidationData<'a> {
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
 pub struct Locations<'a> {
-    #[serde()]
-    #[builder(private, setter(into, name = "_metadata"))]
-    pub(crate) metadata: BTreeMap<Cow<'a, str>, Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[builder(default, private, setter(into, name = "_metadata"))]
+    pub(crate) metadata: Option<BTreeMap<Cow<'a, str>, Value>>,
 
     #[serde()]
     #[builder(setter(into))]
@@ -137,6 +137,7 @@ impl<'a> LocationsBuilder<'a> {
         V: Into<Value>,
     {
         self.metadata
+            .get_or_insert(None)
             .get_or_insert_with(BTreeMap::new)
             .extend(iter.map(|(k, v)| (k.into(), v.into())));
         self

--- a/openstack_types/data/compute/v2.100.yaml
+++ b/openstack_types/data/compute/v2.100.yaml
@@ -17796,11 +17796,9 @@ components:
           additionalProperties: false
           properties:
             type:
-              const: rdp
-              description: ''
+              const: rdp-html5
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -17820,10 +17818,8 @@ components:
           properties:
             type:
               const: serial
-              description: ''
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -17843,10 +17839,8 @@ components:
           properties:
             type:
               const: spice-html5
-              description: ''
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -17863,13 +17857,11 @@ components:
           additionalProperties: false
           properties:
             type:
-              description: ''
               enum:
                 - novnc
                 - xvpvnc
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -45102,10 +45094,12 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
                 - mks
+                - rdp
                 - serial
                 - spice
                 - vnc
@@ -45113,11 +45107,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-html5
                 - webmks
@@ -45147,9 +45144,11 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
+                - rdp
                 - serial
                 - spice
                 - vnc
@@ -45157,11 +45156,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-html5
                 - xvpvnc
@@ -45187,10 +45189,12 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
                 - mks
+                - rdp
                 - serial
                 - spice
                 - vnc
@@ -45198,11 +45202,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-html5
                 - webmks
@@ -45229,8 +45236,9 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
                 - mks
                 - rdp
@@ -45241,11 +45249,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-direct
                 - spice-html5

--- a/openstack_types/data/compute/v2.yaml
+++ b/openstack_types/data/compute/v2.yaml
@@ -17796,11 +17796,9 @@ components:
           additionalProperties: false
           properties:
             type:
-              const: rdp
-              description: ''
+              const: rdp-html5
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -17820,10 +17818,8 @@ components:
           properties:
             type:
               const: serial
-              description: ''
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -17843,10 +17839,8 @@ components:
           properties:
             type:
               const: spice-html5
-              description: ''
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -17863,13 +17857,11 @@ components:
           additionalProperties: false
           properties:
             type:
-              description: ''
               enum:
                 - novnc
                 - xvpvnc
               type: string
             url:
-              description: ''
               format: uri
               type: string
           required:
@@ -45102,10 +45094,12 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
                 - mks
+                - rdp
                 - serial
                 - spice
                 - vnc
@@ -45113,11 +45107,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-html5
                 - webmks
@@ -45147,9 +45144,11 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
+                - rdp
                 - serial
                 - spice
                 - vnc
@@ -45157,11 +45156,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-html5
                 - xvpvnc
@@ -45187,10 +45189,12 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
                 - mks
+                - rdp
                 - serial
                 - spice
                 - vnc
@@ -45198,11 +45202,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-html5
                 - webmks
@@ -45229,8 +45236,9 @@ components:
             protocol:
               description: |-
                 The protocol of remote console. The valid values are `vnc`, `spice`,
-                `serial` and `mks`. The protocol `mks` is added since Microversion
-                `2.8`.
+                `rdp`, `serial` and `mks`. The protocol `mks` is added since
+                Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+                which was removed in the 29.0.0 (Caracal) release.
               enum:
                 - mks
                 - rdp
@@ -45241,11 +45249,14 @@ components:
             type:
               description: |-
                 The type of remote console. The valid values are `novnc`,
-                `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-                `webmks` was added in Microversion `2.8`, and the type
-                `spice-direct` was added in Microversion `2.99`.
+                `rdp-html5`, `spice-html5`, `spice-direct`, `serial`, and
+                `webmks`. The type `webmks` was added in Microversion `2.8` and the
+                type `spice-direct` was added in Microversion `2.99`. The type
+                `rdp-html5` requires the Hyper-V driver which was removed in the 29.0.0
+                (Caracal) release.
               enum:
                 - novnc
+                - rdp-html5
                 - serial
                 - spice-direct
                 - spice-html5

--- a/openstack_types/data/image/v2.16.yaml
+++ b/openstack_types/data/image/v2.16.yaml
@@ -2315,7 +2315,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -2649,7 +2648,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -2964,7 +2962,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -3257,7 +3254,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -3568,7 +3564,6 @@ components:
                       type: object
                       writeOnly: true
                   required:
-                    - metadata
                     - url
                   type: object
                 type: array
@@ -3713,7 +3708,6 @@ components:
           type: object
           writeOnly: true
       required:
-        - metadata
         - url
       type: object
     ImagesLocationsAdd_LocationResponse:
@@ -3747,7 +3741,6 @@ components:
             type: object
             writeOnly: true
         required:
-          - metadata
           - url
         type: object
       type: array
@@ -3782,7 +3775,6 @@ components:
             type: object
             writeOnly: true
         required:
-          - metadata
           - url
         type: object
       type: array

--- a/openstack_types/data/image/v2.yaml
+++ b/openstack_types/data/image/v2.yaml
@@ -2315,7 +2315,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -2649,7 +2648,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -2964,7 +2962,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -3257,7 +3254,6 @@ components:
                 type: object
                 writeOnly: true
             required:
-              - metadata
               - url
             type: object
           type: array
@@ -3568,7 +3564,6 @@ components:
                       type: object
                       writeOnly: true
                   required:
-                    - metadata
                     - url
                   type: object
                 type: array
@@ -3713,7 +3708,6 @@ components:
           type: object
           writeOnly: true
       required:
-        - metadata
         - url
       type: object
     ImagesLocationsAdd_LocationResponse:
@@ -3747,7 +3741,6 @@ components:
             type: object
             writeOnly: true
         required:
-          - metadata
           - url
         type: object
       type: array
@@ -3782,7 +3775,6 @@ components:
             type: object
             writeOnly: true
         required:
-          - metadata
           - url
         type: object
       type: array

--- a/openstack_types/src/compute/v2/server/remote_console/response/create.rs
+++ b/openstack_types/src/compute/v2/server/remote_console/response/create.rs
@@ -23,15 +23,17 @@ use structable::{StructTable, StructTableOptions};
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct RemoteConsoleResponse {
     /// The protocol of remote console. The valid values are `vnc`, `spice`,
-    /// `serial` and `mks`. The protocol `mks` is added since Microversion
-    /// `2.8`.
+    /// `rdp`, `serial` and `mks`. The protocol `mks` is added since
+    /// Microversion `2.8`. The protocol `rdp` requires the Hyper-V driver
+    /// which was removed in the 29.0.0 (Caracal) release.
     #[structable(serialize)]
     pub protocol: Protocol,
 
-    /// The type of remote console. The valid values are `novnc`,
+    /// The type of remote console. The valid values are `novnc`, `rdp-html5`,
     /// `spice-html5`, `spice-direct`, `serial`, and `webmks`. The type
-    /// `webmks` was added in Microversion `2.8`, and the type `spice-direct`
-    /// was added in Microversion `2.99`.
+    /// `webmks` was added in Microversion `2.8` and the type `spice-direct`
+    /// was added in Microversion `2.99`. The type `rdp-html5` requires the
+    /// Hyper-V driver which was removed in the 29.0.0 (Caracal) release.
     #[serde(rename = "type")]
     #[structable(serialize, title = "type")]
     pub _type: Type,
@@ -46,6 +48,10 @@ pub enum Protocol {
     // Mks
     #[serde(rename = "mks")]
     Mks,
+
+    // Rdp
+    #[serde(rename = "rdp")]
+    Rdp,
 
     // Serial
     #[serde(rename = "serial")]
@@ -65,6 +71,7 @@ impl std::str::FromStr for Protocol {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         match input {
             "mks" => Ok(Self::Mks),
+            "rdp" => Ok(Self::Rdp),
             "serial" => Ok(Self::Serial),
             "spice" => Ok(Self::Spice),
             "vnc" => Ok(Self::Vnc),
@@ -78,6 +85,10 @@ pub enum Type {
     // Novnc
     #[serde(rename = "novnc")]
     Novnc,
+
+    // RdpHtml5
+    #[serde(rename = "rdp-html5")]
+    RdpHtml5,
 
     // Serial
     #[serde(rename = "serial")]
@@ -101,6 +112,7 @@ impl std::str::FromStr for Type {
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         match input {
             "novnc" => Ok(Self::Novnc),
+            "rdp-html5" => Ok(Self::RdpHtml5),
             "serial" => Ok(Self::Serial),
             "spice-html5" => Ok(Self::SpiceHtml5),
             "webmks" => Ok(Self::Webmks),

--- a/openstack_types/src/image/v2/image/location/response/create.rs
+++ b/openstack_types/src/image/v2/image/location/response/create.rs
@@ -24,8 +24,9 @@ use structable::{StructTable, StructTableOptions};
 /// Location response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct LocationResponse {
-    #[structable(serialize)]
-    pub metadata: BTreeMap<String, Value>,
+    #[serde(default)]
+    #[structable(optional, serialize)]
+    pub metadata: Option<BTreeMap<String, Value>>,
 
     #[structable()]
     pub url: String,

--- a/openstack_types/src/image/v2/image/location/response/list.rs
+++ b/openstack_types/src/image/v2/image/location/response/list.rs
@@ -24,8 +24,9 @@ use structable::{StructTable, StructTableOptions};
 /// Location response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct LocationResponse {
-    #[structable(serialize)]
-    pub metadata: BTreeMap<String, Value>,
+    #[serde(default)]
+    #[structable(optional, serialize)]
+    pub metadata: Option<BTreeMap<String, Value>>,
 
     #[structable()]
     pub url: String,

--- a/openstack_types/src/image/v2/image/response/create.rs
+++ b/openstack_types/src/image/v2/image/response/create.rs
@@ -274,7 +274,8 @@ pub struct ValidationData {
 /// `Locations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Locations {
-    pub metadata: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub metadata: Option<BTreeMap<String, Value>>,
     pub url: String,
     #[serde(default)]
     pub validation_data: Option<ValidationData>,

--- a/openstack_types/src/image/v2/image/response/get.rs
+++ b/openstack_types/src/image/v2/image/response/get.rs
@@ -274,7 +274,8 @@ pub struct ValidationData {
 /// `Locations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Locations {
-    pub metadata: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub metadata: Option<BTreeMap<String, Value>>,
     pub url: String,
     #[serde(default)]
     pub validation_data: Option<ValidationData>,

--- a/openstack_types/src/image/v2/image/response/list.rs
+++ b/openstack_types/src/image/v2/image/response/list.rs
@@ -293,7 +293,8 @@ pub struct ValidationData {
 /// `Locations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Locations {
-    pub metadata: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub metadata: Option<BTreeMap<String, Value>>,
     pub url: String,
     #[serde(default)]
     pub validation_data: Option<ValidationData>,

--- a/openstack_types/src/image/v2/image/response/patch.rs
+++ b/openstack_types/src/image/v2/image/response/patch.rs
@@ -273,7 +273,8 @@ pub struct ValidationData {
 /// `Locations` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Locations {
-    pub metadata: BTreeMap<String, Value>,
+    #[serde(default)]
+    pub metadata: Option<BTreeMap<String, Value>>,
     pub url: String,
     #[serde(default)]
     pub validation_data: Option<ValidationData>,


### PR DESCRIPTION
Glance defines metadata property of the image location as mandatory
while in devstack it is not present. Hardcode a dirty fix for the
schema.

In addition to that in the meanwhile another schema in nova has been
added, so are the changes.

Change-Id: I15f2f0a543174eccbeb5c0d4da9e5222ce1e5d7a
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/953698
