### PR TITLE
chore(ci): Vendor cirros image under GitHub releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,7 +13,7 @@ jobs:
     name: Release-plz
     environment: release
     runs-on: ubuntu-latest
-    if: github.repository_owner == "gtema"
+    if: github.repository_owner == 'gtema'
     permissions:
       id-token: write
       pull-requests: write

--- a/openstack_cli/tests/image/v2/image/file/roundtrip.rs
+++ b/openstack_cli/tests/image/v2/image/file/roundtrip.rs
@@ -98,10 +98,11 @@ fn extract_filename_from_url(url: &str) -> Option<String> {
 async fn image_upload_download_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = Builder::new().prefix("data").tempdir()?;
     let cirros_ver = "0.6.3";
-    let target = format!(
-        "http://download.cirros-cloud.net/{ver}/cirros-{ver}-x86_64-disk.img",
-        ver = cirros_ver
-    );
+    // let target = format!(
+    //     "http://download.cirros-cloud.net/{ver}/cirros-{ver}-x86_64-disk.img",
+    //     ver = cirros_ver
+    // );
+    let target = "https://github.com/gtema/openstack/releases/download/internal/cirros-0.6.3-x86_64-disk.img";
     let (fname, checksum) = download_with_md5_and_filename(&target, &tmp_dir)
         .await
         .expect("Download failed");


### PR DESCRIPTION
403 error started to occure very often when functional tests tries to
download cirros image from the original location. To workaround this
make a draft release with the necessary image. This helps to keep data
necessary in the test close to where it is necessary.
