### PR TITLE
chore: Ease code contributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - name: Rust Cache
-        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
-
       - name: Run tests
         run: cargo nextest run ${{ matrix.test_args }} --all-features
 
@@ -88,9 +85,6 @@ jobs:
         with:
           toolchain: nightly
 
-      - name: Rust Cache
-        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
-
       - name: Install cargo-fuzz
         run: |
           cargo install cargo-fuzz
@@ -101,15 +95,17 @@ jobs:
   mock:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
         with:
           toolchain: stable
-
-      - name: Rust Cache
-        uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
       - name: Start prism mock server - BlockStorage
         run: |

--- a/.github/workflows/committed.yml
+++ b/.github/workflows/committed.yml
@@ -1,9 +1,11 @@
 # Not run as part of pre-commit checks because they don't handle sending the correct commit
 # range to `committed`
 name: Lint Commits
-on: [pull_request]
+on:
+  pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   RUST_BACKTRACE: 1
@@ -16,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Harden Runner
-      uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
 
-    - name: Checkout Actions Repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        fetch-depth: 0
+      - name: Checkout Actions Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
 
-    - name: Lint Commits
-      uses: crate-ci/committed@15229711f8f597474c0b636f327cde5969f9a529 # v1.1.7
+      - name: Lint Commits
+        uses: crate-ci/committed@15229711f8f597474c0b636f327cde5969f9a529 # v1.1.7

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -44,33 +44,34 @@ jobs:
           toolchain: stable
           components: rustfmt
 
-      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
-
       - name: Run rustfmt
         run: cargo fmt -- --check
 
   clippy:
     name: Run clippy on the minimum supported toolchain
     runs-on: ubuntu-latest
+    # reduce job-level privileges so this job can run for forked PRs without requiring maintainer approval
     permissions:
       contents: read
-      security-events: write
     steps:
-
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Ensure bash is installed
+        run: sudo apt-get update && sudo apt-get install -y bash
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable
         with:
           toolchain: stable
           components: rustfmt, clippy
-
-      - uses: swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
 
       - name: Install cargo-binstall
         uses: taiki-e/install-action@f37a1e4d34f3e1c6a571e294b0258f2805eab48d # v2.58.4
@@ -87,6 +88,39 @@ jobs:
           --all-features
           --message-format=json | ${CARGO_HOME}/bin/clippy-sarif | tee rust-clippy-results.sarif | ${CARGO_HOME}/bin/sarif-fmt
 
+      - name: Upload SARIF as artifact (so a separate, trusted job can upload to GitHub)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: rust-clippy-results
+          path: rust-clippy-results.sarif
+
+  upload-sarif:
+    name: Upload CodeQL results
+    needs: clippy
+    runs-on: ubuntu-latest
+    # grant the write permission only to this job (trusted execution)
+    permissions:
+      contents: read
+      security-events: write
+    # Only run the upload step for trusted contexts:
+    # - pushes (e.g. push to main)
+    # - pull requests whose head repo is not a fork (i.e. runs from trusted repository)
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) }}
+    steps:
+
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Download SARIF artifact
+        uses: actions/download-artifact@abefc31eafcfbdf6c5336127c1346fdae79ff41c # v5.0.0
+        with:
+          name: rust-clippy-results
+          path: .
+
       - name: Upload analysis results to GitHub
         uses: github/codeql-action/upload-sarif@2d92b76c45b91eb80fc44c74ce3fce0ee94e8f9d # v3.30.0
         with:
@@ -97,15 +131,15 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-      with:
-        egress-policy: audit
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
 
-    - name: Checkout Actions Repository
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Checkout Actions Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-    - name: Check spelling of file.txt
-      uses: crate-ci/typos@7436548694def3314aacd93ed06c721b1f91ea04 # v1.37.2
-      with:
-        config: typos.toml
+      - name: Check for typos
+        uses: crate-ci/typos@7436548694def3314aacd93ed06c721b1f91ea04 # v1.37.2
+        with:
+          config: typos.toml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,12 @@ if you have an idea how generated code can be improved open an issue or discussi
   fixed upstream. The only exception is that during code generation spelling
   issues are automatically addressed by `typos -w`.
 
+- Merge commits are forbidden. Whenever you open a PR please update it with
+  rebase and not a merge commit. It is also recommended to "allow edits from
+  maintainers" to help us get the quick fixes to the PR.
+
+- PRs are merged as squash commits.
+
 ## Releasing
 
 There are 2 projects being used to take care of release process:


### PR DESCRIPTION
- Add few more statements to the contributions guide.
- Make ci/committed/lintes workflows run without waiting for approval.
