### PR TITLE
fix: Fix neutron qos/policies.rules definition

### DIFF
--- a/openstack_types/data/identity/keystone_rust.yaml
+++ b/openstack_types/data/identity/keystone_rust.yaml
@@ -959,12 +959,6 @@ paths:
         allowed to the admin user.
       operationId: /federation/mapping:list
       parameters:
-      - name: name
-        in: query
-        description: Filters the response by IDP name.
-        required: false
-        schema:
-          type: string
       - name: domain_id
         in: query
         description: Filters the response by a domain ID.
@@ -977,6 +971,30 @@ paths:
         required: false
         schema:
           type: string
+      - name: name
+        in: query
+        description: Filters the response by IDP name.
+        required: false
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Limit number of entries on the single response page (Maximal 100)
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          minimum: 0
+      - name: marker
+        in: query
+        description: Page marker (id of the last entry on the previous page.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
       - name: type
         in: query
         description: Filters the response by a mapping type.
@@ -1665,6 +1683,7 @@ components:
           description: The type of credential.
     Assignment:
       type: object
+      description: Assignment.
       required:
       - role
       - scope
@@ -1673,18 +1692,21 @@ components:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/Group'
+            description: Group.
         role:
           $ref: '#/components/schemas/Role'
-          description: Role ID
+          description: Role.
         scope:
           $ref: '#/components/schemas/Scope'
+          description: Target scope.
         user:
           oneOf:
           - type: 'null'
           - $ref: '#/components/schemas/User'
+            description: User.
     AssignmentList:
       type: object
-      description: Assignments
+      description: Assignments.
       required:
       - role_assignments
       properties:
@@ -3856,7 +3878,7 @@ components:
       - experimental
     Versions:
       type: object
-      description: List of the supported API versionts as [Values].
+      description: List of the supported API versions as [Values].
       required:
       - versions
       properties:

--- a/openstack_types/data/network/v2.28.yaml
+++ b/openstack_types/data/network/v2.28.yaml
@@ -20472,7 +20472,54 @@ components:
             rules:
               description: |-
                 A set of zero or more policy rules.
-              type: string
+              items:
+                properties:
+                  direction:
+                    description: The direction of the traffic to which the QoS 
+                      rule is applied, as seen from the point of view of the 
+                      port. Valid values are `egress` and `ingress`. Default 
+                      value is `egress`.
+                    type: string
+                  dscp_mark:
+                    type: string
+                  id:
+                    description: The rule ID
+                    type: string
+                  max_burst_kbps:
+                    description: The maximum burst size (in kilobits).
+                    minimum: 0
+                    type: integer
+                  max_burst_kpps:
+                    description: The max burst kpps (kilo packets per second) 
+                      value.
+                    minimum: 0
+                    type: integer
+                  max_kbps:
+                    description: The maximum KBPS (kilobits per second) value. 
+                      If you specify this value, must be greater than 0 
+                      otherwise max_kbps will have no value
+                    minimum: 0
+                    type: integer
+                  max_kpps:
+                    description: The max kpps (kilo packets per second) value.
+                    minimum: 0
+                    type: integer
+                  min_kbps:
+                    description: The minimum KBPS (kilobits per second) value 
+                      which should be available for port.
+                    minimum: 0
+                    type: integer
+                  min_kpps:
+                    description: The minimum kilo (1000) packets per second 
+                      (kpps) value.
+                    minimum: 0
+                    type: integer
+                  qos_policy_id:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
             shared:
               description: |-
                 Indicates whether this policy is shared across
@@ -20791,7 +20838,54 @@ components:
               rules:
                 description: |-
                   A set of zero or more policy rules.
-                type: string
+                items:
+                  properties:
+                    direction:
+                      description: The direction of the traffic to which the QoS
+                        rule is applied, as seen from the point of view of the 
+                        port. Valid values are `egress` and `ingress`. Default 
+                        value is `egress`.
+                      type: string
+                    dscp_mark:
+                      type: string
+                    id:
+                      description: The rule ID
+                      type: string
+                    max_burst_kbps:
+                      description: The maximum burst size (in kilobits).
+                      minimum: 0
+                      type: integer
+                    max_burst_kpps:
+                      description: The max burst kpps (kilo packets per second) 
+                        value.
+                      minimum: 0
+                      type: integer
+                    max_kbps:
+                      description: The maximum KBPS (kilobits per second) value.
+                        If you specify this value, must be greater than 0 
+                        otherwise max_kbps will have no value
+                      minimum: 0
+                      type: integer
+                    max_kpps:
+                      description: The max kpps (kilo packets per second) value.
+                      minimum: 0
+                      type: integer
+                    min_kbps:
+                      description: The minimum KBPS (kilobits per second) value 
+                        which should be available for port.
+                      minimum: 0
+                      type: integer
+                    min_kpps:
+                      description: The minimum kilo (1000) packets per second 
+                        (kpps) value.
+                      minimum: 0
+                      type: integer
+                    qos_policy_id:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
               shared:
                 description: |-
                   Indicates whether this policy is shared across
@@ -21191,7 +21285,54 @@ components:
             rules:
               description: |-
                 A set of zero or more policy rules.
-              type: string
+              items:
+                properties:
+                  direction:
+                    description: The direction of the traffic to which the QoS 
+                      rule is applied, as seen from the point of view of the 
+                      port. Valid values are `egress` and `ingress`. Default 
+                      value is `egress`.
+                    type: string
+                  dscp_mark:
+                    type: string
+                  id:
+                    description: The rule ID
+                    type: string
+                  max_burst_kbps:
+                    description: The maximum burst size (in kilobits).
+                    minimum: 0
+                    type: integer
+                  max_burst_kpps:
+                    description: The max burst kpps (kilo packets per second) 
+                      value.
+                    minimum: 0
+                    type: integer
+                  max_kbps:
+                    description: The maximum KBPS (kilobits per second) value. 
+                      If you specify this value, must be greater than 0 
+                      otherwise max_kbps will have no value
+                    minimum: 0
+                    type: integer
+                  max_kpps:
+                    description: The max kpps (kilo packets per second) value.
+                    minimum: 0
+                    type: integer
+                  min_kbps:
+                    description: The minimum KBPS (kilobits per second) value 
+                      which should be available for port.
+                    minimum: 0
+                    type: integer
+                  min_kpps:
+                    description: The minimum kilo (1000) packets per second 
+                      (kpps) value.
+                    minimum: 0
+                    type: integer
+                  qos_policy_id:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
             shared:
               description: |-
                 Indicates whether this policy is shared across
@@ -21286,7 +21427,54 @@ components:
             rules:
               description: |-
                 A set of zero or more policy rules.
-              type: string
+              items:
+                properties:
+                  direction:
+                    description: The direction of the traffic to which the QoS 
+                      rule is applied, as seen from the point of view of the 
+                      port. Valid values are `egress` and `ingress`. Default 
+                      value is `egress`.
+                    type: string
+                  dscp_mark:
+                    type: string
+                  id:
+                    description: The rule ID
+                    type: string
+                  max_burst_kbps:
+                    description: The maximum burst size (in kilobits).
+                    minimum: 0
+                    type: integer
+                  max_burst_kpps:
+                    description: The max burst kpps (kilo packets per second) 
+                      value.
+                    minimum: 0
+                    type: integer
+                  max_kbps:
+                    description: The maximum KBPS (kilobits per second) value. 
+                      If you specify this value, must be greater than 0 
+                      otherwise max_kbps will have no value
+                    minimum: 0
+                    type: integer
+                  max_kpps:
+                    description: The max kpps (kilo packets per second) value.
+                    minimum: 0
+                    type: integer
+                  min_kbps:
+                    description: The minimum KBPS (kilobits per second) value 
+                      which should be available for port.
+                    minimum: 0
+                    type: integer
+                  min_kpps:
+                    description: The minimum kilo (1000) packets per second 
+                      (kpps) value.
+                    minimum: 0
+                    type: integer
+                  qos_policy_id:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
             shared:
               description: |-
                 Indicates whether this policy is shared across
@@ -23680,8 +23868,8 @@ components:
               items:
                 properties:
                   belongs_to_default_sg:
-                    description: "Indicates if the security group rule belongs to
-                      the default security\ngroup of the project or not."
+                    description: Indicates if the security group rule belongs to
+                      the default security group of the project or not.
                     type:
                       - boolean
                       - 'null'
@@ -23739,8 +23927,8 @@ components:
                       an integer, or `null`.
                     type: string
                   remote_address_group_id:
-                    description: "The remote address group UUID that is associated
-                      with this\nsecurity group rule."
+                    description: The remote address group UUID that is 
+                      associated with this security group rule.
                     type: string
                   remote_group_id:
                     description: "The remote group UUID to associate with this\nsecurity
@@ -23858,8 +24046,8 @@ components:
               items:
                 properties:
                   belongs_to_default_sg:
-                    description: "Indicates if the security group rule belongs to
-                      the default security\ngroup of the project or not."
+                    description: Indicates if the security group rule belongs to
+                      the default security group of the project or not.
                     type:
                       - boolean
                       - 'null'
@@ -23917,8 +24105,8 @@ components:
                       an integer, or `null`.
                     type: string
                   remote_address_group_id:
-                    description: "The remote address group UUID that is associated
-                      with this\nsecurity group rule."
+                    description: The remote address group UUID that is 
+                      associated with this security group rule.
                     type: string
                   remote_group_id:
                     description: "The remote group UUID to associate with this\nsecurity
@@ -24571,8 +24759,8 @@ components:
               items:
                 properties:
                   belongs_to_default_sg:
-                    description: "Indicates if the security group rule belongs to
-                      the default security\ngroup of the project or not."
+                    description: Indicates if the security group rule belongs to
+                      the default security group of the project or not.
                     type:
                       - boolean
                       - 'null'
@@ -24630,8 +24818,8 @@ components:
                       an integer, or `null`.
                     type: string
                   remote_address_group_id:
-                    description: "The remote address group UUID that is associated
-                      with this\nsecurity group rule."
+                    description: The remote address group UUID that is 
+                      associated with this security group rule.
                     type: string
                   remote_group_id:
                     description: "The remote group UUID to associate with this\nsecurity
@@ -24726,8 +24914,8 @@ components:
                 items:
                   properties:
                     belongs_to_default_sg:
-                      description: "Indicates if the security group rule belongs to
-                        the default security\ngroup of the project or not."
+                      description: Indicates if the security group rule belongs 
+                        to the default security group of the project or not.
                       type:
                         - boolean
                         - 'null'
@@ -24786,8 +24974,8 @@ components:
                         string, an integer, or `null`.
                       type: string
                     remote_address_group_id:
-                      description: "The remote address group UUID that is associated
-                        with this\nsecurity group rule."
+                      description: The remote address group UUID that is 
+                        associated with this security group rule.
                       type: string
                     remote_group_id:
                       description: "The remote group UUID to associate with this\n\

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -20472,7 +20472,54 @@ components:
             rules:
               description: |-
                 A set of zero or more policy rules.
-              type: string
+              items:
+                properties:
+                  direction:
+                    description: The direction of the traffic to which the QoS 
+                      rule is applied, as seen from the point of view of the 
+                      port. Valid values are `egress` and `ingress`. Default 
+                      value is `egress`.
+                    type: string
+                  dscp_mark:
+                    type: string
+                  id:
+                    description: The rule ID
+                    type: string
+                  max_burst_kbps:
+                    description: The maximum burst size (in kilobits).
+                    minimum: 0
+                    type: integer
+                  max_burst_kpps:
+                    description: The max burst kpps (kilo packets per second) 
+                      value.
+                    minimum: 0
+                    type: integer
+                  max_kbps:
+                    description: The maximum KBPS (kilobits per second) value. 
+                      If you specify this value, must be greater than 0 
+                      otherwise max_kbps will have no value
+                    minimum: 0
+                    type: integer
+                  max_kpps:
+                    description: The max kpps (kilo packets per second) value.
+                    minimum: 0
+                    type: integer
+                  min_kbps:
+                    description: The minimum KBPS (kilobits per second) value 
+                      which should be available for port.
+                    minimum: 0
+                    type: integer
+                  min_kpps:
+                    description: The minimum kilo (1000) packets per second 
+                      (kpps) value.
+                    minimum: 0
+                    type: integer
+                  qos_policy_id:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
             shared:
               description: |-
                 Indicates whether this policy is shared across
@@ -20791,7 +20838,54 @@ components:
               rules:
                 description: |-
                   A set of zero or more policy rules.
-                type: string
+                items:
+                  properties:
+                    direction:
+                      description: The direction of the traffic to which the QoS
+                        rule is applied, as seen from the point of view of the 
+                        port. Valid values are `egress` and `ingress`. Default 
+                        value is `egress`.
+                      type: string
+                    dscp_mark:
+                      type: string
+                    id:
+                      description: The rule ID
+                      type: string
+                    max_burst_kbps:
+                      description: The maximum burst size (in kilobits).
+                      minimum: 0
+                      type: integer
+                    max_burst_kpps:
+                      description: The max burst kpps (kilo packets per second) 
+                        value.
+                      minimum: 0
+                      type: integer
+                    max_kbps:
+                      description: The maximum KBPS (kilobits per second) value.
+                        If you specify this value, must be greater than 0 
+                        otherwise max_kbps will have no value
+                      minimum: 0
+                      type: integer
+                    max_kpps:
+                      description: The max kpps (kilo packets per second) value.
+                      minimum: 0
+                      type: integer
+                    min_kbps:
+                      description: The minimum KBPS (kilobits per second) value 
+                        which should be available for port.
+                      minimum: 0
+                      type: integer
+                    min_kpps:
+                      description: The minimum kilo (1000) packets per second 
+                        (kpps) value.
+                      minimum: 0
+                      type: integer
+                    qos_policy_id:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
               shared:
                 description: |-
                   Indicates whether this policy is shared across
@@ -21191,7 +21285,54 @@ components:
             rules:
               description: |-
                 A set of zero or more policy rules.
-              type: string
+              items:
+                properties:
+                  direction:
+                    description: The direction of the traffic to which the QoS 
+                      rule is applied, as seen from the point of view of the 
+                      port. Valid values are `egress` and `ingress`. Default 
+                      value is `egress`.
+                    type: string
+                  dscp_mark:
+                    type: string
+                  id:
+                    description: The rule ID
+                    type: string
+                  max_burst_kbps:
+                    description: The maximum burst size (in kilobits).
+                    minimum: 0
+                    type: integer
+                  max_burst_kpps:
+                    description: The max burst kpps (kilo packets per second) 
+                      value.
+                    minimum: 0
+                    type: integer
+                  max_kbps:
+                    description: The maximum KBPS (kilobits per second) value. 
+                      If you specify this value, must be greater than 0 
+                      otherwise max_kbps will have no value
+                    minimum: 0
+                    type: integer
+                  max_kpps:
+                    description: The max kpps (kilo packets per second) value.
+                    minimum: 0
+                    type: integer
+                  min_kbps:
+                    description: The minimum KBPS (kilobits per second) value 
+                      which should be available for port.
+                    minimum: 0
+                    type: integer
+                  min_kpps:
+                    description: The minimum kilo (1000) packets per second 
+                      (kpps) value.
+                    minimum: 0
+                    type: integer
+                  qos_policy_id:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
             shared:
               description: |-
                 Indicates whether this policy is shared across
@@ -21286,7 +21427,54 @@ components:
             rules:
               description: |-
                 A set of zero or more policy rules.
-              type: string
+              items:
+                properties:
+                  direction:
+                    description: The direction of the traffic to which the QoS 
+                      rule is applied, as seen from the point of view of the 
+                      port. Valid values are `egress` and `ingress`. Default 
+                      value is `egress`.
+                    type: string
+                  dscp_mark:
+                    type: string
+                  id:
+                    description: The rule ID
+                    type: string
+                  max_burst_kbps:
+                    description: The maximum burst size (in kilobits).
+                    minimum: 0
+                    type: integer
+                  max_burst_kpps:
+                    description: The max burst kpps (kilo packets per second) 
+                      value.
+                    minimum: 0
+                    type: integer
+                  max_kbps:
+                    description: The maximum KBPS (kilobits per second) value. 
+                      If you specify this value, must be greater than 0 
+                      otherwise max_kbps will have no value
+                    minimum: 0
+                    type: integer
+                  max_kpps:
+                    description: The max kpps (kilo packets per second) value.
+                    minimum: 0
+                    type: integer
+                  min_kbps:
+                    description: The minimum KBPS (kilobits per second) value 
+                      which should be available for port.
+                    minimum: 0
+                    type: integer
+                  min_kpps:
+                    description: The minimum kilo (1000) packets per second 
+                      (kpps) value.
+                    minimum: 0
+                    type: integer
+                  qos_policy_id:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
             shared:
               description: |-
                 Indicates whether this policy is shared across
@@ -23680,8 +23868,8 @@ components:
               items:
                 properties:
                   belongs_to_default_sg:
-                    description: "Indicates if the security group rule belongs to
-                      the default security\ngroup of the project or not."
+                    description: Indicates if the security group rule belongs to
+                      the default security group of the project or not.
                     type:
                       - boolean
                       - 'null'
@@ -23739,8 +23927,8 @@ components:
                       an integer, or `null`.
                     type: string
                   remote_address_group_id:
-                    description: "The remote address group UUID that is associated
-                      with this\nsecurity group rule."
+                    description: The remote address group UUID that is 
+                      associated with this security group rule.
                     type: string
                   remote_group_id:
                     description: "The remote group UUID to associate with this\nsecurity
@@ -23858,8 +24046,8 @@ components:
               items:
                 properties:
                   belongs_to_default_sg:
-                    description: "Indicates if the security group rule belongs to
-                      the default security\ngroup of the project or not."
+                    description: Indicates if the security group rule belongs to
+                      the default security group of the project or not.
                     type:
                       - boolean
                       - 'null'
@@ -23917,8 +24105,8 @@ components:
                       an integer, or `null`.
                     type: string
                   remote_address_group_id:
-                    description: "The remote address group UUID that is associated
-                      with this\nsecurity group rule."
+                    description: The remote address group UUID that is 
+                      associated with this security group rule.
                     type: string
                   remote_group_id:
                     description: "The remote group UUID to associate with this\nsecurity
@@ -24571,8 +24759,8 @@ components:
               items:
                 properties:
                   belongs_to_default_sg:
-                    description: "Indicates if the security group rule belongs to
-                      the default security\ngroup of the project or not."
+                    description: Indicates if the security group rule belongs to
+                      the default security group of the project or not.
                     type:
                       - boolean
                       - 'null'
@@ -24630,8 +24818,8 @@ components:
                       an integer, or `null`.
                     type: string
                   remote_address_group_id:
-                    description: "The remote address group UUID that is associated
-                      with this\nsecurity group rule."
+                    description: The remote address group UUID that is 
+                      associated with this security group rule.
                     type: string
                   remote_group_id:
                     description: "The remote group UUID to associate with this\nsecurity
@@ -24726,8 +24914,8 @@ components:
                 items:
                   properties:
                     belongs_to_default_sg:
-                      description: "Indicates if the security group rule belongs to
-                        the default security\ngroup of the project or not."
+                      description: Indicates if the security group rule belongs 
+                        to the default security group of the project or not.
                       type:
                         - boolean
                         - 'null'
@@ -24786,8 +24974,8 @@ components:
                         string, an integer, or `null`.
                       type: string
                     remote_address_group_id:
-                      description: "The remote address group UUID that is associated
-                        with this\nsecurity group rule."
+                      description: The remote address group UUID that is 
+                        associated with this security group rule.
                       type: string
                     remote_group_id:
                       description: "The remote group UUID to associate with this\n\

--- a/openstack_types/src/network/v2/qos/policy/response/create.rs
+++ b/openstack_types/src/network/v2/qos/policy/response/create.rs
@@ -54,8 +54,8 @@ pub struct PolicyResponse {
 
     /// A set of zero or more policy rules.
     #[serde(default)]
-    #[structable(optional)]
-    pub rules: Option<String>,
+    #[structable(optional, serialize)]
+    pub rules: Option<Vec<Rules>>,
 
     /// Indicates whether this policy is shared across all projects.
     #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
@@ -75,4 +75,31 @@ pub struct PolicyResponse {
     #[serde(default)]
     #[structable(optional)]
     pub updated_at: Option<String>,
+}
+
+/// `Rules` type
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Rules {
+    #[serde(default)]
+    pub direction: Option<String>,
+    #[serde(default)]
+    pub dscp_mark: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub max_burst_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_burst_kpps: Option<u32>,
+    #[serde(default)]
+    pub max_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_kpps: Option<u32>,
+    #[serde(default)]
+    pub min_kbps: Option<u32>,
+    #[serde(default)]
+    pub min_kpps: Option<u32>,
+    #[serde(default)]
+    pub qos_policy_id: Option<String>,
+    #[serde(default, rename = "type")]
+    pub _type: Option<String>,
 }

--- a/openstack_types/src/network/v2/qos/policy/response/get.rs
+++ b/openstack_types/src/network/v2/qos/policy/response/get.rs
@@ -54,8 +54,8 @@ pub struct PolicyResponse {
 
     /// A set of zero or more policy rules.
     #[serde(default)]
-    #[structable(optional)]
-    pub rules: Option<String>,
+    #[structable(optional, serialize)]
+    pub rules: Option<Vec<Rules>>,
 
     /// Indicates whether this policy is shared across all projects.
     #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
@@ -75,4 +75,31 @@ pub struct PolicyResponse {
     #[serde(default)]
     #[structable(optional)]
     pub updated_at: Option<String>,
+}
+
+/// `Rules` type
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Rules {
+    #[serde(default)]
+    pub direction: Option<String>,
+    #[serde(default)]
+    pub dscp_mark: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub max_burst_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_burst_kpps: Option<u32>,
+    #[serde(default)]
+    pub max_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_kpps: Option<u32>,
+    #[serde(default)]
+    pub min_kbps: Option<u32>,
+    #[serde(default)]
+    pub min_kpps: Option<u32>,
+    #[serde(default)]
+    pub qos_policy_id: Option<String>,
+    #[serde(default, rename = "type")]
+    pub _type: Option<String>,
 }

--- a/openstack_types/src/network/v2/qos/policy/response/list.rs
+++ b/openstack_types/src/network/v2/qos/policy/response/list.rs
@@ -54,8 +54,8 @@ pub struct PolicyResponse {
 
     /// A set of zero or more policy rules.
     #[serde(default)]
-    #[structable(optional, wide)]
-    pub rules: Option<String>,
+    #[structable(optional, serialize, wide)]
+    pub rules: Option<Vec<Rules>>,
 
     /// Indicates whether this policy is shared across all projects.
     #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
@@ -76,4 +76,31 @@ pub struct PolicyResponse {
     #[serde(default)]
     #[structable(optional)]
     pub updated_at: Option<String>,
+}
+
+/// `Rules` type
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Rules {
+    #[serde(default)]
+    pub direction: Option<String>,
+    #[serde(default)]
+    pub dscp_mark: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub max_burst_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_burst_kpps: Option<u32>,
+    #[serde(default)]
+    pub max_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_kpps: Option<u32>,
+    #[serde(default)]
+    pub min_kbps: Option<u32>,
+    #[serde(default)]
+    pub min_kpps: Option<u32>,
+    #[serde(default)]
+    pub qos_policy_id: Option<String>,
+    #[serde(default, rename = "type")]
+    pub _type: Option<String>,
 }

--- a/openstack_types/src/network/v2/qos/policy/response/set.rs
+++ b/openstack_types/src/network/v2/qos/policy/response/set.rs
@@ -54,8 +54,8 @@ pub struct PolicyResponse {
 
     /// A set of zero or more policy rules.
     #[serde(default)]
-    #[structable(optional)]
-    pub rules: Option<String>,
+    #[structable(optional, serialize)]
+    pub rules: Option<Vec<Rules>>,
 
     /// Indicates whether this policy is shared across all projects.
     #[serde(default, deserialize_with = "crate::common::deser_bool_str_opt")]
@@ -75,4 +75,31 @@ pub struct PolicyResponse {
     #[serde(default)]
     #[structable(optional)]
     pub updated_at: Option<String>,
+}
+
+/// `Rules` type
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Rules {
+    #[serde(default)]
+    pub direction: Option<String>,
+    #[serde(default)]
+    pub dscp_mark: Option<String>,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub max_burst_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_burst_kpps: Option<u32>,
+    #[serde(default)]
+    pub max_kbps: Option<u32>,
+    #[serde(default)]
+    pub max_kpps: Option<u32>,
+    #[serde(default)]
+    pub min_kbps: Option<u32>,
+    #[serde(default)]
+    pub min_kpps: Option<u32>,
+    #[serde(default)]
+    pub qos_policy_id: Option<String>,
+    #[serde(default, rename = "type")]
+    pub _type: Option<String>,
 }


### PR DESCRIPTION
Neutron does not have any definition for the rules returned under the
qos/policies EP. Sadly need to hardcode it.

Change-Id: I4b59793abf6a82ea235596aed6c368df4a9be83e
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/971509
