### PR TITLE
feat: Capture request-id in the OpenStack API error

### DIFF
--- a/openstack_sdk/src/api/ignore.rs
+++ b/openstack_sdk/src/api/ignore.rs
@@ -66,9 +66,9 @@ where
             let v = if let Ok(v) = serde_json::from_slice(rsp.body()) {
                 v
             } else {
-                return Err(ApiError::server_error(query_uri, rsp.status(), rsp.body()));
+                return Err(ApiError::server_error(query_uri, &rsp, rsp.body()));
             };
-            return Err(ApiError::from_openstack(query_uri, status, v));
+            return Err(ApiError::from_openstack(query_uri, &rsp, v));
         }
 
         Ok(())
@@ -101,9 +101,9 @@ where
             let v = if let Ok(v) = serde_json::from_slice(rsp.body()) {
                 v
             } else {
-                return Err(ApiError::server_error(query_uri, rsp.status(), rsp.body()));
+                return Err(ApiError::server_error(query_uri, &rsp, rsp.body()));
             };
-            return Err(ApiError::from_openstack(query_uri, status, v));
+            return Err(ApiError::from_openstack(query_uri, &rsp, v));
         }
 
         Ok(())

--- a/openstack_sdk/src/api/paged.rs
+++ b/openstack_sdk/src/api/paged.rs
@@ -155,10 +155,10 @@ where
             let mut v = if let Ok(v) = serde_json::from_slice(rsp.body()) {
                 v
             } else {
-                return Err(ApiError::server_error(query_uri, status, rsp.body()));
+                return Err(ApiError::server_error(query_uri, &rsp, rsp.body()));
             };
             if !status.is_success() {
-                return Err(ApiError::from_openstack(query_uri, status, v));
+                return Err(ApiError::from_openstack(query_uri, &rsp, v));
             }
 
             if use_keyset_pagination {

--- a/openstack_sdk/src/api/paged/iter.rs
+++ b/openstack_sdk/src/api/paged/iter.rs
@@ -254,14 +254,14 @@ where
         } else {
             return Err(ApiError::server_error(
                 Some(query::url_to_http_uri(base)),
-                status,
+                &rsp,
                 rsp.body(),
             ));
         };
         if !status.is_success() {
             return Err(ApiError::from_openstack(
                 Some(query::url_to_http_uri(base)),
-                status,
+                &rsp,
                 v,
             ));
         }

--- a/openstack_sdk/src/api/rest_endpoint.rs
+++ b/openstack_sdk/src/api/rest_endpoint.rs
@@ -166,10 +166,10 @@ where
     let v = if let Ok(v) = serde_json::from_slice(rsp.body()) {
         v
     } else {
-        return Err(ApiError::server_error(uri, status, rsp.body()));
+        return Err(ApiError::server_error(uri, rsp, rsp.body()));
     };
     if !status.is_success() {
-        return Err(ApiError::from_openstack(uri, status, v));
+        return Err(ApiError::from_openstack(uri, rsp, v));
     }
     Ok(v)
 }
@@ -187,9 +187,9 @@ where
         let v = if let Ok(v) = serde_json::from_slice(rsp.body()) {
             v
         } else {
-            return Err(ApiError::server_error(uri, status, rsp.body()));
+            return Err(ApiError::server_error(uri, rsp, rsp.body()));
         };
-        return Err(ApiError::from_openstack(uri, status, v));
+        return Err(ApiError::from_openstack(uri, rsp, v));
     }
     Ok(())
 }
@@ -487,6 +487,7 @@ mod tests {
             status: _,
             uri: _,
             msg,
+            ..
         } = err
         {
             assert_eq!(msg, "dummy error message");
@@ -513,6 +514,7 @@ mod tests {
             status: _,
             uri: _,
             obj,
+            ..
         } = err
         {
             assert_eq!(obj, err_obj);


### PR DESCRIPTION
Capture the openstack request-id when an error is being returned. This
helps debugging since the user immediately sees it and can further pass
to the ops. Without that getting request-id requires enabling verbose
logging.
