### PR TITLE
feat: Replace unwrap in `api_version` and `xtask`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,6 @@ dependencies = [
  "hyper-util",
  "itertools 0.14.0",
  "json-patch",
- "lazy_static",
  "open",
  "regex",
  "reqwest",
@@ -4497,7 +4496,6 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "clap",
- "lazy_static",
  "mdbook",
  "openstack_cli",
  "regex",

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -62,7 +62,6 @@ hyper = { version = "^1.7", features = ["full"] }
 hyper-util = { version = "^0.1", features = ["full"] }
 itertools = { workspace = true }
 json-patch = { workspace = true }
-lazy_static = { workspace = true }
 open.workspace = true
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["gzip", "deflate", "http2",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,7 +11,6 @@ openstack_cli = { path="../openstack_cli" }
 mdbook = { version = "^0.4", default-features = false }
 serde_json = { workspace = true }
 semver = { version = "^1.0" }
-lazy_static = { workspace = true }
 regex = { workspace = true }
 
 [package.metadata.dist]


### PR DESCRIPTION
Replace use of `unwrap` for Regex initialization in the `ApiVersion` at
the same time replacing the `lazy_static` with the
`std::sync::OnceLock`. This removes use of `lazy_static` from the sdk.
Apply similar approach in the `xtask`.
