### PR TITLE
chore: Dump glance log on functest failure

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -78,3 +78,7 @@ jobs:
         env:
           OS_CLOUD: devstack
         run: cargo nextest run --test functional
+
+      - name: Dump glance logs on failure
+        if: failure()
+        run: journalctl -u devstack@g-api --no-pager


### PR DESCRIPTION
Failures in glance happen to often. To help identify the issue dump the
api logs when the job fails.
