### PR TITLE
refactor: Address diverse clippy findings

### DIFF
--- a/cli/identity/src/v4.rs
+++ b/cli/identity/src/v4.rs
@@ -47,8 +47,8 @@ pub struct IdentityCommand {
 #[allow(missing_docs)]
 #[derive(Subcommand)]
 pub enum IdentityCommands {
-    Federation(federation::FederationCommand),
-    User(user::UserCommand),
+    Federation(Box<federation::FederationCommand>),
+    User(Box<user::UserCommand>),
 }
 
 impl IdentityCommand {

--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -42,7 +42,7 @@ pub enum Action {
     /// Trigger connection to the cloud
     ConnectToCloud(String),
     /// Request rescoping current connection
-    CloudChangeScope(openstack_sdk::auth::authtoken::AuthTokenScope),
+    CloudChangeScope(Box<openstack_sdk::auth::authtoken::AuthTokenScope>),
     /// New cloud connection established
     ConnectedToCloud(Box<openstack_sdk::types::identity::v3::TokenInfo>),
     /// Perform API request
@@ -109,7 +109,7 @@ pub enum Action {
     // Compute (Nova)
     SetComputeServerListFilters(Box<cloud_types::ComputeServerList>),
     SetComputeServerInstanceActionListFilters(Box<cloud_types::ComputeServerInstanceActionList>),
-    SetComputeServerInstanceActionShowFilters(cloud_types::ComputeServerInstanceActionShow),
+    SetComputeServerInstanceActionShowFilters(Box<cloud_types::ComputeServerInstanceActionShow>),
     /// Show servers provisioned with selected flavor
     ShowComputeServersWithFlavor,
     /// Delete selected server

--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -523,7 +523,7 @@ impl App {
                     self.action_tx.send(action)?;
                 };
             }
-            for (mode, component) in self.components.iter_mut() {
+            for (mode, component) in &mut self.components {
                 // only update component if it belongs to the current mode or it is not refresh
                 // event
                 if *mode == self.mode

--- a/openstack_tui/src/cloud_worker/common.rs
+++ b/openstack_tui/src/cloud_worker/common.rs
@@ -23,22 +23,35 @@ pub trait ConfirmableRequest {
 
 #[derive(Error, Debug)]
 pub enum CloudWorkerError {
-    /// OpenStack API error.
     #[error(transparent)]
     OpenStackApi {
         /// The source of the error.
-        #[from]
-        source: openstack_sdk::api::ApiError<openstack_sdk::RestError>,
+        source: Box<openstack_sdk::api::ApiError<openstack_sdk::RestError>>,
     },
 
     #[error("error sending action: {}", source)]
     SenderError {
         /// The source of the error.
-        #[from]
-        source: tokio::sync::mpsc::error::SendError<action::Action>,
+        source: Box<tokio::sync::mpsc::error::SendError<action::Action>>,
     },
 
     /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),
+}
+
+impl From<tokio::sync::mpsc::error::SendError<action::Action>> for CloudWorkerError {
+    fn from(source: tokio::sync::mpsc::error::SendError<action::Action>) -> Self {
+        CloudWorkerError::SenderError {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<openstack_sdk::api::ApiError<openstack_sdk::RestError>> for CloudWorkerError {
+    fn from(source: openstack_sdk::api::ApiError<openstack_sdk::RestError>) -> Self {
+        CloudWorkerError::OpenStackApi {
+            source: Box::new(source),
+        }
+    }
 }

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -55,8 +55,7 @@ impl ComputeFlavors<'_> {
 
     /// Normalized filters
     fn normalized_filters(&self) -> ComputeFlavorList {
-        self.normalize_filters(self.get_filters().clone())
-            .to_owned()
+        self.normalize_filters(self.get_filters().clone()).clone()
     }
 }
 

--- a/openstack_tui/src/components/compute/server_instance_action_events.rs
+++ b/openstack_tui/src/components/compute/server_instance_action_events.rs
@@ -123,11 +123,11 @@ impl Component for ComputeServerInstanceActionEvents<'_> {
                     && let Some(events) = data.get("events")
                     && let Some(ar) = events.as_array()
                 {
-                    self.set_data(ar.to_vec())?;
+                    self.set_data(ar.clone())?;
                 }
             }
-            Action::SetComputeServerInstanceActionShowFilters(req) => {
-                self.set_filters(req);
+            Action::SetComputeServerInstanceActionShowFilters(f) => {
+                self.set_filters(*f);
                 self.set_loading(true);
                 return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
                     ComputeServerInstanceActionApiRequest::Get(Box::new(

--- a/openstack_tui/src/components/compute/server_instance_actions.rs
+++ b/openstack_tui/src/components/compute/server_instance_actions.rs
@@ -119,7 +119,7 @@ impl Component for ComputeServerInstanceActions<'_> {
                                 req.server_name(name.clone());
                             }
                             command_tx.send(Action::SetComputeServerInstanceActionShowFilters(
-                                req.build().wrap_err("cannot prepare request")?,
+                                Box::new(req.build().wrap_err("cannot prepare request")?),
                             ))?;
                             // and switch mode
                             command_tx.send(Action::Mode {

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -63,8 +63,7 @@ impl ComputeServers<'_> {
 
     /// Normalized filters
     fn normalized_filters(&self) -> ComputeServerList {
-        self.normalize_filters(self.get_filters().clone())
-            .to_owned()
+        self.normalize_filters(self.get_filters().clone()).clone()
     }
 }
 

--- a/openstack_tui/src/components/error_popup.rs
+++ b/openstack_tui/src/components/error_popup.rs
@@ -134,7 +134,7 @@ impl Component for ErrorPopup {
         } = action
         {
             self.msg = Some(strip_ansi_escapes::strip_str(msg));
-            self.source = action.clone();
+            self.source.clone_from(action);
 
             self.text = strip_ansi_escapes::strip_str(msg)
                 .split("\n")

--- a/openstack_tui/src/components/fuzzy_select_list.rs
+++ b/openstack_tui/src/components/fuzzy_select_list.rs
@@ -183,7 +183,7 @@ impl Component for FuzzySelectList {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(self.config.styles.fg));
 
-        let input = Paragraph::new(self.input.clone().unwrap_or_default()).block(input_block);
+        let input = Paragraph::new(self.input.as_deref().unwrap_or_default()).block(input_block);
 
         frame.render_widget(input, layout[0]);
 
@@ -191,13 +191,12 @@ impl Component for FuzzySelectList {
             .borders(Borders::ALL)
             .border_style(Style::default().fg(self.config.styles.buffer_bg));
 
-        let mut rows: Vec<ListItem> = Vec::new();
+        let mut list_items = Vec::new();
         for item in &self.filtered_items {
-            rows.push(ListItem::new(item.clone().fg(self.config.styles.item_fg)));
+            list_items.push(ListItem::new(item.as_str()).fg(self.config.styles.item_fg));
         }
-
         let list = List::default()
-            .items(self.filtered_items.clone())
+            .items(list_items)
             .style(self.config.styles.popup_item_title_fg)
             .highlight_style(Style::new().bg(self.config.styles.item_selected_bg))
             .block(data_block);

--- a/openstack_tui/src/components/header.rs
+++ b/openstack_tui/src/components/header.rs
@@ -102,7 +102,7 @@ impl Header {
             let mut descriptions_width: usize = 0;
             // Collect data into rows simultaneously counting max widths
             let (bindings, descriptions): (Vec<ListItem>, Vec<ListItem>) = col_bindings
-                .map(|x| (x.0.clone().into(), x.1.clone().into()))
+                .map(|x| (x.0.as_str().into(), x.1.as_str().into()))
                 .map(|(k, d): (ListItem, ListItem)| {
                     bindings_width = max(bindings_width, k.width());
                     descriptions_width = max(descriptions_width, d.width());
@@ -110,10 +110,8 @@ impl Header {
                 })
                 .collect();
 
-            let bindings_list = List::default().items(bindings.clone()).style(style);
-            let descriptions_list = List::default()
-                .items(descriptions.clone())
-                .style(Style::new());
+            let bindings_list = List::default().items(bindings).style(style);
+            let descriptions_list = List::default().items(descriptions).style(Style::new());
 
             // Split current area into 3 (binding, description, remainder)
             let cols = Layout::default()
@@ -147,7 +145,7 @@ impl Component for Header {
             Action::Render => self.render_tick()?,
             Action::ConnectToCloud(ref cloud) => {
                 // Save information about reconnecting to the cloud
-                self.cloud_name = cloud.clone();
+                self.cloud_name.clone_from(cloud);
                 self.project_name.clear();
                 self.domain_name.clear();
                 self.connection_data_rows.clear();
@@ -195,19 +193,19 @@ impl Component for Header {
                     if let Some(domain) = &project.domain
                         && let Some(name) = &domain.name
                     {
-                        self.domain_name = name.clone();
+                        self.domain_name.clone_from(name);
                         self.connection_data_rows
                             .push((String::from("Domain:"), self.domain_name.clone()));
                     }
                     if let Some(name) = &project.name {
-                        self.project_name = name.clone();
+                        self.project_name.clone_from(name);
                         self.connection_data_rows
                             .push((String::from("Project:"), self.project_name.clone()));
                     }
                 } else if let Some(domain) = &auth_token.domain
                     && let Some(name) = &domain.name
                 {
-                    self.domain_name = name.clone();
+                    self.domain_name.clone_from(name);
                     self.connection_data_rows
                         .push((String::from("Domain:"), self.domain_name.clone()));
                 }
@@ -236,13 +234,13 @@ impl Component for Header {
             let (c1, c2): (Vec<ListItem>, Vec<ListItem>) = self
                 .connection_data_rows
                 .iter()
-                .map(|x| (x.0.clone().into(), x.1.clone().into()))
+                .map(|x| (x.0.as_str().into(), x.1.as_str().into()))
                 .collect();
 
             let c1_list = List::default()
-                .items(c1.clone())
+                .items(c1)
                 .style(Style::new().fg(Color::Yellow));
-            let c2_list = List::default().items(c2.clone()).style(Style::new());
+            let c2_list = List::default().items(c2).style(Style::new());
 
             let cols = Layout::default()
                 .direction(Direction::Horizontal)

--- a/openstack_tui/src/components/identity/projects.rs
+++ b/openstack_tui/src/components/identity/projects.rs
@@ -99,7 +99,7 @@ impl Component for IdentityProjects<'_> {
                     };
                     let new_scope =
                         openstack_sdk::auth::authtoken::AuthTokenScope::Project(new_project);
-                    return Ok(Some(Action::CloudChangeScope(new_scope)));
+                    return Ok(Some(Action::CloudChangeScope(Box::new(new_scope))));
                 }
             }
             _ => {}

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -72,8 +72,7 @@ impl NetworkNetworks<'_> {
 
     /// Normalized filters
     fn normalized_filters(&self) -> NetworkNetworkList {
-        self.normalize_filters(self.get_filters().clone())
-            .to_owned()
+        self.normalize_filters(self.get_filters().clone()).clone()
     }
 }
 

--- a/openstack_tui/src/components/network/routers.rs
+++ b/openstack_tui/src/components/network/routers.rs
@@ -56,8 +56,7 @@ impl NetworkRouters<'_> {
 
     /// Normalized filters
     fn normalized_filters(&self) -> NetworkRouterList {
-        self.normalize_filters(self.get_filters().clone())
-            .to_owned()
+        self.normalize_filters(self.get_filters().clone()).clone()
     }
 }
 

--- a/openstack_tui/src/components/network/security_group_rules.rs
+++ b/openstack_tui/src/components/network/security_group_rules.rs
@@ -68,8 +68,7 @@ impl NetworkSecurityGroupRules<'_> {
 
     /// Normalized filters
     fn normalized_filters(&self) -> NetworkSecurityGroupRuleList {
-        self.normalize_filters(self.get_filters().clone())
-            .to_owned()
+        self.normalize_filters(self.get_filters().clone()).clone()
     }
 }
 

--- a/openstack_tui/src/components/network/security_groups.rs
+++ b/openstack_tui/src/components/network/security_groups.rs
@@ -74,8 +74,7 @@ impl NetworkSecurityGroups<'_> {
 
     /// Normalized filters
     fn normalized_filters(&self) -> NetworkSecurityGroupList {
-        self.normalize_filters(self.get_filters().clone())
-            .to_owned()
+        self.normalize_filters(self.get_filters().clone()).clone()
     }
 }
 

--- a/openstack_tui/src/components/network/subnets.rs
+++ b/openstack_tui/src/components/network/subnets.rs
@@ -55,8 +55,7 @@ impl NetworkSubnets<'_> {
 
     /// Normalized filters
     fn normalized_filters(&self) -> NetworkSubnetList {
-        self.normalize_filters(self.get_filters().clone())
-            .to_owned()
+        self.normalize_filters(self.get_filters().clone()).clone()
     }
 }
 

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -133,7 +133,7 @@ impl Component for ProjectSelect {
                 }),
             };
             let new_scope = openstack_sdk::auth::authtoken::AuthTokenScope::Project(new_project);
-            return Ok(Some(Action::CloudChangeScope(new_scope)));
+            return Ok(Some(Action::CloudChangeScope(Box::new(new_scope))));
         }
         Ok(None)
     }

--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -320,23 +320,10 @@ where
     }
 
     pub fn set_data(&mut self, data: Vec<Value>) -> Result<(), TuiError> {
-        let items = serde_json::from_value::<Vec<T>>(serde_json::Value::Array(data.clone()))
-            //.map_err(|err| {
-            //    TuiError::deserialize(
-            //        err,
-            //        serde_json::to_string(&serde_json::Value::Array(
-            //            data.clone()
-            //                .into_iter()
-            //                .filter(|item| serde_json::from_value::<T>(item.clone()).is_err())
-            //                .collect(),
-            //        ))
-            //        .unwrap_or_else(|v| format!("{:?}", v)),
-            //    )
-            //})
-        ?;
         if data != self.raw_items {
+            let items = serde_json::from_value::<Vec<T>>(serde_json::Value::Array(data.clone()))?;
             self.items = items;
-            self.raw_items = data.clone();
+            self.raw_items = data;
             self.state.select_first();
             self.scroll_state =
                 ScrollbarState::new(self.items.len().saturating_sub(1) * ITEM_HEIGHT);
@@ -368,7 +355,7 @@ where
                     // Swap headers between current and should pos
                     if default_idx - idx_offset < headers.len() {
                         headers.swap(default_idx - idx_offset, curr_idx);
-                        for row in rows.iter_mut() {
+                        for row in &mut rows {
                             // Swap also data columns
                             row.swap(default_idx - idx_offset, curr_idx);
                         }
@@ -379,7 +366,7 @@ where
                     if default_idx - idx_offset < headers.len() {
                         let curr_hdr = headers.remove(default_idx - idx_offset);
                         headers.push(curr_hdr);
-                        for row in rows.iter_mut() {
+                        for row in &mut rows {
                             let curr_cell = row.remove(default_idx - idx_offset);
                             row.push(curr_cell);
                         }
@@ -418,8 +405,11 @@ where
         let view_config = self.get_output_config().clone();
         let data = build_list_table(self.items.iter(), &view_config);
         let (table_headers, table_rows, _table_constraints) = self.prepare_table(data.0, data.1);
-        let mut statuses: Vec<Option<String>> =
-            self.items.iter().map(|item| item.status()).collect();
+        let mut statuses: Vec<Option<String>> = self
+            .items
+            .iter()
+            .map(structable::StructTable::status)
+            .collect();
 
         // Ensure we have as many statuses as rows to zip them properly
         statuses.resize_with(table_rows.len(), Default::default);
@@ -535,7 +525,7 @@ where
             .zip(self.table_row_styles.clone())
             .map(|(data, row_style)| {
                 data.iter()
-                    .map(|content| Cell::from(Text::from(content.to_string())))
+                    .map(|content| Cell::from(Text::from(content.clone())))
                     .collect::<Row>()
                     .style(row_style)
                     .height(1)

--- a/openstack_tui/src/config.rs
+++ b/openstack_tui/src/config.rs
@@ -131,8 +131,8 @@ impl ConfigFileBuilder {
     pub fn build(self) -> Result<Config, ConfigFileBuilderError> {
         let mut config = config::Config::builder();
 
-        for source in &self.sources {
-            config = config.add_source(source.clone());
+        for source in self.sources {
+            config = config.add_source(source);
         }
 
         config

--- a/openstack_tui/src/error.rs
+++ b/openstack_tui/src/error.rs
@@ -33,17 +33,17 @@ pub enum TuiError {
     #[error("error sending action: {}", source)]
     ActionSenderError {
         /// The source of the error.
-        #[from]
-        source: tokio::sync::mpsc::error::SendError<action::Action>,
+        source: Box<tokio::sync::mpsc::error::SendError<action::Action>>,
     },
 
     /// Error sending the AuthAction.
     #[error("error sending action: {}", source)]
     AuthActionSenderError {
         /// The source of the error.
-        #[from]
-        source: tokio::sync::mpsc::error::SendError<
-            tokio::sync::oneshot::Sender<crate::cloud_worker::AuthAction>,
+        source: Box<
+            tokio::sync::mpsc::error::SendError<
+                tokio::sync::oneshot::Sender<crate::cloud_worker::AuthAction>,
+            >,
         >,
     },
 
@@ -51,15 +51,13 @@ pub enum TuiError {
     #[error(transparent)]
     OpenStackError {
         /// The source of the error.
-        #[from]
-        source: openstack_sdk::OpenStackError,
+        source: Box<openstack_sdk::OpenStackError>,
     },
 
     #[error(transparent)]
     CloudWorker {
         /// The source of the error.
-        #[from]
-        source: crate::cloud_worker::CloudWorkerError,
+        source: Box<crate::cloud_worker::CloudWorkerError>,
     },
 
     /// IO communication error
@@ -97,4 +95,46 @@ pub enum TuiError {
     /// Others.
     #[error(transparent)]
     Other(#[from] eyre::Report),
+}
+
+impl From<tokio::sync::mpsc::error::SendError<action::Action>> for TuiError {
+    fn from(source: tokio::sync::mpsc::error::SendError<action::Action>) -> Self {
+        TuiError::ActionSenderError {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl
+    From<
+        tokio::sync::mpsc::error::SendError<
+            tokio::sync::oneshot::Sender<crate::cloud_worker::AuthAction>,
+        >,
+    > for TuiError
+{
+    fn from(
+        source: tokio::sync::mpsc::error::SendError<
+            tokio::sync::oneshot::Sender<crate::cloud_worker::AuthAction>,
+        >,
+    ) -> Self {
+        TuiError::AuthActionSenderError {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<openstack_sdk::OpenStackError> for TuiError {
+    fn from(source: openstack_sdk::OpenStackError) -> Self {
+        TuiError::OpenStackError {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<crate::cloud_worker::CloudWorkerError> for TuiError {
+    fn from(source: crate::cloud_worker::CloudWorkerError) -> Self {
+        TuiError::CloudWorker {
+            source: Box::new(source),
+        }
+    }
 }

--- a/openstack_tui/src/utils.rs
+++ b/openstack_tui/src/utils.rs
@@ -29,7 +29,7 @@ pub trait ResourceKey {
 }
 
 lazy_static! {
-    pub static ref PROJECT_NAME: String = env!("CARGO_CRATE_NAME").to_uppercase().to_string();
+    pub static ref PROJECT_NAME: String = env!("CARGO_CRATE_NAME").to_uppercase().clone();
     pub static ref DATA_FOLDER: Option<PathBuf> =
         std::env::var(format!("{}_DATA", PROJECT_NAME.clone()))
             .ok()

--- a/sdk/auth-application-credential/src/lib.rs
+++ b/sdk/auth-application-credential/src/lib.rs
@@ -20,6 +20,7 @@
 //! 1. **ID + Secret**: Authenticate using the application credential ID and its secret.
 //! 2. **Name + Secret + User**: Authenticate using the application credential name, its secret,
 //!    and the associated user's identity (ID or name with domain).
+//!
 //! Authentication using Application Credentials look like:
 //!
 //! With ID and Secret

--- a/sdk/auth-token/src/lib.rs
+++ b/sdk/auth-token/src/lib.rs
@@ -140,7 +140,7 @@ impl OpenStackAuthType for TokenAuthenticator {
         scope: Option<&AuthTokenScope>,
         _hints: Option<&serde_json::Value>,
     ) -> Result<Auth, AuthError> {
-        let (method, data) = self._get_auth_data(&values)?;
+        let (method, data) = self._get_auth_data(values)?;
         let mut body = json!({ "auth": { "identity": data } });
         body["auth"]["identity"]["methods"] = [method].into();
         if let Some(scope) = scope {


### PR DESCRIPTION
- Box large enum variants in Action, TuiError, CloudWorkerError, and
  IdentityCommands to reduce stack size and eliminate large_enum_variant
  warnings; add manual From impls for boxed error types
- Eliminate unnecessary clones: replace .clone() with as_deref(),
  as_str(), and moves in render loops (header, fuzzy_select_list,
  table_view)
- Replace .to_owned() with .clone() in normalized_filters
  (implicit_clone)
- Use .clone_from() instead of assignment + .clone() (assigning_clones)
- Replace .iter_mut() loops with &mut (explicit_iter_loop)
- Remove redundant closure in table_view .map(|item| item.status())
- Move sources directly in config::ConfigFileBuilder::build() instead of
  borrow + clone
- auth-token: remove unnecessary borrow in _get_auth_data call
