### PR TITLE
feat: Refetch object-storage resources

### DIFF
--- a/openstack_cli/src/object_store/v1/account/show.rs
+++ b/openstack_cli/src/object_store/v1/account/show.rs
@@ -21,14 +21,13 @@
 use bytes::Bytes;
 use clap::Args;
 use http::Response;
-
-use serde::{Deserialize, Serialize};
+use regex::Regex;
+use std::collections::HashMap;
 use tracing::info;
 
 use crate::Cli;
 use crate::OpenStackCliError;
 use crate::output::OutputProcessor;
-use structable::{StructTable, StructTableOptions};
 
 use openstack_sdk::{
     AsyncOpenStack,
@@ -39,8 +38,6 @@ use openstack_sdk::{
 use crate::common::HashMapStringString;
 use openstack_sdk::api::RawQueryAsync;
 use openstack_sdk::api::object_store::v1::account::head::Request;
-use regex::Regex;
-use std::collections::HashMap;
 
 /// Shows metadata for an account.
 /// Because the storage system can store large amounts of data, take care when
@@ -50,13 +47,6 @@ use std::collections::HashMap;
 /// Do not include metadata headers in this request.
 #[derive(Args, Clone, Debug)]
 pub struct AccountCommand {}
-
-/// Account
-#[derive(Deserialize, Debug, Clone, Serialize, StructTable)]
-pub struct Account {
-    #[structable(title = "metadata")]
-    metadata: HashMapStringString,
-}
 
 impl AccountCommand {
     /// Perform command action
@@ -129,11 +119,9 @@ impl AccountCommand {
                 }
             }
         }
-        let data = Account {
-            metadata: metadata.into(),
-        };
-        // Maybe output some headers metadata
-        op.output_human::<Account>(&data)?;
+        let data = HashMapStringString(metadata);
+
+        op.output_single::<HashMapStringString>(serde_json::to_value(&data)?)?;
         op.show_command_hint()?;
         Ok(())
     }

--- a/openstack_cli/src/object_store/v1/container/create.rs
+++ b/openstack_cli/src/object_store/v1/container/create.rs
@@ -19,14 +19,13 @@
 use bytes::Bytes;
 use clap::Args;
 use http::Response;
-
-use serde::{Deserialize, Serialize};
+use regex::Regex;
+use std::collections::HashMap;
 use tracing::info;
 
 use crate::Cli;
 use crate::OpenStackCliError;
 use crate::output::OutputProcessor;
