### PR TITLE
feat: Enable `OS_CLIENT_CONFIG_PATH` environment variable

### DIFF
--- a/doc/src/auth.md
+++ b/doc/src/auth.md
@@ -39,6 +39,22 @@ Rust based tools support typical
 [`clouds.yaml`/`secure.yaml`](https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html)
 files for configuration.
 
+Using traditional configuration files may become challenging when many
+connections need to be configured. For example there might be few lists of
+connections from different providers, some of them may be distributed through
+source control. It is possible to simplify such situation and let them be merged
+together into the single "virtual" configuration instead of explicitly
+specifying them as runtime parameters. The `OS_CLIENT_CONFIG_PATH` environment
+variable can point at a single file or list of files and directories.
+
+```console
+export OS_CLIENT_CONFIG_PATH=./clouds.yaml:~/.config/clouds1.yaml:~/.config/clouds2.yaml:~/.config/secure.yaml:~/.config/openstack/"
+```
+Being set like that every tool of the project will merge all individual elements
+together. When an entry is a directory traditionally `clouds.yaml`/`secure.yaml`
+files are being searched in the directory and merged into the resulting
+configuration.
+
 Most authentication methods support interactive data provisioning. When certain
 required auth attributes are not provided in the configuration file or through
 the supported cli arguments (or environment variables) clients that implement


### PR DESCRIPTION
In a way similar to `KUBECONFIG` environment variable add possibility to
predefine locations at which configurations are searched and all merged
into the single "virtual" config.

```
export
OS_CLIENT_CONFIG_PATH=c1.yaml:~/.config/openstack/c3.yaml:/etc/openstack/secure.yaml"
```

When entry point to the file it is tried to be parsed as is. When an
entry is a directory a regular clouds.yaml/secure.yaml files are being
searched in it.
