### PR TITLE
fix: Do not stop version discovery on unreachable url

### DIFF
--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -434,21 +434,34 @@ impl OpenStack {
                         .method(http::Method::GET)
                         .uri(query::url_to_http_uri(try_url.clone()));
 
-                    let rsp = self.rest_with_auth(req, Vec::new(), &self.auth)?;
-                    if rsp.status() != StatusCode::NOT_FOUND
-                        && self
-                            .catalog
-                            .process_endpoint_discovery(
-                                service_type,
-                                &try_url,
-                                rsp.body(),
-                                self.config.region_name.as_ref(),
-                            )
-                            .is_ok()
-                    {
-                        debug!("Finished service version discovery at {}", try_url.as_str());
-                        return Ok(());
-                    }
+                    match self.rest_with_auth(req, Vec::new(), &self.auth) {
+                        Ok(rsp) => {
+                            if rsp.status() != StatusCode::NOT_FOUND
+                                && self
+                                    .catalog
+                                    .process_endpoint_discovery(
+                                        service_type,
+                                        &try_url,
+                                        rsp.body(),
+                                        self.config.region_name.as_ref(),
+                                    )
+                                    .is_ok()
+                            {
+                                debug!(
+                                    "Finished service version discovery at {}",
+                                    try_url.as_str()
+                                );
+                                return Ok(());
+                            }
+                        }
+                        Err(err) => {
+                            error!(
+                                "Error querying {} for the version discovery. It is most likely a misconfiguration on the cloud side. {}",
+                                try_url.as_str(),
+                                err
+                            );
+                        }
+                    };
                     if try_url.path() != "/" {
                         // We are not at the root yet and have not found a
                         // valid version document so far, try one level up


### PR DESCRIPTION
Certain misconfigurations in the cloud may lead to version discovery
process to crash. Instead we should only log the error and treat it the
same way as for 404.

Fixes: #1494
