### PR TITLE
feat: Improve openapi type conversion

### DIFF
--- a/openstack_cli/src/compute/v2/flavor/list.rs
+++ b/openstack_cli/src/compute/v2/flavor/list.rs
@@ -69,7 +69,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/compute/v2/hypervisor/list.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/list.rs
@@ -73,7 +73,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/compute/v2/keypair/list.rs
+++ b/openstack_cli/src/compute/v2/keypair/list.rs
@@ -70,7 +70,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/compute/v2/migration/get.rs
+++ b/openstack_cli/src/compute/v2/migration/get.rs
@@ -88,7 +88,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/compute/v2/server/create_backup_20.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_20.rs
@@ -84,7 +84,7 @@ struct CreateBackup {
     /// The rotation of the back up image, the oldest image will be removed
     /// when image count exceed the rotation count.
     #[arg(help_heading = "Body parameters", long)]
-    rotation: i32,
+    rotation: u32,
 }
 
 impl ServerCommand {

--- a/openstack_cli/src/compute/v2/server/create_backup_21.rs
+++ b/openstack_cli/src/compute/v2/server/create_backup_21.rs
@@ -84,7 +84,7 @@ struct CreateBackup {
     /// The rotation of the back up image, the oldest image will be removed
     /// when image count exceed the rotation count.
     #[arg(help_heading = "Body parameters", long)]
-    rotation: i32,
+    rotation: u32,
 }
 
 impl ServerCommand {

--- a/openstack_cli/src/compute/v2/server/instance_action/list.rs
+++ b/openstack_cli/src/compute/v2/server/instance_action/list.rs
@@ -80,7 +80,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/compute/v2/server/list.rs
+++ b/openstack_cli/src/compute/v2/server/list.rs
@@ -158,7 +158,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[arg(help_heading = "Query parameters", long)]
     locked: Option<String>,

--- a/openstack_cli/src/compute/v2/server/volume_attachment/list.rs
+++ b/openstack_cli/src/compute/v2/server/volume_attachment/list.rs
@@ -66,10 +66,10 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[arg(help_heading = "Query parameters", long)]
-    offset: Option<i32>,
+    offset: Option<u32>,
 }
 
 /// Path parameters

--- a/openstack_cli/src/compute/v2/server_group/list.rs
+++ b/openstack_cli/src/compute/v2/server_group/list.rs
@@ -72,10 +72,10 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[arg(help_heading = "Query parameters", long)]
-    offset: Option<i32>,
+    offset: Option<u32>,
 }
 
 /// Path parameters

