### PR TITLE
chore: Replace abandoned `bincode` with `postcard`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,16 +340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +505,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1069,6 +1068,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -2531,7 +2542,6 @@ version = "0.22.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
- "bincode",
  "bytes",
  "chrono",
  "config",
@@ -2549,6 +2559,7 @@ dependencies = [
  "itertools 0.14.0",
  "json-patch",
  "open",
+ "postcard",
  "regex",
  "reqwest",
  "reserve-port",
@@ -2813,6 +2824,18 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"
@@ -4339,12 +4362,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,8 @@ ignore = [
     #"RUSTSEC-0000-0000",
     "RUSTSEC-2021-0127", # serde_cbor as optional transitive dep: https://github.com/mozilla/authenticator-rs/issues/327
     "RUSTSEC-2024-0436",
+    # ratatui is going to be updated soon
+    "RUSTSEC-2026-0002",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -46,7 +46,6 @@ passkey = ["keystone_ng", "dep:webauthn-authenticator-rs", "dep:webauthn-rs-prot
 [dependencies]
 async-trait = {workspace = true}
 base64 = { workspace = true }
-bincode = { version = "^2.0", default-features = false, features = ["serde", "std"] }
 bytes = {workspace = true}
 chrono = { workspace= true }
 config = { workspace = true, features = ["yaml"] }
@@ -63,6 +62,7 @@ hyper-util = { version = "^0.1", features = ["full"] }
 itertools = { workspace = true }
 json-patch = { workspace = true }
 open.workspace = true
+postcard = { version = "1.1", default-features = false, features = ["use-std"] }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["gzip", "deflate", "form", "http2",
   "socks", "system-proxy"] }


### PR DESCRIPTION
Bincode was abandoned. The usecase is very small (only for the auth
caching). Replace it with a similar `postcard`. On the way ensure that
the cache file is setting reasonable file permissions.
