### PR TITLE
feat: Drop connection_name from the AuthHelper

### DIFF
--- a/openstack_cli/README.md
+++ b/openstack_cli/README.md
@@ -100,6 +100,11 @@ to that.
   authentication helper resolves the missing authentication parameters (like
   password or similar).
 
+- With no cloud being specified in any of the above ways a fuzzy select with all
+  cloud connections configured in the `clouds.yaml` file is used to get the user
+  selection interactively. This will not happen in a non-interactive mode (i.e
+  when stdin is not a terminal).
+
 - `--os-project-name` and `--os-project-id` cause the connection to be
   established with the regular credentials, but use the different project for
   the `scoped token.

--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -33,9 +33,7 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{Layer, prelude::*};
 
 use openstack_sdk::{
-    AsyncOpenStack,
-    auth::auth_helper::{AuthHelper, Dialoguer},
-    auth::authtoken::AuthTokenScope,
+    AsyncOpenStack, auth::auth_helper::Dialoguer, auth::authtoken::AuthTokenScope,
     types::identity::v3::Project,
 };
 
@@ -166,7 +164,6 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
     if std::io::stdin().is_terminal() {
         // Interactive session (may ask for password/MFA/SSO)
         let mut auth_helper = Dialoguer::default();
-        auth_helper.set_cloud_name(cloud_config.name.clone());
         session = AsyncOpenStack::new_with_authentication_helper(
             &cloud_config,
             &mut auth_helper,

--- a/openstack_sdk/src/auth/auth_helper.rs
+++ b/openstack_sdk/src/auth/auth_helper.rs
@@ -64,12 +64,6 @@ pub trait AuthHelper {
         key: String,
         connection_name: Option<String>,
     ) -> Result<SecretString, AuthHelperError>;
-
-    /// Get the cloud name
-    fn get_cloud_name(&self) -> Option<String>;
-
-    /// Set the cloud name to be used as a hint in the callback
-    fn set_cloud_name(&mut self, cloud_name: Option<String>);
 }
 
 #[derive(Clone, Default)]
@@ -105,14 +99,6 @@ impl AuthHelper for Dialoguer {
         let secret = Password::new().with_prompt(prompt).interact()?;
         Ok(SecretString::from(secret))
     }
-
-    fn get_cloud_name(&self) -> Option<String> {
-        self.cloud_name.clone()
-    }
-
-    fn set_cloud_name(&mut self, cloud_name: Option<String>) {
-        self.cloud_name = cloud_name;
-    }
 }
 
 #[derive(Clone, Default)]
@@ -134,11 +120,5 @@ impl AuthHelper for NonInteractive {
         _connection_name: Option<String>,
     ) -> Result<SecretString, AuthHelperError> {
         Err(AuthHelperError::NotSupported)
-    }
-
-    fn set_cloud_name(&mut self, _cloud_name: Option<String>) {}
-
-    fn get_cloud_name(&self) -> Option<String> {
-        None
     }
 }

--- a/openstack_sdk/src/auth/v3oidcaccesstoken.rs
+++ b/openstack_sdk/src/auth/v3oidcaccesstoken.rs
@@ -146,13 +146,10 @@ impl RestEndpoint for OidcAccessTokenRequest<'_> {
 }
 
 /// Get [`RestEndpoint`] for initializing the OIDC authentication
-pub async fn get_auth_ep<A>(
+pub async fn get_auth_ep<A: AuthHelper>(
     config: &config::CloudConfig,
     auth_helper: &mut A,
-) -> Result<impl RestEndpoint, OidcAccessTokenError>
-where
-    A: AuthHelper,
-{
+) -> Result<impl RestEndpoint, OidcAccessTokenError> {
     if let Some(auth) = &config.auth {
         let mut ep = OidcAccessTokenRequest::builder();
 
@@ -160,7 +157,7 @@ where
             ep.idp_id(identity_provider.clone());
         } else {
             let idp_id = auth_helper
-                .get("idp_id".into(), auth_helper.get_cloud_name())
+                .get("idp_id".into(), config.name.clone())
                 .await
                 .map_err(|_| OidcAccessTokenError::MissingIdpId)?
                 .to_owned();
@@ -171,7 +168,7 @@ where
             ep.protocol(protocol.clone());
         } else {
             let protocol = auth_helper
-                .get("protocol".into(), auth_helper.get_cloud_name())
+                .get("protocol".into(), config.name.clone())
                 .await
                 .map_err(|_| OidcAccessTokenError::MissingProtocolId)?
                 .to_owned();
@@ -184,7 +181,7 @@ where
             ep.header(header::AUTHORIZATION, token_header_value);
         } else {
             let access_token = auth_helper
-                .get_secret("access_token".into(), auth_helper.get_cloud_name())
+                .get_secret("access_token".into(), config.name.clone())
                 .await
                 .map_err(|_| OidcAccessTokenError::MissingAccessToken)?
                 .to_owned();

--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -88,7 +88,6 @@ impl Cloud {
             .cloud_configs
             .get_cloud_config(cloud.clone())?
             .ok_or_else(|| eyre!("Cloud `{}` is not present in configuration files", cloud))?;
-        self.auth_helper.set_cloud_name(Some(cloud));
         let mut session =
             AsyncOpenStack::new_with_authentication_helper(&profile, &mut self.auth_helper, false)
                 .await?;
@@ -217,7 +216,6 @@ impl Cloud {
 }
 
 struct TuiAuthHelper {
-    cloud_name: Option<String>,
     app_tx: Option<UnboundedSender<Action>>,
     auth_helper_control_tx: mpsc::Sender<oneshot::Sender<AuthAction>>,
 }
@@ -225,7 +223,6 @@ struct TuiAuthHelper {
 impl TuiAuthHelper {
     pub fn new(auth_helper_control_tx: mpsc::Sender<oneshot::Sender<AuthAction>>) -> Self {
         Self {
-            cloud_name: None,
             app_tx: None,
             auth_helper_control_tx,
         }
@@ -312,17 +309,6 @@ impl AuthHelper for TuiAuthHelper {
                 ));
             }
         }
-    }
-
-    #[instrument(skip(self))]
-    fn set_cloud_name(&mut self, cloud_name: Option<String>) {
-        trace!("Setting cloud name to {:?}", cloud_name);
-        self.cloud_name = cloud_name;
-    }
-
-    #[instrument(skip(self))]
-    fn get_cloud_name(&self) -> Option<String> {
-        self.cloud_name.clone()
     }
 }
 


### PR DESCRIPTION
Use the CloudConfig.name as the connection name in the AuthHelper. This
requires sometimes passing additional parameter into the function, but
makes AuthHelper actually thread safe.
