### PR TITLE
feat: Introduce possibility to skip auth cache

### DIFF
--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -55,7 +55,7 @@ use openstack_sdk_core::auth::{
     gather_auth_data,
 };
 use openstack_sdk_core::catalog::{CatalogError, ServiceEndpoint};
-use openstack_sdk_core::config::{CloudConfig, ConfigFile};
+use openstack_sdk_core::config::CloudConfig;
 use openstack_sdk_core::error::{OpenStackError, OpenStackResult, RestError};
 use openstack_sdk_core::types::{ApiVersion, ServiceType};
 use openstack_sdk_core::utils::expand_tilde;
@@ -219,10 +219,8 @@ impl OpenStack {
             client_builder = client_builder.danger_accept_invalid_certs(true);
         }
 
-        let auth_cache = ConfigFile::new()
-            .ok()
-            .is_some_and(|c| c.is_auth_cache_enabled());
-        let session_ctx = session::SessionContext::new(config, auth, auth_cache)?;
+        // Pass CloudConfig.auth_cache as override; SessionContext resolves priority chain.
+        let session_ctx = session::SessionContext::new(config, auth, config.auth_cache)?;
 
         Ok(OpenStack {
             client: client_builder.build()?,
@@ -320,6 +318,18 @@ impl OpenStack {
 
     pub fn set_max_auth_retries(&mut self, n: u32) -> &mut Self {
         self.max_auth_retries = n;
+        self
+    }
+
+    /// Disable authentication caching for this session.
+    ///
+    /// Clears any cached tokens and prevents further caching — both the
+    /// in-memory store and the on-disk state file. Useful for scenarios
+    /// requiring fresh authentication on every request.
+    pub fn disable_auth_cache(&self) -> &Self {
+        if let Ok(mut session) = self.session.write() {
+            session.state.disable_auth_cache();
+        }
         self
     }
 

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -68,7 +68,7 @@ use openstack_sdk_core::auth::{
     gather_auth_data,
 };
 use openstack_sdk_core::catalog::{CatalogError, ServiceEndpoint};
-use openstack_sdk_core::config::{CloudConfig, ConfigFile};
+use openstack_sdk_core::config::CloudConfig;
 use openstack_sdk_core::error::{OpenStackError, OpenStackResult, RestError};
 use openstack_sdk_core::types::{ApiVersion, BoxedAsyncRead, ServiceType};
 use openstack_sdk_core::utils::expand_tilde;
@@ -351,10 +351,8 @@ impl AsyncOpenStack {
         client_builder = client_builder.gzip(true);
         client_builder = client_builder.deflate(true);
 
-        let auth_cache = ConfigFile::new()
-            .ok()
-            .is_some_and(|c| c.is_auth_cache_enabled());
-        let session_ctx = session::SessionContext::new(config, auth, auth_cache)?;
+        // Pass CloudConfig.auth_cache as override; SessionContext resolves priority chain.
+        let session_ctx = session::SessionContext::new(config, auth, config.auth_cache)?;
 
         Ok(AsyncOpenStack {
             client: client_builder.build()?,
@@ -502,6 +500,18 @@ impl AsyncOpenStack {
                 .await?;
         }
         Ok(())
+    }
+
+    /// Disable authentication caching for this session.
+    ///
+    /// Clears any cached tokens and prevents further caching — both the
+    /// in-memory store and the on-disk state file. Useful for scenarios
+    /// requiring fresh authentication on every request.
+    pub fn disable_auth_cache(&self) -> &Self {
+        if let Ok(mut session) = self.session.write() {
+            session.state.disable_auth_cache();
+        }
+        self
     }
 
     /// Authorize against the cloud using provided credentials and get the session token with the

--- a/sdk/core/src/config.rs
+++ b/sdk/core/src/config.rs
@@ -382,6 +382,13 @@ pub struct CloudConfig {
     /// Verify SSL Certificates.
     pub verify: Option<bool>,
 
+    /// Override for authentication caching.
+    ///
+    /// If `Some(true)`, enables; if `Some(false)`, disables.
+    /// If `None`, falls back to the global `cache.auth` setting in the
+    /// `clouds.yaml` ConfigFile (default: `true`).
+    pub auth_cache: Option<bool>,
+
     /// Catch-all for additional configuration fields not explicitly typed.
     /// Any extra YAML keys at this level are captured here.
     #[serde(flatten)]

--- a/sdk/core/src/session.rs
+++ b/sdk/core/src/session.rs
@@ -16,9 +16,9 @@
 
 use crate::auth::Auth;
 use crate::catalog::Catalog;
+use crate::config::{CloudConfig, ConfigFile, get_config_identity_hash};
 use crate::state::State;
 
-use crate::config::{CloudConfig, get_config_identity_hash};
 use crate::error::OpenStackError;
 
 use openstack_sdk_auth_core::authtoken::AuthTokenError;
@@ -39,10 +39,14 @@ impl SessionContext {
     ///
     /// This is shared between sync and async clients — the ~30 lines of
     /// catalog/state initialization are identical.
+    ///
+    /// The `auth_cache` parameter is the session-level override. When `None`,
+    /// the CloudConfig's `auth_cache` field is checked, then the global
+    /// `ConfigFile` fallback, then defaults to `true`.
     pub fn new(
         config: &CloudConfig,
         auth: Auth,
-        auth_cache_enabled: bool,
+        auth_cache: Option<bool>,
     ) -> Result<Self, OpenStackError> {
         let mut catalog = Catalog::default();
 
@@ -64,6 +68,20 @@ impl SessionContext {
         )?;
 
         catalog.configure(config)?;
+
+        // Resolve auth cache priority:
+        //   1. explicit parameter override
+        //   2. CloudConfig.auth_cache
+        //   3. ConfigFile.cache.auth
+        //   4. default true
+        let auth_cache_enabled = auth_cache
+            .or(config.auth_cache)
+            .or_else(|| {
+                ConfigFile::new()
+                    .ok()
+                    .and_then(|cf| cf.cache.as_ref().and_then(|c| c.auth))
+            })
+            .unwrap_or(true);
 
         let mut state = State::new();
         state

--- a/sdk/core/src/state.rs
+++ b/sdk/core/src/state.rs
@@ -103,6 +103,17 @@ impl State {
         self
     }
 
+    /// Disable all authorization caching (in-memory and on-disk).
+    ///
+    /// When disabled, `get_scope_auth()` and `get_any_valid_auth()` will
+    /// always return `None`, and `set_scope_auth()` will skip both the
+    /// in-memory store and file persistence.
+    pub fn disable_auth_cache(&mut self) -> &mut Self {
+        self.auth_cache_enabled = false;
+        self.auth_state.0.clear();
+        self
+    }
+
     /// Set authz into the state
     pub fn set_scope_auth(&mut self, scope: &AuthTokenScope, authz: &AuthToken) {
         self.auth_state.filter_invalid_auths();


### PR DESCRIPTION
- CloudConfig now has a dedicated auth_cache property allowing to
  request explicit opt-out from auth caching.
- Add explicit method to disable auth caching on the Client.
