### PR TITLE
fix: Disable all-features in build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,12 +122,6 @@ jobs:
         uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921 # stable
         with:
           toolchain: stable
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev
-
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
@@ -198,10 +192,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev
       - uses: actions/checkout@v5
         with:
           persist-credentials: false

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -3,7 +3,7 @@ members = ["cargo:."]
 
 # Config for 'dist'
 [dist]
-all-features = true
+all-features = false
 # Skip checking whether the specified configuration files are up to date
 allow-dirty = ["ci"]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
@@ -17,7 +17,7 @@ cargo-auditable = true
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "plan"
+pr-run-mode = "upload"
 # Whether dist should create a Github Release or use an existing draft
 create-release = false
 # Whether to install an updater program


### PR DESCRIPTION
We cannot build artifacts with all features without adding dependencies
to runners. It is not trivial to do so, thus temporarily disable.
