### PR TITLE
feat: Add support for overriding the region name

### DIFF
--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -168,6 +168,10 @@ pub struct ConnectionOpts {
     #[arg(long, env = "OS_PROJECT_NAME", global = true, display_order = 803)]
     pub os_project_name: Option<String>,
 
+    /// Region Name to use instead of the one in the connection profile.
+    #[arg(long, env = "OS_REGION_NAME", global = true, display_order = 804)]
+    pub os_region_name: Option<String>,
+
     /// Custom path to the `clouds.yaml` config file.
     #[arg(
         long,

--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -110,7 +110,7 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         .with(rtl)
         .init();
 
-    let cloud_config = if cli.global_opts.connection.cloud_config_from_env {
+    let mut cloud_config = if cli.global_opts.connection.cloud_config_from_env {
         // Environment variables should be used to get the cloud configuration
         tracing::debug!("Using environment variables for the cloud connection");
         let cloud_name = cli
@@ -152,6 +152,10 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         cfg.get_cloud_config(&cloud_name)?
             .ok_or(OpenStackCliError::ConnectionNotFound(cloud_name.clone()))?
     };
+    if let Some(region_name) = &cli.global_opts.connection.os_region_name {
+        cloud_config.region_name = Some(region_name.clone());
+    }
+
     let mut renew_auth: bool = false;
 
     // Login command need to be analyzed before authorization


### PR DESCRIPTION
Add possibility to specify the cli connection region name as a parameter
to the cli or the `OS_REGION_NAME` env.

Closes: #1534
