### PR TITLE
chore: Try to improve handling for '{}' schemas

### DIFF
--- a/openstack_cli/src/block_storage/v3/attachment/os_complete_344.rs
+++ b/openstack_cli/src/block_storage/v3/attachment/os_complete_344.rs
@@ -43,7 +43,8 @@ pub struct AttachmentCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_complete: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/backup/os_force_delete.rs
+++ b/openstack_cli/src/block_storage/v3/backup/os_force_delete.rs
@@ -43,7 +43,8 @@ pub struct BackupCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_force_delete: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/consistencygroup/create.rs
+++ b/openstack_cli/src/block_storage/v3/consistencygroup/create.rs
@@ -65,6 +65,7 @@ struct PathParameters {}
 /// Consistencygroup Body data
 #[derive(Args, Clone)]
 struct Consistencygroup {
+    /// OpenAPI specifies the field as '{}'.
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     availability_zone: Option<Value>,
 
@@ -84,6 +85,7 @@ struct Consistencygroup {
     #[arg(help_heading = "Body parameters", long, action = clap::ArgAction::SetTrue, conflicts_with = "name")]
     no_name: bool,
 
+    /// OpenAPI specifies the field as '{}'.
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     volume_types: Value,
 }

--- a/openstack_cli/src/block_storage/v3/snapshot/os_force_delete.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/os_force_delete.rs
@@ -43,7 +43,8 @@ pub struct SnapshotCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_force_delete: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/snapshot/os_unmanage.rs
+++ b/openstack_cli/src/block_storage/v3/snapshot/os_unmanage.rs
@@ -43,7 +43,8 @@ pub struct SnapshotCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_unmanage: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_begin_detaching.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_begin_detaching.rs
@@ -44,7 +44,8 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_begin_detaching: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_force_delete.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_force_delete.rs
@@ -44,7 +44,8 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_force_delete: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_reserve.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_reserve.rs
@@ -44,7 +44,8 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_reserve: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_roll_detaching.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_roll_detaching.rs
@@ -44,7 +44,8 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_roll_detaching: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_show_image_metadata.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_show_image_metadata.rs
@@ -44,7 +44,8 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_show_image_metadata: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_unmanage.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unmanage.rs
@@ -44,7 +44,8 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_unmanage: Value,
 }
 

--- a/openstack_cli/src/block_storage/v3/volume/os_unreserve.rs
+++ b/openstack_cli/src/block_storage/v3/volume/os_unreserve.rs
@@ -44,7 +44,8 @@ pub struct VolumeCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_unreserve: Value,
 }
 

--- a/openstack_cli/src/compute/v2/availability_zone/list_detail.rs
+++ b/openstack_cli/src/compute/v2/availability_zone/list_detail.rs
@@ -34,7 +34,7 @@ use openstack_types::compute::v2::availability_zone::response::list_detail::Avai
 
 /// Gets detailed availability zone information. Policy defaults enable only
 /// users with the administrative role to perform this operation. Cloud
-/// providers can change these permissions through the `policy.json` file.
+/// providers can change these permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/flavor/set_255.rs
+++ b/openstack_cli/src/compute/v2/flavor/set_255.rs
@@ -41,7 +41,7 @@ use openstack_types::compute::v2::flavor::response::set::FlavorResponse;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/floating_ip/create.rs
+++ b/openstack_cli/src/compute/v2/floating_ip/create.rs
@@ -41,7 +41,7 @@ use openstack_types::compute::v2::floating_ip::response::create::FloatingIpRespo
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/floating_ip/delete.rs
+++ b/openstack_cli/src/compute/v2/floating_ip/delete.rs
@@ -40,7 +40,7 @@ use openstack_sdk::api::compute::v2::floating_ip::delete;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///

--- a/openstack_cli/src/compute/v2/floating_ip/list.rs
+++ b/openstack_cli/src/compute/v2/floating_ip/list.rs
@@ -37,7 +37,7 @@ use openstack_types::compute::v2::floating_ip::response::list::FloatingIpRespons
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/floating_ip/show.rs
+++ b/openstack_cli/src/compute/v2/floating_ip/show.rs
@@ -38,7 +38,7 @@ use openstack_types::compute::v2::floating_ip::response::get::FloatingIpResponse
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/hypervisor/list.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/list.rs
@@ -37,7 +37,7 @@ use openstack_types::compute::v2::hypervisor::response::list_detailed::Hyperviso
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/hypervisor/search/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/search/get.rs
@@ -37,7 +37,7 @@ use openstack_types::compute::v2::hypervisor::search::response::get::SearchRespo
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response code: 200
 ///

--- a/openstack_cli/src/compute/v2/hypervisor/server/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/server/get.rs
@@ -38,7 +38,7 @@ use openstack_types::compute::v2::hypervisor::server::response::get::ServerRespo
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response code: 200
 ///

--- a/openstack_cli/src/compute/v2/hypervisor/show.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/show.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::hypervisor::response::get::HypervisorResponse;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/hypervisor/statistic/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/statistic/get.rs
@@ -38,7 +38,7 @@ use openstack_types::compute::v2::hypervisor::statistic::response::get::Statisti
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/hypervisor/uptime/get.rs
+++ b/openstack_cli/src/compute/v2/hypervisor/uptime/get.rs
@@ -37,7 +37,7 @@ use openstack_types::compute::v2::hypervisor::uptime::response::get::UptimeRespo
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/migration/get.rs
+++ b/openstack_cli/src/compute/v2/migration/get.rs
@@ -41,7 +41,7 @@ use tracing::warn;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Starting from microversion 2.59, the response is sorted by `created_at` and
 /// `id` in descending order.

--- a/openstack_cli/src/compute/v2/server/add_fixed_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/add_fixed_ip_21.rs
@@ -40,7 +40,7 @@ use openstack_sdk::api::compute::v2::server::add_fixed_ip_21;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///

--- a/openstack_cli/src/compute/v2/server/change_password.rs
+++ b/openstack_cli/src/compute/v2/server/change_password.rs
@@ -38,7 +38,7 @@ use openstack_sdk::api::compute::v2::server::change_password;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///

--- a/openstack_cli/src/compute/v2/server/confirm_resize.rs
+++ b/openstack_cli/src/compute/v2/server/confirm_resize.rs
@@ -76,7 +76,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     confirm_resize: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/diagnostic/get.rs
+++ b/openstack_cli/src/compute/v2/server/diagnostic/get.rs
@@ -35,7 +35,7 @@ use openstack_types::compute::v2::server::diagnostic::response::get::DiagnosticR
 /// Shows basic usage data for a server.
 ///
 /// Policy defaults enable only users with the administrative role. Cloud
-/// providers can change these permissions through the `policy.json` file.
+/// providers can change these permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/force_delete.rs
+++ b/openstack_cli/src/compute/v2/server/force_delete.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -55,7 +55,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     force_delete: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/inject_network_info.rs
+++ b/openstack_cli/src/compute/v2/server/inject_network_info.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -55,7 +55,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     inject_network_info: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/instance_action/list.rs
+++ b/openstack_cli/src/compute/v2/server/instance_action/list.rs
@@ -40,7 +40,7 @@ use openstack_types::compute::v2::server::instance_action::response::list::Insta
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/instance_action/show.rs
+++ b/openstack_cli/src/compute/v2/server/instance_action/show.rs
@@ -39,7 +39,7 @@ use openstack_types::compute::v2::server::instance_action::response::get::Instan
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/ip/list.rs
+++ b/openstack_cli/src/compute/v2/server/ip/list.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::server::ip::response::list::IpResponse;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/ip/show.rs
+++ b/openstack_cli/src/compute/v2/server/ip/show.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::server::ip::response::get::IpResponse;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/lock_21.rs
+++ b/openstack_cli/src/compute/v2/server/lock_21.rs
@@ -45,7 +45,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     lock: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/metadata/create.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/create.rs
@@ -41,7 +41,7 @@ use openstack_types::compute::v2::server::metadata::response::create::MetadataRe
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/metadata/delete.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/delete.rs
@@ -35,7 +35,7 @@ use openstack_sdk::api::compute::v2::server::metadata::delete;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 204
 ///

