### PR TITLE
feat: Add header query params to dns list operations

### DIFF
--- a/openstack_cli/src/dns/v2/blacklist/list.rs
+++ b/openstack_cli/src/dns/v2/blacklist/list.rs
@@ -65,7 +65,7 @@ impl BlacklistsCommand {
         let op = OutputProcessor::from_args(parsed_args, Some("dns.blacklist"), Some("list"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/pool/list.rs
+++ b/openstack_cli/src/dns/v2/pool/list.rs
@@ -65,7 +65,7 @@ impl PoolsCommand {
         let op = OutputProcessor::from_args(parsed_args, Some("dns.pool"), Some("list"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/quota/set.rs
+++ b/openstack_cli/src/dns/v2/quota/set.rs
@@ -63,7 +63,7 @@ pub struct QuotaCommand {
     zone_records: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    zone_recorsets: Option<i32>,
+    zone_recordsets: Option<i32>,
 
     #[arg(help_heading = "Body parameters", long)]
     zones: Option<i32>,
@@ -178,9 +178,9 @@ impl QuotaCommand {
             ep_builder.zone_records(*arg);
         }
 
-        // Set Request.zone_recorsets data
-        if let Some(arg) = &self.zone_recorsets {
-            ep_builder.zone_recorsets(*arg);
+        // Set Request.zone_recordsets data
+        if let Some(arg) = &self.zone_recordsets {
+            ep_builder.zone_recordsets(*arg);
         }
 
         // Set Request.zones data

--- a/openstack_cli/src/dns/v2/service_status/list.rs
+++ b/openstack_cli/src/dns/v2/service_status/list.rs
@@ -65,7 +65,7 @@ impl ServiceStatusesCommand {
         let op = OutputProcessor::from_args(parsed_args, Some("dns.service_status"), Some("list"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/tld/list.rs
+++ b/openstack_cli/src/dns/v2/tld/list.rs
@@ -65,7 +65,7 @@ impl TldsCommand {
         let op = OutputProcessor::from_args(parsed_args, Some("dns.tld"), Some("list"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/tsigkey/list.rs
+++ b/openstack_cli/src/dns/v2/tsigkey/list.rs
@@ -65,7 +65,7 @@ impl TsigkeiesCommand {
         let op = OutputProcessor::from_args(parsed_args, Some("dns.tsigkey"), Some("list"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/zone/task/export/list.rs
+++ b/openstack_cli/src/dns/v2/zone/task/export/list.rs
@@ -66,7 +66,7 @@ impl ExportsCommand {
             OutputProcessor::from_args(parsed_args, Some("dns.zone/task/export"), Some("list"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/zone/task/import/list.rs
+++ b/openstack_cli/src/dns/v2/zone/task/import/list.rs
@@ -66,7 +66,7 @@ impl ImportsCommand {
             OutputProcessor::from_args(parsed_args, Some("dns.zone/task/import"), Some("list"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/zone/task/transfer_accept/list.rs
+++ b/openstack_cli/src/dns/v2/zone/task/transfer_accept/list.rs
@@ -69,7 +69,7 @@ impl TransferAcceptsCommand {
         );
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_cli/src/dns/v2/zone/task/transfer_request/list.rs
+++ b/openstack_cli/src/dns/v2/zone/task/transfer_request/list.rs
@@ -70,7 +70,7 @@ impl TransferRequestsCommand {
         );
         op.validate_args(parsed_args)?;
 
-        let ep_builder = list::Request::builder();
+        let mut ep_builder = list::Request::builder();
 
         // Set path parameters
         // Set query parameters

--- a/openstack_sdk/src/api/dns/v2/blacklist/list.rs
+++ b/openstack_sdk/src/api/dns/v2/blacklist/list.rs
@@ -22,6 +22,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/limit/get.rs
+++ b/openstack_sdk/src/api/dns/v2/limit/get.rs
@@ -22,6 +22,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/pool/list.rs
+++ b/openstack_sdk/src/api/dns/v2/pool/list.rs
@@ -22,6 +22,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/quota/set.rs
+++ b/openstack_sdk/src/api/dns/v2/quota/set.rs
@@ -41,7 +41,7 @@ pub struct Request<'a> {
     pub(crate) zone_records: Option<i32>,
 
     #[builder(default, setter(into))]
-    pub(crate) zone_recorsets: Option<i32>,
+    pub(crate) zone_recordsets: Option<i32>,
 
     #[builder(default, setter(into))]
     pub(crate) zones: Option<i32>,
@@ -110,8 +110,8 @@ impl RestEndpoint for Request<'_> {
         if let Some(val) = &self.zone_records {
             params.push("zone_records", serde_json::to_value(val)?);
         }
-        if let Some(val) = &self.zone_recorsets {
-            params.push("zone_recorsets", serde_json::to_value(val)?);
+        if let Some(val) = &self.zone_recordsets {
+            params.push("zone_recordsets", serde_json::to_value(val)?);
         }
         if let Some(val) = &self.zones {
             params.push("zones", serde_json::to_value(val)?);

--- a/openstack_sdk/src/api/dns/v2/service_status/list.rs
+++ b/openstack_sdk/src/api/dns/v2/service_status/list.rs
@@ -22,6 +22,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/tld/list.rs
+++ b/openstack_sdk/src/api/dns/v2/tld/list.rs
@@ -22,6 +22,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/tsigkey/list.rs
+++ b/openstack_sdk/src/api/dns/v2/tsigkey/list.rs
@@ -22,6 +22,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/zone/task/export/list.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/task/export/list.rs
@@ -20,6 +20,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/zone/task/import/list.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/task/import/list.rs
@@ -20,6 +20,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/zone/task/transfer_accept/list.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/task/transfer_accept/list.rs
@@ -22,6 +22,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_sdk/src/api/dns/v2/zone/task/transfer_request/list.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/task/transfer_request/list.rs
@@ -23,6 +23,8 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::rest_endpoint_prelude::*;
 
+use std::borrow::Cow;
+
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request {

--- a/openstack_types/data/dns/v2.1.yaml
+++ b/openstack_types/data/dns/v2.1.yaml
@@ -10,6 +10,9 @@ paths:
       description: |-
         List all blacklists
       operationId: blacklists:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -54,6 +57,9 @@ paths:
       description: |-
         Show a blacklist
       operationId: blacklists/blacklist_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -94,6 +100,9 @@ paths:
       description: |-
         List project limits
       operationId: limits:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -109,6 +118,9 @@ paths:
       description: |-
         Get the list of Pools.
       operationId: pools:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -155,6 +167,9 @@ paths:
 
         Error response codes: 405,404,403,401,400,503
       operationId: pools/pool_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -188,6 +203,9 @@ paths:
   /v2/quotas:
     get:
       operationId: quotas:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -214,6 +232,9 @@ paths:
 
         This returns a key:value set of quotas on the system.
       operationId: quotas/project_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -283,6 +304,9 @@ paths:
       description: |-
         Get RecordSet
       operationId: recordsets/recordset_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -317,6 +341,9 @@ paths:
       description: |-
         Shows a particular FloatingIP PTR
       operationId: reverse/floatingips/fip_key:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -354,6 +381,9 @@ paths:
       description: |-
         List all Services and statuses.
       operationId: service_statuses:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -369,6 +399,9 @@ paths:
       description: |-
         Show the status of a service.
       operationId: service_statuses/service_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -386,6 +419,9 @@ paths:
       description: |-
         List the tlds associated with the Project
       operationId: tlds:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -430,6 +466,9 @@ paths:
       description: |-
         Show a tld
       operationId: tlds/tld_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -466,6 +505,9 @@ paths:
       description: |-
         List all tsigkeys
       operationId: tsigkeys:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -510,6 +552,9 @@ paths:
       description: |-
         Show a tsigkey
       operationId: tsigkeys/tsigkey_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -592,6 +637,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/exports:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -607,6 +655,9 @@ paths:
       description: |-
         Get Zone Exports
       operationId: zones/tasks/exports/export_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -622,6 +673,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/exports/export_id/export:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -653,6 +707,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/imports:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -687,6 +744,9 @@ paths:
       description: |-
         Get Zone Imports
       operationId: zones/tasks/imports/import_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -721,6 +781,9 @@ paths:
       description: |-
         This will list all your accepted ownership transfer.
       operationId: zones/tasks/transfer_accepts:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -755,6 +818,9 @@ paths:
       description: |-
         Get transfer_accepts
       operationId: zones/tasks/transfer_accepts/transfer_accept_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -772,6 +838,9 @@ paths:
         This will list all your outgoing requests, and any incoming requests that
         have been scoped to your project.
       operationId: zones/tasks/transfer_requests:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -795,6 +864,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/transfer_requests/zone_transfer_request_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -840,6 +912,9 @@ paths:
       description: |-
         Show a zone
       operationId: zones/zone_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -876,6 +951,9 @@ paths:
       description: |-
         Show the nameservers for a zone
       operationId: zones/zone_id/nameservers:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -952,6 +1030,9 @@ paths:
       description: |-
         Show an single recordset
       operationId: zones/zone_id/recordsets/recordset_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -1049,6 +1130,9 @@ paths:
 
         **New in version 2.1**
       operationId: zones/zone_id/shares/zone_share_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -1631,7 +1715,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1644,7 +1728,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1657,7 +1741,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1670,7 +1754,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1686,6 +1770,7 @@ components:
             self:
               format: uri
               type: string
+          readOnly: true
           type: object
         recordsets:
           items:
@@ -2877,6 +2962,7 @@ components:
                   self:
                     format: uri
                     type: string
+                readOnly: true
                 type: object
               priority:
                 description: |-
@@ -3409,6 +3495,7 @@ components:
             self:
               format: uri
               type: string
+          readOnly: true
           type: object
         recordsets:
           items:

--- a/openstack_types/data/dns/v2.yaml
+++ b/openstack_types/data/dns/v2.yaml
@@ -10,6 +10,9 @@ paths:
       description: |-
         List all blacklists
       operationId: blacklists:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -54,6 +57,9 @@ paths:
       description: |-
         Show a blacklist
       operationId: blacklists/blacklist_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -94,6 +100,9 @@ paths:
       description: |-
         List project limits
       operationId: limits:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -109,6 +118,9 @@ paths:
       description: |-
         Get the list of Pools.
       operationId: pools:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -155,6 +167,9 @@ paths:
 
         Error response codes: 405,404,403,401,400,503
       operationId: pools/pool_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -188,6 +203,9 @@ paths:
   /v2/quotas:
     get:
       operationId: quotas:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -214,6 +232,9 @@ paths:
 
         This returns a key:value set of quotas on the system.
       operationId: quotas/project_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -283,6 +304,9 @@ paths:
       description: |-
         Get RecordSet
       operationId: recordsets/recordset_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -317,6 +341,9 @@ paths:
       description: |-
         Shows a particular FloatingIP PTR
       operationId: reverse/floatingips/fip_key:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -354,6 +381,9 @@ paths:
       description: |-
         List all Services and statuses.
       operationId: service_statuses:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -369,6 +399,9 @@ paths:
       description: |-
         Show the status of a service.
       operationId: service_statuses/service_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -386,6 +419,9 @@ paths:
       description: |-
         List the tlds associated with the Project
       operationId: tlds:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -430,6 +466,9 @@ paths:
       description: |-
         Show a tld
       operationId: tlds/tld_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -466,6 +505,9 @@ paths:
       description: |-
         List all tsigkeys
       operationId: tsigkeys:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -510,6 +552,9 @@ paths:
       description: |-
         Show a tsigkey
       operationId: tsigkeys/tsigkey_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -592,6 +637,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/exports:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -607,6 +655,9 @@ paths:
       description: |-
         Get Zone Exports
       operationId: zones/tasks/exports/export_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -622,6 +673,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/exports/export_id/export:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -653,6 +707,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/imports:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -687,6 +744,9 @@ paths:
       description: |-
         Get Zone Imports
       operationId: zones/tasks/imports/import_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -721,6 +781,9 @@ paths:
       description: |-
         This will list all your accepted ownership transfer.
       operationId: zones/tasks/transfer_accepts:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -755,6 +818,9 @@ paths:
       description: |-
         Get transfer_accepts
       operationId: zones/tasks/transfer_accepts/transfer_accept_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -772,6 +838,9 @@ paths:
         This will list all your outgoing requests, and any incoming requests that
         have been scoped to your project.
       operationId: zones/tasks/transfer_requests:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -795,6 +864,9 @@ paths:
     get:
       description: |
       operationId: zones/tasks/transfer_requests/zone_transfer_request_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -840,6 +912,9 @@ paths:
       description: |-
         Show a zone
       operationId: zones/zone_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -876,6 +951,9 @@ paths:
       description: |-
         Show the nameservers for a zone
       operationId: zones/zone_id/nameservers:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -952,6 +1030,9 @@ paths:
       description: |-
         Show an single recordset
       operationId: zones/zone_id/recordsets/recordset_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -1049,6 +1130,9 @@ paths:
 
         **New in version 2.1**
       operationId: zones/zone_id/shares/zone_share_id:get
+      parameters:
+        - $ref: '#/components/parameters/x-auth-all-projects'
+        - $ref: '#/components/parameters/x-auth-sudo-project-id'
       responses:
         '200':
           content:
@@ -1631,7 +1715,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1644,7 +1728,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1657,7 +1741,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1670,7 +1754,7 @@ components:
           type: integer
         zone_records:
           type: integer
-        zone_recorsets:
+        zone_recordsets:
           type: integer
         zones:
           type: integer
@@ -1686,6 +1770,7 @@ components:
             self:
               format: uri
               type: string
+          readOnly: true
           type: object
         recordsets:
           items:
@@ -2877,6 +2962,7 @@ components:
                   self:
                     format: uri
                     type: string
+                readOnly: true
                 type: object
               priority:
                 description: |-
@@ -3409,6 +3495,7 @@ components:
             self:
               format: uri
               type: string
+          readOnly: true
           type: object
         recordsets:
           items:

--- a/openstack_types/src/dns/v2/quota/response/get.rs
+++ b/openstack_types/src/dns/v2/quota/response/get.rs
@@ -36,7 +36,7 @@ pub struct QuotaResponse {
 
     #[serde(default)]
     #[structable(optional)]
-    pub zone_recorsets: Option<i32>,
+    pub zone_recordsets: Option<i32>,
 
     #[serde(default)]
     #[structable(optional)]

--- a/openstack_types/src/dns/v2/quota/response/set.rs
+++ b/openstack_types/src/dns/v2/quota/response/set.rs
@@ -36,7 +36,7 @@ pub struct QuotaResponse {
 
     #[serde(default)]
     #[structable(optional)]
-    pub zone_recorsets: Option<i32>,
+    pub zone_recordsets: Option<i32>,
 
     #[serde(default)]
     #[structable(optional)]


### PR DESCRIPTION
All dns list/get operations support `x-auth-all-projects` and
`x-auth-sudo-project-id` headers, which can be used by admins.

Change-Id: Ic5a7cd6c0312a6ac28d895c290924621943e598a
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/955289
