### PR TITLE
chore: Use absolute path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,15 @@
 FROM rust:1.94.1-slim-trixie AS base
 
 RUN cargo install --locked cargo-chef
-WORKDIR app
+
+WORKDIR /app
 
 ################
 ##### Planner
 FROM base AS planner
+
 COPY . .
+
 # Prepare the build recipe
 RUN cargo chef prepare --recipe-path recipe.json
 


### PR DESCRIPTION
Address https://docs.docker.com/reference/build-checks/workdir-relative-path/