--- a/openstack_cli/src/compute/v2/server/metadata/list.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/list.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::server::metadata::response::list::MetadataResp
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/metadata/replace.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/replace.rs
@@ -41,7 +41,7 @@ use openstack_types::compute::v2::server::metadata::response::replace::MetadataR
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/metadata/set.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/set.rs
@@ -41,7 +41,7 @@ use openstack_types::compute::v2::server::metadata::response::set::MetadataRespo
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/metadata/show.rs
+++ b/openstack_cli/src/compute/v2/server/metadata/show.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::server::metadata::response::get::MetadataRespo
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/migrate_256.rs
+++ b/openstack_cli/src/compute/v2/server/migrate_256.rs
@@ -52,7 +52,7 @@ use openstack_sdk::api::compute::v2::server::migrate_256;
 /// There are two different policies for this action, depending on whether the
 /// host parameter is set. Both defaults enable only users with the
 /// administrative role to perform this operation. Cloud providers can change
-/// these permissions through the `policy.json` file.
+/// these permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///

--- a/openstack_cli/src/compute/v2/server/migration/delete.rs
+++ b/openstack_cli/src/compute/v2/server/migration/delete.rs
@@ -35,7 +35,7 @@ use openstack_sdk::api::compute::v2::server::migration::delete;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// **Preconditions**
 ///

--- a/openstack_cli/src/compute/v2/server/migration/force_complete_222.rs
+++ b/openstack_cli/src/compute/v2/server/migration/force_complete_222.rs
@@ -37,7 +37,7 @@ use openstack_sdk::api::compute::v2::server::migration::force_complete_222;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// **Preconditions**
 ///

--- a/openstack_cli/src/compute/v2/server/migration/list.rs
+++ b/openstack_cli/src/compute/v2/server/migration/list.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::server::migration::response::list::MigrationRe
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/migration/show.rs
+++ b/openstack_cli/src/compute/v2/server/migration/show.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::server::migration::response::get::MigrationRes
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/os_reset_state.rs
+++ b/openstack_cli/src/compute/v2/server/os_reset_state.rs
@@ -39,7 +39,7 @@ use openstack_sdk::api::compute::v2::server::os_reset_state;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///

--- a/openstack_cli/src/compute/v2/server/os_start.rs
+++ b/openstack_cli/src/compute/v2/server/os_start.rs
@@ -69,7 +69,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_start: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/os_stop.rs
+++ b/openstack_cli/src/compute/v2/server/os_stop.rs
@@ -64,7 +64,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     os_stop: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/pause.rs
+++ b/openstack_cli/src/compute/v2/server/pause.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -55,7 +55,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     pause: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/remove_fixed_ip_21.rs
+++ b/openstack_cli/src/compute/v2/server/remove_fixed_ip_21.rs
@@ -38,7 +38,7 @@ use openstack_sdk::api::compute::v2::server::remove_fixed_ip_21;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///

--- a/openstack_cli/src/compute/v2/server/reset_network.rs
+++ b/openstack_cli/src/compute/v2/server/reset_network.rs
@@ -37,7 +37,7 @@ use openstack_sdk::api::compute::v2::server::reset_network;
 ///
 /// Policy defaults enable only users with the administrative role to perform
 /// this operation. Cloud providers can change these permissions through the
-/// `policy.json` file.
+/// `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///

--- a/openstack_cli/src/compute/v2/server/restore.rs
+++ b/openstack_cli/src/compute/v2/server/restore.rs
@@ -39,7 +39,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -56,7 +56,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     restore: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/resume.rs
+++ b/openstack_cli/src/compute/v2/server/resume.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -55,7 +55,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     resume: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/revert_resize.rs
+++ b/openstack_cli/src/compute/v2/server/revert_resize.rs
@@ -77,7 +77,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     revert_resize: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/server_password/delete.rs
+++ b/openstack_cli/src/compute/v2/server/server_password/delete.rs
@@ -38,7 +38,7 @@ use openstack_sdk::api::compute::v2::server::server_password::delete;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 204
 ///

--- a/openstack_cli/src/compute/v2/server/server_password/get.rs
+++ b/openstack_cli/src/compute/v2/server/server_password/get.rs
@@ -43,7 +43,7 @@ use openstack_types::compute::v2::server::server_password::response::get::Server
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/shelve.rs
+++ b/openstack_cli/src/compute/v2/server/shelve.rs
@@ -42,7 +42,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// **Preconditions**
 ///
@@ -83,7 +83,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     shelve: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/shelve_offload.rs
+++ b/openstack_cli/src/compute/v2/server/shelve_offload.rs
@@ -42,7 +42,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// **Preconditions**
 ///
@@ -78,7 +78,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     shelve_offload: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/suspend.rs
+++ b/openstack_cli/src/compute/v2/server/suspend.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -55,7 +55,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     suspend: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/topology/list.rs
+++ b/openstack_cli/src/compute/v2/server/topology/list.rs
@@ -36,7 +36,7 @@ use openstack_types::compute::v2::server::topology::response::list::TopologyResp
 ///
 /// Policy defaults enable only users with the administrative role or the
 /// owners of the server to perform this operation. Cloud providers can change
-/// these permissions through the `policy.json` file.
+/// these permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 200
 ///

--- a/openstack_cli/src/compute/v2/server/unlock_21.rs
+++ b/openstack_cli/src/compute/v2/server/unlock_21.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -54,7 +54,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     unlock: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/unpause.rs
+++ b/openstack_cli/src/compute/v2/server/unpause.rs
@@ -38,7 +38,7 @@ use serde_json::Value;
 ///
 /// Policy defaults enable only users with the administrative role or the owner
 /// of the server to perform this operation. Cloud providers can change these
-/// permissions through the `policy.json` file.
+/// permissions through the `policy.yaml` file.
 ///
 /// Normal response codes: 202
 ///
@@ -55,7 +55,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     unpause: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/unrescue.rs
+++ b/openstack_cli/src/compute/v2/server/unrescue.rs
@@ -62,7 +62,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     unrescue: Value,
 }
 

--- a/openstack_cli/src/compute/v2/server/unshelve_21.rs
+++ b/openstack_cli/src/compute/v2/server/unshelve_21.rs
@@ -45,7 +45,8 @@ pub struct ServerCommand {
     #[command(flatten)]
     path: PathParameters,
 
-    #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
+    /// OpenAPI specifies the field as '{}'.
+    #[arg(default_value_t=Value::Null, help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     unshelve: Value,
 }
 

