### PR TITLE
feat: Allow cli cloud config from env vars

### DIFF
--- a/openstack_cli/README.md
+++ b/openstack_cli/README.md
@@ -76,3 +76,30 @@ marking the whole command deprecated and/or drop it completely.
 
 `osc` supports `--timing` argument that enables capturing of all HTTP requests
 and outputs timings grouped by URL (ignoring the query parameters) and method.
+
+## Connection configuration
+
+`osc` tool supports connection configuration using the `clouds.yaml` files and
+environment variables. In difference to the `python-openstackclient` no merging
+of configuration file data with the environment variables is supported. Reason
+for that is number of errors and unexpected behavior users are experiencing due
+to that.
+
+- `--os-cloud <CLOUD_NAME>` command argument points to the connection configured
+  in the `clouds.yaml` file(s).
+
+- `$OS_CLOUD` environment variable points to the configuration in the
+  `clouds.yaml` file
+
+- `--cloud-config-from-env` flag directs cli to ignore `clouds.yaml`
+  configuration file completely and only rely on the environment variables
+  (prefixed as usual with `OS_` prefix).
+
+- `--os-cloud-name <CLOUD_NAME>` or `$OS_CLOUD_NAME` environment variable uses
+  the specified value as the reference connection name i.e when the
+  authentication helper resolves the missing authentication parameters (like
+  password or similar).
+
+- `--os-project-name` and `--os-project-id` cause the connection to be
+  established with the regular credentials, but use the different project for
+  the `scoped token.

--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -143,6 +143,16 @@ pub struct GlobalOpts {
     #[arg(long, env = "OS_CLOUD", global = true, display_order = 900)]
     pub os_cloud: Option<String>,
 
+    /// Get the cloud config from environment variables.
+    #[arg(long, global = true, action = clap::ArgAction::SetTrue, display_order = 900, conflicts_with("os_cloud"))]
+    pub cloud_config_from_env: bool,
+
+    /// Cloud name used when configuration is retrieved from environment variables. When not
+    /// specified the `envvars` would be used as a default. This value will be used eventually by
+    /// the authentication helper when data need to be provided dynamically.
+    #[arg(long, env = "OS_CLOUD_NAME", global = true, display_order = 900)]
+    pub os_cloud_name: Option<String>,
+
     /// Project ID to use instead of the one in connection profile
     #[arg(long, env = "OS_PROJECT_ID", global = true, display_order = 901)]
     pub os_project_id: Option<String>,


### PR DESCRIPTION
Apparently there is a real demand for connection configuration using
environment variables. Most likely this is never going to die against
our expectations and hopes. So add support for that, but in difference
to the python world deliberately prevent merging of clouds.yaml data
with the environment variables to prevent unexpected things.
