### PR TITLE
chore(ci): Changes that were necessary for making initial release of subcrates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2760,7 +2760,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-auth"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-block-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-catalog"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "openstack-cli-core",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-compute"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-container-infrastructure-management"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-core"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-dns"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-identity"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-image"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-load-balancer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2933,7 +2933,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-network"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-object-store"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "clap",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "openstack-cli-placement"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,25 @@ itertools = { version = "^0.14" }
 json-patch = { version = "^4.2" }
 lazy_static = { version = "^1.5" }
 open = { version = "^5.3" }
+openstack-cli-api = { path="cli/api", version = "0.2.0" }
+openstack-cli-auth = { path="cli/auth", version = "0.2.0" }
+openstack-cli-block-storage = { path="cli/block-storage/", version = "0.2.0" }
+openstack-cli-catalog = { path="cli/catalog/", version = "0.2.0" }
+openstack-cli-compute = { path="cli/compute/", version = "0.2.0" }
+openstack-cli-container-infrastructure-management = { path="cli/container-infrastructure-management/", version = "0.2.0" }
+openstack-cli-core = { path="cli/core", version = "0.13.6" }
+openstack-cli-dns = { path="cli/dns/", version = "0.2.0" }
+openstack-cli-identity = { path="cli/identity/", version = "0.2.0" }
+openstack-cli-image = { path="cli/image/", version = "0.2.0" }
+openstack-cli-load-balancer = { path="cli/load-balancer/", version = "0.2.0" }
+openstack-cli-network = { path="cli/network/", version = "0.2.0" }
+openstack-cli-object-store = { path="cli/object-store/", version = "0.2.0" }
+openstack-cli-placement = { path="cli/placement/", version = "^0.2" }
+openstack-sdk-auth-core = { version = "0.22.5", path = "sdk/auth-core" }
+openstack_sdk_core = { version = "0.22.6", path = "sdk/core" }
+openstack_sdk = { version = "0.22.6", path = "openstack_sdk" }
+openstack_types = { version = "0.22.6", path = "openstack_types" }
+openstack-types-core = { version = "0.1", path = "types/core" }
 regex = { version = "^1.12" }
 reqwest = { version = "^0.13", default-features = false }
 reserve-port = "^2.4"
@@ -109,3 +128,7 @@ unwrap_used = "deny"
 expect_used = "deny"
 enum_glob_use = "deny"
 module_inception = "allow"
+
+#[patch.crates-io]
+#openstack-cli-core = {path = "./cli/core"}
+#openstack_sdk_core = {path = "./sdk/core"}

--- a/cli/api/Cargo.toml
+++ b/cli/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-api"
 description = "OpenStack CLI Api commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,8 +11,8 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "identity"] }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "identity"] }
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/cli/auth/Cargo.toml
+++ b/cli/auth/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-auth"
 description = "OpenStack CLI auth commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -13,9 +13,9 @@ repository.workspace = true
 chrono.workspace = true
 clap.workspace = true
 eyre.workspace = true
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "identity"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "identity"] }
+openstack_sdk_core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/cli/block-storage/Cargo.toml
+++ b/cli/block-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-block-storage"
 description = "OpenStack CLI Block Storage commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,10 +11,10 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "block_storage", "identity"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "block_storage", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/cli/catalog/Cargo.toml
+++ b/cli/catalog/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-catalog"
 description = "OpenStack CLI Catalog commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,9 +11,9 @@ repository.workspace = true
 
 [dependencies]
 clap.workspace = true
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "identity"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "identity"] }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 structable = { workspace = true }

--- a/cli/compute/Cargo.toml
+++ b/cli/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-compute"
 description = "OpenStack CLI Compute commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,10 +11,10 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "compute", "identity"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "compute", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/cli/container-infrastructure-management/Cargo.toml
+++ b/cli/container-infrastructure-management/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-container-infrastructure-management"
 description = "OpenStack CLI Container infra commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,10 +11,10 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "container_infra"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "container_infra"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/cli/core/.config/config.yaml
