### PR TITLE
fix: Add libudev-dev to the clippy test

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Additional dependency is necessary for the clippy, or actually for our
project when running clippy.
