### PR TITLE
chore: Switch to trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -41,8 +41,11 @@ jobs:
         with:
           toolchain: stable
 
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@7419a2cb1535b9c0e852b4dec626967baf65c022 # v0.5.102
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Switch to the trusted publishing of crates to crates.io instead of using
the manual token managed through secrets.