--- a/openstack_cli/src/image/v2/metadef/namespace/property/create.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/create.rs
@@ -48,6 +48,7 @@ pub struct PropertyCommand {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     _default: Option<Value>,
 

--- a/openstack_cli/src/image/v2/metadef/namespace/property/set.rs
+++ b/openstack_cli/src/image/v2/metadef/namespace/property/set.rs
@@ -48,6 +48,7 @@ pub struct PropertyCommand {
     #[arg(action=clap::ArgAction::Set, help_heading = "Body parameters", long)]
     additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[arg(help_heading = "Body parameters", long, value_name="JSON", value_parser=crate::common::parse_json)]
     _default: Option<Value>,
 

--- a/openstack_sdk/src/api/block_storage/v3/attachment/os_complete_344.rs
+++ b/openstack_sdk/src/api/block_storage/v3/attachment/os_complete_344.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_complete: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/backup/os_force_delete.rs
+++ b/openstack_sdk/src/api/block_storage/v3/backup/os_force_delete.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_force_delete: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/consistencygroup/create.rs
+++ b/openstack_sdk/src/api/block_storage/v3/consistencygroup/create.rs
@@ -32,6 +32,7 @@ use std::collections::BTreeMap;
 #[derive(Builder, Debug, Deserialize, Clone, Serialize)]
 #[builder(setter(strip_option))]
 pub struct Consistencygroup<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) availability_zone: Option<Value>,
@@ -46,6 +47,7 @@ pub struct Consistencygroup<'a> {
     #[builder(default, setter(into))]
     pub(crate) name: Option<Option<Cow<'a, str>>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde()]
     #[builder(setter(into))]
     pub(crate) volume_types: Value,

--- a/openstack_sdk/src/api/block_storage/v3/snapshot/os_force_delete.rs
+++ b/openstack_sdk/src/api/block_storage/v3/snapshot/os_force_delete.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_force_delete: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/snapshot/os_unmanage.rs
+++ b/openstack_sdk/src/api/block_storage/v3/snapshot/os_unmanage.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_unmanage: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/os_begin_detaching.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/os_begin_detaching.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_begin_detaching: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/os_force_delete.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/os_force_delete.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_force_delete: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/os_reserve.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/os_reserve.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_reserve: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/os_roll_detaching.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/os_roll_detaching.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_roll_detaching: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/os_show_image_metadata.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/os_show_image_metadata.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_show_image_metadata: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/os_unmanage.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/os_unmanage.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_unmanage: Value,
 

--- a/openstack_sdk/src/api/block_storage/v3/volume/os_unreserve.rs
+++ b/openstack_sdk/src/api/block_storage/v3/volume/os_unreserve.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_unreserve: Value,
 

--- a/openstack_sdk/src/api/compute/v2/availability_zone/list_detail.rs
+++ b/openstack_sdk/src/api/compute/v2/availability_zone/list_detail.rs
@@ -17,7 +17,7 @@
 
 //! Gets detailed availability zone information. Policy defaults enable only
 //! users with the administrative role to perform this operation. Cloud
-//! providers can change these permissions through the `policy.json` file.
+//! providers can change these permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/flavor/set_255.rs
+++ b/openstack_sdk/src/api/compute/v2/flavor/set_255.rs
@@ -21,7 +21,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/floating_ip/create.rs
+++ b/openstack_sdk/src/api/compute/v2/floating_ip/create.rs
@@ -23,7 +23,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/floating_ip/delete.rs
+++ b/openstack_sdk/src/api/compute/v2/floating_ip/delete.rs
@@ -23,7 +23,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 202
 //!

--- a/openstack_sdk/src/api/compute/v2/floating_ip/get.rs
+++ b/openstack_sdk/src/api/compute/v2/floating_ip/get.rs
@@ -20,7 +20,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/floating_ip/list.rs
+++ b/openstack_sdk/src/api/compute/v2/floating_ip/list.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/hypervisor/get.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/get.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/hypervisor/list.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/list.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/hypervisor/list_detailed.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/list_detailed.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/hypervisor/search/get.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/search/get.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response code: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/hypervisor/server/get.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/server/get.rs
@@ -20,7 +20,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response code: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/hypervisor/statistic/get.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/statistic/get.rs
@@ -20,7 +20,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/hypervisor/uptime/get.rs
+++ b/openstack_sdk/src/api/compute/v2/hypervisor/uptime/get.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/migration/get.rs
+++ b/openstack_sdk/src/api/compute/v2/migration/get.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Starting from microversion 2.59, the response is sorted by `created_at` and
 //! `id` in descending order.

--- a/openstack_sdk/src/api/compute/v2/server/confirm_resize.rs
+++ b/openstack_sdk/src/api/compute/v2/server/confirm_resize.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) confirm_resize: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/create_20.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_20.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_21.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_219.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_219.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_232.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_232.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_233.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_233.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_237.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_237.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_242.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_242.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_252.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_252.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_257.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_257.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_263.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_263.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_267.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_267.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_274.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_274.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_290.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_290.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/create_294.rs
+++ b/openstack_sdk/src/api/compute/v2/server/create_294.rs
@@ -286,6 +286,7 @@ pub struct BlockDeviceMapping<'a> {
     #[builder(default, setter(into))]
     pub(crate) device_name: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,
@@ -366,6 +367,7 @@ pub struct BlockDeviceMappingV2<'a> {
     #[builder(default, setter(into))]
     pub(crate) image_id: Option<Cow<'a, str>>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) no_device: Option<Value>,

--- a/openstack_sdk/src/api/compute/v2/server/diagnostic/get.rs
+++ b/openstack_sdk/src/api/compute/v2/server/diagnostic/get.rs
@@ -18,7 +18,7 @@
 //! Shows basic usage data for a server.
 //!
 //! Policy defaults enable only users with the administrative role. Cloud
-//! providers can change these permissions through the `policy.json` file.
+//! providers can change these permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/force_delete.rs
+++ b/openstack_sdk/src/api/compute/v2/server/force_delete.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) force_delete: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/inject_network_info.rs
+++ b/openstack_sdk/src/api/compute/v2/server/inject_network_info.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) inject_network_info: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/instance_action/get.rs
+++ b/openstack_sdk/src/api/compute/v2/server/instance_action/get.rs
@@ -22,7 +22,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/instance_action/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/instance_action/list.rs
@@ -22,7 +22,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/ip/get.rs
+++ b/openstack_sdk/src/api/compute/v2/server/ip/get.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/ip/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/ip/list.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/lock_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/lock_21.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) lock: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/metadata/create.rs
+++ b/openstack_sdk/src/api/compute/v2/server/metadata/create.rs
@@ -23,7 +23,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/metadata/delete.rs
+++ b/openstack_sdk/src/api/compute/v2/server/metadata/delete.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 204
 //!

--- a/openstack_sdk/src/api/compute/v2/server/metadata/get.rs
+++ b/openstack_sdk/src/api/compute/v2/server/metadata/get.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/metadata/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/metadata/list.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/metadata/replace.rs
+++ b/openstack_sdk/src/api/compute/v2/server/metadata/replace.rs
@@ -23,7 +23,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/metadata/set.rs
+++ b/openstack_sdk/src/api/compute/v2/server/metadata/set.rs
@@ -23,7 +23,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/migration/delete.rs
+++ b/openstack_sdk/src/api/compute/v2/server/migration/delete.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! **Preconditions**
 //!

--- a/openstack_sdk/src/api/compute/v2/server/migration/get.rs
+++ b/openstack_sdk/src/api/compute/v2/server/migration/get.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/migration/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/migration/list.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role to perform
 //! this operation. Cloud providers can change these permissions through the
-//! `policy.json` file.
+//! `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/os_start.rs
+++ b/openstack_sdk/src/api/compute/v2/server/os_start.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_start: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/os_stop.rs
+++ b/openstack_sdk/src/api/compute/v2/server/os_stop.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) os_stop: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/pause.rs
+++ b/openstack_sdk/src/api/compute/v2/server/pause.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) pause: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/restore.rs
+++ b/openstack_sdk/src/api/compute/v2/server/restore.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) restore: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/resume.rs
+++ b/openstack_sdk/src/api/compute/v2/server/resume.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) resume: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/revert_resize.rs
+++ b/openstack_sdk/src/api/compute/v2/server/revert_resize.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) revert_resize: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/server_password/delete.rs
+++ b/openstack_sdk/src/api/compute/v2/server/server_password/delete.rs
@@ -22,7 +22,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 204
 //!

--- a/openstack_sdk/src/api/compute/v2/server/server_password/get.rs
+++ b/openstack_sdk/src/api/compute/v2/server/server_password/get.rs
@@ -26,7 +26,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the owner
 //! of the server to perform this operation. Cloud providers can change these
-//! permissions through the `policy.json` file.
+//! permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/shelve.rs
+++ b/openstack_sdk/src/api/compute/v2/server/shelve.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) shelve: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/shelve_offload.rs
+++ b/openstack_sdk/src/api/compute/v2/server/shelve_offload.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) shelve_offload: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/suspend.rs
+++ b/openstack_sdk/src/api/compute/v2/server/suspend.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) suspend: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/topology/list.rs
+++ b/openstack_sdk/src/api/compute/v2/server/topology/list.rs
@@ -19,7 +19,7 @@
 //!
 //! Policy defaults enable only users with the administrative role or the
 //! owners of the server to perform this operation. Cloud providers can change
-//! these permissions through the `policy.json` file.
+//! these permissions through the `policy.yaml` file.
 //!
 //! Normal response codes: 200
 //!

--- a/openstack_sdk/src/api/compute/v2/server/unlock_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/unlock_21.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) unlock: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/unpause.rs
+++ b/openstack_sdk/src/api/compute/v2/server/unpause.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) unpause: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/unrescue.rs
+++ b/openstack_sdk/src/api/compute/v2/server/unrescue.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) unrescue: Value,
 

--- a/openstack_sdk/src/api/compute/v2/server/unshelve_21.rs
+++ b/openstack_sdk/src/api/compute/v2/server/unshelve_21.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 #[derive(Builder, Debug, Clone)]
 #[builder(setter(strip_option))]
 pub struct Request<'a> {