+++ b/cli/core/.config/config.yaml
@@ -1,0 +1,405 @@
+---
+views:
+  # block storage
+  block-storage.attachment:
+    default_fields: [id, instance, volume_id, status, attach_mode, attached_at]
+    fields:
+      - name: id
+        width: 38
+      - name: instance
+        width: 38
+      - name: volume_id
+        width: 38
+  block-storage.backup:
+    default_fields: [id, name, availability_zone, description, fail_reason, is_incremental, metadata, object_count, size, snapshot_id, status, volume_id, created_at]
+    fields:
+      - name: id
+        width: 38
+      - name: volume_id
+        width: 38
+  block-storage.snapshot:
+    default_fields: [id, name, description, "os-extended-snapshot-attributes:progress", size, status, volume_id, created_at]
+    fields:
+      - name: id
+        width: 38
+      - name: volume_id
+        width: 38
+      - name: group_snapshot_id
+        width: 38
+  block-storage.volume:
+    default_fields: [id, name, availability_zone, bootable, description, encrypted, imetadata, migration_status, multiattach, replication_status, size, status, volume_type]
+    fields:
+      - name: id
+        width: 38
+      - name: service_uuid
+        width: 38
+      - name: user_id
+        width: 34
+      - name: volume_type_id
+        width: 38
+  # compute
+  compute.aggregate:
+    default_fields: [name, uuid, az, updated_at]
+    fields:
+      - name: uuid
+        width: 38
+  compute.flavor:
+    default_fields: [id, name, vcpus, ram, disk, swap, description]
+    fields:
+      - name: id
+        width: 38
+  compute.hypervisor:
+    default_fields: [ip, hostname, status, state]
+    fields:
+      - name: id
+        width: 38
+  compute.server/instance_action/event:
+    default_fields: [event, result, start_time, finish_time, host]
+    fields:
+      - name: id
+        width: 38
+  compute.server/instance_action:
+    default_fields: [id, action, message, start_time, user_id]
+    fields:
+      - name: id
+        width: 38
+  compute.server:
+    default_fields: [id, name, status, created, address, image, flavor, security_groups]
+    fields:
+      - name: id
+        width: 38
+      - name: hostId
+        width: 38
+      - name: tenant_id
+        width: 34
+      - name: locked
+        width: 7
+      - name: status
+        width: 8
+      - name: flavor
+        json_pointer: "/original_name"
+      - name: image
+        json_pointer: "/id"
+  # dns
+  dns.recordset:
+    default_fields: [id, name, description, records, status, type, zone_id, zone_name, created_at, updated_at]
+    fields:
+      - name: id
+        width: 38
+      - name: zone_id
+        width: 38
+      - name: project_id
+        width: 34
+  dns.zone/recordset:
+    default_fields: [id, name, description, records, status, type, zone_name, created_at, updated_at]
+    fields:
+      - name: id
+        width: 38
+      - name: zone_id
+        width: 38
+      - name: project_id
+        width: 34
+  dns.zone:
+    default_fields: [id, name, description, email, shared, status, ttl, type, created_at, updated_at]
+    fields:
+      - name: id
+        width: 38
+      - name: pool_id
+        width: 38
+      - name: project_id
+        width: 34
+  # identity
+  identity.domain:
+    default_fields: [id, name, enabled, description, options, tags]
+    fields:
+      - name: id
+        width: 34
+  identity.endpoint:
+    default_fields: [id, url, interface, region_id, service_id, enabled]
+    fields:
+      - name: id
+        width: 34
+  identity.group:
+    default_fields: [id, name, domain_id, description]
+    fields:
+      - name: id
+        width: 34
+      - name: domain_id
+        width: 34
+  identity.federation/identity_provider:
+    default_fields: [id, name, domain_id, oidc_discovery_url, oidc_client_id, oidc_response_mode, oidc_response_types, default_mapping_name, jwks_url, jwt_validation_pubkeys, bound_issuer, provider_config]
+    fields:
+      - name: id
+        min_width: 34
+      - name: domain_id
+        min_width: 34
+  identity.federation/mapping:
+    default_fields: [id, name, idp_id, domain_id, domain_id_claim, type, oidc_scopes, allowed_redirect_uris, user_id_claim, user_name_claim, groups_claim, bound_audiences, bound_subject, bound_claims, token_user_id, token_project_id, token_role_ids]
+    fields:
+      - name: id
+        width: 38
+      - name: idp_id
+        min_width: 34
+      - name: domain_id
+        min_width: 34
+  identity.project:
+    default_fields: [id, name, domain_id, enabled, parent_id, description, options, tags]
+    fields:
+      - name: id
+        width: 34
+      - name: domain_id
+        width: 34
+      - name: parent_id
+        width: 34
+  identity.region:
+    default_fields: [id, parent_id, description]
+    fields:
+      - name: id
+        width: 34
+      - name: parent_id
+        width: 34
+  identity.role:
+    default_fields: [id, name, domain_id, description, options]
+    fields:
+      - name: id
+        width: 34
+      - name: domain_id
+        width: 34
+  identity.role_assignment:
+    default_fields: [role, group, user, scope]
+  identity.service:
+    default_fields: [id, name, type, description, enabled]
+    fields:
+      - name: id
+        width: 34
+  identity.user/application_credential:
+    default_fields: [id, name, description, project_id, expires_at, roles, unrestricted]
+    fields:
+      - name: id
+        width: 34
+      - name: project_id
+        width: 34
+  identity.user/access_rule:
+    default_fields: [id, service, path, method]
+    fields:
+      - name: id
+        width: 34
+  identity.user:
+    default_fields: [id, name, domain_id, enabled, description, password_expires_at]
+    fields:
+      - name: id
+        width: 34
+      - name: domain_id
+        width: 34
+      - name: default_project_id
+        width: 34
+  # image
+  image.image:
+    default_fields: [id, name, distro, version, arch, min_disk, min_ram, os_hidden, protected, status, visibility, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: owner
+        width: 34
+  # load balancer
+  load-balancer.healthmonitor:
+    default_fields: [id, name, admin_state_up, delay, http_method, timeout, type, operating_status, provisioning_status, url_path, tags]
+    fields:
+      - name: id
+        width: 38
+  load-balancer.listener:
+    default_fields: [id, name, description, admin_state_up, default_pool_id, l7policies, loadbalancers, operating_status, protocol, protocol_port, provisioning_status, port, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: default_pool_id
+        width: 38
+  load-balancer.loadbalancer:
+    default_fields: [id, name, admin_state_up, description, listeners, operating_status, pools, provisioning_status, status, vip_address, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: vip_network_id
+        width: 38
+      - name: vip_subnet_id
+        width: 38
+      - name: vip_port_id
+        width: 38
+      - name: tenant_id
+        width: 34
+      - name: project_id
+        width: 34
+  load-balancer.pool/member:
+    default_fields: [id, name, address, admin_state_up, backup, monitor_address, monitor_port, operating_status, protocol_port, provisioning_status, subnet_id, weight, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: subnet_id
+        width: 38
+      - name: tenant_id
+        width: 34
+      - name: project_id
+        width: 34
+  load-balancer.pool:
+    default_fields: [id, name, admin_state_up, description, healthmonitor_id, lb_algorithm, listeners, loadbalancers, members, operating_status, protocol, provisioning_status, tls_enabled, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: healthmonitor_id
+        width: 38
+      - name: admin_state_up
+        min_width: 5
+      - name: tenant_id
+        width: 34
+      - name: project_id
+        width: 34
+  # network
+  network.network:
+    default_fields: [id, name, admin_state_up, dns_domain, "provider:network_type", "router:external", shared, status, subnets, created_at, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: network_id
+        width: 38
+      - name: subnets
+        min_width: 42
+      - name: tenant_id
+        width: 34
+  network.port:
+    default_fields: [id, name, admin_state_up, device_id, device_owner, dns_assignment, fixed_ips, network_id, security_groups, status, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: device_id
+        width: 38
+      - name: network_id
+        width: 38
+      - name: security_groups
+        min_width: 42
+      - name: admin_state_up
+        min_width: 6
+      - name: port_security_enabled
+        min_width: 6
+      - name: status
+        min_width: 8
+      - name: tenant_id
+        width: 34
+  network.router:
+    default_fields: [id, name, admin_state_up, description, external_gateway_info, status, created_at, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: tenant_id
+        width: 34
+  network.subnet:
+    default_fields: [id, name, allocation_pools, cidr, created_at, description, dns_nameservers, gateway_ip, ip_version, tags]
+    fields:
+      - name: id
+        width: 38
+      - name: network_id
+        width: 38
+      - name: tenant_id
+        width: 34
+      - name: cidr
+        min_width: 13
+  network.security_group_rule:
+    default_fields: [id, ethertype, description, direction, protocol, port_range_min, port_range_max, remote_group_id, remote_ip_prefix]
+    fields:
+      - name: id
+        width: 38
+      - name: remote_group_id
+        max_width: 38
+      - name: tenant_id
+        width: 34
+  network.security_group:
+    default_fields: [id, name, description, created_at]
+    fields:
+      - name: id
+        width: 38
+      - name: tenant_id
+        width: 34
+      - name: security_group_rules
+        max_width: 70
+  object-store.container:
+    default_fields: [name, count, bytes, last_modified]
+  object-store.object:
+    default_fields: [name, bytes, content_type, last_modified, hash, symlink_path]
+hints:
+  - >
+    You can configure which fields are returned for the resource by setting the
+    `default_fields` option in the `general` section of the configuration file
+    ($XDG_CONFIG_DIR/osc/config.yaml).
+  - >
+    Use $XDG_CONFIG_DIR/osc/config.yaml configuration file to modify default
+    fields, column width constraints or hints.
+  - "Use `-o json | jq -r '.[].id'` to return list of resource ids only."
+  - "Use `--pretty` to apply pretty formatting of the serialized data in the table."
+  - "List operations support `--max-items <NUM>` argument to limit the number of items returned."
+  - "Place you custom hints in the `hints` or `command_hints` section of the configuration file."
+  - "Disable hints by setting `enable_hints: false` in the configuration file."
+  - "If you think that by default other resource fields should be returned consider reporting that."
+  - "`osc` supports authenticated API calls (similar to curl) with `osc api <SERVICE_TYPE> <URL> ...`. Use this if certain API is not natively supported yet."
+command_hints:
+  auth:
+    show:
+      - "Auth token can be set to the shell variable with `TOKEN=$(osc auth login)`"
+      - "A full authentication response can be seen with `osc auth show -o json --pretty`"
+    login:
+      - "You can force new token instead of the cached one with the `--renew` argument."
+  block-storage.quota_set:
+    defaults:
+      - "You can specify `--project-id <PROJECT_ID>` or `--project-name <PROJECT_NAME>` or `--current-project` in the quota-set commands. Use \"name\" with caution."
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set --project-id <PROJECT_ID> --quota-set gigabyes=10`"
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set <PROJECT_ID> --quota-set <QUOTA_TYPE>=<VALUE>`"
+      - "Block storage quota defaults for the project can be seen with `osc block-storage quota-set defaults --current-project`"
+      - "Block storage quota defaults for the project can be seen with `osc block-storage quota-set defaults --project-id <PROJECT_ID>`"
+      - "Block storage quota defaults for the project can be seen with `osc block-storage quota-set defaults --project-name <PROJECT_NAME>`"
+    show:
+      - "You can specify `--project-id <PROJECT_ID>` or `--project-name <PROJECT_NAME>` or `--current-project` in the quota-set commands. Use \"name\" with caution."
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set --project-id <PROJECT_ID> --quota-set gigabyes=10`"
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set --project-id <PROJECT_ID> --quota-set <QUOTA_TYPE>=<VALUE>`"
+      - "Block storage quota defaults for the project can be seen with `osc block-storage quota-set defaults --project-id <PROJECT_ID>`"
+      - "Block storage quota with the usage can be seen with `osc block-storage quota-set show [--current-project|--project-id <PROJECT_ID>|--project-name <PROJECT_NAME>] --usage true`"
+    set:
+      - "You can specify `--project-id <PROJECT_ID>` or `--project-name <PROJECT_NAME>` or `--current-project` in the quota-set commands. Use \"name\" with caution."
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set --project-id <PROJECT_ID> --quota-set gigabyes=10`"
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set --project-id <PROJECT_ID> --quota-set <QUOTA_TYPE>=<VALUE>`"
+      - "Block storage quota defaults for the project can be seen with `osc block-storage quota-set defaults --project-id <PROJECT_ID>`"
+    delete:
+      - "You can specify `--project-id <PROJECT_ID>` or `--project-name <PROJECT_NAME>` or `--current-project` in the quota-set commands. Use \"name\" with caution."
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set --current-project --quota-set gigabyes=10`"
+      - "Block storage quota for the project can be set with `osc block-storage quota-set set --project-id <PROJECT_ID> --quota-set <QUOTA_TYPE>=<VALUE>`"
+      - "Block storage quota defaults for the project can be seen with `osc block-storage quota-set defaults --project-id <PROJECT_ID>`"
+  network.router:
+    list:
+      - "Router interfaces can be seen with `osc network port list --device-id <ROUTER_ID>` command."
+    show:
+      - "Router interfaces can be seen with `osc network port list --device-id <ROUTER_ID>` command."
+    create:
+      - "Router interfaces can be seen with `osc network port list --device-id <ROUTER_ID>` command."
+    add_router_interface:
+      - "Router interfaces can be seen with `osc network port list --device-id <ROUTER_ID>` command."
+    remove_router_interface:
+      - "Router interfaces can be seen with `osc network port list --device-id <ROUTER_ID>` command."
+  object-store.container:
+    create:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    delete:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    list:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    set:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    show:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+  object-store.object:
+    delete:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    download:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    list:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    show:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"
+    upload:
+      - "Container can be pruned with `osc object-store container prune [--prefix <PREFIX>] <CONTAINER>`"

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-core"
 description = "OpenStack CLI core"
-version = "0.13.5"
+version = "0.13.6"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -21,8 +21,8 @@ eyre = { workspace = true }
 http = { workspace = true }
 indicatif = "^0.18"
 itertools = { workspace = true }
-openstack-sdk-auth-core = { path="../../sdk/auth-core", version = "^0.22", default-features = false }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22", default-features = false }
+openstack-sdk-auth-core.workspace = true
+openstack_sdk_core.workspace = true
 owo-colors = { version = "^4.3", features = ["supports-colors"] }
 rand = { version = "^0.10" }
 reqwest = { workspace = true }
@@ -30,7 +30,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = {workspace = true}
 structable = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["fs", "io-std"]}
+tokio = { workspace = true, features = ["fs", "io-std", "io-util"]}
 tokio-util = {workspace = true}
 tracing = { workspace = true}
 tracing-subscriber = { workspace = true }

--- a/cli/core/src/common.rs
+++ b/cli/core/src/common.rs
@@ -23,7 +23,7 @@ use std::io::IsTerminal;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::path::Path;
 use tokio::fs;
-use tokio::io::{self};
+use tokio::io::{self, copy};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 use tokio_util::io::InspectReader;
 
@@ -122,7 +122,7 @@ pub async fn download_file(
         );
 
         let mut writer = io::stdout();
-        io::copy(&mut inspect_reader, &mut writer).await?;
+        copy(&mut inspect_reader, &mut writer).await?;
     } else {
         let path = Path::new(&dst_name);
         let fname = path

--- a/cli/core/src/config.rs
+++ b/cli/core/src/config.rs
@@ -39,7 +39,7 @@ use std::{
 use thiserror::Error;
 use tracing::error;
 
-const CONFIG: &str = include_str!("../../../openstack_cli/.config/config.yaml");
+const CONFIG: &str = include_str!("../.config/config.yaml");
 
 /// Errors which may occur when dealing with OpenStack connection
 /// configuration data.

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -24,6 +24,9 @@ pub mod error;
 pub mod output;
 pub mod tracing_stats;
 
+pub use openstack_sdk_auth_core;
+pub use openstack_sdk_core;
+
 use crate::tracing_stats::HttpRequestStats;
 
 /// Build a table of HTTP request timings

--- a/cli/dns/Cargo.toml
+++ b/cli/dns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-dns"
 description = "OpenStack CLI DNS commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,10 +11,10 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "dns", "identity"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "dns", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/cli/identity/Cargo.toml
+++ b/cli/identity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-identity"
 description = "OpenStack CLI Identity commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -13,11 +13,11 @@ repository.workspace = true
 base64 = { workspace = true, optional = true }
 clap.workspace = true
 dialoguer.workspace = true
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "identity"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
 eyre.workspace = true
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "identity", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 http.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/cli/image/Cargo.toml
+++ b/cli/image/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-image"
 description = "OpenStack CLI Image commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -12,10 +12,10 @@ repository.workspace = true
 [dependencies]
 clap = { workspace = true }
 json-patch = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "identity", "image"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "image", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/cli/load-balancer/Cargo.toml
+++ b/cli/load-balancer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-load-balancer"
 description = "OpenStack CLI Load Balancer commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,10 +11,10 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "identity", "load_balancer"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "load_balancer", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/cli/network/Cargo.toml
+++ b/cli/network/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "openstack-cli-network"
-version = "0.1.0"
+description = "OpenStack CLI Network commands"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -10,11 +11,11 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "network"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
 eyre = { workspace = true }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "network", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 http = { workspace = true }
 serde_json = {workspace = true}
 tracing = { workspace = true}

--- a/cli/object-store/Cargo.toml
+++ b/cli/object-store/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-object-store"
 description = "OpenStack CLI Object Storage commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -12,10 +12,10 @@ repository.workspace = true
 [dependencies]
 bytes.workspace = true
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "object_store"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "object_store", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 regex.workspace = true

--- a/cli/placement/Cargo.toml
+++ b/cli/placement/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openstack-cli-placement"
 description = "OpenStack CLI Placement commands"
-version = "0.1.0"
+version = "0.2.0"
 license.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,10 +11,10 @@ repository.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-openstack-cli-core = { version = "0.13", path = "../core/" }
-openstack_sdk = { path="../../openstack_sdk", version = "^0.22", default-features = false, features = ["async", "identity", "placement"] }
-openstack_sdk_core = { path="../../sdk/core", version = "^0.22" }
-openstack_types = { path="../../openstack_types", version = "^0.22" }
+openstack-cli-core.workspace = true
+openstack_sdk = { workspace = true, features = ["async", "identity"] }
+openstack_sdk_core.workspace = true
+openstack_types.workspace = true
 eyre = { workspace = true }
 http = { workspace = true }
 serde_json = {workspace = true}

--- a/openstack_cli/Cargo.toml
+++ b/openstack_cli/Cargo.toml
@@ -64,21 +64,21 @@ clap_complete = { workspace = true, features = ["unstable-dynamic"] }
 color-eyre = { workspace = true }
 dialoguer = { workspace = true, features=["fuzzy-select"] }
 eyre = { workspace = true }
-openstack-cli-api = { path="../cli/api", version = "^0.1" }
-openstack-cli-auth = { path="../cli/auth", version = "^0.1" }
-openstack-cli-block-storage = { path="../cli/block-storage/", version = "^0.1" }
-openstack-cli-catalog = { path="../cli/catalog/", version = "^0.1" }
-openstack-cli-compute = { path="../cli/compute/", version = "^0.1" }
-openstack-cli-container-infrastructure-management = { path="../cli/container-infrastructure-management/", version = "^0.1" }
-openstack-cli-core = { path="../cli/core", version = "^0.13" }
-openstack-cli-dns = { path="../cli/dns/", version = "^0.1" }
-openstack-cli-identity = { path="../cli/identity/", version = "^0.1" }
-openstack-cli-image = { path="../cli/image/", version = "^0.1" }
-openstack-cli-load-balancer = { path="../cli/load-balancer/", version = "^0.1" }
-openstack-cli-network = { path="../cli/network/", version = "^0.1" }
-openstack-cli-object-store = { path="../cli/object-store/", version = "^0.1" }
-openstack-cli-placement = { path="../cli/placement/", version = "^0.1" }
-openstack_sdk = { path="../openstack_sdk", version = "^0.22", default-features = false, features = ["async"] }
+openstack-cli-api.workspace = true
+openstack-cli-auth.workspace = true
+openstack-cli-block-storage.workspace = true
+openstack-cli-catalog.workspace = true
+openstack-cli-compute.workspace = true
+openstack-cli-container-infrastructure-management.workspace = true
+openstack-cli-core.workspace = true
+openstack-cli-dns.workspace = true
+openstack-cli-identity.workspace = true
+openstack-cli-image.workspace = true
+openstack-cli-load-balancer.workspace = true
+openstack-cli-network.workspace = true
+openstack-cli-object-store.workspace = true
+openstack-cli-placement.workspace = true
+openstack_sdk = { workspace = true, features = ["async"] }
 strip-ansi-escapes = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true}

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -75,7 +75,7 @@ futures-util.workspace = true
 http.workspace = true
 inventory.workspace = true
 openstack-sdk-auth-applicationcredential = { version = "0.22", path = "../sdk/auth-application-credential/" }
-openstack-sdk-auth-core = { version = "0.22", path = "../sdk/auth-core/" }
+openstack-sdk-auth-core.workspace = true
 openstack-sdk-auth-federation = { version = "0.22", path = "../sdk/auth-federation/", optional = true }
 openstack-sdk-auth-jwt = { version = "0.22", path = "../sdk/auth-jwt/", optional = true }
 openstack-sdk-auth-oidcaccesstoken = { version = "0.22", path = "../sdk/auth-oidcaccesstoken/" }
@@ -85,7 +85,7 @@ openstack-sdk-auth-receipt = { version = "0.1", path = "../sdk/auth-receipt/" }
 openstack-sdk-auth-token = { version = "0.1", path = "../sdk/auth-token/" }
 openstack-sdk-auth-totp = { version = "0.1", path = "../sdk/auth-totp/" }
 openstack-sdk-auth-websso = { version = "0.22", path = "../sdk/auth-websso/" }
-openstack_sdk_core = { path = "../sdk/core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 openstack-sdk-block-storage = { path = "../sdk/block-storage/", version = "^0.1", optional = true }
 openstack-sdk-compute = { path = "../sdk/compute/", version = "^0.1", optional = true }
 openstack-sdk-container-infrastructure-management = { path = "../sdk/container-infrastructure-management/", version = "^0.1", optional = true }

--- a/sdk/auth-application-credential/Cargo.toml
+++ b/sdk/auth-application-credential/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-applicationcredential"
+description = "OpenStack SDK auth plugin for authenticating with application credentials"
 version = "0.22.5"
 license.workspace = true
 edition.workspace = true
@@ -12,7 +13,7 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/auth-federation/Cargo.toml
+++ b/sdk/auth-federation/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-federation"
+description = "OpenStack SDK auth plugin for authenticating with v4 federation"
 version = "0.22.5"
 license.workspace = true
 edition.workspace = true
@@ -21,14 +22,14 @@ hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["full"] }
 inventory.workspace = true
 open.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true
 reqwest = { workspace = true, features = ["form"] }
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["signal"] }
 tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true

--- a/sdk/auth-jwt/Cargo.toml
+++ b/sdk/auth-jwt/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-jwt"
+description = "OpenStack SDK auth plugin for authenticating with JWT"
 version = "0.22.5"
 license.workspace = true
 edition.workspace = true
@@ -12,7 +13,7 @@ repository.workspace = true
 async-trait.workspace = true
 derive_builder.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/auth-multifactor/Cargo.toml
+++ b/sdk/auth-multifactor/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-multifactor"
+description = "OpenStack SDK auth plugin for multifactor authentication"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -12,7 +13,7 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 openstack-sdk-auth-password = { version = "0.1", path = "../auth-password" }
 openstack-sdk-auth-token = { version = "0.1", path = "../auth-token" }
 openstack-sdk-auth-totp = { version = "0.1", path = "../auth-totp" }

--- a/sdk/auth-oidcaccesstoken/Cargo.toml
+++ b/sdk/auth-oidcaccesstoken/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-oidcaccesstoken"
+description = "OpenStack SDK auth plugin for authenticating with OIDC token"
 version = "0.22.5"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +12,7 @@ repository.workspace = true
 [dependencies]
 async-trait.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/auth-passkey/Cargo.toml
+++ b/sdk/auth-passkey/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-passkey"
+description = "OpenStack SDK auth plugin for authenticating with Webauthn credentials"
 version = "0.22.5"
 license.workspace = true
 edition.workspace = true
@@ -13,7 +14,7 @@ async-trait.workspace = true
 base64.workspace = true
 derive_builder.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/auth-password/Cargo.toml
+++ b/sdk/auth-password/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-password"
+description = "OpenStack SDK auth plugin for authenticating with username/password"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -12,7 +13,7 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/auth-receipt/Cargo.toml
+++ b/sdk/auth-receipt/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-receipt"
+description = "OpenStack SDK auth plugin for receipt based authenticating"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -12,7 +13,7 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 openstack-sdk-auth-password = { version = "0.1", path = "../auth-password" }
 openstack-sdk-auth-token = { version = "0.1", path = "../auth-token" }
 openstack-sdk-auth-totp = { version = "0.1", path = "../auth-totp" }

--- a/sdk/auth-token/Cargo.toml
+++ b/sdk/auth-token/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-token"
+description = "OpenStack SDK auth plugin for authenticating with a token"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -12,7 +13,7 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/auth-totp/Cargo.toml
+++ b/sdk/auth-totp/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-totp"
+description = "OpenStack SDK auth plugin for authenticating with a TOTP token"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -12,7 +13,7 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 inventory.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/auth-websso/Cargo.toml
+++ b/sdk/auth-websso/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "openstack-sdk-auth-websso"
+description = "OpenStack SDK auth plugin for authenticating with a WebSSO method"
 version = "0.22.5"
 license.workspace = true
 edition.workspace = true
@@ -21,7 +22,7 @@ hyper = { workspace = true, features = ["full"] }
 hyper-util = { workspace = true, features = ["full"] }
 inventory.workspace = true
 open.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core" }
+openstack-sdk-auth-core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/block-storage/Cargo.toml
+++ b/sdk/block-storage/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/compute/Cargo.toml
+++ b/sdk/compute/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/container-infrastructure-management/Cargo.toml
+++ b/sdk/container-infrastructure-management/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -34,7 +34,7 @@ futures-util.workspace = true
 http.workspace = true
 inventory.workspace = true
 itertools.workspace = true
-openstack-sdk-auth-core = { version = "0.22", path = "../auth-core/" }
+openstack-sdk-auth-core.workspace = true
 postcard = { version = "1.1", default-features = false, features = ["use-std"] }
 regex.workspace = true
 reqwest = { workspace = true, default-features = false }

--- a/sdk/dns/Cargo.toml
+++ b/sdk/dns/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/sdk/image/Cargo.toml
+++ b/sdk/image/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 derive_builder.workspace = true
 http.workspace = true
 json-patch.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/load-balancer/Cargo.toml
+++ b/sdk/load-balancer/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/network/Cargo.toml
+++ b/sdk/network/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/object-store/Cargo.toml
+++ b/sdk/object-store/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = { workspace = true, optional = true }
 derive_builder.workspace = true
 futures = { workspace = true, optional = true }
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/sdk/placement/Cargo.toml
+++ b/sdk/placement/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 [dependencies]
 derive_builder.workspace = true
 http.workspace = true
-openstack_sdk_core = { path = "../core/", version = "^0.22" }
+openstack_sdk_core.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/types/block-storage/Cargo.toml
+++ b/types/block-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-block-storage"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Block Storage"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/compute/Cargo.toml
+++ b/types/compute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-compute"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Compute"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/container-infrastructure-management/Cargo.toml
+++ b/types/container-infrastructure-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-container-infrastructure-management"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Container Infrastructure Management"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/core/Cargo.toml
+++ b/types/core/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 [dependencies]
 chrono = { workspace= true }
 serde = { workspace = true }
-#structable = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/types/dns/Cargo.toml
+++ b/types/dns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-dns"
-description = "OpenStack API Types"
+description = "OpenStack API Types - DNS"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/identity/Cargo.toml
+++ b/types/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-identity"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Identity"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/image/Cargo.toml
+++ b/types/image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-image"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Image"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/load-balancer/Cargo.toml
+++ b/types/load-balancer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-load-balancer"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Load Balancer"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/network/Cargo.toml
+++ b/types/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-network"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Network"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/object-store/Cargo.toml
+++ b/types/object-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-object-store"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Object Store"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }

--- a/types/placement/Cargo.toml
+++ b/types/placement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openstack-types-placement"
-description = "OpenStack API Types"
+description = "OpenStack API Types - Placement"
 version = "0.1.0"
 license.workspace = true
 edition.workspace = true
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 chrono = { workspace= true }
-openstack-types-core = { path = "../core" }
+openstack-types-core.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 structable = { workspace = true }


### PR DESCRIPTION
When a button was pressed in the PR to make a release a lot of packages
were not existing and the release failed. Further analysis showed that
CLI modules have difficulty resolving the proper openstack_sdk_core
after that was released AFTER the openstack-cli-core dependency
duplication. Some rework in workspace arrangement has been done that
will hopefully work for the future releases.
