### PR TITLE
fix: Patch the neutron.network.l2_adjacency type with no hints

### DIFF
--- a/openstack_types/data/network/v2.27.yaml
+++ b/openstack_types/data/network/v2.27.yaml
@@ -15823,7 +15823,7 @@ components:
               description: |-
                 Indicates whether L2 connectivity is available throughout
                 the `network`.
-              type: string
+              type: boolean
             mtu:
               description: |-
                 The maximum transmission unit (MTU) value to
@@ -16129,7 +16129,7 @@ components:
               description: |-
                 Indicates whether L2 connectivity is available throughout
                 the `network`.
-              type: string
+              type: boolean
             mtu:
               description: |-
                 The maximum transmission unit (MTU) value to
@@ -16946,7 +16946,7 @@ components:
               description: |-
                 Indicates whether L2 connectivity is available throughout
                 the `network`.
-              type: string
+              type: boolean
             mtu:
               description: |-
                 The maximum transmission unit (MTU) value to
@@ -17161,7 +17161,7 @@ components:
                 description: |-
                   Indicates whether L2 connectivity is available throughout
                   the `network`.
-                type: string
+                type: boolean
               mtu:
                 description: |-
                   The maximum transmission unit (MTU) value to

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -15823,7 +15823,7 @@ components:
               description: |-
                 Indicates whether L2 connectivity is available throughout
                 the `network`.
-              type: string
+              type: boolean
             mtu:
               description: |-
                 The maximum transmission unit (MTU) value to
@@ -16129,7 +16129,7 @@ components:
               description: |-
                 Indicates whether L2 connectivity is available throughout
                 the `network`.
-              type: string
+              type: boolean
             mtu:
               description: |-
                 The maximum transmission unit (MTU) value to
@@ -16946,7 +16946,7 @@ components:
               description: |-
                 Indicates whether L2 connectivity is available throughout
                 the `network`.
-              type: string
+              type: boolean
             mtu:
               description: |-
                 The maximum transmission unit (MTU) value to
@@ -17161,7 +17161,7 @@ components:
                 description: |-
                   Indicates whether L2 connectivity is available throughout
                   the `network`.
-                type: string
+                type: boolean
               mtu:
                 description: |-
                   The maximum transmission unit (MTU) value to

--- a/openstack_types/src/network/v2/network/response/create.rs
+++ b/openstack_types/src/network/v2/network/response/create.rs
@@ -77,7 +77,7 @@ pub struct NetworkResponse {
     /// `network`.
     #[serde(default)]
     #[structable(optional)]
-    pub l2_adjacency: Option<String>,
+    pub l2_adjacency: Option<bool>,
 
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.

--- a/openstack_types/src/network/v2/network/response/get.rs
+++ b/openstack_types/src/network/v2/network/response/get.rs
@@ -77,7 +77,7 @@ pub struct NetworkResponse {
     /// `network`.
     #[serde(default)]
     #[structable(optional)]
-    pub l2_adjacency: Option<String>,
+    pub l2_adjacency: Option<bool>,
 
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.

--- a/openstack_types/src/network/v2/network/response/list.rs
+++ b/openstack_types/src/network/v2/network/response/list.rs
@@ -77,7 +77,7 @@ pub struct NetworkResponse {
     /// `network`.
     #[serde(default)]
     #[structable(optional, wide)]
-    pub l2_adjacency: Option<String>,
+    pub l2_adjacency: Option<bool>,
 
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.

--- a/openstack_types/src/network/v2/network/response/set.rs
+++ b/openstack_types/src/network/v2/network/response/set.rs
@@ -77,7 +77,7 @@ pub struct NetworkResponse {
     /// `network`.
     #[serde(default)]
     #[structable(optional)]
-    pub l2_adjacency: Option<String>,
+    pub l2_adjacency: Option<bool>,
 
     /// The maximum transmission unit (MTU) value to address fragmentation.
     /// Minimum value is 68 for IPv4, and 1280 for IPv6.


### PR DESCRIPTION
The attribute is a boolean, but the code does not have a single hint
available about that.

Change-Id: I9c8fb00350e13c61ab7f93e67c1b5502a0c9633b
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/963928
