### PR TITLE
fix: Discard deviating domain in pagination links

### DIFF
--- a/openstack_types/tests/mocked/block_storage/v3/attachment/response/list.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/attachment/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::attachment::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::attachment::response::list::AttachmentResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<AttachmentResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<AttachmentResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/attachment/response/list_detailed.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/attachment/response/list_detailed.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::attachment::list_detailed::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::attachment::response::list_detailed::AttachmentResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<AttachmentResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<AttachmentResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/backup/response/list.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/backup/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::backup::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::backup::response::list::BackupResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<BackupResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<BackupResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/backup/response/list_detailed.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/backup/response/list_detailed.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::backup::list_detailed::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::backup::response::list_detailed::BackupResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<BackupResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<BackupResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/host/response/list.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/host/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::volume::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::host::response::list::HostResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<HostResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<HostResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/snapshot/response/list.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/snapshot/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::snapshot::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::snapshot::response::list::SnapshotResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<SnapshotResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<SnapshotResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/snapshot/response/list_detailed.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/snapshot/response/list_detailed.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::snapshot::list_detailed::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::snapshot::response::list_detailed::SnapshotResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<SnapshotResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<SnapshotResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/volume/response/list.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/volume/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::volume::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::volume::response::list::VolumeResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<VolumeResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<VolumeResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/block_storage/v3/volume/response/list_detailed.rs
+++ b/openstack_types/tests/mocked/block_storage/v3/volume/response/list_detailed.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::volume::list_detailed::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::block_storage::v3::volume::response::list_detailed::VolumeResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("block-storage");
 
-    let _res: Vec<VolumeResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<VolumeResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/compute/v2/server/response/list.rs
+++ b/openstack_types/tests/mocked/compute/v2/server/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::server::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::compute::v2::server::response;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("compute");
 