--- a/openstack_cli/src/compute/v2/simple_tenant_usage/list.rs
+++ b/openstack_cli/src/compute/v2/simple_tenant_usage/list.rs
@@ -72,7 +72,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/compute/v2/simple_tenant_usage/show.rs
+++ b/openstack_cli/src/compute/v2/simple_tenant_usage/show.rs
@@ -64,7 +64,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/identity/v3/domain/list.rs
+++ b/openstack_cli/src/identity/v3/domain/list.rs
@@ -71,7 +71,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/identity/v3/group/list.rs
+++ b/openstack_cli/src/identity/v3/group/list.rs
@@ -73,7 +73,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/create.rs
@@ -71,7 +71,7 @@ struct IdentityProvider {
     /// through mapping and persisted in the database. If left unset, the
     /// default value configured in keystone will be used, if enabled.
     #[arg(help_heading = "Body parameters", long)]
-    authorization_ttl: Option<Option<i32>>,
+    authorization_ttl: Option<Option<u32>>,
 
     /// The identity provider description
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_cli/src/identity/v3/os_federation/identity_provider/set.rs
@@ -69,7 +69,7 @@ struct IdentityProvider {
     /// through mapping and persisted in the database. If left unset, the
     /// default value configured in keystone will be used, if enabled.
     #[arg(help_heading = "Body parameters", long)]
-    authorization_ttl: Option<Option<i32>>,
+    authorization_ttl: Option<Option<u32>>,
 
     /// The identity provider description
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/identity/v3/os_trust/trust/create.rs
+++ b/openstack_cli/src/identity/v3/os_trust/trust/create.rs
@@ -127,7 +127,7 @@ struct Trust {
     /// resulting value is 0, this means that the new trust will not be
     /// redelegatable, regardless of the value of allow_redelegation.
     #[arg(help_heading = "Body parameters", long)]
-    redelegation_count: Option<Option<i32>>,
+    redelegation_count: Option<Option<u32>>,
 
     /// Specifies how many times the trust can be used to obtain a token. This
     /// value is decreased each time a token is issued through the trust. Once

--- a/openstack_cli/src/identity/v3/project/list.rs
+++ b/openstack_cli/src/identity/v3/project/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/identity/v3/user/list.rs
+++ b/openstack_cli/src/identity/v3/user/list.rs
@@ -81,7 +81,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/image/v2/metadef/namespace/property/create.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/create.rs
@@ -65,19 +65,19 @@ pub struct PropertyCommand {
     maximum: Option<f32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_items: Option<i32>,
+    max_items: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_length: Option<i32>,
+    max_length: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
     minimum: Option<f32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_items: Option<i32>,
+    min_items: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_length: Option<i32>,
+    min_length: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: String,

--- a/openstack_cli/src/image/v2/metadef/namespace/property/set.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/set.rs
@@ -65,19 +65,19 @@ pub struct PropertyCommand {
     maximum: Option<f32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_items: Option<i32>,
+    max_items: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    max_length: Option<i32>,
+    max_length: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
     minimum: Option<f32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_items: Option<i32>,
+    min_items: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
-    min_length: Option<i32>,
+    min_length: Option<u32>,
 
     #[arg(help_heading = "Body parameters", long)]
     name: String,

--- a/openstack_cli/src/network/v2/address_group/list.rs
+++ b/openstack_cli/src/network/v2/address_group/list.rs
@@ -91,7 +91,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/address_scope/list.rs
+++ b/openstack_cli/src/network/v2/address_scope/list.rs
@@ -91,7 +91,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/agent/dhcp_network/list.rs
+++ b/openstack_cli/src/network/v2/agent/dhcp_network/list.rs
@@ -78,7 +78,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/agent/l3_router/list.rs
+++ b/openstack_cli/src/network/v2/agent/l3_router/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/agent/list.rs
+++ b/openstack_cli/src/network/v2/agent/list.rs
@@ -111,7 +111,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/auto_allocated_topology/list.rs
+++ b/openstack_cli/src/network/v2/auto_allocated_topology/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/availability_zone/list.rs
+++ b/openstack_cli/src/network/v2/availability_zone/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/default_security_group_rule/list.rs
+++ b/openstack_cli/src/network/v2/default_security_group_rule/list.rs
@@ -98,7 +98,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/flavor/list.rs
+++ b/openstack_cli/src/network/v2/flavor/list.rs
@@ -93,7 +93,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/flavor/next_provider/list.rs
+++ b/openstack_cli/src/network/v2/flavor/next_provider/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/flavor/service_profile/list.rs
+++ b/openstack_cli/src/network/v2/flavor/service_profile/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/floatingip/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/list.rs
@@ -104,7 +104,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/port_forwarding/list.rs
@@ -108,7 +108,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/floatingip/tag/list.rs
+++ b/openstack_cli/src/network/v2/floatingip/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/floatingip_pool/list.rs
+++ b/openstack_cli/src/network/v2/floatingip_pool/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/local_ip/list.rs
+++ b/openstack_cli/src/network/v2/local_ip/list.rs
@@ -73,7 +73,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// local_ip_address query parameter for /v2.0/local-ips API
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/network/v2/local_ip/port_association/list.rs
+++ b/openstack_cli/src/network/v2/local_ip/port_association/list.rs
@@ -94,7 +94,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// local_ip_address query parameter for
     /// /v2.0/local_ips/{local_ip_id}/port_associations API

--- a/openstack_cli/src/network/v2/log/log/list.rs
+++ b/openstack_cli/src/network/v2/log/log/list.rs
@@ -97,7 +97,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/log/loggable_resource/list.rs
+++ b/openstack_cli/src/network/v2/log/loggable_resource/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/metering/metering_label/list.rs
+++ b/openstack_cli/src/network/v2/metering/metering_label/list.rs
@@ -89,7 +89,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/metering/metering_label_rule/list.rs
+++ b/openstack_cli/src/network/v2/metering/metering_label_rule/list.rs
@@ -104,7 +104,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/ndp_proxy/list.rs
+++ b/openstack_cli/src/network/v2/ndp_proxy/list.rs
@@ -65,7 +65,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/network/create.rs
+++ b/openstack_cli/src/network/v2/network/create.rs
@@ -98,7 +98,7 @@ struct Network {
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[arg(help_heading = "Body parameters", long)]
-    mtu: Option<i32>,
+    mtu: Option<u32>,
 
     /// Human-readable name of the network.
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_cli/src/network/v2/network/dhcp_agent/list.rs
@@ -78,7 +78,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/network/list.rs
+++ b/openstack_cli/src/network/v2/network/list.rs
@@ -104,7 +104,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the
@@ -114,7 +114,7 @@ struct QueryParameters {
 
     /// mtu query parameter for /v2.0/networks API
     #[arg(help_heading = "Query parameters", long)]
-    mtu: Option<i32>,
+    mtu: Option<u32>,
 
     /// name query parameter for /v2.0/networks API
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/network/v2/network/set.rs
+++ b/openstack_cli/src/network/v2/network/set.rs
@@ -95,7 +95,7 @@ struct Network {
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[arg(help_heading = "Body parameters", long)]
-    mtu: Option<i32>,
+    mtu: Option<u32>,
 
     /// Human-readable name of the network.
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/network/v2/network/tag/list.rs
+++ b/openstack_cli/src/network/v2/network/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/network_ip_availability/list.rs
+++ b/openstack_cli/src/network/v2/network_ip_availability/list.rs
@@ -86,7 +86,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/network_segment_range/list.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/list.rs
@@ -69,7 +69,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/network_segment_range/tag/list.rs
+++ b/openstack_cli/src/network/v2/network_segment_range/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -71,7 +71,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/policy/tag/list.rs
+++ b/openstack_cli/src/network/v2/policy/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/port/binding/list.rs
+++ b/openstack_cli/src/network/v2/port/binding/list.rs
@@ -71,7 +71,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/port/list.rs
+++ b/openstack_cli/src/network/v2/port/list.rs
@@ -121,7 +121,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// mac_address query parameter for /v2.0/ports API
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/network/v2/port/tag/list.rs
+++ b/openstack_cli/src/network/v2/port/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -69,7 +69,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/alias_dscp_marking_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_dscp_marking_rule/list.rs
@@ -69,7 +69,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -70,7 +70,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -70,7 +70,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -86,7 +86,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/policy/dscp_marking_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/dscp_marking_rule/list.rs
@@ -91,7 +91,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/policy/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/list.rs
@@ -94,7 +94,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -91,7 +91,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_cli/src/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -71,7 +71,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/qos/rule_type/list.rs
+++ b/openstack_cli/src/network/v2/qos/rule_type/list.rs
@@ -87,7 +87,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/quota/list.rs
+++ b/openstack_cli/src/network/v2/quota/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/rbac_policy/list.rs
+++ b/openstack_cli/src/network/v2/rbac_policy/list.rs
@@ -87,7 +87,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_cli/src/network/v2/router/conntrack_helper/list.rs
@@ -88,7 +88,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/router/l3_agent/list.rs
+++ b/openstack_cli/src/network/v2/router/l3_agent/list.rs
@@ -78,7 +78,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/router/list.rs
+++ b/openstack_cli/src/network/v2/router/list.rs
@@ -99,7 +99,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/router/tag/list.rs
+++ b/openstack_cli/src/network/v2/router/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/security_group/list.rs
+++ b/openstack_cli/src/network/v2/security_group/list.rs
@@ -90,7 +90,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/security_group/tag/list.rs
+++ b/openstack_cli/src/network/v2/security_group/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/security_group_rule/list.rs
+++ b/openstack_cli/src/network/v2/security_group_rule/list.rs
@@ -103,7 +103,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/segment/list.rs
+++ b/openstack_cli/src/network/v2/segment/list.rs
@@ -87,7 +87,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/service_profile/list.rs
+++ b/openstack_cli/src/network/v2/service_profile/list.rs
@@ -97,7 +97,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/service_provider/list.rs
+++ b/openstack_cli/src/network/v2/service_provider/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/subnet/create.rs
+++ b/openstack_cli/src/network/v2/subnet/create.rs
@@ -196,7 +196,7 @@ struct Subnet {
     /// not specified, the `default_prefixlen` value of the subnet pool will be
     /// used.
     #[arg(help_heading = "Body parameters", long)]
-    prefixlen: Option<i32>,
+    prefixlen: Option<u32>,
 
     /// The ID of a network segment the subnet is associated with. It is
     /// available when `segment` extension is enabled.

--- a/openstack_cli/src/network/v2/subnet/list.rs
+++ b/openstack_cli/src/network/v2/subnet/list.rs
@@ -116,7 +116,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/subnet/tag/list.rs
+++ b/openstack_cli/src/network/v2/subnet/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/subnetpool/create.rs
+++ b/openstack_cli/src/network/v2/subnetpool/create.rs
@@ -75,7 +75,7 @@ struct Subnetpool {
     /// attributes are omitted when you create the subnet. Default is
     /// `min_prefixlen`.
     #[arg(help_heading = "Body parameters", long)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<u32>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -84,7 +84,7 @@ struct Subnetpool {
     /// `default_quota` is measured units of /64. All projects that use the
     /// subnet pool have the same prefix quota applied.
     #[arg(help_heading = "Body parameters", long)]
-    default_quota: Option<i32>,
+    default_quota: Option<u32>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
@@ -99,12 +99,12 @@ struct Subnetpool {
     /// IPv4 subnet pools, default is `32`. For IPv6 subnet pools, default is
     /// `128`.
     #[arg(help_heading = "Body parameters", long)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<u32>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     #[arg(help_heading = "Body parameters", long)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<u32>,
 
     /// Human-readable name of the resource.
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/network/v2/subnetpool/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/list.rs
@@ -80,11 +80,11 @@ struct QueryParameters {
 
     /// default_prefixlen query parameter for /v2.0/subnetpools API
     #[arg(help_heading = "Query parameters", long)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<u32>,
 
     /// default_quota query parameter for /v2.0/subnetpools API
     #[arg(help_heading = "Query parameters", long)]
-    default_quota: Option<i32>,
+    default_quota: Option<u32>,
 
     /// description query parameter for /v2.0/subnetpools API
     #[arg(help_heading = "Query parameters", long)]
@@ -111,7 +111,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the
@@ -121,11 +121,11 @@ struct QueryParameters {
 
     /// max_prefixlen query parameter for /v2.0/subnetpools API
     #[arg(help_heading = "Query parameters", long)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<u32>,
 
     /// min_prefixlen query parameter for /v2.0/subnetpools API
     #[arg(help_heading = "Query parameters", long)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<u32>,
 
     /// name query parameter for /v2.0/subnetpools API
     #[arg(help_heading = "Query parameters", long)]

--- a/openstack_cli/src/network/v2/subnetpool/set.rs
+++ b/openstack_cli/src/network/v2/subnetpool/set.rs
@@ -85,7 +85,7 @@ struct Subnetpool {
     /// attributes are omitted when you create the subnet. Default is
     /// `min_prefixlen`.
     #[arg(help_heading = "Body parameters", long)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<u32>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -94,7 +94,7 @@ struct Subnetpool {
     /// `default_quota` is measured units of /64. All projects that use the
     /// subnet pool have the same prefix quota applied.
     #[arg(help_heading = "Body parameters", long)]
-    default_quota: Option<i32>,
+    default_quota: Option<u32>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
@@ -109,12 +109,12 @@ struct Subnetpool {
     /// IPv4 subnet pools, default is `32`. For IPv6 subnet pools, default is
     /// `128`.
     #[arg(help_heading = "Body parameters", long)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<u32>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     #[arg(help_heading = "Body parameters", long)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<u32>,
 
     /// Human-readable name of the resource.
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/network/v2/subnetpool/tag/list.rs
+++ b/openstack_cli/src/network/v2/subnetpool/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/trunk/tag/list.rs
+++ b/openstack_cli/src/network/v2/trunk/tag/list.rs
@@ -61,7 +61,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/vpn/endpoint_group/list.rs
+++ b/openstack_cli/src/network/v2/vpn/endpoint_group/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/vpn/ikepolicy/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ikepolicy/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/create.rs
@@ -121,7 +121,7 @@ struct IpsecSiteConnection {
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[arg(help_heading = "Body parameters", long)]
-    mtu: Option<i32>,
+    mtu: Option<u32>,
 
     /// Human-readable name of the resource. Default is an empty string.
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsec_site_connection/set.rs
@@ -123,7 +123,7 @@ struct IpsecSiteConnection {
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[arg(help_heading = "Body parameters", long)]
-    mtu: Option<i32>,
+    mtu: Option<u32>,
 
     /// Human-readable name of the resource. Default is an empty string.
     #[arg(help_heading = "Body parameters", long)]

--- a/openstack_cli/src/network/v2/vpn/ipsecpolicy/list.rs
+++ b/openstack_cli/src/network/v2/vpn/ipsecpolicy/list.rs
@@ -79,7 +79,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/network/v2/vpn/vpnservice/list.rs
+++ b/openstack_cli/src/network/v2/vpn/vpnservice/list.rs
@@ -81,7 +81,7 @@ struct QueryParameters {
         long("page-size"),
         visible_alias("limit")
     )]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_cli/src/placement/v1/resource_provider/inventory/set.rs
+++ b/openstack_cli/src/placement/v1/resource_provider/inventory/set.rs
@@ -73,7 +73,7 @@ pub struct InventoryCommand {
 
     /// The amount of the resource a provider has reserved for its own use.
     #[arg(help_heading = "Body parameters", long)]
-    reserved: Option<i32>,
+    reserved: Option<u32>,
 
     /// A consistent view marker that assists with the management of concurrent
     /// resource provider updates.

--- a/openstack_sdk/src/api/compute/v2/flavor/list.rs
+++ b/openstack_sdk/src/api/compute/v2/flavor/list.rs
@@ -36,7 +36,7 @@ pub struct Request<'a> {
     is_public: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/flavor/list_detailed.rs
+++ b/openstack_sdk/src/api/compute/v2/flavor/list_detailed.rs
@@ -36,7 +36,7 @@ pub struct Request<'a> {
     is_public: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/hypervisor/list.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/list.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     hypervisor_hostname_pattern: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/hypervisor/list_detailed.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/list_detailed.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     hypervisor_hostname_pattern: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/keypair/list.rs
+++ b/openstack_sdk/src/api/compute/v2/keypair/list.rs
@@ -33,7 +33,7 @@ use crate::api::Pageable;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/migration/get.rs
+++ b/openstack_sdk/src/api/compute/v2/migration/get.rs
@@ -55,7 +55,7 @@ pub struct Request<'a> {
     instance_uuid: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/server/create_backup_20.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_backup_20.rs
@@ -49,7 +49,7 @@ pub struct CreateBackup<'a> {
     /// when image count exceed the rotation count.
     #[serde()]
     #[builder(setter(into))]
-    pub(crate) rotation: i32,
+    pub(crate) rotation: u32,
 }
 
 impl<'a> CreateBackupBuilder<'a> {
@@ -177,7 +177,7 @@ mod tests {
                     CreateBackupBuilder::default()
                         .backup_type("foo")
                         .name("foo")
-                        .rotation(123)
+                        .rotation(7_u32)
                         .build()
                         .unwrap()
                 )
@@ -196,7 +196,7 @@ mod tests {
                     CreateBackupBuilder::default()
                         .backup_type("foo")
                         .name("foo")
-                        .rotation(123)
+                        .rotation(7_u32)
                         .build()
                         .unwrap()
                 )
@@ -228,7 +228,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation(123)
+                    .rotation(7_u32)
                     .build()
                     .unwrap(),
             )
@@ -259,7 +259,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation(123)
+                    .rotation(7_u32)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/server/create_backup_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_backup_21.rs
@@ -49,7 +49,7 @@ pub struct CreateBackup<'a> {
     /// when image count exceed the rotation count.
     #[serde()]
     #[builder(setter(into))]
-    pub(crate) rotation: i32,
+    pub(crate) rotation: u32,
 }
 
 impl<'a> CreateBackupBuilder<'a> {
@@ -177,7 +177,7 @@ mod tests {
                     CreateBackupBuilder::default()
                         .backup_type("foo")
                         .name("foo")
-                        .rotation(123)
+                        .rotation(7_u32)
                         .build()
                         .unwrap()
                 )
@@ -196,7 +196,7 @@ mod tests {
                     CreateBackupBuilder::default()
                         .backup_type("foo")
                         .name("foo")
-                        .rotation(123)
+                        .rotation(7_u32)
                         .build()
                         .unwrap()
                 )
@@ -228,7 +228,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation(123)
+                    .rotation(7_u32)
                     .build()
                     .unwrap(),
             )
@@ -259,7 +259,7 @@ mod tests {
                 CreateBackupBuilder::default()
                     .backup_type("foo")
                     .name("foo")
-                    .rotation(123)
+                    .rotation(7_u32)
                     .build()
                     .unwrap(),
             )

--- a/openstack_sdk/src/api/compute/v2/server/instance_action/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/instance_action/list.rs
@@ -47,7 +47,7 @@ pub struct Request<'a> {
     changes_since: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/server/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/list.rs
@@ -122,7 +122,7 @@ pub struct Request<'a> {
     launched_at: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     locked: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/server/list_detailed.rs
+++ b/openstack_sdk/src/api/compute/v2/server/list_detailed.rs
@@ -120,7 +120,7 @@ pub struct Request<'a> {
     launched_at: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     locked: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/server/volume_attachment/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/volume_attachment/list.rs
@@ -33,10 +33,10 @@ use crate::api::Pageable;
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default)]
-    offset: Option<i32>,
+    offset: Option<u32>,
 
     /// server_id parameter for
     /// /v2.1/servers/{server_id}/os-volume_attachments/{id} API

--- a/openstack_sdk/src/api/compute/v2/server_group/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server_group/list.rs
@@ -39,10 +39,10 @@ pub struct Request<'a> {
     all_projects: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default)]
-    offset: Option<i32>,
+    offset: Option<u32>,
 
     #[builder(setter(name = "_headers"), default, private)]
     _headers: Option<HeaderMap>,

--- a/openstack_sdk/src/api/compute/v2/simple_tenant_usage/get.rs
+++ b/openstack_sdk/src/api/compute/v2/simple_tenant_usage/get.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     id: Cow<'a, str>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/compute/v2/simple_tenant_usage/list.rs
+++ b/openstack_sdk/src/api/compute/v2/simple_tenant_usage/list.rs
@@ -39,7 +39,7 @@ pub struct Request<'a> {
     end: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     #[builder(default, setter(into))]
     marker: Option<Cow<'a, str>>,

--- a/openstack_sdk/src/api/identity/v3/domain/list.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/list.rs
@@ -38,7 +38,7 @@ pub struct Request<'a> {
     enabled: Option<bool>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/group/head.rs
+++ b/openstack_sdk/src/api/identity/v3/group/head.rs
@@ -35,7 +35,7 @@ pub struct Request<'a> {
     domain_id: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/group/list.rs
+++ b/openstack_sdk/src/api/identity/v3/group/list.rs
@@ -36,7 +36,7 @@ pub struct Request<'a> {
     domain_id: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/create.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/create.rs
@@ -36,7 +36,7 @@ pub struct IdentityProvider<'a> {
     /// default value configured in keystone will be used, if enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) authorization_ttl: Option<Option<i32>>,
+    pub(crate) authorization_ttl: Option<Option<u32>>,
 
     /// The identity provider description
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/set.rs
+++ b/openstack_sdk/src/api/identity/v3/os_federation/identity_provider/set.rs
@@ -34,7 +34,7 @@ pub struct IdentityProvider<'a> {
     /// default value configured in keystone will be used, if enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) authorization_ttl: Option<Option<i32>>,
+    pub(crate) authorization_ttl: Option<Option<u32>>,
 
     /// The identity provider description
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/identity/v3/os_trust/trust/create.rs
+++ b/openstack_sdk/src/api/identity/v3/os_trust/trust/create.rs
@@ -106,7 +106,7 @@ pub struct Trust<'a> {
     /// redelegatable, regardless of the value of allow_redelegation.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) redelegation_count: Option<Option<i32>>,
+    pub(crate) redelegation_count: Option<Option<u32>>,
 
     /// Specifies how many times the trust can be used to obtain a token. This
     /// value is decreased each time a token is issued through the trust. Once

--- a/openstack_sdk/src/api/identity/v3/project/list.rs
+++ b/openstack_sdk/src/api/identity/v3/project/list.rs
@@ -42,7 +42,7 @@ pub struct Request<'a> {
     is_domain: Option<bool>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/head.rs
+++ b/openstack_sdk/src/api/identity/v3/user/head.rs
@@ -43,7 +43,7 @@ pub struct Request<'a> {
     idp_id: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/identity/v3/user/list.rs
+++ b/openstack_sdk/src/api/identity/v3/user/list.rs
@@ -44,7 +44,7 @@ pub struct Request<'a> {
     idp_id: Option<Cow<'a, str>>,
 
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// ID of the last fetched entry
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/create.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/create.rs
@@ -83,11 +83,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "maxItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_items: Option<i32>,
+    pub(crate) max_items: Option<u32>,
 
     #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_length: Option<i32>,
+    pub(crate) max_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
@@ -95,11 +95,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_items: Option<i32>,
+    pub(crate) min_items: Option<u32>,
 
     #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_length: Option<i32>,
+    pub(crate) min_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/object/create.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/object/create.rs
@@ -83,11 +83,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "maxItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_items: Option<i32>,
+    pub(crate) max_items: Option<u32>,
 
     #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_length: Option<i32>,
+    pub(crate) max_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
@@ -95,11 +95,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_items: Option<i32>,
+    pub(crate) min_items: Option<u32>,
 
     #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_length: Option<i32>,
+    pub(crate) min_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/object/set.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/object/set.rs
@@ -83,11 +83,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "maxItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_items: Option<i32>,
+    pub(crate) max_items: Option<u32>,
 
     #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_length: Option<i32>,
+    pub(crate) max_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
@@ -95,11 +95,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_items: Option<i32>,
+    pub(crate) min_items: Option<u32>,
 
     #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_length: Option<i32>,
+    pub(crate) min_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/property/create.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/property/create.rs
@@ -75,19 +75,19 @@ pub struct Request<'a> {
     pub(crate) maximum: Option<f32>,
 
     #[builder(default, setter(into))]
-    pub(crate) max_items: Option<i32>,
+    pub(crate) max_items: Option<u32>,
 
     #[builder(default, setter(into))]
-    pub(crate) max_length: Option<i32>,
+    pub(crate) max_length: Option<u32>,
 
     #[builder(default, setter(into))]
     pub(crate) minimum: Option<f32>,
 
     #[builder(default, setter(into))]
-    pub(crate) min_items: Option<i32>,
+    pub(crate) min_items: Option<u32>,
 
     #[builder(default, setter(into))]
-    pub(crate) min_length: Option<i32>,
+    pub(crate) min_length: Option<u32>,
 
     #[builder(setter(into))]
     pub(crate) name: Cow<'a, str>,

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/property/set.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/property/set.rs
@@ -75,19 +75,19 @@ pub struct Request<'a> {
     pub(crate) maximum: Option<f32>,
 
     #[builder(default, setter(into))]
-    pub(crate) max_items: Option<i32>,
+    pub(crate) max_items: Option<u32>,
 
     #[builder(default, setter(into))]
-    pub(crate) max_length: Option<i32>,
+    pub(crate) max_length: Option<u32>,
 
     #[builder(default, setter(into))]
     pub(crate) minimum: Option<f32>,
 
     #[builder(default, setter(into))]
-    pub(crate) min_items: Option<i32>,
+    pub(crate) min_items: Option<u32>,
 
     #[builder(default, setter(into))]
-    pub(crate) min_length: Option<i32>,
+    pub(crate) min_length: Option<u32>,
 
     #[builder(setter(into))]
     pub(crate) name: Cow<'a, str>,

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/set.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/set.rs
@@ -83,11 +83,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "maxItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_items: Option<i32>,
+    pub(crate) max_items: Option<u32>,
 
     #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_length: Option<i32>,
+    pub(crate) max_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
@@ -95,11 +95,11 @@ pub struct Properties<'a> {
 
     #[serde(rename = "minItems", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_items: Option<i32>,
+    pub(crate) min_items: Option<u32>,
 
     #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_length: Option<i32>,
+    pub(crate) min_length: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/address_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/address_group/list.rs
@@ -62,7 +62,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/address_scope/list.rs
+++ b/openstack_sdk/src/api/network/v2/address_scope/list.rs
@@ -62,7 +62,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/agent/dhcp_network/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/dhcp_network/list.rs
@@ -54,7 +54,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/agent/l3_router/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/l3_router/list.rs
@@ -54,7 +54,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/agent/list.rs
@@ -82,7 +82,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/auto_allocated_topology/list.rs
+++ b/openstack_sdk/src/api/network/v2/auto_allocated_topology/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/availability_zone/list.rs
+++ b/openstack_sdk/src/api/network/v2/availability_zone/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/default_security_group_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/default_security_group_rule/list.rs
@@ -69,7 +69,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/flavor/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/list.rs
@@ -64,7 +64,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/flavor/next_provider/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/next_provider/list.rs
@@ -36,7 +36,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/flavor/service_profile/list.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/service_profile/list.rs
@@ -36,7 +36,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/floatingip/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/list.rs
@@ -76,7 +76,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/floatingip/port_forwarding/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/port_forwarding/list.rs
@@ -84,7 +84,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/floatingip/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip/tag/list.rs
@@ -36,7 +36,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/floatingip_pool/list.rs
+++ b/openstack_sdk/src/api/network/v2/floatingip_pool/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/local_ip/list.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/list.rs
@@ -43,7 +43,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// local_ip_address query parameter for /v2.0/local-ips API
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/local_ip/port_association/list.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/port_association/list.rs
@@ -65,7 +65,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// local_ip_address query parameter for
     /// /v2.0/local_ips/{local_ip_id}/port_associations API

--- a/openstack_sdk/src/api/network/v2/log/log/list.rs
+++ b/openstack_sdk/src/api/network/v2/log/log/list.rs
@@ -68,7 +68,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/log/loggable_resource/list.rs
+++ b/openstack_sdk/src/api/network/v2/log/loggable_resource/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/metering/metering_label/list.rs
+++ b/openstack_sdk/src/api/network/v2/metering/metering_label/list.rs
@@ -60,7 +60,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/metering/metering_label_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/metering/metering_label_rule/list.rs
@@ -75,7 +75,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/ndp_proxy/list.rs
+++ b/openstack_sdk/src/api/network/v2/ndp_proxy/list.rs
@@ -35,7 +35,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/network/create.rs
+++ b/openstack_sdk/src/api/network/v2/network/create.rs
@@ -98,7 +98,7 @@ pub struct Network<'a> {
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) mtu: Option<i32>,
+    pub(crate) mtu: Option<u32>,
 
     /// Human-readable name of the network.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/network/v2/network/dhcp_agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/dhcp_agent/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/network/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/list.rs
@@ -76,7 +76,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the
@@ -86,7 +86,7 @@ pub struct Request<'a> {
 
     /// mtu query parameter for /v2.0/networks API
     #[builder(default)]
-    mtu: Option<i32>,
+    mtu: Option<u32>,
 
     /// name query parameter for /v2.0/networks API
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/network/set.rs
+++ b/openstack_sdk/src/api/network/v2/network/set.rs
@@ -85,7 +85,7 @@ pub struct Network<'a> {
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) mtu: Option<i32>,
+    pub(crate) mtu: Option<u32>,
 
     /// Human-readable name of the network.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/network/v2/network/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/network/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/network_ip_availability/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_ip_availability/list.rs
@@ -57,7 +57,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/network_segment_range/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/list.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/network_segment_range/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/policy/packet_rate_limit_rule/list.rs
@@ -41,7 +41,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/policy/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/policy/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/port/binding/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/binding/list.rs
@@ -42,7 +42,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/port/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/list.rs
@@ -93,7 +93,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// mac_address query parameter for /v2.0/ports API
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/port/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/port/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_bandwidth_limit_rule/list.rs
@@ -39,7 +39,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/alias_dscp_marking_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_dscp_marking_rule/list.rs
@@ -39,7 +39,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_bandwidth_rule/list.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/alias_minimum_packet_rate_rule/list.rs
@@ -40,7 +40,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/bandwidth_limit_rule/list.rs
@@ -57,7 +57,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/policy/dscp_marking_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/dscp_marking_rule/list.rs
@@ -62,7 +62,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/policy/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/list.rs
@@ -66,7 +66,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_bandwidth_rule/list.rs
@@ -62,7 +62,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/minimum_packet_rate_rule/list.rs
@@ -41,7 +41,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/qos/rule_type/list.rs
+++ b/openstack_sdk/src/api/network/v2/qos/rule_type/list.rs
@@ -58,7 +58,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/quota/list.rs
+++ b/openstack_sdk/src/api/network/v2/quota/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/rbac_policy/list.rs
+++ b/openstack_sdk/src/api/network/v2/rbac_policy/list.rs
@@ -58,7 +58,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/conntrack_helper/list.rs
@@ -59,7 +59,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/router/l3_agent/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/l3_agent/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/router/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/list.rs
@@ -71,7 +71,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/router/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/router/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/security_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group/list.rs
@@ -62,7 +62,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/security_group/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/security_group_rule/list.rs
+++ b/openstack_sdk/src/api/network/v2/security_group_rule/list.rs
@@ -74,7 +74,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/segment/list.rs
+++ b/openstack_sdk/src/api/network/v2/segment/list.rs
@@ -58,7 +58,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/service_profile/list.rs
+++ b/openstack_sdk/src/api/network/v2/service_profile/list.rs
@@ -68,7 +68,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/service_provider/list.rs
+++ b/openstack_sdk/src/api/network/v2/service_provider/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/subnet/create.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/create.rs
@@ -194,7 +194,7 @@ pub struct Subnet<'a> {
     /// used.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) prefixlen: Option<i32>,
+    pub(crate) prefixlen: Option<u32>,
 
     /// The ID of a network segment the subnet is associated with. It is
     /// available when `segment` extension is enabled.

--- a/openstack_sdk/src/api/network/v2/subnet/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/list.rs
@@ -88,7 +88,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/subnet/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/subnetpool/create.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/create.rs
@@ -44,7 +44,7 @@ pub struct Subnetpool<'a> {
     /// `min_prefixlen`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) default_prefixlen: Option<i32>,
+    pub(crate) default_prefixlen: Option<u32>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -54,7 +54,7 @@ pub struct Subnetpool<'a> {
     /// subnet pool have the same prefix quota applied.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) default_quota: Option<i32>,
+    pub(crate) default_quota: Option<u32>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
@@ -72,13 +72,13 @@ pub struct Subnetpool<'a> {
     /// `128`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_prefixlen: Option<i32>,
+    pub(crate) max_prefixlen: Option<u32>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_prefixlen: Option<i32>,
+    pub(crate) min_prefixlen: Option<u32>,
 
     /// Human-readable name of the resource.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/network/v2/subnetpool/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/list.rs
@@ -56,11 +56,11 @@ pub struct Request<'a> {
 
     /// default_prefixlen query parameter for /v2.0/subnetpools API
     #[builder(default)]
-    default_prefixlen: Option<i32>,
+    default_prefixlen: Option<u32>,
 
     /// default_quota query parameter for /v2.0/subnetpools API
     #[builder(default)]
-    default_quota: Option<i32>,
+    default_quota: Option<u32>,
 
     /// description query parameter for /v2.0/subnetpools API
     #[builder(default, setter(into))]
@@ -83,7 +83,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the
@@ -93,11 +93,11 @@ pub struct Request<'a> {
 
     /// max_prefixlen query parameter for /v2.0/subnetpools API
     #[builder(default)]
-    max_prefixlen: Option<i32>,
+    max_prefixlen: Option<u32>,
 
     /// min_prefixlen query parameter for /v2.0/subnetpools API
     #[builder(default)]
-    min_prefixlen: Option<i32>,
+    min_prefixlen: Option<u32>,
 
     /// name query parameter for /v2.0/subnetpools API
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/network/v2/subnetpool/set.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/set.rs
@@ -44,7 +44,7 @@ pub struct Subnetpool<'a> {
     /// `min_prefixlen`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) default_prefixlen: Option<i32>,
+    pub(crate) default_prefixlen: Option<u32>,
 
     /// A per-project quota on the prefix space that can be allocated from the
     /// subnet pool for project subnets. Default is no quota is enforced on
@@ -54,7 +54,7 @@ pub struct Subnetpool<'a> {
     /// subnet pool have the same prefix quota applied.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) default_quota: Option<i32>,
+    pub(crate) default_quota: Option<u32>,
 
     /// A human-readable description for the resource. Default is an empty
     /// string.
@@ -72,13 +72,13 @@ pub struct Subnetpool<'a> {
     /// `128`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) max_prefixlen: Option<i32>,
+    pub(crate) max_prefixlen: Option<u32>,
 
     /// The smallest prefix that can be allocated from a subnet pool. For IPv4
     /// subnet pools, default is `8`. For IPv6 subnet pools, default is `64`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) min_prefixlen: Option<i32>,
+    pub(crate) min_prefixlen: Option<u32>,
 
     /// Human-readable name of the resource.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/network/v2/subnetpool/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/trunk/tag/list.rs
+++ b/openstack_sdk/src/api/network/v2/trunk/tag/list.rs
@@ -31,7 +31,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/vpn/endpoint_group/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/endpoint_group/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/vpn/ikepolicy/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ikepolicy/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/create.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/create.rs
@@ -97,7 +97,7 @@ pub struct IpsecSiteConnection<'a> {
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) mtu: Option<i32>,
+    pub(crate) mtu: Option<u32>,
 
     /// Human-readable name of the resource. Default is an empty string.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/set.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/set.rs
@@ -87,7 +87,7 @@ pub struct IpsecSiteConnection<'a> {
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) mtu: Option<i32>,
+    pub(crate) mtu: Option<u32>,
 
     /// Human-readable name of the resource. Default is an empty string.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/list.rs
@@ -50,7 +50,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/network/v2/vpn/vpnservice/list.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/vpnservice/list.rs
@@ -52,7 +52,7 @@ pub struct Request<'a> {
     /// use the ID of the last-seen item from the response as the marker
     /// parameter value in a subsequent limited request.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// The ID of the last-seen item. Use the limit parameter to make an
     /// initial limited request and use the ID of the last-seen item from the

--- a/openstack_sdk/src/api/placement/v1/reshaper/create_134.rs
+++ b/openstack_sdk/src/api/placement/v1/reshaper/create_134.rs
@@ -151,7 +151,7 @@ pub struct InventoriesItem {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) reserved: Option<i32>,
+    pub(crate) reserved: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/placement/v1/reshaper/create_138.rs
+++ b/openstack_sdk/src/api/placement/v1/reshaper/create_138.rs
@@ -161,7 +161,7 @@ pub struct InventoriesItem {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) reserved: Option<i32>,
+    pub(crate) reserved: Option<u32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/openstack_sdk/src/api/placement/v1/resource_provider/inventory/create.rs
+++ b/openstack_sdk/src/api/placement/v1/resource_provider/inventory/create.rs
@@ -61,7 +61,7 @@ pub struct InventoriesItem {
     /// The amount of the resource a provider has reserved for its own use.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) reserved: Option<i32>,
+    pub(crate) reserved: Option<u32>,
 
     /// A representation of the divisible amount of the resource that may be
     /// requested. For example, step_size = 5 means that only values divisible

--- a/openstack_sdk/src/api/placement/v1/resource_provider/inventory/replace.rs
+++ b/openstack_sdk/src/api/placement/v1/resource_provider/inventory/replace.rs
@@ -63,7 +63,7 @@ pub struct InventoriesItem {
     /// The amount of the resource a provider has reserved for its own use.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
-    pub(crate) reserved: Option<i32>,
+    pub(crate) reserved: Option<u32>,
 
     /// A representation of the divisible amount of the resource that may be
     /// requested. For example, step_size = 5 means that only values divisible

--- a/openstack_sdk/src/api/placement/v1/resource_provider/inventory/set.rs
+++ b/openstack_sdk/src/api/placement/v1/resource_provider/inventory/set.rs
@@ -56,7 +56,7 @@ pub struct Request<'a> {
 
     /// The amount of the resource a provider has reserved for its own use.
     #[builder(default, setter(into))]
-    pub(crate) reserved: Option<i32>,
+    pub(crate) reserved: Option<u32>,
 
     /// A consistent view marker that assists with the management of concurrent
     /// resource provider updates.

--- a/openstack_tui/src/cloud_worker/compute/v2/flavor/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/flavor/list_detailed.rs
@@ -34,7 +34,7 @@ pub struct ComputeFlavorList {
     #[builder(default)]
     pub is_public: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/compute/v2/hypervisor/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/hypervisor/list_detailed.rs
@@ -34,7 +34,7 @@ pub struct ComputeHypervisorList {
     #[builder(default)]
     pub hypervisor_hostname_pattern: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
@@ -36,7 +36,7 @@ pub struct ComputeServerInstanceActionList {
     #[builder(default)]
     pub changes_since: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     pub server_id: String,

--- a/openstack_tui/src/cloud_worker/compute/v2/server/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/list_detailed.rs
@@ -86,7 +86,7 @@ pub struct ComputeServerList {
     #[builder(default)]
     pub launched_at: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub locked: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/identity/v3/group/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/list.rs
@@ -36,7 +36,7 @@ pub struct IdentityGroupList {
     #[builder(default)]
     pub domain_name: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/identity/v3/project/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/project/list.rs
@@ -40,7 +40,7 @@ pub struct IdentityProjectList {
     #[builder(default)]
     pub is_domain: Option<bool>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/identity/v3/user/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/list.rs
@@ -42,7 +42,7 @@ pub struct IdentityUserList {
     #[builder(default)]
     pub idp_name: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/network/v2/network/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/network/list.rs
@@ -40,11 +40,11 @@ pub struct NetworkNetworkList {
     #[builder(default)]
     pub is_default: Option<bool>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]
-    pub mtu: Option<i32>,
+    pub mtu: Option<u32>,
     #[builder(default)]
     pub name: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/network/v2/router/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/router/list.rs
@@ -40,7 +40,7 @@ pub struct NetworkRouterList {
     #[builder(default)]
     pub id: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/network/v2/security_group/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group/list.rs
@@ -36,7 +36,7 @@ pub struct NetworkSecurityGroupList {
     #[builder(default)]
     pub id: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/network/v2/security_group_rule/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group_rule/list.rs
@@ -44,7 +44,7 @@ pub struct NetworkSecurityGroupRuleList {
     #[builder(default)]
     pub name: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_tui/src/cloud_worker/network/v2/subnet/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/subnet/list.rs
@@ -48,7 +48,7 @@ pub struct NetworkSubnetList {
     #[builder(default)]
     pub ipv6_ra_mode: Option<String>,
     #[builder(default)]
-    pub limit: Option<i32>,
+    pub limit: Option<u32>,
     #[builder(default)]
     pub marker: Option<String>,
     #[builder(default)]

--- a/openstack_types/data/compute/v2.100.yaml
+++ b/openstack_types/data/compute/v2.100.yaml
@@ -12948,8 +12948,10 @@ components:
               type: string
             uptime:
               description: |-
-                The total uptime of the hypervisor and information about average load. Only
-                reported for active hosts where the virt driver supports this feature.
+                The response format of this api depends on the virt driver in use on a
+                given host. The libvirt driver returns the output of the uptime command
+                directly, the z/VM driver returns the ILP time. All other drivers
+                always return null. Note this value is cached and updated periodically.
 
                 **New in version 2.88**
               type: string
@@ -13199,8 +13201,10 @@ components:
                 type: string
               uptime:
                 description: |-
-                  The total uptime of the hypervisor and information about average load. Only
-                  reported for active hosts where the virt driver supports this feature.
+                  The response format of this api depends on the virt driver in use on a
+                  given host. The libvirt driver returns the output of the uptime command
+                  directly, the z/VM driver returns the ILP time. All other drivers
+                  always return null. Note this value is cached and updated periodically.
 
                   **New in version 2.88**
                 type: string
@@ -21092,7 +21096,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -21161,7 +21165,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -21509,7 +21513,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -21578,7 +21582,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -21924,7 +21928,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -21993,7 +21997,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -22347,7 +22351,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -22416,7 +22420,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -22780,7 +22784,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -22849,7 +22853,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -23208,7 +23212,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -23277,7 +23281,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -23638,7 +23642,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -23707,7 +23711,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -24078,7 +24082,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -24147,7 +24151,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -24526,7 +24530,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -24595,7 +24599,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -24963,7 +24967,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -25032,7 +25036,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -25410,7 +25414,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -25479,7 +25483,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -25863,7 +25867,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -25932,7 +25936,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -26326,7 +26330,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -26395,7 +26399,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -26794,7 +26798,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -26863,7 +26867,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -33312,7 +33316,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -33406,7 +33410,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -34013,7 +34017,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -34107,7 +34111,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -34700,7 +34704,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -34794,7 +34798,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -35401,7 +35405,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -35495,7 +35499,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -36112,7 +36116,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -36206,7 +36210,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -36818,7 +36822,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -36912,7 +36916,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -37521,7 +37525,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -37615,7 +37619,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -38234,7 +38238,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -38328,7 +38332,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -38967,7 +38971,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -39061,7 +39065,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -39683,7 +39687,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -39777,7 +39781,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -40417,7 +40421,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -40511,7 +40515,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -41157,7 +41161,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -41251,7 +41255,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -41919,7 +41923,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -42013,7 +42017,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -42699,7 +42703,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -42793,7 +42797,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255

--- a/openstack_types/data/compute/v2.yaml
+++ b/openstack_types/data/compute/v2.yaml
@@ -12948,8 +12948,10 @@ components:
               type: string
             uptime:
               description: |-
-                The total uptime of the hypervisor and information about average load. Only
-                reported for active hosts where the virt driver supports this feature.
+                The response format of this api depends on the virt driver in use on a
+                given host. The libvirt driver returns the output of the uptime command
+                directly, the z/VM driver returns the ILP time. All other drivers
+                always return null. Note this value is cached and updated periodically.
 
                 **New in version 2.88**
               type: string
@@ -13199,8 +13201,10 @@ components:
                 type: string
               uptime:
                 description: |-
-                  The total uptime of the hypervisor and information about average load. Only
-                  reported for active hosts where the virt driver supports this feature.
+                  The response format of this api depends on the virt driver in use on a
+                  given host. The libvirt driver returns the output of the uptime command
+                  directly, the z/VM driver returns the ILP time. All other drivers
+                  always return null. Note this value is cached and updated periodically.
 
                   **New in version 2.88**
                 type: string
@@ -21092,7 +21096,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -21161,7 +21165,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -21509,7 +21513,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -21578,7 +21582,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -21924,7 +21928,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -21993,7 +21997,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -22347,7 +22351,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -22416,7 +22420,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -22780,7 +22784,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -22849,7 +22853,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -23208,7 +23212,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -23277,7 +23281,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -23638,7 +23642,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -23707,7 +23711,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -24078,7 +24082,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -24147,7 +24151,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -24526,7 +24530,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -24595,7 +24599,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -24963,7 +24967,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -25032,7 +25036,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -25410,7 +25414,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -25479,7 +25483,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -25863,7 +25867,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -25932,7 +25936,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -26326,7 +26330,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -26395,7 +26399,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -26794,7 +26798,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -26863,7 +26867,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -33312,7 +33316,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -33406,7 +33410,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -34013,7 +34017,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -34107,7 +34111,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -34700,7 +34704,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -34794,7 +34798,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -35401,7 +35405,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -35495,7 +35499,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -36112,7 +36116,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -36206,7 +36210,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -36818,7 +36822,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -36912,7 +36916,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -37521,7 +37525,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -37615,7 +37619,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -38234,7 +38238,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -38328,7 +38332,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -38967,7 +38971,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -39061,7 +39065,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -39683,7 +39687,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -39777,7 +39781,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -40417,7 +40421,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -40511,7 +40515,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -41157,7 +41161,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -41251,7 +41255,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -41919,7 +41923,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -42013,7 +42017,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255
@@ -42699,7 +42703,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   no_device: {}
                   snapshot_id:
@@ -42793,7 +42797,7 @@ components:
                   device_name:
                     maxLength: 255
                     minLength: 1
-                    pattern: ^[a-zA-Z0-9._-r/]*$
+                    pattern: ^[a-zA-Z0-9._/-]*$
                     type: string
                   device_type:
                     maxLength: 255

--- a/openstack_types/src/compute/v2/hypervisor/response/get.rs
+++ b/openstack_types/src/compute/v2/hypervisor/response/get.rs
@@ -165,9 +165,10 @@ pub struct HypervisorResponse {
     #[structable(optional, serialize)]
     pub status: Option<Status>,
 
-    /// The total uptime of the hypervisor and information about average load.
-    /// Only reported for active hosts where the virt driver supports this
-    /// feature.
+    /// The response format of this api depends on the virt driver in use on a
+    /// given host. The libvirt driver returns the output of the uptime command
+    /// directly, the z/VM driver returns the ILP time. All other drivers
+    /// always return null. Note this value is cached and updated periodically.
     ///
     /// **New in version 2.88**
     #[serde(default)]

--- a/openstack_types/src/compute/v2/hypervisor/response/list_detailed.rs
+++ b/openstack_types/src/compute/v2/hypervisor/response/list_detailed.rs
@@ -165,9 +165,10 @@ pub struct HypervisorResponse {
     #[structable(optional, serialize)]
     pub status: Option<Status>,
 
-    /// The total uptime of the hypervisor and information about average load.
-    /// Only reported for active hosts where the virt driver supports this
-    /// feature.
+    /// The response format of this api depends on the virt driver in use on a
+    /// given host. The libvirt driver returns the output of the uptime command
+    /// directly, the z/VM driver returns the ILP time. All other drivers
+    /// always return null. Note this value is cached and updated periodically.
     ///
     /// **New in version 2.88**
     #[serde(default)]

--- a/openstack_types/src/identity/v3/os_trust/trust/response/create.rs
+++ b/openstack_types/src/identity/v3/os_trust/trust/response/create.rs
@@ -94,7 +94,7 @@ pub struct TrustResponse {
     /// redelegatable, regardless of the value of allow_redelegation.
     #[serde(default)]
     #[structable(optional)]
-    pub redelegation_count: Option<i32>,
+    pub redelegation_count: Option<u32>,
 
     /// Specifies how many times the trust can be used to obtain a token. This
     /// value is decreased each time a token is issued through the trust. Once

--- a/openstack_types/src/identity/v3/os_trust/trust/response/get.rs
+++ b/openstack_types/src/identity/v3/os_trust/trust/response/get.rs
@@ -94,7 +94,7 @@ pub struct TrustResponse {
     /// redelegatable, regardless of the value of allow_redelegation.
     #[serde(default)]
     #[structable(optional)]
-    pub redelegation_count: Option<i32>,
+    pub redelegation_count: Option<u32>,
 
     /// Specifies how many times the trust can be used to obtain a token. This
     /// value is decreased each time a token is issued through the trust. Once

--- a/openstack_types/src/identity/v3/os_trust/trust/response/list.rs
+++ b/openstack_types/src/identity/v3/os_trust/trust/response/list.rs
@@ -89,7 +89,7 @@ pub struct TrustResponse {
     /// redelegatable, regardless of the value of allow_redelegation.
     #[serde(default)]
     #[structable(optional, wide)]
-    pub redelegation_count: Option<i32>,
+    pub redelegation_count: Option<u32>,
 
     /// Specifies how many times the trust can be used to obtain a token. This
     /// value is decreased each time a token is issued through the trust. Once

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/create.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/create.rs
@@ -125,15 +125,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/get.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/get.rs
@@ -125,15 +125,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/list.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/list.rs
@@ -125,15 +125,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/image/v2/metadef/namespace/object/response/set.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/object/response/set.rs
@@ -125,15 +125,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/create.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/create.rs
@@ -49,11 +49,11 @@ pub struct PropertyResponse {
 
     #[serde(default, rename = "maxItems")]
     #[structable(optional, title = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
 
     #[serde(default, rename = "maxLength")]
     #[structable(optional, title = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
 
     #[serde(default)]
     #[structable(optional)]

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/get.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/get.rs
@@ -49,11 +49,11 @@ pub struct PropertyResponse {
 
     #[serde(default, rename = "maxItems")]
     #[structable(optional, title = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
 
     #[serde(default, rename = "maxLength")]
     #[structable(optional, title = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
 
     #[serde(default)]
     #[structable(optional)]

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/set.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/set.rs
@@ -49,11 +49,11 @@ pub struct PropertyResponse {
 
     #[serde(default, rename = "maxItems")]
     #[structable(optional, title = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
 
     #[serde(default, rename = "maxLength")]
     #[structable(optional, title = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
 
     #[serde(default)]
     #[structable(optional)]

--- a/openstack_types/src/image/v2/metadef/namespace/response/create.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/create.rs
@@ -155,15 +155,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/image/v2/metadef/namespace/response/get.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/get.rs
@@ -155,15 +155,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/image/v2/metadef/namespace/response/list.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/list.rs
@@ -155,15 +155,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/image/v2/metadef/namespace/response/set.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/response/set.rs
@@ -155,15 +155,15 @@ pub struct Properties {
     #[serde(default)]
     pub maximum: Option<f32>,
     #[serde(default, rename = "maxItems")]
-    pub max_items: Option<i32>,
+    pub max_items: Option<u32>,
     #[serde(default, rename = "maxLength")]
-    pub max_length: Option<i32>,
+    pub max_length: Option<u32>,
     #[serde(default)]
     pub minimum: Option<f32>,
     #[serde(default, rename = "minItems")]
-    pub min_items: Option<i32>,
+    pub min_items: Option<u32>,
     #[serde(default, rename = "minLength")]
-    pub min_length: Option<i32>,
+    pub min_length: Option<u32>,
     #[serde(default)]
     pub name: Option<String>,
     #[serde(default)]

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/create.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/create.rs
@@ -43,7 +43,7 @@ pub struct InventoriesItem {
     #[serde(default)]
     pub min_unit: Option<i32>,
     #[serde(default)]
-    pub reserved: Option<i32>,
+    pub reserved: Option<u32>,
     #[serde(default)]
     pub step_size: Option<i32>,
     pub total: i32,

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/get.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/get.rs
@@ -50,7 +50,7 @@ pub struct InventoryResponse {
     /// The amount of the resource a provider has reserved for its own use.
     #[serde(default)]
     #[structable(optional)]
-    pub reserved: Option<i32>,
+    pub reserved: Option<u32>,
 
     /// A consistent view marker that assists with the management of concurrent
     /// resource provider updates.

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/list.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/list.rs
@@ -43,7 +43,7 @@ pub struct InventoriesItem {
     #[serde(default)]
     pub min_unit: Option<i32>,
     #[serde(default)]
-    pub reserved: Option<i32>,
+    pub reserved: Option<u32>,
     #[serde(default)]
     pub step_size: Option<i32>,
     pub total: i32,

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/replace.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/replace.rs
@@ -43,7 +43,7 @@ pub struct InventoriesItem {
     #[serde(default)]
     pub min_unit: Option<i32>,
     #[serde(default)]
-    pub reserved: Option<i32>,
+    pub reserved: Option<u32>,
     #[serde(default)]
     pub step_size: Option<i32>,
     pub total: i32,

--- a/openstack_types/src/placement/v1/resource_provider/inventory/response/set.rs
+++ b/openstack_types/src/placement/v1/resource_provider/inventory/response/set.rs
@@ -50,7 +50,7 @@ pub struct InventoryResponse {
     /// The amount of the resource a provider has reserved for its own use.
     #[serde(default)]
     #[structable(optional)]
-    pub reserved: Option<i32>,
+    pub reserved: Option<u32>,
 
     /// A consistent view marker that assists with the management of concurrent
     /// resource provider updates.


### PR DESCRIPTION
The codegenerator has been improved to better respect the integer
constraints and formats present in the openapi. With this we now have a
more correct primitive types (u8, u32, etc) where previously i32 has
been used as a default. This may break users, but is bringing types
closer to reality and what server side really expects.

Changes are triggered by https://review.opendev.org/960402
