### PR TITLE
chore: Raise a warn for `expect` and `unwrap` use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,6 @@ lto = "thin"
 
 [workspace.lints.clippy]
 result_large_err = "allow"
+unwrap_used = "warn"
+expect_used = "warn"
+enum_glob_use = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true


### PR DESCRIPTION
In order to be able to get rid of unwrap and expect (forbid the as such) lot of changes in the code are necessary including the generated code. For now just start to raise a warning helping to see what should be addressed.