### PR TITLE
feat: Clean use of `uwrap` and `expect` in `openstack_sdk`

### DIFF
--- a/openstack_sdk/src/api/error.rs
+++ b/openstack_sdk/src/api/error.rs
@@ -160,6 +160,7 @@ where
         #[from]
         source: crate::catalog::CatalogError,
     },
+
     /// Poisoned guard lock in the internal processing.
     #[error("internal error: poisoned lock: {}", context)]
     PoisonedLock {
@@ -172,6 +173,23 @@ where
     EndpointBuilder {
         /// The error message,
         message: String,
+    },
+
+    /// Invalid response header.
+    #[error("invalid header {}: {}", header, message)]
+    InvalidHeader {
+        /// The error message,
+        header: String,
+        /// The error message,
+        message: String,
+    },
+
+    /// Invalid URL.
+    #[error("invalid url: {}", source)]
+    InvalidUri {
+        /// The source of the error.
+        #[from]
+        source: http::uri::InvalidUri,
     },
 }
 

--- a/openstack_sdk/src/api/paged.rs
+++ b/openstack_sdk/src/api/paged.rs
@@ -131,7 +131,7 @@ where
 
             let mut req = Request::builder()
                 .method(self.endpoint.method())
-                .uri(query::url_to_http_uri(page_url.clone()))
+                .uri(query::url_to_http_uri(page_url.clone())?)
                 .header(header::ACCEPT, HeaderValue::from_static("application/json"));
             set_latest_microversion(&mut req, ep, &self.endpoint);
             // Set endpoint headers

--- a/openstack_sdk/src/api/query.rs
+++ b/openstack_sdk/src/api/query.rs
@@ -12,7 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use http::Uri;
+use http::{uri::InvalidUri, Uri};
 
 use url::Url;
 
@@ -29,10 +29,8 @@ use crate::api::Client;
 use crate::types::BoxedAsyncRead;
 use http::{HeaderMap, Response};
 
-pub fn url_to_http_uri(url: Url) -> Uri {
-    url.as_str()
-        .parse::<Uri>()
-        .expect("failed to parse a url::Url as an http::Uri")
+pub fn url_to_http_uri(url: Url) -> Result<Uri, InvalidUri> {
+    url.as_str().parse::<Uri>()
 }
 
 /// A trait which represents a query which may be made to a OpenStack

--- a/openstack_sdk/src/auth.rs
+++ b/openstack_sdk/src/auth.rs
@@ -48,28 +48,41 @@ use authtoken_scope::AuthTokenScopeError;
 use v3oidcaccesstoken::OidcAccessTokenError;
 use v3websso::WebSsoError;
 
-/// Authentication error
+/// Authentication error.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum AuthError {
-    /// Header error
+    /// Header error.
     #[error("header value error: {}", source)]
     HeaderValue {
-        /// Error source
+        /// The source of the error.
         #[from]
         source: http::header::InvalidHeaderValue,
     },
 
-    /// AuthToken error
+    /// AuthToken error.
     #[error("AuthToken error: {}", source)]
     AuthToken {
-        /// Error source
+        /// The source of the error.
         #[from]
         source: AuthTokenError,
     },
 
+    /// Token is missing in the authentication response.
     #[error("token missing in the response")]
     AuthTokenNotInResponse,
+
+    /// X-Subject-Token cannot be converted to string.
+    #[error("token missing cannot be converted to string")]
+    AuthTokenNotString,
+
+    /// (De)Serialization error.
+    #[error("failed to deserialize response body: {}", source)]
+    DeserializeResponse {
+        /// The source of the error.
+        #[from]
+        source: serde_json::Error,
+    },
 }
 
 // Explicitly implement From to easier propagate nested errors

--- a/openstack_sdk/src/error.rs
+++ b/openstack_sdk/src/error.rs
@@ -167,12 +167,29 @@ pub enum OpenStackError {
         #[from]
         source: serde_json::Error,
     },
-    /// IO error.
-    #[error("IO error: {}\n\tPath: {}", source, path)]
+
+    /// General IO error.
+    #[error("general IO error: {}", source)]
     IO {
+        /// The source of the error.
+        #[from]
+        source: std::io::Error,
+    },
+
+    /// IO error with associated with path processing.
+    #[error("IO error: {}\n\tPath: {}", source, path)]
+    IOWithPath {
         /// The source of the error.
         source: std::io::Error,
         path: String,
+    },
+
+    /// Invalid URL.
+    #[error("invalid url: {}", source)]
+    InvalidUri {
+        /// The source of the error.
+        #[from]
+        source: http::uri::InvalidUri,
     },
 
     /// Endpoint builder error

--- a/openstack_sdk/src/state.rs
+++ b/openstack_sdk/src/state.rs
@@ -23,31 +23,31 @@ use std::collections::HashMap;
 use std::fs::{DirBuilder, File};
 use std::io::prelude::*;
 use std::path::PathBuf;
+//use thiserror::Error;
 use tracing::{debug, info, trace, warn};
 
 use crate::auth::{
     authtoken::{AuthToken, AuthTokenScope},
     AuthState,
 };
-use thiserror::Error;
 
-/// Errors which may occur when creating connection state data.
-#[derive(Debug, Error)]
-#[non_exhaustive]
-pub enum StateError {
-    #[error("failed to deserialize config: {}", source)]
-    Parse {
-        /// The source of the error.
-        #[from]
-        source: config::ConfigError,
-    },
-    #[error("IO error: {}", source)]
-    IO {
-        /// The source of the error.
-        #[from]
-        source: std::io::Error,
-    },
-}
+// /// Errors which may occur when creating connection state data.
+// #[derive(Debug, Error)]
+// #[non_exhaustive]
+// pub enum StateError {
+//     #[error("failed to deserialize config: {}", source)]
+//     Parse {
+//         /// The source of the error.
+//         #[from]
+//         source: config::ConfigError,
+//     },
+//     #[error("IO error: {}", source)]
+//     IO {
+//         /// The source of the error.
+//         #[from]
+//         source: std::io::Error,
+//     },
+// }
 
 /// A HashMap of Scope to Token
 #[derive(Clone, Default, Deserialize, Serialize, Debug)]
@@ -100,7 +100,8 @@ impl State {
             auth_state: Default::default(),
             auth_cache_enabled: false,
             base_dir: dirs::home_dir()
-                .expect("Cannot determine users XDG_HOME")
+                .unwrap_or_default()
+                //.expect("Cannot determine users XDG_HOME")
                 .join(".osc"),
         };
         DirBuilder::new()

--- a/openstack_sdk/src/utils.rs
+++ b/openstack_sdk/src/utils.rs
@@ -29,9 +29,9 @@ pub(crate) fn expand_tilde<P: AsRef<Path>>(path_user_input: P) -> Option<PathBuf
         if home == Path::new("/") {
             // Corner case: `home` is root directory;
             // don't prepend extra `/`, just drop the tilde.
-            path.strip_prefix("~").unwrap().to_path_buf()
+            path.strip_prefix("~").unwrap_or(path).to_path_buf()
         } else {
-            home.push(path.strip_prefix("~/").unwrap());
+            home.push(path.strip_prefix("~").unwrap_or(path));
             home
         }
     })


### PR DESCRIPTION
Cleanup remaining usage of `unwrap` and `expect` from the sdk code. The
only expection is the `FakeOpenStackClient` which would require mass
change and is also technically only used in tests.