+    /// OpenAPI specifies the field as '{}'.
     #[builder(setter(into))]
     pub(crate) unshelve: Value,
 

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/create.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/create.rs
@@ -61,6 +61,7 @@ pub struct Properties<'a> {
     #[builder(default, setter(into))]
     pub(crate) additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) _default: Option<Value>,

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/object/create.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/object/create.rs
@@ -61,6 +61,7 @@ pub struct Properties<'a> {
     #[builder(default, setter(into))]
     pub(crate) additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) _default: Option<Value>,

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/object/set.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/object/set.rs
@@ -61,6 +61,7 @@ pub struct Properties<'a> {
     #[builder(default, setter(into))]
     pub(crate) additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) _default: Option<Value>,

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/property/create.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/property/create.rs
@@ -59,6 +59,7 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     pub(crate) additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[builder(default, setter(into))]
     pub(crate) _default: Option<Value>,
 

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/property/set.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/property/set.rs
@@ -59,6 +59,7 @@ pub struct Request<'a> {
     #[builder(default, setter(into))]
     pub(crate) additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[builder(default, setter(into))]
     pub(crate) _default: Option<Value>,
 

--- a/openstack_sdk/src/api/image/v2/metadef/namespace/set.rs
+++ b/openstack_sdk/src/api/image/v2/metadef/namespace/set.rs
@@ -61,6 +61,7 @@ pub struct Properties<'a> {
     #[builder(default, setter(into))]
     pub(crate) additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "default", skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]
     pub(crate) _default: Option<Value>,

--- a/openstack_types/data/compute/v2.100.yaml
+++ b/openstack_types/data/compute/v2.100.yaml
@@ -357,7 +357,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1098,7 +1098,7 @@ paths:
       description: |-
         Gets detailed availability zone information.
         Policy defaults enable only users with the administrative role to perform this operation.
-        Cloud providers can change these permissions through the `policy.json` file.
+        Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1779,7 +1779,7 @@ paths:
         Policy defaults enable only users with the administrative role or user
         who is authorized to operate on tenant <tenant_id> to perform this
         operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1806,7 +1806,7 @@ paths:
 
         Policy defaults enable only users with the administrative role
         or the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1836,7 +1836,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1958,7 +1958,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -1989,7 +1989,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2027,7 +2027,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2054,7 +2054,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2265,7 +2265,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2301,7 +2301,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2337,7 +2337,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2364,7 +2364,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2399,7 +2399,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response code: 200
 
@@ -2431,7 +2431,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response code: 200
 
@@ -2462,7 +2462,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2649,7 +2649,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Starting from microversion 2.59, the response is sorted by `created_at`
         and `id` in descending order.
@@ -2693,7 +2693,7 @@ paths:
         Lists networks for the project.
 
         Policy defaults enable all users to perform this operation. Cloud
-        providers can change these permissions through the `policy.json` file.
+        providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2719,7 +2719,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the network to perform this operation. Cloud providers can change
-        these permissions through the `policy.json` file.
+        these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2746,7 +2746,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -2773,7 +2773,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the network to perform this operation. Cloud providers can change
-        these permissions through the `policy.json` file.
+        these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -2794,7 +2794,7 @@ paths:
         Shows details for a network.
 
         Policy defaults enable all users to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -3742,7 +3742,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the network to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -3768,7 +3768,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -3797,7 +3797,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the network to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -3819,7 +3819,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the network to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4853,7 +4853,7 @@ paths:
         Shows basic usage data for a server.
 
         Policy defaults enable only users with the administrative role. Cloud
-        providers can change these permissions through the `policy.json`
+        providers can change these permissions through the `policy.yaml`
         file.
 
         Normal response codes: 200
@@ -4887,7 +4887,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4914,7 +4914,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4940,7 +4940,7 @@ paths:
       description: |-
         Lists all metadata for a server.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4968,7 +4968,7 @@ paths:
         exists metadata items that match keys. Does not modify items that are not in
         the request.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5002,7 +5002,7 @@ paths:
 
         Creates any metadata items that do not already exist in the server. Removes and completely replaces any metadata items that already exist in the server with the metadata items in the request.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5035,7 +5035,7 @@ paths:
       description: |-
         Deletes a metadata item, by key, from a server.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 204
 
@@ -5055,7 +5055,7 @@ paths:
       description: |-
         Shows details for a metadata item, by key, for a server.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5083,7 +5083,7 @@ paths:
         Creates a metadata item that does not already exist in the server. Replaces
         existing metadata items that match keys with the metadata item in the request.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5120,7 +5120,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5149,7 +5149,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         **Preconditions**
 
@@ -5199,7 +5199,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5260,7 +5260,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5300,7 +5300,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5465,7 +5465,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner
         of the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 204
 
@@ -5492,7 +5492,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner
         of the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5520,7 +5520,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5988,7 +5988,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owners
         of the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -30567,7 +30567,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -30604,7 +30604,7 @@ components:
 
         Policy defaults enable only users with the administrative role or the
         owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -30925,7 +30925,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
         Administrators can overwrite owner’s lock.
 
         Normal response codes: 202
@@ -31088,7 +31088,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Starting from REST API version 2.34 pre-live-migration checks are done
         asynchronously, results of these checks are available in `instance-actions`.
@@ -31175,7 +31175,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -31196,7 +31196,7 @@ components:
 
         Specify the `unshelve` action in the request body.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         **Preconditions**
 
@@ -32924,7 +32924,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33448,7 +33448,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33471,7 +33471,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33543,7 +33543,7 @@ components:
         There are two different policies for this action, depending on whether the host
         parameter is set. Both defaults enable only users with the administrative role
         to perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33958,7 +33958,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33981,7 +33981,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34134,7 +34134,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34171,7 +34171,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34194,7 +34194,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34217,7 +34217,7 @@ components:
 
         All associated data and resources are kept but anything still in memory is not retained. To restore a shelved instance, use the `unshelve` action. To remove a shelved instance, use the `shelveOffload` action.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         **Preconditions**
 
@@ -34255,7 +34255,7 @@ components:
 
         Data and resource associations are deleted. If an instance is no longer needed, you can remove that instance from the hypervisor to minimize resource usage.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         **Preconditions**
 
@@ -34360,7 +34360,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34383,7 +34383,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34407,7 +34407,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -45947,7 +45947,7 @@ components:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         **Preconditions**
 
@@ -46131,7 +46131,7 @@ components:
 
                 Policy defaults enable only users with the administrative role or the owner
                 of the server to see instance action event information. Cloud providers can
-                change these permissions through the `policy.json` file.
+                change these permissions through the `policy.yaml` file.
 
                 **New in version 2.51**
               items:

--- a/openstack_types/data/compute/v2.yaml
+++ b/openstack_types/data/compute/v2.yaml
@@ -357,7 +357,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1098,7 +1098,7 @@ paths:
       description: |-
         Gets detailed availability zone information.
         Policy defaults enable only users with the administrative role to perform this operation.
-        Cloud providers can change these permissions through the `policy.json` file.
+        Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1779,7 +1779,7 @@ paths:
         Policy defaults enable only users with the administrative role or user
         who is authorized to operate on tenant <tenant_id> to perform this
         operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1806,7 +1806,7 @@ paths:
 
         Policy defaults enable only users with the administrative role
         or the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1836,7 +1836,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -1958,7 +1958,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -1989,7 +1989,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2027,7 +2027,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2054,7 +2054,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2265,7 +2265,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2301,7 +2301,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2337,7 +2337,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2364,7 +2364,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2399,7 +2399,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response code: 200
 
@@ -2431,7 +2431,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response code: 200
 
@@ -2462,7 +2462,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through
-        the `policy.json` file.
+        the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2649,7 +2649,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Starting from microversion 2.59, the response is sorted by `created_at`
         and `id` in descending order.
@@ -2693,7 +2693,7 @@ paths:
         Lists networks for the project.
 
         Policy defaults enable all users to perform this operation. Cloud
-        providers can change these permissions through the `policy.json` file.
+        providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2719,7 +2719,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the network to perform this operation. Cloud providers can change
-        these permissions through the `policy.json` file.
+        these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -2746,7 +2746,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -2773,7 +2773,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the
         owner of the network to perform this operation. Cloud providers can change
-        these permissions through the `policy.json` file.
+        these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -2794,7 +2794,7 @@ paths:
         Shows details for a network.
 
         Policy defaults enable all users to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -3742,7 +3742,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the network to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -3768,7 +3768,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -3797,7 +3797,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the network to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -3819,7 +3819,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or
         the owner of the network to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4853,7 +4853,7 @@ paths:
         Shows basic usage data for a server.
 
         Policy defaults enable only users with the administrative role. Cloud
-        providers can change these permissions through the `policy.json`
+        providers can change these permissions through the `policy.yaml`
         file.
 
         Normal response codes: 200
