### PR TITLE
feat: add socks feature to reqwest

### DIFF
--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -66,7 +66,7 @@ lazy_static = { workspace = true }
 open.workspace = true
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["gzip", "deflate", "http2",
-  "system-proxy"] }
+  "socks", "system-proxy"] }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { workspace = true }
 serde_json = {workspace = true}


### PR DESCRIPTION
I need to use a socks proxy, e.g.

export https_proxy=socks5h://127.0.0.1:1239
export HTTP_PROXY=socks5h://127.0.0.1:1239

and this commit adds that functionality.

See https://docs.rs/reqwest/latest/reqwest/#optional-features for reqwest features.