### PR TITLE
chore: Log update of comfy-table in the Cargo.toml

### DIFF
--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -61,7 +61,7 @@ chrono = { workspace= true }
 clap = { workspace = true, features = ["color", "derive", "env"] }
 clap_complete = { workspace = true }
 color-eyre = { workspace = true }
-comfy-table = { version = "^7.1" }
+comfy-table = { version = "^7.2" }
 dialoguer = { workspace = true, features=["fuzzy-select"] }
 eyre = { workspace = true }
 http = { workspace = true }


### PR DESCRIPTION
renovate PR only updated lock file and left Cargo.toml unchanged.