@@ -4887,7 +4887,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4914,7 +4914,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4940,7 +4940,7 @@ paths:
       description: |-
         Lists all metadata for a server.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -4968,7 +4968,7 @@ paths:
         exists metadata items that match keys. Does not modify items that are not in
         the request.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5002,7 +5002,7 @@ paths:
 
         Creates any metadata items that do not already exist in the server. Removes and completely replaces any metadata items that already exist in the server with the metadata items in the request.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5035,7 +5035,7 @@ paths:
       description: |-
         Deletes a metadata item, by key, from a server.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 204
 
@@ -5055,7 +5055,7 @@ paths:
       description: |-
         Shows details for a metadata item, by key, for a server.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5083,7 +5083,7 @@ paths:
         Creates a metadata item that does not already exist in the server. Replaces
         existing metadata items that match keys with the metadata item in the request.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5120,7 +5120,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5149,7 +5149,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         **Preconditions**
 
@@ -5199,7 +5199,7 @@ paths:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5260,7 +5260,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5300,7 +5300,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5465,7 +5465,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner
         of the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 204
 
@@ -5492,7 +5492,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner
         of the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5520,7 +5520,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owner of
         the server to perform this operation. Change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -5988,7 +5988,7 @@ paths:
 
         Policy defaults enable only users with the administrative role or the owners
         of the server to perform this operation. Cloud providers can change these
-        permissions through the `policy.json` file.
+        permissions through the `policy.yaml` file.
 
         Normal response codes: 200
 
@@ -30567,7 +30567,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -30604,7 +30604,7 @@ components:
 
         Policy defaults enable only users with the administrative role or the
         owner of the server to perform this operation. Cloud providers can
-        change these permissions through the `policy.json` file.
+        change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -30925,7 +30925,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
         Administrators can overwrite owner’s lock.
 
         Normal response codes: 202
@@ -31088,7 +31088,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Starting from REST API version 2.34 pre-live-migration checks are done
         asynchronously, results of these checks are available in `instance-actions`.
@@ -31175,7 +31175,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -31196,7 +31196,7 @@ components:
 
         Specify the `unshelve` action in the request body.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         **Preconditions**
 
@@ -32924,7 +32924,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33448,7 +33448,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33471,7 +33471,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33543,7 +33543,7 @@ components:
         There are two different policies for this action, depending on whether the host
         parameter is set. Both defaults enable only users with the administrative role
         to perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33958,7 +33958,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -33981,7 +33981,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34134,7 +34134,7 @@ components:
 
         Policy defaults enable only users with the administrative role to
         perform this operation. Cloud providers can change these permissions
-        through the `policy.json` file.
+        through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34171,7 +34171,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34194,7 +34194,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34217,7 +34217,7 @@ components:
 
         All associated data and resources are kept but anything still in memory is not retained. To restore a shelved instance, use the `unshelve` action. To remove a shelved instance, use the `shelveOffload` action.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         **Preconditions**
 
@@ -34255,7 +34255,7 @@ components:
 
         Data and resource associations are deleted. If an instance is no longer needed, you can remove that instance from the hypervisor to minimize resource usage.
 
