### PR TITLE
feat: Make `Findable` trait using `Result` consistently

### DIFF
--- a/openstack_sdk/src/api/block_storage/v3/backup/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/backup/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate backup in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/group/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate group in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/group_snapshot/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group_snapshot/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate group_snapshot in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/group_type/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/group_type/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate group_type in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/os_volume_transfer/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/os_volume_transfer/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate os_volume_transfer in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/qos_spec/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/qos_spec/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate qos_spec in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/snapshot/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/snapshot/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate snapshot in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/type/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/type/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate type in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/volume/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate volume in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/block_storage/v3/volume_transfer/find.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume_transfer/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate volume_transfer in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/compute/v2/aggregate/find.rs
+++ b/openstack_sdk/src/api/compute/v2/aggregate/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate aggregate in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/compute/v2/flavor/find.rs
+++ b/openstack_sdk/src/api/compute/v2/flavor/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate flavor in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/compute/v2/keypair/find.rs
+++ b/openstack_sdk/src/api/compute/v2/keypair/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate keypair in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/compute/v2/server/find.rs
+++ b/openstack_sdk/src/api/compute/v2/server/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::compute::v2::server::{get as Get, list_detailed as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/compute/v2/server_group/find.rs
+++ b/openstack_sdk/src/api/compute/v2/server_group/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate server_group in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/container_infrastructure_management/v1/cluster/nodegroup/find.rs
+++ b/openstack_sdk/src/api/container_infrastructure_management/v1/cluster/nodegroup/find.rs
@@ -75,20 +75,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate cluster/nodegroup in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/dns/v2/zone/find.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::dns::v2::zone::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/dns/v2/zone/recordset/find.rs
+++ b/openstack_sdk/src/api/dns/v2/zone/recordset/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::dns::v2::zone::recordset::{get as Get, list as List};
 
@@ -73,22 +74,23 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         ep.zone_id(self.zone_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         ep.zone_id(self.zone_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/error.rs
+++ b/openstack_sdk/src/api/error.rs
@@ -166,6 +166,13 @@ where
         /// The source of the error.
         context: String,
     },
+
+    /// Endpoint builder error.
+    #[error("endpoint builder error: {}", message)]
+    EndpointBuilder {
+        /// The error message,
+        message: String,
+    },
 }
 
 impl<E> ApiError<E>
@@ -275,6 +282,13 @@ where
     pub(crate) fn poisoned_lock<CTX: AsRef<str>>(context: CTX) -> Self {
         ApiError::PoisonedLock {
             context: context.as_ref().into(),
+        }
+    }
+
+    /// Create EndpointBuilder error with the message.
+    pub(crate) fn endpoint_builder<EX: Error + Send>(error: EX) -> Self {
+        ApiError::EndpointBuilder {
+            message: error.to_string(),
         }
     }
 }

--- a/openstack_sdk/src/api/identity/v3/domain/find.rs
+++ b/openstack_sdk/src/api/identity/v3/domain/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::identity::v3::domain::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/identity/v3/group/find.rs
+++ b/openstack_sdk/src/api/identity/v3/group/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate group in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/identity/v3/project/find.rs
+++ b/openstack_sdk/src/api/identity/v3/project/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::identity::v3::project::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/identity/v3/role/find.rs
+++ b/openstack_sdk/src/api/identity/v3/role/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate role in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/identity/v3/service/find.rs
+++ b/openstack_sdk/src/api/identity/v3/service/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate service in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/identity/v3/user/access_rule/find.rs
+++ b/openstack_sdk/src/api/identity/v3/user/access_rule/find.rs
@@ -76,22 +76,22 @@ where {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: crate::api::RestClient>(&self) -> Result<Get::Request<'a>, crate::api::ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         ep.user_id(self.user_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(|err| ApiError::endpoint_builder(err))
     }
-    fn list_ep(&self) -> List::Request<'a> {
+    fn list_ep<C: crate::api::RestClient>(&self) -> Result<List::Request<'a>, crate::api::ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         ep.user_id(self.user_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(|err| ApiError::endpoint_builder(err))
     }
     /// Locate user/access_rule in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/identity/v3/user/application_credential/find.rs
+++ b/openstack_sdk/src/api/identity/v3/user/application_credential/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::identity::v3::user::application_credential::{get as Get, list as List};
 