-use structable::{StructTable, StructTableOptions};
 
 use openstack_sdk::{
     AsyncOpenStack,
@@ -34,8 +33,10 @@ use openstack_sdk::{
     types::{ApiVersion, ServiceType},
 };
 
+use crate::common::HashMapStringString;
 use openstack_sdk::api::RawQueryAsync;
 use openstack_sdk::api::object_store::v1::container::create::Request;
+use openstack_sdk::api::object_store::v1::container::head::Request as GetRequest;
 
 /// Creates a container.
 /// You do not need to check whether a container already exists before issuing
@@ -53,10 +54,6 @@ pub struct ContainerCommand {
     #[arg()]
     container: String,
 }
-
-/// Container
-#[derive(Deserialize, Debug, Clone, Serialize, StructTable)]
-pub struct Container {}
 
 impl ContainerCommand {
     /// Perform command action
@@ -92,9 +89,62 @@ impl ContainerCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
-        let data = Container {};
-        // Maybe output some headers metadata
-        op.output_human::<Container>(&data)?;
+
+        let mut ep_builder = GetRequest::builder();
+        if let Some(account) = account {
+            ep_builder.account(account);
+        }
+        ep_builder.container(&self.container);
+        // Set query parameters
+        // Set body parameters
+        let ep = ep_builder
+            .build()
+            .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+        let rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+
+        let mut metadata: HashMap<String, String> = HashMap::new();
+        let headers = rsp.headers();
+
+        let regexes: Vec<Regex> = vec![Regex::new(r"(?i)X-Container-Meta-\.*").unwrap()];
+
+        for (hdr, val) in headers.iter() {
+            if [
+                "x-timestamp",
+                "x-container-bytes-used",
+                "x-container-object-count",
+                "accept-ranges",
+                "x-container-meta-temp-url-key",
+                "x-container-meta-temp-url-key-2",
+                "x-container-meta-quota-count",
+                "x-container-meta-quota-bytes",
+                "x-storage-policy",
+                "x-container-read",
+                "x-container-write",
+                "x-container-sync-key",
+                "x-container-sync-to",
+                "x-versions-location",
+                "x-history-location",
+            ]
+            .contains(&hdr.as_str())
+            {
+                metadata.insert(
+                    hdr.to_string(),
+                    val.to_str().unwrap_or_default().to_string(),
+                );
+            } else if !regexes.is_empty() {
+                for rex in regexes.iter() {
+                    if rex.is_match(hdr.as_str()) {
+                        metadata.insert(
+                            hdr.to_string(),
+                            val.to_str().unwrap_or_default().to_string(),
+                        );
+                    }
+                }
+            }
+        }
+        let data = HashMapStringString(metadata);
+
+        op.output_single::<HashMapStringString>(serde_json::to_value(&data)?)?;
         op.show_command_hint()?;
         Ok(())
     }

--- a/openstack_cli/src/object_store/v1/container/show.rs
+++ b/openstack_cli/src/object_store/v1/container/show.rs
@@ -17,14 +17,13 @@
 use bytes::Bytes;
 use clap::Args;
 use http::Response;
-
-use serde::{Deserialize, Serialize};
+use regex::Regex;
+use std::collections::HashMap;
 use tracing::info;
 
 use crate::Cli;
 use crate::OpenStackCliError;
 use crate::output::OutputProcessor;
-use structable::{StructTable, StructTableOptions};
 
 use openstack_sdk::{
     AsyncOpenStack,
@@ -35,8 +34,6 @@ use openstack_sdk::{
 use crate::common::HashMapStringString;
 use openstack_sdk::api::RawQueryAsync;
 use openstack_sdk::api::object_store::v1::container::head::Request;
-use regex::Regex;
-use std::collections::HashMap;
 
 /// Shows container metadata, including the number of objects and the total
 /// bytes of all objects stored in the container.
@@ -51,13 +48,6 @@ pub struct ContainerCommand {
     /// container.
     #[arg()]
     container: String,
-}
-
-/// Container
-#[derive(Deserialize, Debug, Clone, Serialize, StructTable)]
-pub struct Container {
-    #[structable(title = "metadata")]
-    metadata: HashMapStringString,
 }
 
 impl ContainerCommand {
@@ -134,11 +124,9 @@ impl ContainerCommand {
                 }
             }
         }
-        let data = Container {
-            metadata: metadata.into(),
-        };
-        // Maybe output some headers metadata
-        op.output_human::<Container>(&data)?;
+        let data = HashMapStringString(metadata);
+
+        op.output_single::<HashMapStringString>(serde_json::to_value(&data)?)?;
         op.show_command_hint()?;
         Ok(())
     }

--- a/openstack_cli/src/tracing_stats.rs
+++ b/openstack_cli/src/tracing_stats.rs
@@ -94,7 +94,7 @@ impl Visit for HttpRequest {
             _ => {}
         };
     }
-    fn record_debug(&mut self, _: &Field, _: &dyn (core::fmt::Debug)) {}
+    fn record_debug(&mut self, _: &Field, _: &dyn core::fmt::Debug) {}
 }
 
 impl<C> Layer<C> for RequestTracingCollector


### PR DESCRIPTION
Refetch the resources (account/container) on create/set operations to
return the same what the show command would return.

Drop the orphan types that were used before the structtable was
extended. Since object-store commands still rely on one of those types
reimplement it with the new interface streamlining (at least partially)
the output processing.
