### PR TITLE
chore: Drop json5 feature of config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,9 +555,7 @@ version = "0.15.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef036f0ecf99baef11555578630e2cca559909b4c50822dbba828c252d21c49"
 dependencies = [
- "json5",
  "pathdiff",
- "serde-untagged",
  "serde_core",
  "serde_json",
  "winnow",
@@ -954,17 +952,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "erased-serde"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
-dependencies = [
- "serde",
- "serde_core",
- "typeid",
-]
 
 [[package]]
 name = "errno"
@@ -1794,17 +1781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "jsonptr"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,7 +2276,6 @@ dependencies = [
  "eyre",
  "futures",
  "itertools 0.14.0",
- "json5",
  "lazy_static",
  "open",
  "openstack_sdk",
@@ -2989,18 +2964,6 @@ checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-untagged"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
-dependencies = [
- "erased-serde",
- "serde",
- "serde_core",
- "typeid",
 ]
 
 [[package]]
@@ -3759,12 +3722,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "typeid"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/deny.toml
+++ b/deny.toml
@@ -73,7 +73,6 @@ ignore = [
     #"RUSTSEC-0000-0000",
     "RUSTSEC-2021-0127", # serde_cbor as optional transitive dep: https://github.com/mozilla/authenticator-rs/issues/327
     "RUSTSEC-2024-0436",
-    "RUSTSEC-2025-0052"  # unless low maintained httpmock uses it
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },

--- a/openstack_tui/Cargo.toml
+++ b/openstack_tui/Cargo.toml
@@ -23,7 +23,7 @@ async-trait.workspace = true
 chrono = { workspace= true }
 clap = { workspace = true, features = ["cargo", "derive", "env", "wrap_help", "unicode", "string", "unstable-styles"] }
 color-eyre = { workspace = true }
-config = { workspace = true, features = ["json", "json5", "yaml"] }
+config = { workspace = true, features = ["json", "yaml"] }
 # edtui MUST use the same version as ratatui otherwise the Into does not work
 crossterm = { version = "0.28.1", features = ["serde", "event-stream"] }
 derive_builder = { workspace = true }
@@ -34,7 +34,6 @@ edit = "0.1.5"
 eyre = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-json5 = "^0.4"
 lazy_static = "^1.5"
 open.workspace = true
 openstack_sdk = { path = "../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "block_storage", "compute", "dns", "identity", "image", "load_balancer", "network"] }


### PR DESCRIPTION
json5 crate used by the config is marked as unmaintained. Since there is
no real use for it in the code now let's get rid of it while it is
painless.