-        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.json` file.
+        Policy defaults enable only users with the administrative role or the owner of the server to perform this operation. Cloud providers can change these permissions through the `policy.yaml` file.
 
         **Preconditions**
 
@@ -34360,7 +34360,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34383,7 +34383,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -34407,7 +34407,7 @@ components:
 
         Policy defaults enable only users with the administrative role or
         the owner of the server to perform this operation. Cloud providers
-        can change these permissions through the `policy.json` file.
+        can change these permissions through the `policy.yaml` file.
 
         Normal response codes: 202
 
@@ -45947,7 +45947,7 @@ components:
 
         Policy defaults enable only users with the administrative role to perform
         this operation. Cloud providers can change these permissions through the
-        `policy.json` file.
+        `policy.yaml` file.
 
         **Preconditions**
 
@@ -46131,7 +46131,7 @@ components:
 
                 Policy defaults enable only users with the administrative role or the owner
                 of the server to see instance action event information. Cloud providers can
-                change these permissions through the `policy.json` file.
+                change these permissions through the `policy.yaml` file.
 
                 **New in version 2.51**
               items:

--- a/openstack_types/data/identity/keystone_rust.yaml
+++ b/openstack_types/data/identity/keystone_rust.yaml
@@ -151,6 +151,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SingleVersion'
+  /v3/auth/projects:
+    get:
+      tags:
+      - auth
+      summary: Get available project scopes.
+      description: |-
+        This call returns the list of projects that are available to be scoped to
+        based on the X-Auth-Token provided in the request.
+      operationId: list
+      responses:
+        '200':
+          description: Project list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectShortList'
   /v3/auth/tokens:
     get:
       tags:
@@ -328,11 +344,44 @@ paths:
           description: Deleted
         '404':
           description: group not found
+  /v3/projects/{project_id}/users/{user_id}/roles/{role_id}:
+    head:
+      tags:
+      - role_assignments
+      summary: Check whether user has role assignment on project
+      description: Validates that a user has a role on a project.
+      operationId: /project/user/role:check
+      parameters:
+      - name: role_id
+        in: path
+        description: The user ID.
+        required: true
+        schema:
+          type: string
+      - name: project_id
+        in: path
+        description: The project ID.
+        required: true
+        schema:
+          type: string
+      - name: user_id
+        in: path
+        description: The user ID.
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Grant is present.
+        '404':
+          description: Grant not found
+      security:
+      - x-auth: []
   /v3/role_assignments:
     get:
       tags:
-      - roles
-      summary: List role assignments
+      - role_assignments
+      summary: List role assignments.
       description: List roles
       operationId: list
       parameters:
@@ -1231,11 +1280,44 @@ paths:
           description: Deleted
         '404':
           description: group not found
-  /v4/role_assignments:
+  /v4/role_assignments/projects/{project_id}/users/{user_id}/roles/{role_id}:
+    head:
+      tags:
+      - role_assignments
+      summary: Check whether user has role assignment on project
+      description: Validates that a user has a role on a project.
+      operationId: /project/user/role:check
+      parameters:
+      - name: role_id
+        in: path
+        description: The user ID.
+        required: true
+        schema:
+          type: string
+      - name: project_id
+        in: path
+        description: The project ID.
+        required: true
+        schema:
+          type: string
+      - name: user_id
+        in: path
+        description: The user ID.
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Grant is present.
+        '404':
+          description: Grant not found
+      security:
+      - x-auth: []
+  /v4/role_assignments/role_assignments:
     get:
       tags:
-      - roles
-      summary: List role assignments
+      - role_assignments
+      summary: List role assignments.
       description: List roles
       operationId: list
       parameters:
@@ -1782,7 +1864,7 @@ components:
               sufficient to uniquely identify a project but if a project is
               specified by name, then the domain of the project must also be
               specified in order to uniquely identify the project by name. A domain
-              scope may be specified by either the domain’s ID or name with
+              scope may be specified by either the domain's ID or name with
               equivalent results.
     AuthenticationExtensionsClientOutputs:
       type: object
@@ -1945,7 +2027,7 @@ components:
     CredProtect:
       type: object
       description: |-
-        The desired options for the client’s use of the credProtect extension
+        The desired options for the client's use of the credProtect extension
 
         <https://fidoalliance.org/specs/fido-v2.1-rd-20210309/fido-client-to-authenticator-protocol-v2.1-rd-20210309.html#sctn-credProtect-extension>
       required:
@@ -2355,6 +2437,13 @@ components:
           items:
             $ref: '#/components/schemas/IdentityProvider'
           description: Collection of identity provider objects.
+        links:
+          type:
+          - array
+          - 'null'
+          items:
+            $ref: '#/components/schemas/Link'
+          description: Pagination links.
     IdentityProviderResponse:
       type: object
       description: Identity provider response.
@@ -2650,6 +2739,13 @@ components:
       required:
       - mappings
       properties:
+        links:
+          type:
+          - array
+          - 'null'
+          items:
+            $ref: '#/components/schemas/Link'
+          description: Pagination links.
         mappings:
           type: array
           items:
@@ -2849,7 +2945,7 @@ components:
       description: |-
         Passkey Authorization challenge.
 
-        A JSON serializable challenge which is issued to the user’s webbrowser for
+        A JSON serializable challenge which is issued to the user's webbrowser for
         handling. This is meant to be opaque, that is, you should not need to
         inspect or alter the content of the struct
         - you should serialise it and transmit it to the client only.
@@ -2890,13 +2986,13 @@ components:
         display_name:
           type: string
           description: |-
-            The user’s preferred name for display. This value can change, so must
+            The user's preferred name for display. This value can change, so must
             not be used as a primary key.
         id:
           type: string
           format: binary
           description: |-
-            The user’s id in base64 form. This MUST be a unique id, and must NOT
+            The user's id in base64 form. This MUST be a unique id, and must NOT
             contain personally identifying information, as this value can NEVER
             be changed. If in doubt, use a UUID.
           contentEncoding: base64
@@ -2940,6 +3036,40 @@ components:
         name:
           type: string
           description: Project Name.
+    ProjectShort:
+      type: object
+      description: Short Project representation.
+      required:
+      - domain_id
+      - enabled
+      - id
+      - name
+      properties:
+        domain_id:
+          type: string
+          description: The ID of the domain for the project.
+        enabled:
+          type: boolean
+          description: |-
+            If set to true, project is enabled. If set to false, project is
+            disabled.
+        id:
+          type: string
+          description: The ID for the project.
+        name:
+          type: string
+          description: The name of the project.
+    ProjectShortList:
+      type: object
+      description: List of projects.
+      required:
+      - projects
+      properties:
+        projects:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectShort'
+          description: Collection of project objects.
     PubKeyCredParams:
       type: object
       description: Public key cryptographic parameters
@@ -2983,7 +3113,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PublicKeyCredentialDescriptor'
-          description: Credential ID’s that are excluded from being able to be registered.
+          description: Credential ID's that are excluded from being able to be registered.
         extensions:
           $ref: '#/components/schemas/RequestRegistrationExtensions'
           description: extensions.
@@ -3181,7 +3311,7 @@ components:
     ResidentKeyRequirement:
       type: string
       description: |-
-        The Relying Party’s requirements for client-side discoverable credentials.
+        The Relying Party's requirements for client-side discoverable credentials.
 
         <https://www.w3.org/TR/webauthn-2/#enumdef-residentkeyrequirement>
       enum:
@@ -3212,6 +3342,7 @@ components:
           name:
             type: string
             description: Role name
+      description: The role data.
     RoleCreate:
       allOf:
       - description: Extra attributes for the role.
@@ -3243,7 +3374,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Role'
-          description: Collection of role objects
+          description: Collection of role objects.
     RoleResponse:
       type: object
       required:
@@ -3287,7 +3418,7 @@ components:
         ID is sufficient to uniquely identify a project but if a project is
         specified by name, then the domain of the project must also be specified in
         order to uniquely identify the project by name. A domain scope may be
-        specified by either the domain’s ID or name with equivalent results.
+        specified by either the domain's ID or name with equivalent results.
     ScopeProject:
       type: object
       description: Project scope information.
@@ -3318,13 +3449,13 @@ components:
           description: The version.
     System:
       type: object
-      description: System scope.
+      description: System information.
+      required:
+      - all
       properties:
         all:
-          type:
-          - boolean
-          - 'null'
-          description: All systems access.
+          type: boolean
+          description: All
     Token:
       type: object
       description: Authorization token
@@ -3332,8 +3463,14 @@ components:
       - audit_ids
       - methods
       - expires_at
+      - issued_at
       - user
       properties:
+        OS-TRUST:trust:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/TokenTrustRepr'
+            description: A trust object.
         audit_ids:
           type: array
           items:
@@ -3365,6 +3502,10 @@ components:
           type: string
           format: date-time
           description: The date and time when the token expires.
+        issued_at:
+          type: string
+          format: date-time
+          description: The date and time when the token was issued.
         methods:
           type: array
           items:
@@ -3396,6 +3537,11 @@ components:
           items:
             $ref: '#/components/schemas/Role'
           description: A list of role objects
+        system:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/System'
+            description: A system object.
         user:
           $ref: '#/components/schemas/User'
           description: A user object.
@@ -3555,6 +3701,101 @@ components:
         restriction:
           $ref: '#/components/schemas/TokenRestrictionUpdate'
           description: Restriction object.
+    TokenTrustRepr:
+      type: object
+      description: A trust object returned in the token.
+      required:
+      - id
+      - impersonation
+      - trustor_user
+      - trustee_user
+      properties:
+        expires_at:
+          type:
+          - string
+          - 'null'
+          format: date-time
+          description: |-
+            Specifies the expiration time of the trust. A trust may be revoked ahead
+            of expiration. If the value represents a time in the past, the trust is
+            deactivated. In the redelegation case it must not exceed the value of
+            the corresponding `expires_at` field of the redelegated trust or it may
+            be omitted, then the `expires_at` value is copied from the
+            redelegated trust.
+        id:
+          type: string
+          description: The ID of the trust.
+        impersonation:
+          type: boolean
+          description: |-
+            If set to `true`, then the user attribute of tokens generated based on
+            the trust will represent that of the `trustor` rather than the
+            `trustee`, thus allowing the `trustee` to impersonate the `trustor`.
+            If impersonation is set to `false`, then the token's user attribute
+            will represent that of the `trustee`.
+        redelegated_trust_id:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Returned with redelegated trust provides information about the
+            predecessor in the trust chain.
+        redelegation_count:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: |-
+            Specifies the maximum remaining depth of the redelegated trust chain.
+            Each subsequent trust has this field decremented by 1 automatically. The
+            initial trustor issuing new trust that can be redelegated, must set
+            allow_redelegation to true and may set `redelegation_count` to an
+            integer value less than or equal to `max_redelegation_count`
+            configuration parameter in order to limit the possible length of
+            derived trust chains. The trust issued by the `trustor` using a
+            project-scoped token (not redelegating), in which
+            `allow_redelegation` is set to true (the new
+            trust is redelegatable), will be populated with the value specified in
+            the `max_redelegation_count` configuration parameter if
+            `redelegation_count` is not set or set to `null`. If
+            `allow_redelegation` is set to `false` then `redelegation_count`
+            will be set to 0 in the trust. If the trust is being issued by the
+            `trustee` of a redelegatable trust-scoped token (redelegation case)
+            then `redelegation_count` should not be set, as it
+            will automatically be set to the value in the redelegatable
+            trust-scoped token decremented by 1. Note, if the resulting value is
+            0, this means that the new trust will not be redelegatable,
+            regardless of the value of `allow_redelegation`.
+          minimum: 0
+        remaining_uses:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: |-
+            Specifies how many times the trust can be used to obtain a token. This
+            value is decreased each time a token is issued through the trust. Once
+            it reaches 0, no further tokens will be issued through the trust. The
+            default value is null, meaning there is no limit on the number of tokens
+            issued through the trust. If redelegation is enabled it must not be set.
+          minimum: 0
+        trustee_user:
+          $ref: '#/components/schemas/TokenTrustUser'
+          description: Represents the user who is capable of consuming the trust.
+        trustor_user:
+          $ref: '#/components/schemas/TokenTrustUser'
+          description: |-
+            Represents the user who created the trust, and who's authorization is
+            being delegated.
+    TokenTrustUser:
+      type: object
+      description: A trust object returned in the token.
+      required:
+      - id
+      properties:
+        id:
+          type: string
+          description: The ID of the user.
     User:
       type: object
       description: User information.
@@ -3592,7 +3833,7 @@ components:
             - string
             - 'null'
             description: |-
-              The ID of the default project for the user. A user’s default project
+              The ID of the default project for the user. A user's default project
               must not be a domain. Setting this attribute does not grant any actual
               authorization on the project, and is merely provided for convenience.
               Therefore, the referenced project does not need to exist within the user
@@ -3689,7 +3930,7 @@ components:
       type: object
       description: |-
         A client response to a registration challenge. This contains all required
-        information to assess and assert trust in a credential’s legitimacy,
+        information to assess and assert trust in a credential's legitimacy,
         followed by registration to a user.
 
         You should not need to handle the inner content of this structure - you
@@ -3791,7 +4032,7 @@ components:
       description: |-
         Defines the User Authenticator Verification policy. This is documented
         <https://w3c.github.io/webauthn/#enumdef-userverificationrequirement>, and each variant lists
-        it’s effects.
+        it's effects.
 
         To be clear, Verification means that the Authenticator perform extra or
         supplementary interaction with the user to verify who they are. An example
@@ -3800,7 +4041,7 @@ components:
 
         An example of a non-verified interaction is a yubico device with no pin
         where touch is the only interaction - we only verify a user is present, but
-        we don’t have extra details to the legitimacy of that user.
+        we don't have extra details to the legitimacy of that user.
 
         As UserVerificationPolicy is only used in credential registration, this
         stores the verification state of the credential in the persisted credential.

--- a/openstack_types/data/shared-file-system/v2.91.yaml
+++ b/openstack_types/data/shared-file-system/v2.91.yaml
@@ -2406,10 +2406,10 @@ paths:
                 - $ref: '#/components/schemas/SharesActionDeny_AccessRequest'
                 - $ref: '#/components/schemas/SharesActionExtendRequest'
                 - $ref: '#/components/schemas/SharesActionExtend_Legacy_20'
-                - $ref: '#/components/schemas/SharesActionMigration_CancelRequest'
-                - $ref: '#/components/schemas/SharesActionMigration_CompleteRequest'
-                - $ref: '#/components/schemas/SharesActionMigration_Get_ProgressRequest'
-                - $ref: '#/components/schemas/SharesActionMigration_StartRequest'
+                - $ref: '#/components/schemas/SharesActionMigration_Cancel_222'
+                - $ref: '#/components/schemas/SharesActionMigration_Complete_222'
+                - $ref: '#/components/schemas/SharesActionMigration_Get_Progress_222'
+                - $ref: '#/components/schemas/SharesActionMigration_Start_229'
                 - $ref: '#/components/schemas/SharesActionOs-Access_ListRequest'
                 - $ref: '#/components/schemas/SharesActionOs-Allow_AccessRequest'
                 - $ref: '#/components/schemas/SharesActionOs-Deny_AccessRequest'
@@ -4429,16 +4429,38 @@ components:
       schema:
         type: string
     snapshots_all_tenants:
-      description: Set 1 to list resources for all projects;set 0 to list 
-        resources only for the current project
       in: query
       name: all_tenants
       schema:
         description: Set 1 to list resources for all projects;set 0 to list 
           resources only for the current project
         enum:
-          - 0
-          - 1
+          - '0'
+          - '1'
+          - 'FALSE'
+          - false
+          - 'False'
+          - NO
+          - No
+          - OFF
+          - ON
+          - Off
+          - On
+          - 'TRUE'
+          - true
+          - 'True'
+          - YES
+          - Yes
+          - f
+          - 'false'
+          - n
+          - no
+          - off
+          - on
+          - t
+          - 'true'
+          - y
+          - yes
         type:
           - boolean
           - string
@@ -6633,60 +6655,248 @@ components:
       type: 'null'
       x-openstack:
         action-name: force_delete
-    SharesActionMigration_CancelRequest:
-      description: Empty body for migration_cancel action
-      properties:
-        migration_cancel:
-          type: 'null'
-      type: object
-      x-openstack:
-        action-name: migration_cancel
     SharesActionMigration_CancelResponse:
-      description: Response of the shares/id/action:post:migration_cancel action
+      type: 'null'
+      x-openstack:
+        action-name: migration_cancel
+    SharesActionMigration_Cancel_222:
+      additionalProperties: false
+      properties:
+        migration_cancel: {}
+      required:
+        - migration_cancel
       type: object
       x-openstack:
         action-name: migration_cancel
-    SharesActionMigration_CompleteRequest:
-      description: Empty body for migration_complete action
-      properties:
-        migration_complete:
-          type: 'null'
-      type: object
-      x-openstack:
-        action-name: migration_complete
+        min-ver: '2.22'
     SharesActionMigration_CompleteResponse:
-      description: Response of the shares/id/action:post:migration_complete 
-        action
+      type: 'null'
+      x-openstack:
+        action-name: migration_complete
+    SharesActionMigration_Complete_222:
+      additionalProperties: false
+      properties:
+        migration_complete: {}
+      required:
+        - migration_complete
       type: object
       x-openstack:
         action-name: migration_complete
-    SharesActionMigration_Get_ProgressRequest:
-      description: Empty body for migration_get_progress action
-      properties:
-        migration_get_progress:
-          type: 'null'
-      type: object
-      x-openstack:
-        action-name: migration_get_progress
+        min-ver: '2.22'
     SharesActionMigration_Get_ProgressResponse:
-      description: Response of the shares/id/action:post:migration_get_progress 
-        action
+      additionalProperties: false
+      properties:
+        details: {}
+        task_state: {}
+        total_progress:
+          max: 100
+          min: 0
+          type: integer
+      required:
+        - details
+        - task_state
+        - total_progress
       type: object
       x-openstack:
         action-name: migration_get_progress
-    SharesActionMigration_StartRequest:
-      description: Empty body for migration_start action
+    SharesActionMigration_Get_Progress_222:
+      additionalProperties: false
+      properties:
+        migration_get_progress: {}
+      required:
+        - migration_get_progress
+      type: object
+      x-openstack:
+        action-name: migration_get_progress
+        min-ver: '2.22'
+    SharesActionMigration_StartResponse:
+      type: 'null'
+      x-openstack:
+        action-name: migration_start
+    SharesActionMigration_Start_229:
+      additionalProperties: false
       properties:
         migration_start:
-          type: 'null'
+          additionalProperties: true
+          properties:
+            force_host_assisted_migration:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            host:
+              type: string
+            new_share_network_id:
+              type:
+                - 'null'
+                - string
+            new_share_type_id:
+              type:
+                - 'null'
+                - string
+            nondisruptive:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            preserve_metadata:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            preserve_snapshots:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            writable:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+          required:
+            - host
+            - nondisruptive
+            - preserve_metadata
+            - preserve_snapshots
+            - writable
+          type: object
+      required:
+        - migration_start
       type: object
       x-openstack:
         action-name: migration_start
-    SharesActionMigration_StartResponse:
-      description: Response of the shares/id/action:post:migration_start action
-      type: object
-      x-openstack:
-        action-name: migration_start
+        min-ver: '2.29'
     SharesActionOs-Access_ListRequest:
       description: Empty body for os-access_list action
       properties:

--- a/openstack_types/data/shared-file-system/v2.yaml
+++ b/openstack_types/data/shared-file-system/v2.yaml
@@ -2406,10 +2406,10 @@ paths:
                 - $ref: '#/components/schemas/SharesActionDeny_AccessRequest'
                 - $ref: '#/components/schemas/SharesActionExtendRequest'
                 - $ref: '#/components/schemas/SharesActionExtend_Legacy_20'
-                - $ref: '#/components/schemas/SharesActionMigration_CancelRequest'
-                - $ref: '#/components/schemas/SharesActionMigration_CompleteRequest'
-                - $ref: '#/components/schemas/SharesActionMigration_Get_ProgressRequest'
-                - $ref: '#/components/schemas/SharesActionMigration_StartRequest'
+                - $ref: '#/components/schemas/SharesActionMigration_Cancel_222'
+                - $ref: '#/components/schemas/SharesActionMigration_Complete_222'
+                - $ref: '#/components/schemas/SharesActionMigration_Get_Progress_222'
+                - $ref: '#/components/schemas/SharesActionMigration_Start_229'
                 - $ref: '#/components/schemas/SharesActionOs-Access_ListRequest'
                 - $ref: '#/components/schemas/SharesActionOs-Allow_AccessRequest'
                 - $ref: '#/components/schemas/SharesActionOs-Deny_AccessRequest'
@@ -4429,16 +4429,38 @@ components:
       schema:
         type: string
     snapshots_all_tenants:
-      description: Set 1 to list resources for all projects;set 0 to list 
-        resources only for the current project
       in: query
       name: all_tenants
       schema:
         description: Set 1 to list resources for all projects;set 0 to list 
           resources only for the current project
         enum:
-          - 0
-          - 1
+          - '0'
+          - '1'
+          - 'FALSE'
+          - false
+          - 'False'
+          - NO
+          - No
+          - OFF
+          - ON
+          - Off
+          - On
+          - 'TRUE'
+          - true
+          - 'True'
+          - YES
+          - Yes
+          - f
+          - 'false'
+          - n
+          - no
+          - off
+          - on
+          - t
+          - 'true'
+          - y
+          - yes
         type:
           - boolean
           - string
@@ -6633,60 +6655,248 @@ components:
       type: 'null'
       x-openstack:
         action-name: force_delete
-    SharesActionMigration_CancelRequest:
-      description: Empty body for migration_cancel action
-      properties:
-        migration_cancel:
-          type: 'null'
-      type: object
-      x-openstack:
-        action-name: migration_cancel
     SharesActionMigration_CancelResponse:
-      description: Response of the shares/id/action:post:migration_cancel action
+      type: 'null'
+      x-openstack:
+        action-name: migration_cancel
+    SharesActionMigration_Cancel_222:
+      additionalProperties: false
+      properties:
+        migration_cancel: {}
+      required:
+        - migration_cancel
       type: object
       x-openstack:
         action-name: migration_cancel
-    SharesActionMigration_CompleteRequest:
-      description: Empty body for migration_complete action
-      properties:
-        migration_complete:
-          type: 'null'
-      type: object
-      x-openstack:
-        action-name: migration_complete
+        min-ver: '2.22'
     SharesActionMigration_CompleteResponse:
-      description: Response of the shares/id/action:post:migration_complete 
-        action
+      type: 'null'
+      x-openstack:
+        action-name: migration_complete
+    SharesActionMigration_Complete_222:
+      additionalProperties: false
+      properties:
+        migration_complete: {}
+      required:
+        - migration_complete
       type: object
       x-openstack:
         action-name: migration_complete
-    SharesActionMigration_Get_ProgressRequest:
-      description: Empty body for migration_get_progress action
-      properties:
-        migration_get_progress:
-          type: 'null'
-      type: object
-      x-openstack:
-        action-name: migration_get_progress
+        min-ver: '2.22'
     SharesActionMigration_Get_ProgressResponse:
-      description: Response of the shares/id/action:post:migration_get_progress 
-        action
+      additionalProperties: false
+      properties:
+        details: {}
+        task_state: {}
+        total_progress:
+          max: 100
+          min: 0
+          type: integer
+      required:
+        - details
+        - task_state
+        - total_progress
       type: object
       x-openstack:
         action-name: migration_get_progress
-    SharesActionMigration_StartRequest:
-      description: Empty body for migration_start action
+    SharesActionMigration_Get_Progress_222:
+      additionalProperties: false
+      properties:
+        migration_get_progress: {}
+      required:
+        - migration_get_progress
+      type: object
+      x-openstack:
+        action-name: migration_get_progress
+        min-ver: '2.22'
+    SharesActionMigration_StartResponse:
+      type: 'null'
+      x-openstack:
+        action-name: migration_start
+    SharesActionMigration_Start_229:
+      additionalProperties: false
       properties:
         migration_start:
-          type: 'null'
+          additionalProperties: true
+          properties:
+            force_host_assisted_migration:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            host:
+              type: string
+            new_share_network_id:
+              type:
+                - 'null'
+                - string
+            new_share_type_id:
+              type:
+                - 'null'
+                - string
+            nondisruptive:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            preserve_metadata:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            preserve_snapshots:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+            writable:
+              enum:
+                - '0'
+                - '1'
+                - 'FALSE'
+                - false
+                - 'False'
+                - NO
+                - No
+                - OFF
+                - ON
+                - Off
+                - On
+                - 'TRUE'
+                - true
+                - 'True'
+                - YES
+                - Yes
+                - f
+                - 'false'
+                - n
+                - no
+                - off
+                - on
+                - t
+                - 'true'
+                - y
+                - yes
+              type:
+                - boolean
+                - string
+          required:
+            - host
+            - nondisruptive
+            - preserve_metadata
+            - preserve_snapshots
+            - writable
+          type: object
+      required:
+        - migration_start
       type: object
       x-openstack:
         action-name: migration_start
-    SharesActionMigration_StartResponse:
-      description: Response of the shares/id/action:post:migration_start action
-      type: object
-      x-openstack:
-        action-name: migration_start
+        min-ver: '2.29'
     SharesActionOs-Access_ListRequest:
       description: Empty body for os-access_list action
       properties:

--- a/openstack_types/src/compute/v2/flavor/response/create.rs
+++ b/openstack_types/src/compute/v2/flavor/response/create.rs
@@ -64,6 +64,7 @@ pub struct FlavorResponse {
     #[structable()]
     pub name: String,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "os-flavor-access:is_public")]
     #[structable(serialize, title = "os-flavor-access:is_public")]
     pub os_flavor_access_is_public: Value,
@@ -87,6 +88,7 @@ pub struct FlavorResponse {
     #[structable()]
     pub ram: i32,
 
+    /// OpenAPI specifies the field as '{}'.
     #[structable(serialize)]
     pub rxtx_factor: Value,
 

--- a/openstack_types/src/compute/v2/flavor/response/get.rs
+++ b/openstack_types/src/compute/v2/flavor/response/get.rs
@@ -64,6 +64,7 @@ pub struct FlavorResponse {
     #[structable()]
     pub name: String,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "os-flavor-access:is_public")]
     #[structable(serialize, title = "os-flavor-access:is_public")]
     pub os_flavor_access_is_public: Value,
@@ -87,6 +88,7 @@ pub struct FlavorResponse {
     #[structable()]
     pub ram: i32,
 
+    /// OpenAPI specifies the field as '{}'.
     #[structable(serialize)]
     pub rxtx_factor: Value,
 

--- a/openstack_types/src/compute/v2/flavor/response/list_detailed.rs
+++ b/openstack_types/src/compute/v2/flavor/response/list_detailed.rs
@@ -58,6 +58,7 @@ pub struct FlavorResponse {
     #[structable()]
     pub name: String,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "os-flavor-access:is_public")]
     #[structable(serialize, title = "os-flavor-access:is_public", wide)]
     pub os_flavor_access_is_public: Value,
@@ -81,6 +82,7 @@ pub struct FlavorResponse {
     #[structable(wide)]
     pub ram: i32,
 
+    /// OpenAPI specifies the field as '{}'.
     #[structable(serialize, wide)]
     pub rxtx_factor: Value,
 

--- a/openstack_types/src/compute/v2/flavor/response/set.rs
+++ b/openstack_types/src/compute/v2/flavor/response/set.rs
@@ -62,6 +62,7 @@ pub struct FlavorResponse {
     #[structable()]
     pub name: String,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(rename = "os-flavor-access:is_public")]
     #[structable(serialize, title = "os-flavor-access:is_public")]
     pub os_flavor_access_is_public: Value,
@@ -85,6 +86,7 @@ pub struct FlavorResponse {
     #[structable()]
     pub ram: i32,
 
+    /// OpenAPI specifies the field as '{}'.
     #[structable(serialize)]
     pub rxtx_factor: Value,
 

--- a/openstack_types/src/compute/v2/server/instance_action/response/get.rs
+++ b/openstack_types/src/compute/v2/server/instance_action/response/get.rs
@@ -31,7 +31,7 @@ pub struct InstanceActionResponse {
     ///
     /// Policy defaults enable only users with the administrative role or the
     /// owner of the server to see instance action event information. Cloud
-    /// providers can change these permissions through the `policy.json` file.
+    /// providers can change these permissions through the `policy.yaml` file.
     ///
     /// **New in version 2.51**
     #[structable(serialize)]

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/create.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/create.rs
@@ -27,6 +27,7 @@ pub struct PropertyResponse {
     #[structable(optional, title = "additionalItems")]
     pub additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(default, rename = "default")]
     #[structable(optional, serialize, title = "default")]
     pub _default: Option<Value>,

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/get.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/get.rs
@@ -27,6 +27,7 @@ pub struct PropertyResponse {
     #[structable(optional, title = "additionalItems")]
     pub additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(default, rename = "default")]
     #[structable(optional, serialize, title = "default")]
     pub _default: Option<Value>,

--- a/openstack_types/src/image/v2/metadef/namespace/property/response/set.rs
+++ b/openstack_types/src/image/v2/metadef/namespace/property/response/set.rs
@@ -27,6 +27,7 @@ pub struct PropertyResponse {
     #[structable(optional, title = "additionalItems")]
     pub additional_items: Option<bool>,
 
+    /// OpenAPI specifies the field as '{}'.
     #[serde(default, rename = "default")]
     #[structable(optional, serialize, title = "default")]
     pub _default: Option<Value>,


### PR DESCRIPTION
In some cases nova/cinder (at least) report the body as '{}' (i.e.
server stop/start). On the cli side it makes absolutely no sense to
expose it to the user since it generally stands for the "null" body.

Change-Id: I4aa4f786d3cd60caa404a1850e87fb0167824b6a
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/973122
