### PR TITLE
fix: Fix i32/u32 types in few object-store operations

### DIFF
--- a/openstack_cli/src/object_store/v1/container/list.rs
+++ b/openstack_cli/src/object_store/v1/container/list.rs
@@ -40,7 +40,7 @@ use openstack_sdk::api::{Pagination, paged};
 pub struct ContainersCommand {
     /// For an integer value n, limits the number of results to n.
     #[arg(long)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// For a string value, x, constrains the list to items whose names are
     /// greater than x.

--- a/openstack_cli/src/object_store/v1/object/list.rs
+++ b/openstack_cli/src/object_store/v1/object/list.rs
@@ -60,7 +60,7 @@ pub struct ObjectsCommand {
 
     /// For an integer value n, limits the number of results to n.
     #[arg(long)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// For a string value, x, constrains the list to items whose names are
     /// greater than x.

--- a/openstack_sdk/src/api/object_store/v1/account/get.rs
+++ b/openstack_sdk/src/api/object_store/v1/account/get.rs
@@ -57,7 +57,7 @@ pub struct Request<'a> {
 
     /// For an integer value n, limits the number of results to n.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// For a string value, x, constrains the list to items whose names are
     /// greater than x.

--- a/openstack_sdk/src/api/object_store/v1/container/get.rs
+++ b/openstack_sdk/src/api/object_store/v1/container/get.rs
@@ -71,7 +71,7 @@ pub struct Request<'a> {
 
     /// For an integer value n, limits the number of results to n.
     #[builder(default)]
-    limit: Option<i32>,
+    limit: Option<u32>,
 
     /// For a string value, x, constrains the list to items whose names are
     /// greater than x.

--- a/openstack_types/src/object_store/v1/account/response/get.rs
+++ b/openstack_types/src/object_store/v1/account/response/get.rs
@@ -26,12 +26,12 @@ pub struct AccountResponse {
     /// account.
     #[serde(default)]
     #[structable(optional)]
-    pub bytes: Option<i64>,
+    pub bytes: Option<u64>,
 
     /// The number of objects in the container.
     #[serde(default)]
     #[structable(optional)]
-    pub count: Option<i64>,
+    pub count: Option<u32>,
 
     /// Last modification date of the container
     #[serde(default)]

--- a/openstack_types/src/object_store/v1/container/response/get.rs
+++ b/openstack_types/src/object_store/v1/container/response/get.rs
@@ -26,7 +26,7 @@ pub struct ContainerResponse {
     /// container.
     #[serde(default)]
     #[structable(optional)]
-    pub bytes: Option<i64>,
+    pub bytes: Option<u64>,
 
     /// The content type of the object.
     #[serde(default)]


### PR DESCRIPTION
codegenerator has been improved to respect integer constraints. When
minimum is set to 0 the resulting type would be unsigned.