-    let res: Vec<serde_json::Value> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let res: Vec<serde_json::Value> = Request::builder().build()?.query_async(&client).await?;
 
     // Need to iterate over all possible candidate schemas
     if let Some(val) = res.first() {

--- a/openstack_types/tests/mocked/compute/v2/server/response/list_detailed.rs
+++ b/openstack_types/tests/mocked/compute/v2/server/response/list_detailed.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::server::list_detailed::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::compute::v2::server::response;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("compute");
 
-    let res: Vec<serde_json::Value> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let res: Vec<serde_json::Value> = Request::builder().build()?.query_async(&client).await?;
 
     // Need to iterate over all possible candidate schemas
     if let Some(val) = res.first() {

--- a/openstack_types/tests/mocked/dns/v2/zone/response/list.rs
+++ b/openstack_types/tests/mocked/dns/v2/zone/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::zone::list::Request;
-use openstack_sdk::api::{paged, Pagination, QueryAsync};
 use openstack_types::dns::v2::zone::response::list::ZoneResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("dns");
 
-    let _res: Vec<ZoneResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<ZoneResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/dns/v2/zone/response/mod.rs
+++ b/openstack_types/tests/mocked/dns/v2/zone/response/mod.rs
@@ -11,3 +11,4 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+mod list;

--- a/openstack_types/tests/mocked/identity/v3/user/response/list.rs
+++ b/openstack_types/tests/mocked/identity/v3/user/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::user::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::identity::v3::user::response::list::UserResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("identity");
 
-    let _res: Vec<UserResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<UserResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/load_balancer/v2/healthmonitor/response/list.rs
+++ b/openstack_types/tests/mocked/load_balancer/v2/healthmonitor/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::load_balancer::v2::healthmonitor::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::load_balancer::v2::healthmonitor::response::list::HealthmonitorResponse;
 
 use crate::get_client;
@@ -22,10 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("load-balancer");
 
-    let _res: Vec<HealthmonitorResponse> =
-        paged(Request::builder().build()?, Pagination::Limit(10))
-            .query_async(&client)
-            .await?;
+    let _res: Vec<HealthmonitorResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/load_balancer/v2/listener/response/list.rs
+++ b/openstack_types/tests/mocked/load_balancer/v2/listener/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::load_balancer::v2::listener::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::load_balancer::v2::listener::response::list::ListenerResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("load-balancer");
 
-    let _res: Vec<ListenerResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<ListenerResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/load_balancer/v2/loadbalancer/response/list.rs
+++ b/openstack_types/tests/mocked/load_balancer/v2/loadbalancer/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::load_balancer::v2::loadbalancer::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::load_balancer::v2::loadbalancer::response::list::LoadbalancerResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("load-balancer");
 
-    let _res: Vec<LoadbalancerResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<LoadbalancerResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/load_balancer/v2/pool/member/response/list.rs
+++ b/openstack_types/tests/mocked/load_balancer/v2/pool/member/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::load_balancer::v2::pool::member::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::load_balancer::v2::pool::member::response::list::MemberResponse;
 
 use crate::get_client;
@@ -22,12 +22,11 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("load-balancer");
 
-    let _res: Vec<MemberResponse> = paged(
-        Request::builder().pool_id("dummy").build()?,
-        Pagination::Limit(10),
-    )
-    .query_async(&client)
-    .await?;
+    let _res: Vec<MemberResponse> = Request::builder()
+        .pool_id("dummy")
+        .build()?
+        .query_async(&client)
+        .await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/load_balancer/v2/pool/response/list.rs
+++ b/openstack_types/tests/mocked/load_balancer/v2/pool/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::load_balancer::v2::pool::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::load_balancer::v2::pool::response::list::PoolResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("load-balancer");
 
-    let _res: Vec<PoolResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<PoolResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/openstack_types/tests/mocked/network/v2/floatingip/response/list.rs
+++ b/openstack_types/tests/mocked/network/v2/floatingip/response/list.rs
@@ -12,8 +12,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::floatingip::list::Request;
-use openstack_sdk::api::{Pagination, QueryAsync, paged};
 use openstack_types::network::v2::floatingip::response::list::FloatingipResponse;
 
 use crate::get_client;
@@ -22,9 +22,7 @@ use crate::get_client;
 async fn deserialize() -> Result<(), Box<dyn std::error::Error>> {
     let client = get_client("network");
 
-    let _res: Vec<FloatingipResponse> = paged(Request::builder().build()?, Pagination::Limit(10))
-        .query_async(&client)
-        .await?;
+    let _res: Vec<FloatingipResponse> = Request::builder().build()?.query_async(&client).await?;
 
     Ok(())
 }

--- a/sdk/core/src/api/paged/next_page.rs
+++ b/sdk/core/src/api/paged/next_page.rs
@@ -18,6 +18,7 @@ use http::HeaderMap;
 use serde_json::Value;
 use std::borrow::Cow;
 use thiserror::Error;
+use tracing::warn;
 use url::Url;
 
 use crate::api::PaginationError;
@@ -187,10 +188,10 @@ pub(crate) fn next_page_from_body(
         if let Some(n) = next {
             // We expect that the link contains all initial query parameters and we do NOT read them.
             if let Some(next_url) = n.as_str() {
-                let next: String = if !next_url.starts_with("http") {
+                if !next_url.starts_with("http") {
                     // Some services (i.e. Glance) has a relative link without
                     // domain. So we need to construct it back.
-                    String::from(base_endpoint.scheme())
+                    let next = String::from(base_endpoint.scheme())
                         + "://"
                         + base_endpoint.domain().ok_or_else(|| {
                             PaginationError::MissingEndpointUrlDomain(base_endpoint.to_string())
@@ -203,15 +204,31 @@ pub(crate) fn next_page_from_body(
                             })?
                             //.expect("Port is unknown")
                             .to_string()
-                        + next_url
+                        + next_url;
+
+                    return Some(
+                        Url::parse(&next).map_err(|err| PaginationError::parse(next, err)),
+                    )
+                    .transpose();
                 } else {
-                    next_url.to_string()
+                    let mut next: Url = next_url
+                        .parse()
+                        .map_err(|err| PaginationError::parse(next_url, err))?;
+                    if next.host_str() != base_endpoint.host_str() {
+                        warn!(
+                            "The pagination link points at the different domain `{:?}`. Replacing it with the domain the result was retrieved.",
+                            base_endpoint.host_str()
+                        );
+                        next.set_host(base_endpoint.host_str())
+                            .map_err(|err| PaginationError::parse(next.clone(), err))?;
+                    }
+                    return Ok(Some(next));
                 };
-                return Some(Url::parse(&next).map_err(|x| PaginationError::InvalidUrl {
-                    source: x,
-                    url: next,
-                }))
-                .transpose();
+                //return Some(Url::parse(&next).map_err(|x| PaginationError::InvalidUrl {
+                //    source: x,
+                //    url: next,
+                //}))
+                //.transpose();
             }
         }
     }
@@ -231,17 +248,31 @@ mod tests {
 
     #[test]
     fn test_body_links() {
-        let data = json!({"links": [{"rel": "next", "href": "http://foo.bar"}]});
-        let res = next_page_from_body(&data, &None, Url::parse("http://dummy").unwrap());
-        assert_eq!(res.unwrap().unwrap(), Url::parse("http://foo.bar").unwrap());
+        let data = json!({"links": [{"rel": "next", "href": "http://foo.bar/2"}]});
+        let res = next_page_from_body(&data, &None, Url::parse("http://foo.bar/1").unwrap());
+        assert_eq!(
+            res.unwrap().unwrap(),
+            Url::parse("http://foo.bar/2").unwrap(),
+        );
+
+        let data = json!({"links": [{"rel": "next", "href": "http://foo.bar/2"}]});
+        let res = next_page_from_body(&data, &None, Url::parse("http://example.org/1").unwrap());
+        assert_eq!(
+            res.unwrap().unwrap(),
+            Url::parse("http://example.org/2").unwrap(),
+            "domain differs, need to replace it to the current one"
+        );
     }
 
     #[test]
     fn test_body_nova_links() {
-        let data = json!({"flavors_links": [{"rel": "next", "href": "http://foo.bar"}]});
+        let data = json!({"flavors_links": [{"rel": "next", "href": "http://foo.bar/2"}]});
         let key: Cow<'static, str> = Cow::Owned("flavors".into());
-        let res = next_page_from_body(&data, &Some(key), Url::parse("http://dummy").unwrap());
-        assert_eq!(res.unwrap().unwrap(), Url::parse("http://foo.bar").unwrap());
+        let res = next_page_from_body(&data, &Some(key), Url::parse("http://foo.bar/1").unwrap());
+        assert_eq!(
+            res.unwrap().unwrap(),
+            Url::parse("http://foo.bar/2").unwrap()
+        );
     }
 
     #[test]

--- a/sdk/core/src/api/paged/pagination.rs
+++ b/sdk/core/src/api/paged/pagination.rs
@@ -50,6 +50,18 @@ pub enum PaginationError {
     MissingEndpointUrlPort(String),
 }
 
+impl PaginationError {
+    pub fn parse<S>(url: S, error: url::ParseError) -> Self
+    where
+        S: Into<String>,
+    {
+        Self::InvalidUrl {
+            url: url.into(),
+            source: error,
+        }
+    }
+}
+
 /// Pagination options
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum Pagination {


### PR DESCRIPTION
Sometimes pagination links can be broken and point to the wrong domain.
Log a warning and replace it with the same domain the page was received
from.