@@ -73,22 +74,23 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         ep.user_id(self.user_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         ep.user_id(self.user_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/identity/v3/user/find.rs
+++ b/openstack_sdk/src/api/identity/v3/user/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::identity::v3::user::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/image/v2/image/find.rs
+++ b/openstack_sdk/src/api/image/v2/image/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::image::v2::image::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/availability_zone_profile/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/availability_zone_profile/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::availability_zone_profile::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/flavor/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/flavor/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::flavor::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/flavor_profile/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/flavor_profile/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::flavor_profile::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/healthmonitor/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/healthmonitor/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::healthmonitor::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/l7policy/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/l7policy/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::l7policy::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/listener/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/listener/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::listener::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/loadbalancer/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/loadbalancer/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::loadbalancer::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/pool/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/pool/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::pool::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/load_balancer/v2/pool/member/find.rs
+++ b/openstack_sdk/src/api/load_balancer/v2/pool/member/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::load_balancer::v2::pool::member::{get as Get, list as List};
 
@@ -73,22 +74,23 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         ep.pool_id(self.pool_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         ep.pool_id(self.pool_id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/address_group/find.rs
+++ b/openstack_sdk/src/api/network/v2/address_group/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::address_group::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/address_scope/find.rs
+++ b/openstack_sdk/src/api/network/v2/address_scope/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::address_scope::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/flavor/find.rs
+++ b/openstack_sdk/src/api/network/v2/flavor/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::flavor::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/local_ip/find.rs
+++ b/openstack_sdk/src/api/network/v2/local_ip/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::local_ip::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/log/log/find.rs
+++ b/openstack_sdk/src/api/network/v2/log/log/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::log::log::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/ndp_proxy/find.rs
+++ b/openstack_sdk/src/api/network/v2/ndp_proxy/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::ndp_proxy::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/network/find.rs
+++ b/openstack_sdk/src/api/network/v2/network/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::network::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/network_segment_range/find.rs
+++ b/openstack_sdk/src/api/network/v2/network_segment_range/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::network_segment_range::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/port/find.rs
+++ b/openstack_sdk/src/api/network/v2/port/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::port::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/qos/policy/find.rs
+++ b/openstack_sdk/src/api/network/v2/qos/policy/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::qos::policy::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/router/find.rs
+++ b/openstack_sdk/src/api/network/v2/router/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::router::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/security_group/find.rs
+++ b/openstack_sdk/src/api/network/v2/security_group/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::security_group::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/segment/find.rs
+++ b/openstack_sdk/src/api/network/v2/segment/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::segment::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/subnet/find.rs
+++ b/openstack_sdk/src/api/network/v2/subnet/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::subnet::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/subnetpool/find.rs
+++ b/openstack_sdk/src/api/network/v2/subnetpool/find.rs
@@ -19,6 +19,7 @@ use http::{HeaderMap, HeaderName, HeaderValue};
 
 use crate::api::find::Findable;
 use crate::api::rest_endpoint_prelude::*;
+use crate::api::{ApiError, RestClient};
 
 use crate::api::network::v2::subnetpool::{get as Get, list as List};
 
@@ -71,20 +72,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
         ep.name(self.id.clone());
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
 }

--- a/openstack_sdk/src/api/network/v2/vpn/endpoint_group/find.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/endpoint_group/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate vpn/endpoint_group in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/network/v2/vpn/ikepolicy/find.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ikepolicy/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate vpn/ikepolicy in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/find.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsec_site_connection/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate vpn/ipsec_site_connection in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/find.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/ipsecpolicy/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate vpn/ipsecpolicy in a list
     fn locate_resource_in_list<C: RestClient>(

--- a/openstack_sdk/src/api/network/v2/vpn/vpnservice/find.rs
+++ b/openstack_sdk/src/api/network/v2/vpn/vpnservice/find.rs
@@ -73,20 +73,21 @@ impl<'a> RequestBuilder<'a> {
 impl<'a> Findable for Request<'a> {
     type G = Get::Request<'a>;
     type L = List::Request<'a>;
-    fn get_ep(&self) -> Get::Request<'a> {
+    fn get_ep<C: RestClient>(&self) -> Result<Get::Request<'a>, ApiError<C::Error>> {
         let mut ep = Get::Request::builder();
         ep.id(self.id.clone());
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
-    fn list_ep(&self) -> List::Request<'a> {
+
+    fn list_ep<C: RestClient>(&self) -> Result<List::Request<'a>, ApiError<C::Error>> {
         let mut ep = List::Request::builder();
         if let Some(headers) = &self._headers {
             ep.headers(headers.iter().map(|(k, v)| (Some(k.clone()), v.clone())));
         }
-        ep.build().unwrap()
+        ep.build().map_err(ApiError::endpoint_builder)
     }
     /// Locate vpn/vpnservice in a list
     fn locate_resource_in_list<C: RestClient>(


### PR DESCRIPTION
In the `Findable` trait two methods (`get_ep`, `list_ep`) can
technically error. At the moment they use `unwrap` and `expect` so the
app can crash in runtime. Eliminate them.
