### PR TITLE
chore: Disable building artifacts with every PR

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,7 +17,7 @@ cargo-auditable = true
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # Whether dist should create a Github Release or use an existing draft
 create-release = false
 # Whether to install an updater program


### PR DESCRIPTION
It was necessary at some point in time and is not now. It also makes
jobs to take very long, so disable it again.
