### PR TITLE
chore: Do not set "latest" on release by release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,7 @@
 allow_dirty = true
 # dependencies_update = false # run `cargo update`
 git_release_enable = false
+git_release_latest = false
 
 [[package]]
 name = "openstack_sdk"


### PR DESCRIPTION
Latest release should be the one vX.Y.Z created manually (to properly
build the binary artifacts). Till that is out and ready "latest" should
point to the previous release instead of the ones published
intermediately by the release-plz
