### PR TITLE
feat: Add `--auth-helper-cmd` for external AuthHelper

### DIFF
--- a/openstack_cli/README.md
+++ b/openstack_cli/README.md
@@ -108,3 +108,26 @@ to that.
 - `--os-project-name` and `--os-project-id` cause the connection to be
   established with the regular credentials, but use the different project for
   the `scoped token.
+
+Sometimes it may be undisired to keep secrets in `clouds.yaml` or `secure.yaml`
+files. In the interactive mode such data is retrieved from the user via regular
+prompts. It is possible to specify the path to the external executable command
+that would be called with 2 parameters: the required attribute key (i.e.
+`password`) and the connection name. The executable may be called multiple times
+with different parameters when required. There is no support for passing all
+required parameters in one invocation. This executable must not write anything
+to the stdout except of the actual value. Whatever is written into the stderr
+would be included in the `osc` log in the warning level. Please note that there
+are no security guards possible for what the command actually performs. In
+future pre-built with better security handling may be added (i.e. fetching
+secrets from Vault, Bitwarden, etc).
+
+```shell
+#!/usr/bin/env bash
+
+KEY=$1
+CLOUD=$2
+
+echo -e "Requested $KEY for $CLOUD" > &2
+echo  "a_super_secret"
+```

--- a/openstack_cli/src/output.rs
+++ b/openstack_cli/src/output.rs
@@ -133,7 +133,7 @@ impl OutputProcessor {
         resource_key: Option<R>,
         action: Option<A>,
     ) -> Self {
-        let target = match args.global_opts.output {
+        let target = match args.global_opts.output.output {
             None => OutputFor::Human,
             Some(OutputFormat::Wide) => OutputFor::Human,
             _ => OutputFor::Machine,
@@ -156,10 +156,10 @@ impl OutputProcessor {
                 .as_ref()
                 .and_then(|val| args.config.views.get(val.as_ref()).cloned()),
             target,
-            table_arrangement: args.global_opts.table_arrangement,
-            fields: BTreeSet::from_iter(args.global_opts.fields.iter().cloned()),
-            wide: matches!(args.global_opts.output, Some(OutputFormat::Wide)),
-            pretty: args.global_opts.pretty,
+            table_arrangement: args.global_opts.output.table_arrangement,
+            fields: BTreeSet::from_iter(args.global_opts.output.fields.iter().cloned()),
+            wide: matches!(args.global_opts.output.output, Some(OutputFormat::Wide)),
+            pretty: args.global_opts.output.pretty,
             hints: Some(hints),
         }
     }

--- a/openstack_sdk/src/auth/authtoken.rs
+++ b/openstack_sdk/src/auth/authtoken.rs
@@ -542,7 +542,7 @@ mod tests {
 
     use super::*;
 
-    use crate::auth::auth_helper::NonInteractive;
+    use crate::auth::auth_helper::Noop;
     use crate::config;
 
     #[tokio::test]
@@ -560,7 +560,7 @@ mod tests {
             ..Default::default()
         };
 
-        let auth_data = build_identity_data_from_config(&config, &mut NonInteractive::default())
+        let auth_data = build_identity_data_from_config(&config, &mut Noop::default())
             .await
             .unwrap();
         assert_eq!(
@@ -596,7 +596,7 @@ mod tests {
             ..Default::default()
         };
 
-        let auth_data = build_identity_data_from_config(&config, &mut NonInteractive::default())
+        let auth_data = build_identity_data_from_config(&config, &mut Noop::default())
             .await
             .unwrap();
         assert_eq!(

--- a/openstack_sdk/src/auth/v3applicationcredential.rs
+++ b/openstack_sdk/src/auth/v3applicationcredential.rs
@@ -178,7 +178,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::auth::auth_helper::NonInteractive;
+    use crate::auth::auth_helper::Noop;
     use crate::config;
 
     #[tokio::test]
@@ -188,13 +188,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             ApplicationCredentialError::MissingSecret => {}
             other => {
@@ -210,13 +204,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             ApplicationCredentialError::MissingIdOrName => {}
             other => {
@@ -233,13 +221,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             ApplicationCredentialError::MissingUser => {}
             other => {
@@ -256,14 +238,9 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await
-        .unwrap();
+        fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default())
+            .await
+            .unwrap();
         assert_eq!(
             serde_json::to_value(identity.build().unwrap()).unwrap(),
             json!({
@@ -288,14 +265,9 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await
-        .unwrap();
+        fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default())
+            .await
+            .unwrap();
         assert_eq!(
             serde_json::to_value(identity.build().unwrap()).unwrap(),
             json!({
@@ -329,14 +301,9 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await
-        .unwrap();
+        fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default())
+            .await
+            .unwrap();
         let identity = identity.build().unwrap();
         info!("Auth is {:?}", identity);
         assert!(!logs_contain("secret_value"));

--- a/openstack_sdk/src/auth/v3oidcaccesstoken.rs
+++ b/openstack_sdk/src/auth/v3oidcaccesstoken.rs
@@ -198,7 +198,7 @@ pub async fn get_auth_ep<A: AuthHelper>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::auth_helper::NonInteractive;
+    use crate::auth::auth_helper::Noop;
     use crate::config;
 
     #[tokio::test]
@@ -212,9 +212,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let ep = get_auth_ep(&config, &mut NonInteractive::default())
-            .await
-            .unwrap();
+        let ep = get_auth_ep(&config, &mut Noop::default()).await.unwrap();
         assert_eq!(
             "OS-FEDERATION/identity_providers/foo/protocols/bar/auth",
             ep.endpoint()
@@ -238,7 +236,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let res = get_auth_ep(&config, &mut NonInteractive::default()).await;
+        let res = get_auth_ep(&config, &mut Noop::default()).await;
         match res {
             Err(OidcAccessTokenError::MissingAccessToken) => {}
             _ => {
@@ -257,7 +255,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let res = get_auth_ep(&config, &mut NonInteractive::default()).await;
+        let res = get_auth_ep(&config, &mut Noop::default()).await;
         match res {
             Err(OidcAccessTokenError::MissingIdpId) => {}
             _ => {
@@ -276,7 +274,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let res = get_auth_ep(&config, &mut NonInteractive::default()).await;
+        let res = get_auth_ep(&config, &mut Noop::default()).await;
         match res {
             Err(OidcAccessTokenError::MissingProtocolId) => {}
             _ => {

--- a/openstack_sdk/src/auth/v3password.rs
+++ b/openstack_sdk/src/auth/v3password.rs
@@ -157,7 +157,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::auth::auth_helper::NonInteractive;
+    use crate::auth::auth_helper::Noop;
     use crate::config;
 
     #[tokio::test]
@@ -167,13 +167,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             PasswordError::MissingUserId => {}
             other => {
@@ -189,13 +183,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             PasswordError::MissingPassword => {}
             other => {
@@ -215,14 +203,9 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await
-        .unwrap();
+        fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default())
+            .await
+            .unwrap();
         assert_eq!(
             serde_json::to_value(identity.build().unwrap()).unwrap(),
             json!({
@@ -254,14 +237,9 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await
-        .unwrap();
+        fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default())
+            .await
+            .unwrap();
         let identity = identity.build().unwrap();
         assert!(!logs_contain("secret"));
         assert_eq!(

--- a/openstack_sdk/src/auth/v3token.rs
+++ b/openstack_sdk/src/auth/v3token.rs
@@ -114,20 +114,14 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::auth::auth_helper::NonInteractive;
+    use crate::auth::auth_helper::Noop;
     use crate::config;
 
     #[tokio::test]
     async fn test_fill_raise_no_token() {
         let config = config::Auth::default();
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             TokenError::MissingToken => {}
             other => {
@@ -143,13 +137,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let _res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let _res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         assert_eq!(
             serde_json::to_value(identity.build().unwrap()).unwrap(),
             json!({
@@ -169,13 +157,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let _res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let _res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         let identity = identity.build().unwrap();
         info!("Auth is {:?}", identity);
         assert!(!logs_contain("secret"));

--- a/openstack_sdk/src/auth/v3totp.rs
+++ b/openstack_sdk/src/auth/v3totp.rs
@@ -150,7 +150,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::auth::auth_helper::NonInteractive;
+    use crate::auth::auth_helper::Noop;
     use crate::config;
 
     #[tokio::test]
@@ -160,13 +160,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             TotpError::MissingUserId => {}
             other => {
@@ -182,13 +176,7 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        let res = fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await;
+        let res = fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default()).await;
         match res.unwrap_err() {
             TotpError::MissingPasscode => {}
             other => {
@@ -208,14 +196,9 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await
-        .unwrap();
+        fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default())
+            .await
+            .unwrap();
         assert_eq!(
             serde_json::to_value(identity.build().unwrap()).unwrap(),
             json!({
@@ -246,14 +229,9 @@ mod tests {
             ..Default::default()
         };
         let mut identity = token_v3::IdentityBuilder::default();
-        fill_identity(
-            &mut identity,
-            &config,
-            None::<&str>,
-            &mut NonInteractive::default(),
-        )
-        .await
-        .unwrap();
+        fill_identity(&mut identity, &config, None::<&str>, &mut Noop::default())
+            .await
+            .unwrap();
         identity.build().unwrap();
         assert!(!logs_contain("secret"));
     }

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -35,7 +35,7 @@ use crate::api::query;
 use crate::api::query::RawQuery;
 use crate::auth::{
     self,
-    auth_helper::{AuthHelper, Dialoguer, NonInteractive},
+    auth_helper::{AuthHelper, Dialoguer, Noop},
     authtoken,
     authtoken::{AuthTokenError, AuthType},
     Auth, AuthError, AuthState,
@@ -255,7 +255,7 @@ impl OpenStack {
         if interactive {
             self.authorize_with_auth_helper(scope, &mut Dialoguer::default(), renew_auth)
         } else {
-            self.authorize_with_auth_helper(scope, &mut NonInteractive::default(), renew_auth)
+            self.authorize_with_auth_helper(scope, &mut Noop::default(), renew_auth)
         }
     }
 

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -37,7 +37,7 @@ use crate::api::query::RawQueryAsync;
 use crate::api::RestClient;
 use crate::auth::{
     self,
-    auth_helper::{AuthHelper, Dialoguer, NonInteractive},
+    auth_helper::{AuthHelper, Dialoguer, Noop},
     authtoken::{self, AuthTokenError, AuthType},
     Auth, AuthError, AuthState,
 };
@@ -323,7 +323,7 @@ impl AsyncOpenStack {
             self.authorize_with_auth_helper(scope, &mut Dialoguer::default(), renew_auth)
                 .await
         } else {
-            self.authorize_with_auth_helper(scope, &mut NonInteractive::default(), renew_auth)
+            self.authorize_with_auth_helper(scope, &mut Noop::default(), renew_auth)
                 .await
         }
     }


### PR DESCRIPTION
Users might want to provide alternative ways of handling secrets of
cloud connections (i.e. pass, encrypted file, bitwarden, etc). Enable
them use own managed wrappers to extract secrets with `osc` invoking
such executable passing attribute and connection name that the `osc` is
currently trying to connect to.
