### PR TITLE
fix: Add endpoint interface handling

### DIFF
--- a/cli-cmd/catalog/src/show.rs
+++ b/cli-cmd/catalog/src/show.rs
@@ -74,9 +74,11 @@ impl ShowCommand {
             .collect::<Result<Vec<_>, _>>()?;
 
         if data.is_empty() {
-            return Err(openstack_sdk::catalog::CatalogError::ServiceNotConfigured(
-                self.service_type.clone(),
-            )
+            return Err(openstack_sdk::catalog::CatalogError::ServiceNotConfigured {
+                srv_type: self.service_type.clone(),
+                region: None,
+                interface: None,
+            }
             .into());
         }
 

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -409,8 +409,7 @@ impl OpenStack {
                         self.catalog.configure(&self.config)?;
                     }
                     if let Some(endpoints) = &auth_data.token.catalog {
-                        self.catalog
-                            .process_catalog_endpoints(endpoints, Some("public"))?;
+                        self.catalog.process_catalog_endpoints(endpoints)?;
                     } else {
                         error!("No catalog information");
                     }
@@ -431,6 +430,7 @@ impl OpenStack {
             service_type.to_string(),
             None,
             self.config.region_name.as_ref(),
+            self.config.interface.as_ref(),
         ) {
             if self.catalog.discovery_allowed(service_type.to_string()) {
                 info!("Performing `{}` endpoint version discovery", service_type);
@@ -460,6 +460,7 @@ impl OpenStack {
                                         &try_url,
                                         rsp.body(),
                                         self.config.region_name.as_ref(),
+                                        self.config.interface.as_ref(),
                                     )
                                     .is_ok()
                             {
@@ -593,9 +594,12 @@ impl api::RestClient for OpenStack {
         service_type: &ServiceType,
         version: Option<&ApiVersion>,
     ) -> Result<&ServiceEndpoint, api::ApiError<Self::Error>> {
-        Ok(self
-            .catalog
-            .get_service_endpoint(service_type.to_string(), version, None::<String>)?)
+        Ok(self.catalog.get_service_endpoint(
+            service_type.to_string(),
+            version,
+            self.config.region_name.as_ref(),
+            self.config.interface.as_ref(),
+        )?)
     }
 
     fn get_current_project(&self) -> Option<Project> {

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -142,9 +142,12 @@ impl api::RestClient for AsyncOpenStack {
         service_type: &ServiceType,
         version: Option<&ApiVersion>,
     ) -> Result<&ServiceEndpoint, api::ApiError<Self::Error>> {
-        Ok(self
-            .catalog
-            .get_service_endpoint(service_type.to_string(), version, None::<String>)?)
+        Ok(self.catalog.get_service_endpoint(
+            service_type.to_string(),
+            version,
+            self.config.region_name.as_ref(),
+            self.config.interface.as_ref(),
+        )?)
     }
 
     /// Get project id from the current scope
@@ -534,8 +537,7 @@ impl AsyncOpenStack {
                         self.catalog.configure(&self.config)?;
                     }
                     if let Some(endpoints) = &auth_data.token.catalog {
-                        self.catalog
-                            .process_catalog_endpoints(endpoints, Some("public"))?;
+                        self.catalog.process_catalog_endpoints(endpoints)?;
                     } else {
                         error!("No catalog information");
                     }
@@ -557,6 +559,7 @@ impl AsyncOpenStack {
             service_type.to_string(),
             None,
             self.config.region_name.as_ref(),
+            self.config.interface.as_ref(),
         ) {
             if self.catalog.discovery_allowed(service_type.to_string()) {
                 info!("Performing `{}` endpoint version discovery", service_type);
@@ -586,6 +589,7 @@ impl AsyncOpenStack {
                                         &try_url,
                                         rsp.body(),
                                         self.config.region_name.as_ref(),
+                                        self.config.interface.as_ref(),
                                     )
                                     .is_ok()
                             {
@@ -593,6 +597,7 @@ impl AsyncOpenStack {
                                     "Finished service version discovery at {}",
                                     try_url.as_str()
                                 );
+                                debug!("catalog {:?}", self.catalog);
                                 return Ok(());
                             }
                         }

--- a/sdk/core/src/catalog.rs
+++ b/sdk/core/src/catalog.rs
@@ -92,7 +92,7 @@ impl Catalog {
         self
     }
 
-    /// Register single service endpoint as catalog endpoint
+    /// Register single service endpoint as catalog endpoint.
     pub fn register_catalog_endpoint<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
         &mut self,
         service_type: S1,
@@ -112,15 +112,13 @@ impl Catalog {
         Ok(self)
     }
 
-    /// Process catalog information (usually from the token)
+    /// Process catalog information (usually from the token).
     pub fn process_catalog_endpoints(
         &mut self,
         srv_endpoints: &Vec<ApiServiceEndpoints>,
-        interface: Option<&str>,
     ) -> Result<&mut Self, CatalogError> {
         trace!("Start processing ServiceCatalog response");
         let mut token_catalog = Vec::new();
-        let intf = interface.unwrap_or("public");
         // Reset all previously discovered information. If we re-authed we may get different
         // project_ids
         for (srv, val) in self.service_endpoints.iter_mut() {
@@ -140,26 +138,25 @@ impl Catalog {
             }
             for ep in &srv.endpoints {
                 trace!("Processing endpoint {:?}", ep);
-                if ep.interface == intf {
-                    self.register_catalog_endpoint(
-                        &srv.service_type,
-                        &ep.url,
-                        ep.region.clone(),
-                        Some(&ep.interface),
-                    )?;
-                }
+                self.register_catalog_endpoint(
+                    &srv.service_type,
+                    &ep.url,
+                    ep.region.clone(),
+                    Some(&ep.interface),
+                )?;
             }
         }
         self.token_catalog = Some(token_catalog);
         Ok(self)
     }
 
-    /// Get endpoint
-    pub fn get_service_endpoint<S1: AsRef<str>, S2: AsRef<str>>(
+    /// Get endpoint.
+    pub fn get_service_endpoint<S: AsRef<str>, R: AsRef<str>, I: AsRef<str>>(
         &self,
-        service_type: S1,
+        service_type: S,
         api_version: Option<&ApiVersion>,
-        region_name: Option<S2>,
+        region_name: Option<R>,
+        interface: Option<I>,
     ) -> Result<&ServiceEndpoint, CatalogError> {
         // Check for endpoint_override -> return override directly
         if let Some(ep) = &self.endpoint_overrides.get(service_type.as_ref()) {
@@ -171,6 +168,14 @@ impl Catalog {
             );
             return Ok(ep);
         }
+        // Default to "public" as the interface when nothing is passed explicitly
+        let interface = Some(
+            interface
+                .as_ref()
+                .map(|x| x.as_ref())
+                .unwrap_or("public")
+                .to_string(),
+        );
 
         // Find main service_type
         let main_service_type = self
@@ -189,16 +194,20 @@ impl Catalog {
             .catalog_endpoints
             .get(catalog_service_type)
             .and_then(|eps| match region_name {
-                Some(_) => eps.get_by_region(region_name.as_ref()),
-                None => eps.get_by_region(self.region.as_ref()),
+                Some(_) => {
+                    eps.get_by_region_and_interface(region_name.as_ref(), interface.as_ref())
+                }
+                None => eps.get_by_region_and_interface(self.region.as_ref(), interface.as_ref()),
             });
         // TODO: check the API version
 
         // Get discovered information for the main service
         if let Some(discovered_endpoints) = self.service_endpoints.get(&main_service_type) {
-            if let Some(ep) =
-                discovered_endpoints.get_by_version_and_region(api_version, region_name.as_ref())
-            {
+            if let Some(ep) = discovered_endpoints.get_by_version(
+                api_version,
+                region_name.as_ref(),
+                interface.as_ref(),
+            ) {
                 debug!(
                     "Using discovered endpoint `{:?}` for service_type: `{}` and version `{:?}`",
                     ep,
@@ -231,8 +240,11 @@ impl Catalog {
             .get_all_types_by_service_type(main_service_type)?
         {
             if let Some(catalog_eps) = &self.catalog_endpoints.get(&cat_type)
-                && let Some(catalog_ep) =
-                    catalog_eps.get_by_version_and_region(api_version, region_name.as_ref())
+                && let Some(catalog_ep) = catalog_eps.get_by_version(
+                    api_version,
+                    region_name.as_ref(),
+                    interface.as_ref(),
+                )
             {
                 debug!(
                     "Using catalog endpoint `{:?}` for service_type: `{}` (requested: `{}`) and version `{:?}`",
@@ -268,18 +280,21 @@ impl Catalog {
             }
         }
 
-        Err(CatalogError::ServiceNotConfigured(
-            service_type.as_ref().into(),
-        ))
+        Err(CatalogError::ServiceNotConfigured {
+            srv_type: service_type.as_ref().into(),
+            region: region_name.map(|x| x.as_ref().into()),
+            interface,
+        })
     }
 
     /// Process version discovery response for the service returning list of extracted endpoints
-    pub fn parse_endpoint_discovery<S: AsRef<str>>(
+    pub fn parse_endpoint_discovery<R: AsRef<str>, I: AsRef<str>>(
         &self,
         service_type: &ServiceType,
         url: &Url,
         data: &Bytes,
-        region: Option<S>,
+        region: Option<R>,
+        interface: Option<I>,
     ) -> Result<ServiceEndpoints, CatalogError> {
         let mut service_entry = ServiceEndpoints::default();
         // Get main service type
@@ -294,6 +309,7 @@ impl Catalog {
             discovery::extract_discovery_endpoints(url, data, service_type.to_string())?.iter_mut()
         {
             ep.set_region(region.as_ref());
+            ep.set_interface(interface.as_ref());
             // Rounded (to the major) version so that we respect catalog_endpoints and
             // endpoint_overrides for a higher minor versions
             let ep_maj_ver = ApiVersion::new(ep.version().major, 0);
@@ -309,7 +325,7 @@ impl Catalog {
                     ep.set_last_segment_with_project_id(epo.last_segment_with_project_id().clone());
                 }
                 if let Some(ep_cat) = &self.catalog_endpoints.get(cat_type).and_then(|srv| {
-                    srv.get_by_version_and_region(Some(&ep_maj_ver), region.as_ref())
+                    srv.get_by_version(Some(&ep_maj_ver), region.as_ref(), ep.interface().as_ref())
                 }) {
                     ep.set_last_segment_with_project_id(
                         ep_cat.last_segment_with_project_id().clone(),
@@ -346,15 +362,16 @@ impl Catalog {
     }
 
     /// Parse service endpoint discovery document and set discovered endpoints.
-    pub fn process_endpoint_discovery<S: AsRef<str>>(
+    pub fn process_endpoint_discovery<R: AsRef<str>, I: AsRef<str>>(
         &mut self,
         service_type: &ServiceType,
         url: &Url,
         data: &Bytes,
-        region: Option<S>,
+        region: Option<R>,
+        interface: Option<I>,
     ) -> Result<&mut Self, CatalogError> {
         let discovered_endpoints =
-            self.parse_endpoint_discovery(service_type, url, data, region)?;
+            self.parse_endpoint_discovery(service_type, url, data, region, interface)?;
         self.consume_discovered_endpoints(service_type, discovered_endpoints)
     }
 
@@ -477,21 +494,35 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_register_catalog_endpoint() {
         let mut cat = Catalog::default();
-        cat.register_catalog_endpoint("s1", "http://s1.foo.bar", Some("public"), Some("default"))
+        cat.register_catalog_endpoint("s1", "http://s1.foo.bar", Some("default"), Some("public"))
             .unwrap();
         let check = cat.catalog_endpoints.get("s1").unwrap();
         assert_eq!(
             "http://s1.foo.bar/",
             check.get_by_region(None::<String>).unwrap().url_str()
         );
+        assert_eq!(
+            "http://s1.foo.bar/",
+            check
+                .get_by_region_and_interface(None::<String>, Some("public"))
+                .unwrap()
+                .url_str()
+        );
+        assert!(
+            check
+                .get_by_region_and_interface(None::<String>, Some("internal"))
+                .is_none()
+        );
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_process_catalog_endpoints() {
         let mut cat = Catalog::default();
-        cat.register_catalog_endpoint("s1", "http://s1.foo.bar", Some("public"), Some("default"))
+        cat.register_catalog_endpoint("s1", "http://s1.foo.bar", Some("default"), Some("public"))
             .unwrap();
         cat.process_catalog_endpoints(
             &Vec::from([
@@ -507,16 +538,23 @@ mod tests {
                     "type": "s3",
                     "name": "s3",
                     "endpoints": [
-                        {"id": "dummy", "interface": "public", "region": "r1", "url": "http://r2.foo.bar/s3"}
+                        {"id": "dummy", "interface": "public", "region": "r1", "url": "http://r2.foo.bar/s3"},
+                        {"id": "dummy_internal", "interface": "internal", "region": "r1", "url": "http://r2.internal/s3"}
                     ]
                 })).unwrap()
             ]),
-            Some("public"),
         ).unwrap();
         let check = cat.catalog_endpoints.get("s1").unwrap();
         assert_eq!(
             "http://s1.foo.bar/",
             check.get_by_region(None::<String>).unwrap().url_str()
+        );
+        assert_eq!(
+            "http://s1.foo.bar/",
+            check
+                .get_by_region_and_interface(None::<String>, Some("public"))
+                .unwrap()
+                .url_str()
         );
         let check = cat.catalog_endpoints.get("s2").unwrap();
         assert_eq!(
@@ -527,6 +565,14 @@ mod tests {
                 .iter()
                 .map(|x| x.url_str())
                 .collect::<Vec<_>>()
+        );
+        let check = cat.catalog_endpoints.get("s3").unwrap();
+        assert_eq!(
+            "http://r2.internal/s3",
+            check
+                .get_by_region_and_interface(None::<String>, Some("internal"))
+                .unwrap()
+                .url_str()
         );
         // TODO: Check token_catalog
     }
@@ -557,12 +603,14 @@ mod tests {
                 .to_string(),
             ),
             Some("default"),
+            Some("public"),
         )
         .unwrap();
         assert!(cat.service_endpoints.contains_key("compute"));
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_process_endpoint_discovery_with_endpoint_override() {
         let mut cat = Catalog::default();
         let conf = CloudConfig {
@@ -611,6 +659,7 @@ mod tests {
                 .to_string(),
             ),
             Some("default"),
+            Some("public"),
         )
         .unwrap();
         let srv = cat.service_endpoints.get("block-storage").unwrap();
@@ -644,6 +693,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_process_endpoint_discovery_with_multiversion() {
         let mut cat = Catalog::default();
         cat.set_project_id(Some("PROJECT_ID"));
@@ -687,6 +737,7 @@ mod tests {
                 .to_string(),
             ),
             Some("default"),
+            Some("public"),
         )
         .unwrap();
         let srv = cat.service_endpoints.get("compute").unwrap();
@@ -743,13 +794,19 @@ mod tests {
                 .to_string(),
             ),
             Some("default"),
+            Some("public"),
         )
         .unwrap();
         assert_eq!(
             "http://foo.bar/v2/",
-            cat.get_service_endpoint("volume", Some(&ApiVersion::new(2, 0)), Some("default"))
-                .unwrap()
-                .url_str(),
+            cat.get_service_endpoint(
+                "volume",
+                Some(&ApiVersion::new(2, 0)),
+                Some("default"),
+                Some("public"),
+            )
+            .unwrap()
+            .url_str(),
             "alias service type versioned"
         );
         assert_eq!(
@@ -757,7 +814,8 @@ mod tests {
             cat.get_service_endpoint(
                 "block-storage",
                 Some(&ApiVersion::new(2, 0)),
-                Some("default")
+                Some("default"),
+                Some("public"),
             )
             .unwrap()
             .url_str(),
@@ -768,7 +826,8 @@ mod tests {
             cat.get_service_endpoint(
                 "block-storage",
                 Some(&ApiVersion::new(3, 0)),
-                Some("default")
+                Some("default"),
+                Some("public"),
             )
             .unwrap()
             .url_str(),
@@ -779,7 +838,8 @@ mod tests {
             cat.get_service_endpoint(
                 "block-storage",
                 Some(&ApiVersion::new(0, 0)),
-                Some("default")
+                Some("default"),
+                Some("public"),
             )
             .unwrap()
             .url_str(),
@@ -788,6 +848,7 @@ mod tests {
     }
 
     #[test]
+    #[tracing_test::traced_test]
     fn test_get_service_endpoint_overrides() {
         let mut cat = Catalog::default();
         let conf = CloudConfig {
@@ -839,13 +900,19 @@ mod tests {
                 .to_string(),
             ),
             Some("default"),
+            Some("public"),
         )
         .unwrap();
         assert_eq!(
             "http://foo.bar/v2/",
-            cat.get_service_endpoint("volume", Some(&ApiVersion::new(2, 0)), Some("default"))
-                .unwrap()
-                .url_str(),
+            cat.get_service_endpoint(
+                "volume",
+                Some(&ApiVersion::new(2, 0)),
+                Some("default"),
+                Some("public")
+            )
+            .unwrap()
+            .url_str(),
             "alias service type versioned"
         );
         assert_eq!(
@@ -853,7 +920,8 @@ mod tests {
             cat.get_service_endpoint(
                 "block-storage",
                 Some(&ApiVersion::new(2, 0)),
-                Some("default")
+                Some("default"),
+                Some("public")
             )
             .unwrap()
             .url_str(),
@@ -864,7 +932,8 @@ mod tests {
             cat.get_service_endpoint(
                 "block-storage",
                 Some(&ApiVersion::new(3, 0)),
-                Some("default")
+                Some("default"),
+                Some("public")
             )
             .unwrap()
             .url_str(),
@@ -875,7 +944,8 @@ mod tests {
             cat.get_service_endpoint(
                 "block-storage",
                 Some(&ApiVersion::new(0, 0)),
-                Some("default")
+                Some("default"),
+                Some("public")
             )
             .unwrap()
             .url_str(),
@@ -883,7 +953,7 @@ mod tests {
         );
         assert_eq!(
             "http://another.foo.bar/v3/z_PROJECT_ID",
-            cat.get_service_endpoint("volumev3", None, Some("default"))
+            cat.get_service_endpoint("volumev3", None, Some("default"), Some("public"))
                 .unwrap()
                 .url_str(),
             "endpoint as in endpoint_override"
@@ -891,14 +961,19 @@ mod tests {
         // TODO:
         assert_eq!(
             "http://foo.bar/v3/",
-            cat.get_service_endpoint("volumev2", None, Some("default"))
+            cat.get_service_endpoint("volumev2", None, Some("default"), Some("public"))
                 .unwrap()
                 .url_str(),
             "This must start failing"
         );
 
         let ep = cat
-            .get_service_endpoint("volumev2", Some(&ApiVersion::new(2, 0)), Some("default"))
+            .get_service_endpoint(
+                "volumev2",
+                Some(&ApiVersion::new(2, 0)),
+                Some("default"),
+                Some("public"),
+            )
             .unwrap();
         assert_eq!(
             "http://foo.bar/v2/",
@@ -915,6 +990,7 @@ mod tests {
                 "block-storage",
                 Some(&ApiVersion::new(3, 0)),
                 Some("default"),
+                Some("public"),
             )
             .unwrap();
         assert_eq!(
@@ -962,13 +1038,18 @@ mod tests {
 
         assert_eq!(
             "http://foo.bar/v1/PROJECT_ID",
-            cat.get_service_endpoint("volume", Some(&ApiVersion::new(1, 0)), Some("default"))
-                .unwrap()
-                .url_str(),
+            cat.get_service_endpoint(
+                "volume",
+                Some(&ApiVersion::new(1, 0)),
+                Some("default"),
+                Some("public")
+            )
+            .unwrap()
+            .url_str(),
         );
         assert_eq!(
             "http://foo.bar/v3/PROJECT_ID",
-            cat.get_service_endpoint("block-storage", None, Some("default"))
+            cat.get_service_endpoint("block-storage", None, Some("default"), Some("public"))
                 .unwrap()
                 .url_str(),
         );
@@ -977,10 +1058,20 @@ mod tests {
             cat.get_service_endpoint(
                 "block-storage",
                 Some(&ApiVersion::new(2, 0)),
-                Some("default")
+                Some("default"),
+                Some("public")
             )
             .unwrap()
             .url_str(),
+        );
+        assert!(
+            cat.get_service_endpoint(
+                "block-storage",
+                Some(&ApiVersion::new(2, 0)),
+                Some("default"),
+                Some("internal")
+            )
+            .is_err()
         );
     }
 }

--- a/sdk/core/src/catalog/error.rs
+++ b/sdk/core/src/catalog/error.rs
@@ -67,8 +67,18 @@ pub enum CatalogError {
     #[error("Invalid version discovery document")]
     InvalidDiscoveryDocument,
 
-    #[error("Service `{0}` is not configured")]
-    ServiceNotConfigured(String),
+    /// The service is not configured for the specified type, region and interface.
+    #[error(
+        "Service `{}` is not configured for interface {:?} at region {:?}",
+        srv_type,
+        interface,
+        region
+    )]
+    ServiceNotConfigured {
+        srv_type: String,
+        region: Option<String>,
+        interface: Option<String>,
+    },
 
     #[error("Api Version with id `{id}` for service is not defining `self` link")]
     VersionSelfLinkMissing { id: String },

--- a/sdk/core/src/catalog/service_endpoint.rs
+++ b/sdk/core/src/catalog/service_endpoint.rs
@@ -24,32 +24,31 @@ use crate::catalog::CatalogError;
 use crate::types::ApiVersion;
 use crate::types::identity::v3::version::EndpointVersionStatus;
 
-/// Service endpoint
-///
+/// Service endpoint.
 #[derive(Clone, PartialEq)]
 pub struct ServiceEndpoint {
-    /// ServiceEndpoint URL
+    /// ServiceEndpoint URL.
     url: Url,
-    /// Service endpoint region
+    /// Service endpoint region.
     region: Option<String>,
-    /// Service endpoint interface
+    /// Service endpoint interface.
     interface: Option<String>,
-    /// API version determined from the url
+    /// API version determined from the url.
     version: ApiVersion,
-    /// lowest supported microversion
+    /// lowest supported microversion.
     min_version: Option<String>,
-    /// Highest supported microversion
+    /// Highest supported microversion.
     max_version: Option<String>,
-    /// Service type as used in the ServiceCatalog
+    /// Service type as used in the ServiceCatalog.
     service_type: Option<String>,
-    // Last url segment if it ends with project_id
+    // Last url segment if it ends with project_id.
     last_segment_with_project_id: Option<String>,
-    /// ServiceEndpoint status
+    /// ServiceEndpoint status.
     status: Option<EndpointVersionStatus>,
 }
 
 impl ServiceEndpoint {
-    /// Build new ServiceEndpoint from URL and `[ApiVersion]`
+    /// Build new ServiceEndpoint from URL and `[ApiVersion]`.
     pub fn new(url: Url, api_version: ApiVersion) -> Self {
         Self {
             url,
@@ -63,7 +62,7 @@ impl ServiceEndpoint {
             status: None,
         }
     }
-    /// Build new ServiceEndpoint from string URL
+    /// Build new ServiceEndpoint from string URL.
     ///
     /// optional project_id is used to locate version information in the url
     pub fn from_url_string<S1: AsRef<str>, S2: AsRef<str>>(
@@ -107,56 +106,61 @@ impl ServiceEndpoint {
         Ok(res)
     }
 
-    /// Set service type
+    /// Set service type.
     pub fn set_service_type<S: AsRef<str>>(&mut self, service_type: Option<S>) -> &mut Self {
         self.service_type = service_type.map(|x| x.as_ref().into());
         self
     }
 
-    /// Set endpoint region
+    /// Set endpoint region.
     pub fn set_region<S: AsRef<str>>(&mut self, region: Option<S>) -> &mut Self {
         self.region = region.map(|x| x.as_ref().into());
         self
     }
 
-    /// Set endpoint interface
+    /// Set endpoint interface.
     pub fn set_interface<S: AsRef<str>>(&mut self, interface: Option<S>) -> &mut Self {
         self.interface = interface.map(|x| x.as_ref().into());
         self
     }
 
-    /// Set min_version
+    /// Set min_version.
     pub fn set_min_version<S: AsRef<str>>(&mut self, version: Option<S>) -> &mut Self {
         self.min_version = version.map(|x| x.as_ref().into());
         self
     }
-    /// Set min_version
+    /// Set min_version.
     pub fn set_max_version<S: AsRef<str>>(&mut self, version: Option<S>) -> &mut Self {
         self.max_version = version.map(|x| x.as_ref().into());
         self
     }
-    /// Set status
+    /// Set status.
     pub fn set_status(&mut self, status: Option<EndpointVersionStatus>) -> &mut Self {
         self.status = status;
         self
     }
 
-    /// Returns a reference to Url
+    /// Returns a reference to the Url.
     pub fn url(&self) -> &Url {
         &self.url
     }
 
-    /// Returns a reference to Url as &str
+    /// Returns a reference to the Url as &str.
     pub fn url_str(&self) -> &str {
         self.url.as_str()
     }
 
-    /// Returns a reference to ApiVersion
+    /// Returns a reference to the interface of the endpoint.
+    pub fn interface(&self) -> &Option<String> {
+        &self.interface
+    }
+
+    /// Returns a reference to the ApiVersion.
     pub fn version(&self) -> &ApiVersion {
         &self.version
     }
 
-    /// Returns a reference to region
+    /// Returns a reference to the region.
     pub fn region(&self) -> &Option<String> {
         &self.region
     }
@@ -170,22 +174,22 @@ impl ServiceEndpoint {
         self
     }
 
-    /// Retrieve ServiceServiceEndpoint status
+    /// Retrieve [ServiceServiceEndpoint] status.
     pub fn status(&self) -> &Option<EndpointVersionStatus> {
         &self.status
     }
 
-    /// Retrieve ServiceServiceEndpoint min_version
+    /// Retrieve [ServiceServiceEndpoint] min_version.
     pub fn min_version(&self) -> &Option<String> {
         &self.min_version
     }
 
-    /// Retrieve ServiceServiceEndpoint max_version
+    /// Retrieve [ServiceServiceEndpoint] max_version.
     pub fn max_version(&self) -> &Option<String> {
         &self.max_version
     }
 
-    /// Build request URL from base endpoint url and the `RestEndpoint`
+    /// Build request URL from base endpoint url and the [`RestEndpoint`].
     pub fn build_request_url(&self, endpoint: &str) -> Result<Url, CatalogError> {
         trace!(
             "Constructing request url for service endpoint {} for {}",
@@ -261,14 +265,16 @@ impl fmt::Debug for ServiceEndpoint {
 pub struct ServiceEndpoints(Vec<ServiceEndpoint>);
 
 impl ServiceEndpoints {
-    /// Add endpoint into the list
+    /// Add endpoint into the list.
     pub fn push(&mut self, ep: ServiceEndpoint) -> &mut Self {
         self.0.push(ep);
         self
     }
 
-    /// Get the endpoint by region name. If no reion_name is passed first endpoint is being
-    /// returned.
+    /// Get the endpoint by region name.
+    ///
+    /// If no region_name is passed first endpoint is being returned.
+    #[deprecated(since = "0.23.0", note = "Use `get_by_region_and_interface` instead")]
     pub fn get_by_region<S: AsRef<str>>(&self, region_name: Option<S>) -> Option<&ServiceEndpoint> {
         if let Some(region) = &region_name {
             self.0
@@ -279,8 +285,85 @@ impl ServiceEndpoints {
         }
     }
 
-    /// Get the endpoint by region name. If no reion_name is passed first endpoint is being
-    /// returned.
+    /// Get the endpoint by region and interface name.
+    ///
+    /// Find the endpoint matching the filters.
+    ///
+    /// # Arguments
+    /// * `region_name` - name of the region
+    /// * `interface` - interface name.
+    ///
+    /// # Returns
+    /// * `Some(&ServiceEndpoint)` - reference to the found endpoint.
+    pub fn get_by_region_and_interface<R: AsRef<str>, I: AsRef<str>>(
+        &self,
+        region_name: Option<R>,
+        interface: Option<I>,
+    ) -> Option<&ServiceEndpoint> {
+        self.0.iter().find(|ep| {
+            [
+                region_name
+                    .as_ref()
+                    .is_none_or(|x| ep.region == Some(x.as_ref().into())),
+                interface
+                    .as_ref()
+                    .is_none_or(|x| ep.interface == Some(x.as_ref().into())),
+            ]
+            .iter()
+            .all(|&condition| condition)
+        })
+    }
+
+    /// Get the endpoint by a version and a region name.
+    ///
+    /// # Arguments
+    /// * `api_version` - API version.
+    /// * `region_name` - An optional region name.
+    /// * `interface` - An optional interface name.
+    pub fn get_by_version<R: AsRef<str>, I: AsRef<str>>(
+        &self,
+        api_version: Option<&ApiVersion>,
+        region_name: Option<R>,
+        interface: Option<I>,
+    ) -> Option<&ServiceEndpoint> {
+        for candidate in self.0.iter() {
+            if let Some(requested_version) = &api_version {
+                let cver = candidate.version();
+                if !(cver.major == requested_version.major
+                    && (cver.minor >= requested_version.minor))
+                {
+                    continue;
+                }
+            } else if *candidate.status() != Some(EndpointVersionStatus::Current) {
+                continue;
+            }
+            match (&region_name, candidate.region()) {
+                (Some(requested_region), Some(candidate_region)) => {
+                    if candidate_region.as_str() == requested_region.as_ref()
+                        && candidate.interface.as_ref().map(|x| x.as_ref())
+                            == interface.as_ref().map(|x| x.as_ref())
+                    {
+                        return Some(candidate);
+                    }
+                }
+                (None, _) => {
+                    return Some(candidate);
+                }
+                _ => {}
+            };
+        }
+        // Maybe there is no entry with `status=Current` (i.e. before we do version discovery)
+        if api_version.is_none() {
+            return self.get_by_region_and_interface(region_name, interface);
+        }
+        None
+    }
+
+    /// Get the endpoint by the version and region name.
+    ///
+    /// If no region_name is passed first endpoint is being returned.
+    #[deprecated(since = "0.23.0", note = "Use `get_by_version` instead")]
+    #[allow(deprecated)]
     pub fn get_by_version_and_region<S: AsRef<str>>(
         &self,
         api_version: Option<&ApiVersion>,
@@ -364,6 +447,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_endpoints_by_region() {
         let e1 = ServiceEndpoint::from_url_string("http://r1.foo.bar/s1", None::<String>)
             .unwrap()
@@ -390,6 +474,171 @@ mod tests {
     }
 
     #[test]
+    fn test_endpoints_by_region_and_interface() {
+        let e1 = ServiceEndpoint::from_url_string("http://r1.foo.bar/s1", None::<String>)
+            .unwrap()
+            .set_region(Some("r1"))
+            .set_interface(Some("internal"))
+            .to_owned();
+        let e2 = ServiceEndpoint::from_url_string("http://r2.foo.bar/s1", None::<String>)
+            .unwrap()
+            .set_region(Some("r2"))
+            .set_interface(Some("internal"))
+            .to_owned();
+        let endpoints = ServiceEndpoints(Vec::from([e1, e2]));
+        assert_eq!(
+            "http://r1.foo.bar/s1",
+            endpoints
+                .get_by_region_and_interface(Some("r1"), Some("internal"))
+                .unwrap()
+                .url_str()
+        );
+        assert_eq!(
+            "http://r1.foo.bar/s1",
+            endpoints
+                .get_by_region_and_interface(Some("r1"), None::<String>)
+                .unwrap()
+                .url_str()
+        );
+        assert_eq!(
+            "http://r1.foo.bar/s1",
+            endpoints
+                .get_by_region_and_interface(None::<String>, None::<String>)
+                .unwrap()
+                .url_str()
+        );
+        assert!(
+            endpoints
+                .get_by_region_and_interface(Some("r1"), Some("public"))
+                .is_none()
+        );
+        assert_eq!(
+            "http://r1.foo.bar/s1",
+            endpoints
+                .get_by_region_and_interface(None::<String>, Some("internal"))
+                .unwrap()
+                .url_str()
+        );
+        assert_eq!(
+            "http://r2.foo.bar/s1",
+            endpoints
+                .get_by_region_and_interface(Some("r2"), Some("internal"))
+                .unwrap()
+                .url_str()
+        );
+        assert!(
+            endpoints
+                .get_by_region_and_interface(Some("r3"), Some("internal"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_endpoints_by_version_and() {
+        let endpoints = ServiceEndpoints(Vec::from([
+            ServiceEndpoint::new(
+                Url::parse("http://r1.foo.bar/s1/").unwrap(),
+                ApiVersion::new(0, 0),
+            )
+            .set_region(Some("r1"))
+            .set_interface(Some("internal"))
+            .to_owned(),
+            ServiceEndpoint::new(
+                Url::parse("http://r1.foo.bar/s1/v1/").unwrap(),
+                ApiVersion::new(1, 0),
+            )
+            .set_region(Some("r1"))
+            .set_interface(Some("internal"))
+            .to_owned(),
+            ServiceEndpoint::new(
+                Url::parse("http://r1.foo.bar/s1/v2/").unwrap(),
+                ApiVersion::new(2, 0),
+            )
+            .set_region(Some("r1"))
+            .set_interface(Some("internal"))
+            .set_status(Some(EndpointVersionStatus::Current))
+            .to_owned(),
+            ServiceEndpoint::new(
+                Url::parse("http://r1.foo.bar/s1/v3/").unwrap(),
+                ApiVersion::new(3, 0),
+            )
+            .set_region(Some("r1"))
+            .set_interface(Some("internal"))
+            .set_status(Some(EndpointVersionStatus::Experimental))
+            .to_owned(),
+            ServiceEndpoint::new(
+                Url::parse("http://r2.foo.bar/s1/").unwrap(),
+                ApiVersion::new(0, 0),
+            )
+            .set_region(Some("r2"))
+            .set_interface(Some("internal"))
+            .to_owned(),
+            ServiceEndpoint::new(
+                Url::parse("http://r2.foo.bar/s1/v1/").unwrap(),
+                ApiVersion::new(1, 0),
+            )
+            .set_region(Some("r2"))
+            .set_interface(Some("internal"))
+            .to_owned(),
+            ServiceEndpoint::new(
+                Url::parse("http://r2.foo.bar/s1/v2/").unwrap(),
+                ApiVersion::new(2, 90),
+            )
+            .set_region(Some("r2"))
+            .set_interface(Some("internal"))
+            .set_status(Some(EndpointVersionStatus::Current))
+            .to_owned(),
+        ]));
+        assert_eq!(
+            "http://r1.foo.bar/s1/",
+            endpoints
+                .get_by_version(Some(&ApiVersion::new(0, 0)), Some("r1"), Some("internal"))
+                .unwrap()
+                .url_str(),
+            "Requesting unversioned endpoint"
+        );
+        assert_eq!(
+            "http://r1.foo.bar/s1/v1/",
+            endpoints
+                .get_by_version(Some(&ApiVersion::new(1, 0)), Some("r1"), Some("internal"))
+                .unwrap()
+                .url_str(),
+            "Requesting versioned endpoint"
+        );
+        assert_eq!(
+            "http://r1.foo.bar/s1/v2/",
+            endpoints
+                .get_by_version(None, Some("r1"), Some("internal"))
+                .unwrap()
+                .url_str(),
+            "Requesting current endpoint"
+        );
+        assert_eq!(
+            "http://r2.foo.bar/s1/v2/",
+            endpoints
+                .get_by_version(None, Some("r2"), Some("internal"))
+                .unwrap()
+                .url_str(),
+            "Requesting current endpoint"
+        );
+        assert_eq!(
+            "http://r2.foo.bar/s1/v2/",
+            endpoints
+                .get_by_version(Some(&ApiVersion::new(2, 0)), Some("r2"), Some("internal"))
+                .unwrap()
+                .url_str(),
+            "Requesting versioned endpoint with min 'lower' then available"
+        );
+        assert!(
+            endpoints
+                .get_by_version(Some(&ApiVersion::new(2, 100)), Some("r2"), Some("internal"))
+                .is_none(),
+            "Requesting versioned endpoint with min 'higher' then available"
+        );
+    }
+
+    #[test]
+    #[allow(deprecated)]
     fn test_endpoints_by_version_and_region() {
         let endpoints = ServiceEndpoints(Vec::from([
             ServiceEndpoint::new(

--- a/sdk/core/src/config.rs
+++ b/sdk/core/src/config.rs
@@ -356,6 +356,7 @@ pub struct CloudConfig {
     /// Vendor Profile (by name from clouds-public.yaml or TBD: URL).
     pub profile: Option<String>,
     /// Interface name to be used for endpoints selection.
+    #[serde(default = "default_public")]
     pub interface: Option<String>,
     /// Region name.
     pub region_name: Option<String>,
@@ -372,6 +373,10 @@ pub struct CloudConfig {
     /// All other options.
     #[serde(flatten)]
     pub options: HashMap<String, config::Value>,
+}
+
+fn default_public() -> Option<String> {
+    Some(String::from("public"))
 }
 
 impl fmt::Debug for CloudConfig {

--- a/sdk/core/src/test/client.rs
+++ b/sdk/core/src/test/client.rs
@@ -147,9 +147,11 @@ impl RestClient for FakeOpenStackClient {
         self.endpoints
             .get(&service_type.to_string())
             .or(self.endpoints.get("default"))
-            .ok_or(ApiError::catalog(CatalogError::ServiceNotConfigured(
-                service_type.to_string(),
-            )))
+            .ok_or(ApiError::catalog(CatalogError::ServiceNotConfigured {
+                srv_type: service_type.to_string(),
+                region: None,
+                interface: None,
+            }))
     }
 
     fn get_current_project(&self) -> Option<Project> {


### PR DESCRIPTION
Remove the interface filtering keeping all interfaces retrieved from the
token. Further stick to respecting the endpoint interface information.

- default to "public" in the `get_service_endpoint`
- default to `Some("public")` in the config
- clients pass the config value of the interface with every invocation.

Fixes: #1725
