### PR TITLE
feat: Enable catalog refresh

### DIFF
--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -38,7 +38,9 @@ use openstack_sdk_auth_token as token_auth;
 
 use openstack_sdk_auth_core::{
     Auth, AuthError, AuthPluginRegistration, AuthToken, OpenStackAuthType,
-    authtoken::AuthTokenError, authtoken_scope::AuthTokenScope, types::Project,
+    authtoken::AuthTokenError,
+    authtoken_scope::AuthTokenScope,
+    types::{AuthResponse, Project},
 };
 
 use openstack_sdk_core::api::{
@@ -50,7 +52,7 @@ use openstack_sdk_core::auth::{
     auth_helper::{AuthHelper, Dialoguer, Noop},
     gather_auth_data,
 };
-use openstack_sdk_core::catalog::{CatalogError, ServiceEndpoint};
+use openstack_sdk_core::catalog::{Catalog, CatalogError, ServiceEndpoint};
 use openstack_sdk_core::config::CloudConfig;
 use openstack_sdk_core::error::{OpenStackError, OpenStackResult, RestError};
 use openstack_sdk_core::types::{ApiVersion, ServiceType};
@@ -584,6 +586,69 @@ impl OpenStack {
         None
     }
 
+    /// Return current authentication information
+    pub fn get_auth_info(&self) -> Option<AuthResponse> {
+        let session = self.session.read().unwrap_or_else(|e| e.into_inner());
+        if let Auth::AuthToken(token) = &session.auth {
+            return token.auth_info.clone();
+        }
+        None
+    }
+
+    /// Fetch auth catalog using the /v3/auth/catalog endpoint and update the session catalog.
+    ///
+    /// This retrieves the service catalog from the Identity API using the
+    /// `GET /v3/auth/catalog` endpoint and updates the session's catalog with
+    /// the fetched endpoints. Useful when the token was obtained without a
+    /// catalog or when the catalog needs to be refreshed.
+    pub fn fetch_auth_catalog(&self) -> OpenStackResult<()> {
+        self.refresh_catalog()?;
+        self.persist_catalog_to_cache();
+        Ok(())
+    }
+
+    /// Refresh the catalog from the /v3/auth/catalog endpoint and update the in-memory
+    /// session catalog without persisting to the on-disk auth cache.
+    pub fn refresh_catalog(&self) -> OpenStackResult<()> {
+        let mut catalog: Catalog = {
+            let session = self.session_read("refresh_catalog")?;
+            session.catalog.clone()
+        };
+        catalog.read_auth_catalog(self)?;
+        let mut session = self.session_write("refresh_catalog: update")?;
+
+        // Update session catalog
+        session.catalog = catalog.clone();
+
+        // Update auth token's catalog
+        if let Auth::AuthToken(authz) = &mut session.auth
+            && let Some(ref mut auth_info) = authz.auth_info
+        {
+            auth_info.token.catalog = catalog.get_token_catalog();
+        }
+        Ok(())
+    }
+
+    /// Persist the session's updated catalog to the on-disk auth cache.
+    pub fn persist_catalog_to_cache(&self) {
+        let mut session = match self.session_write("persist_catalog_to_cache") {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    "Failed to acquire session write lock for catalog persistence: {}",
+                    e
+                );
+                return;
+            }
+        };
+
+        if let Auth::AuthToken(authz) = &session.auth {
+            let scope = authz.get_scope();
+            let authz_clone = authz.clone();
+            session.state.set_scope_auth(&scope, &authz_clone);
+        }
+    }
+
     pub fn get_auth_state(&self, offset: Option<TimeDelta>) -> Option<AuthState> {
         let session = self.session.read().unwrap_or_else(|e| e.into_inner());
         if let Auth::AuthToken(token) = &session.auth {
@@ -711,21 +776,51 @@ impl api::Client for OpenStack {
         service_type: &ServiceType,
         version: Option<&ApiVersion>,
     ) -> Result<ServiceEndpoint, api::ApiError<Self::Error>> {
-        let session = self.session.read().map_err(|e| {
-            api::ApiError::client(RestError::SessionPoisoned {
-                msg: format!("get_service_endpoint: session read lock poisoned: {}", e),
-            })
-        })?;
-        session
-            .catalog
-            .get_service_endpoint(
-                service_type.to_string(),
-                version,
-                self.config.region_name.as_ref(),
-                self.config.interface.as_ref(),
-            )
-            .cloned()
-            .map_err(api::ApiError::catalog)
+        let lookup = || {
+            let session = self.session.read().map_err(|e| {
+                api::ApiError::client(RestError::SessionPoisoned {
+                    msg: format!("get_service_endpoint: session read lock poisoned: {}", e),
+                })
+            })?;
+            session
+                .catalog
+                .get_service_endpoint(
+                    service_type.to_string(),
+                    version,
+                    self.config.region_name.as_ref(),
+                    self.config.interface.as_ref(),
+                )
+                .cloned()
+                .map_err(api::ApiError::catalog)
+        };
+
+        let ep = match lookup() {
+            Ok(ep) => return Ok(ep),
+            Err(api::ApiError::Catalog { source }) => {
+                if matches!(source, CatalogError::ServiceNotConfigured { .. }) {
+                    info!(
+                        "Service '{}' not in catalog, attempting refresh via auth/catalog",
+                        service_type
+                    );
+                    if let Err(e) = self.refresh_catalog() {
+                        warn!("Catalog refresh failed: {}", e);
+                    }
+                    match lookup() {
+                        Ok(ep) => {
+                            debug!("Service '{}' found after catalog refresh", service_type);
+                            self.persist_catalog_to_cache();
+                            ep
+                        }
+                        Err(e) => return Err(e),
+                    }
+                } else {
+                    return Err(api::ApiError::Catalog { source });
+                }
+            }
+            Err(e) => return Err(e),
+        };
+
+        Ok(ep)
     }
 }
 
@@ -1245,5 +1340,46 @@ mod tests {
         }
 
         mock.assert_calls(4);
+    }
+
+    #[test]
+    fn test_get_service_endpoint_refresh_catalog_on_missing() {
+        let server = MockServer::start();
+
+        let catalog_json = serde_json::json!({
+            "catalog": [
+                {
+                    "type": "compute",
+                    "name": "nova",
+                    "endpoints": [
+                        {
+                            "id": "ep-compute-1",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://nova.example.com/v2.1",
+                            "availability_zone_hints": ["nova"]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/auth/catalog")
+                .header("X-Auth-Token", "test-token");
+            then.status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .body(catalog_json.to_string());
+        });
+
+        let client = create_test_client(&server, "test-token", 0, None);
+
+        let ep = client
+            .get_service_endpoint(&ServiceType::Compute, None)
+            .unwrap();
+
+        assert_eq!(ep.url_str(), "http://nova.example.com/v2.1");
     }
 }

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -56,7 +56,7 @@ use openstack_sdk_core::auth::{
     auth_helper::{AuthHelper, Dialoguer, Noop},
     gather_auth_data,
 };
-use openstack_sdk_core::catalog::{CatalogError, ServiceEndpoint};
+use openstack_sdk_core::catalog::{Catalog, CatalogError, ServiceEndpoint};
 use openstack_sdk_core::config::CloudConfig;
 use openstack_sdk_core::error::{OpenStackError, OpenStackResult, RestError};
 use openstack_sdk_core::types::{ApiVersion, BoxedAsyncRead, ServiceType};
@@ -234,17 +234,47 @@ impl api::AsyncClient for AsyncOpenStack {
         service_type: &ServiceType,
         version: Option<&ApiVersion>,
     ) -> Result<ServiceEndpoint, api::ApiError<Self::Error>> {
-        let session = self.session_read_rest("AsyncClient::get_service_endpoint")?;
-        session
-            .catalog
-            .get_service_endpoint(
-                service_type.to_string(),
-                version,
-                self.config.region_name.as_ref(),
-                self.config.interface.as_ref(),
-            )
-            .cloned()
-            .map_err(api::ApiError::catalog)
+        let lookup = || {
+            let session = self.session_read_rest("AsyncClient::get_service_endpoint")?;
+            session
+                .catalog
+                .get_service_endpoint(
+                    service_type.to_string(),
+                    version,
+                    self.config.region_name.as_ref(),
+                    self.config.interface.as_ref(),
+                )
+                .cloned()
+                .map_err(api::ApiError::catalog)
+        };
+
+        let ep = match lookup() {
+            Ok(ep) => return Ok(ep),
+            Err(api::ApiError::Catalog { source }) => {
+                if matches!(source, CatalogError::ServiceNotConfigured { .. }) {
+                    info!(
+                        "Service '{}' not in catalog, attempting refresh via auth/catalog",
+                        service_type
+                    );
+                    if let Err(e) = self.refresh_catalog().await {
+                        warn!("Catalog refresh failed: {}", e);
+                    }
+                    match lookup() {
+                        Ok(ep) => {
+                            debug!("Service '{}' found after catalog refresh", service_type);
+                            self.persist_catalog_to_cache();
+                            ep
+                        }
+                        Err(e) => return Err(e),
+                    }
+                } else {
+                    return Err(api::ApiError::Catalog { source });
+                }
+            }
+            Err(e) => return Err(e),
+        };
+
+        Ok(ep)
     }
 }
 
@@ -817,7 +847,66 @@ impl AsyncOpenStack {
         })
     }
 
-    // TODO(gtema): rename to `get_catalog`)
+    /// Fetch auth catalog using current session token and update session catalog.
+    ///
+    /// This retrieves the service catalog from the Identity API using the
+    /// `GET /v3/auth/catalog` endpoint and updates the session's catalog with
+    /// the fetched endpoints. Useful when the token was obtained without a
+    /// catalog or when the catalog needs to be refreshed.
+    ///
+    /// Updates `session.catalog` and `authz.auth_info.token.catalog` in memory.
+    /// If `persist` is `true`, also persists to the on-disk auth cache via
+    /// [`State::set_scope_auth`].
+    pub async fn fetch_auth_catalog(&self, persist: bool) -> OpenStackResult<()> {
+        self.refresh_catalog().await?;
+        if persist {
+            self.persist_catalog_to_cache();
+        }
+        Ok(())
+    }
+
+    /// Updates session catalog from the /v3/auth/catalog endpoint without
+    /// persisting to the on-disk auth cache.
+    async fn refresh_catalog(&self) -> OpenStackResult<()> {
+        let mut catalog: Catalog = {
+            let session = self.session_read("refresh_catalog")?;
+            session.catalog.clone()
+        };
+        catalog.read_auth_catalog_async(self).await?;
+        let mut session = self.session_write("refresh_catalog: update")?;
+
+        // Update session catalog
+        session.catalog = catalog.clone();
+
+        // Update auth token's catalog
+        if let Auth::AuthToken(authz) = &mut session.auth
+            && let Some(ref mut auth_info) = authz.auth_info
+        {
+            auth_info.token.catalog = catalog.get_token_catalog();
+        }
+        Ok(())
+    }
+
+    /// Persist the session's updated catalog to the on-disk auth cache.
+    fn persist_catalog_to_cache(&self) {
+        let mut session = match self.session_write("persist_catalog_to_cache") {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    "Failed to acquire session write lock for catalog persistence: {}",
+                    e
+                );
+                return;
+            }
+        };
+
+        if let Auth::AuthToken(authz) = &session.auth {
+            let scope = authz.get_scope();
+            let authz_clone = authz.clone();
+            session.state.set_scope_auth(&scope, &authz_clone);
+        }
+    }
+
     /// Return catalog information given in the token
     pub fn get_token_catalog(&self) -> Option<Vec<ServiceEndpoints>> {
         let session = self.session.read().unwrap_or_else(|e| e.into_inner());
@@ -1728,5 +1817,95 @@ mod tests {
         assert!(ep1.url_str().starts_with(&base_url));
         assert!(ep2.url_str().starts_with(&base_url));
         assert_eq!(ep1.url_str(), ep2.url_str());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_service_endpoint_refresh_catalog_on_missing() {
+        let server = MockServer::start_async().await;
+
+        // Mock the /auth/catalog endpoint that returns a catalog with compute
+        let catalog_json = json!({
+            "catalog": [
+                {
+                    "type": "compute",
+                    "name": "nova",
+                    "endpoints": [
+                        {
+                            "id": "ep-compute-1",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://nova.example.com/v2.1",
+                            "availability_zone_hints": []
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let _mock_catalog = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/auth/catalog");
+                then.status(StatusCode::OK)
+                    .header("content-type", "application/json")
+                    .body(catalog_json.to_string());
+            })
+            .await;
+
+        let client = create_test_client(&server, "test-token", 0, None);
+
+        // Initially compute is not in catalog, but after refresh it should be found
+        let ep = client
+            .get_service_endpoint(&ServiceType::Compute, None)
+            .await
+            .unwrap();
+
+        assert_eq!(ep.url_str(), "http://nova.example.com/v2.1");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_service_endpoint_no_refresh_if_found() {
+        let server = MockServer::start_async().await;
+
+        let client = create_test_client(&server, "test-token", 0, None);
+
+        // Identity is in the catalog, so no refresh should happen
+        let ep = client
+            .get_service_endpoint(&ServiceType::Identity, None)
+            .await
+            .unwrap();
+
+        assert!(ep.url_str().starts_with(&server.base_url()));
+        // No catalog fetch should occur since identity was in initial catalog
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_service_endpoint_refresh_failure_returns_error() {
+        let server = MockServer::start_async().await;
+
+        // Mock /auth/catalog to return 401 (unauthorized)
+        let _mock_catalog = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/auth/catalog");
+                then.status(StatusCode::UNAUTHORIZED)
+                    .body(r#"{"Error": "Unauthorized"}"#);
+            })
+            .await;
+
+        let client = create_test_client(&server, "invalid-token", 0, None);
+
+        // Attempt to get service not in catalog; refresh fails; error returned
+        let result = client
+            .get_service_endpoint(&ServiceType::Compute, None)
+            .await;
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        match err {
+            api::ApiError::Catalog { source } => {
+                assert!(matches!(source, CatalogError::ServiceNotConfigured { .. }));
+            }
+            other => panic!("Expected Catalog::ServiceNotConfigured, got {:?}", other),
+        }
     }
 }

--- a/openstack_sdk/tests/connection/catalog.rs
+++ b/openstack_sdk/tests/connection/catalog.rs
@@ -1,0 +1,201 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations of the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests that verify catalog refresh behavior with a live OpenStack cloud.
+//! These tests require `OS_CLOUD` environment variable to be set and are
+//! marked `#[ignore]` to opt-in via `--ignored` flag.
+
+use std::env;
+use std::time::Instant;
+
+use openstack_sdk::api::identity::v3::endpoint::create;
+use openstack_sdk::api::identity::v3::endpoint::delete;
+use openstack_sdk::api::identity::v3::service::create as service_create;
+use openstack_sdk::api::identity::v3::service::delete as service_delete;
+use openstack_sdk::api::{AsyncClient, Client, Query, QueryAsync, RawQuery, RawQueryAsync};
+use openstack_sdk::types::ServiceType;
+use openstack_sdk::{AsyncOpenStack, OpenStack, config::ConfigFile};
+use std::borrow::Cow;
+
+fn unique_suffix() -> String {
+    format!(
+        "{}-{}",
+        Instant::now().elapsed().as_millis(),
+        std::process::id()
+    )
+}
+
+#[test]
+fn sync_catalog_refresh_with_new_service() -> Result<(), Box<dyn std::error::Error>> {
+    let config = ConfigFile::new()?
+        .get_cloud_config(&env::var("OS_CLOUD").unwrap_or_default())?
+        .unwrap();
+    let session = OpenStack::new(&config)?;
+
+    if !session.get_auth_info().is_some_and(|auth| {
+        auth.token
+            .roles
+            .is_some_and(|roles| roles.iter().any(|role| role.name == "admin"))
+    }) {
+        eprintln!("No admin role — skipping catalog refresh test");
+        eprintln!(
+            "Following roles are there {:?}",
+            session
+                .get_auth_info()
+                .map(|auth| auth.token.roles.map(|roles| roles
+                    .iter()
+                    .map(|role| role.name.clone())
+                    .collect::<Vec<_>>()))
+        );
+        return Ok(());
+    }
+
+    let suffix = unique_suffix();
+    let svc_type = "search";
+    let ep_url = format!("https://test-catalog-{}.openstack.local/", suffix);
+
+    // Create service
+    let svc_req = service_create::Request::builder()
+        .service(
+            service_create::ServiceBuilder::default()
+                ._type(svc_type)
+                .name("test-catalog")
+                .build()
+                .expect("service builder"),
+        )
+        .build()
+        .expect("request builder");
+    let svc_resp: serde_json::Value = svc_req.query(&session)?;
+    let service_id = svc_resp["id"].as_str().expect("service id");
+
+    // Create endpoint
+    let ep_req = create::Request::builder()
+        .endpoint(
+            create::EndpointBuilder::default()
+                .interface(create::Interface::Public)
+                .service_id(service_id)
+                .region_id(config.region_name.map(Into::into))
+                .url(ep_url.clone())
+                .build()
+                .expect("endpoint builder"),
+        )
+        .build()
+        .expect("request builder");
+    let ep_resp: serde_json::Value = ep_req.query(&session)?;
+    let endpoint_id = ep_resp["id"].as_str().expect("endpoint id");
+
+    // Verify the new service is discoverable via catalog refresh (auto-refresh in get_service_endpoint)
+    let found = session
+        .get_service_endpoint(&ServiceType::Other(svc_type.to_string()), None)
+        .is_ok();
+    assert!(
+        found,
+        "test service endpoint should be found in catalog after auto-refresh"
+    );
+
+    // Cleanup
+    let _del_ep = delete::Request::builder()
+        .id(endpoint_id)
+        .build()
+        .expect("delete request builder")
+        .raw_query(&session)?;
+
+    let _del_svc = service_delete::Request::builder()
+        .id(service_id)
+        .build()
+        .expect("delete request builder")
+        .raw_query(&session)?;
+
+    Ok(())
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn async_catalog_refresh_with_new_service() -> Result<(), Box<dyn std::error::Error>> {
+    let config = ConfigFile::new()?
+        .get_cloud_config(&env::var("OS_CLOUD").unwrap_or_default())?
+        .unwrap();
+    let session = AsyncOpenStack::new(&config).await?;
+
+    if !session.get_auth_info().is_some_and(|auth| {
+        auth.token
+            .roles
+            .is_some_and(|roles| roles.iter().any(|role| role.name == "admin"))
+    }) {
+        eprintln!("No admin role — skipping catalog refresh test");
+        return Ok(());
+    }
+
+    let suffix = unique_suffix();
+    let svc_type = "search";
+    let ep_url = format!("https://test-catalog-{}.openstack.local/", suffix);
+
+    // Create service
+    let svc_req = service_create::Request::builder()
+        .service(
+            service_create::ServiceBuilder::default()
+                ._type(svc_type)
+                .name("test-catalog")
+                .build()
+                .expect("service builder"),
+        )
+        .build()
+        .expect("request builder");
+    let svc_resp: serde_json::Value = svc_req.query_async(&session).await?;
+    let service_id = svc_resp["id"].as_str().expect("service id");
+
+    // Create endpoint
+    let ep_req = create::Request::builder()
+        .endpoint(
+            create::EndpointBuilder::default()
+                .interface(create::Interface::Public)
+                .service_id(service_id)
+                .url(ep_url.clone())
+                .region_id(config.region_name.map(Into::into))
+                .build()
+                .expect("endpoint builder"),
+        )
+        .build()
+        .expect("request builder");
+    let ep_resp: serde_json::Value = ep_req.query_async(&session).await?;
+    let endpoint_id = ep_resp["id"].as_str().expect("endpoint id");
+
+    // Verify the new service is discoverable via catalog refresh (auto-refresh in get_service_endpoint)
+    let found = session
+        .get_service_endpoint(&ServiceType::Other(svc_type.to_string()), None)
+        .await
+        .is_ok();
+
+    // Cleanup
+    let _del_ep = delete::Request::builder()
+        .id(endpoint_id)
+        .build()
+        .expect("delete request builder")
+        .raw_query_async(&session)
+        .await?;
+
+    let _del_svc = service_delete::Request::builder()
+        .id(service_id)
+        .build()
+        .expect("delete request builder")
+        .raw_query_async(&session)
+        .await?;
+
+    assert!(
+        found,
+        "test service endpoint should be found in catalog after auto-refresh"
+    );
+
+    Ok(())
+}

--- a/openstack_sdk/tests/connection/mod.rs
+++ b/openstack_sdk/tests/connection/mod.rs
@@ -20,6 +20,8 @@
 #[cfg(feature = "async")]
 mod r#async;
 #[cfg(all(feature = "async", feature = "sync", feature = "identity"))]
+mod catalog;
+#[cfg(all(feature = "async", feature = "sync", feature = "identity"))]
 mod reauth;
 #[cfg(feature = "sync")]
 mod sync;

--- a/sdk/core/src/catalog.rs
+++ b/sdk/core/src/catalog.rs
@@ -25,6 +25,12 @@ use std::collections::{HashMap, HashSet};
 use tracing::{debug, error, trace, warn};
 use url::Url;
 
+#[cfg(feature = "async")]
+use crate::api::AsyncClient;
+#[cfg(feature = "sync")]
+use crate::api::Client;
+use crate::api::query::url_to_http_uri;
+
 use openstack_sdk_auth_core::types::ServiceEndpoints as ApiServiceEndpoints;
 
 pub use crate::catalog::error::CatalogError;
@@ -380,6 +386,121 @@ impl Catalog {
         self.token_catalog.clone()
     }
 
+    /// Read the auth catalog from the Identity service and update this catalog (async).
+    ///
+    /// Makes a `GET /v3/auth/catalog` request using the provided async client and updates
+    /// internal catalog state with the fetched endpoints.
+    ///
+    /// Useful when the token was obtained without a catalog (e.g., `?nocatalog`)
+    /// or when the catalog needs to be refreshed.
+    #[cfg(feature = "async")]
+    pub async fn read_auth_catalog_async<C>(&mut self, client: &C) -> Result<(), CatalogError>
+    where
+        C: AsyncClient + Sync,
+    {
+        let identity_ep = self.get_service_endpoint(
+            "identity",
+            None::<&ApiVersion>,
+            None::<String>,
+            None::<String>,
+        )?;
+
+        let mut catalog_url = identity_ep.url().clone();
+        catalog_url
+            .path_segments_mut()
+            .map_err(|_| CatalogError::cannot_be_base(identity_ep.url()))?
+            .extend(["auth", "catalog"]);
+
+        let rsp = client
+            .rest_async(
+                http::Request::builder()
+                    .method(http::Method::GET)
+                    .uri(url_to_http_uri(catalog_url.clone())?)
+                    .header(
+                        http::header::ACCEPT,
+                        http::HeaderValue::from_static("application/json"),
+                    ),
+                Vec::new(),
+            )
+            .await
+            .map_err(CatalogError::api_error)?;
+
+        let v: serde_json::Value = serde_json::from_slice(rsp.body())?;
+        if !rsp.status().is_success() {
+            let status = rsp.status();
+            return Err(CatalogError::Http {
+                status,
+                body: String::from("request failed"),
+            });
+        }
+
+        let endpoints: Vec<ApiServiceEndpoints> =
+            if let Some(catalog) = v.get("catalog").and_then(|v| v.as_array()) {
+                serde_json::from_value(serde_json::Value::Array(catalog.clone()))?
+            } else {
+                Vec::new()
+            };
+
+        self.process_catalog_endpoints(&endpoints)?;
+        Ok(())
+    }
+
+    /// Read the auth catalog from the Identity service and update the catalog (sync).
+    ///
+    /// Makes a `GET /v3/auth/catalog` request using the provided sync client and updates
+    /// internal catalog state with the fetched endpoints.
+    ///
+    /// Useful when the token was obtained without a catalog (e.g., `?nocatalog`)
+    /// or when the catalog needs to be refreshed.
+    #[cfg(feature = "sync")]
+    pub fn read_auth_catalog<C>(&mut self, client: &C) -> Result<(), CatalogError>
+    where
+        C: Client,
+    {
+        let identity_ep = self.get_service_endpoint(
+            "identity",
+            None::<&ApiVersion>,
+            None::<String>,
+            None::<String>,
+        )?;
+
+        let mut catalog_url = identity_ep.url().clone();
+        catalog_url
+            .path_segments_mut()
+            .map_err(|_| CatalogError::cannot_be_base(identity_ep.url()))?
+            .extend(["auth", "catalog"]);
+        let query_uri = url_to_http_uri(catalog_url.clone())?;
+
+        let rsp = client
+            .rest(
+                http::Request::builder()
+                    .method(http::Method::GET)
+                    .uri(query_uri)
+                    .header(
+                        http::header::ACCEPT,
+                        http::HeaderValue::from_static("application/json"),
+                    ),
+                Vec::new(),
+            )
+            .map_err(CatalogError::api_error)?;
+        let v: serde_json::Value = serde_json::from_slice(rsp.body())?;
+        if !rsp.status().is_success() {
+            return Err(CatalogError::Http {
+                status: rsp.status(),
+                body: String::from("request failed"),
+            });
+        }
+
+        let endpoints: Vec<ApiServiceEndpoints> = if let Some(catalog_value) = v.get("catalog") {
+            serde_json::from_value(catalog_value.clone())?
+        } else {
+            Vec::new()
+        };
+
+        self.process_catalog_endpoints(&endpoints)?;
+        Ok(())
+    }
+
     // Save endpoint overrides given in the config
     pub fn configure(&mut self, config: &CloudConfig) -> Result<&mut Self, CatalogError> {
         for (name, val) in config.options.iter() {
@@ -425,6 +546,7 @@ mod tests {
     use serde_json::json;
     use url::Url;
 
+    use crate::test::client::FakeOpenStackClient;
     use crate::types::api_version::ApiVersion;
 
     #[test]
@@ -440,6 +562,378 @@ mod tests {
             cat.set_project_id(Some("bar")).project_id.as_deref()
         );
         assert!(cat.set_project_id(None::<String>).project_id.is_none());
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_read_auth_catalog_async_success() {
+        let server = httpmock::MockServer::start_async().await;
+        let catalog_json = json!({
+            "catalog": [
+                {
+                    "type": "compute",
+                    "name": "nova",
+                    "endpoints": [
+                        {
+                            "id": "ep1",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://compute.example.com/v2.1",
+                            "availability_zone_hints": ["nova"]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/auth/catalog");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(catalog_json.to_string());
+            })
+            .await;
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        cat.read_auth_catalog_async(&_client).await.unwrap();
+
+        let eps = cat.catalog_endpoints.get("compute").unwrap();
+        let ep = eps
+            .get_by_region_and_interface(Some("RegionOne"), Some("public"))
+            .unwrap();
+        assert_eq!(ep.url_str(), "http://compute.example.com/v2.1");
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_read_auth_catalog_sync_success() {
+        let server = httpmock::MockServer::start();
+        let catalog_json = json!({
+            "catalog": [
+                {
+                    "type": "compute",
+                    "name": "nova",
+                    "endpoints": [
+                        {
+                            "id": "ep1",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://compute.example.com/v2.1",
+                            "availability_zone_hints": ["nova"]
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/auth/catalog");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(catalog_json.to_string());
+        });
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        cat.read_auth_catalog(&_client).unwrap();
+
+        let eps = cat.catalog_endpoints.get("compute").unwrap();
+        let ep = eps
+            .get_by_region_and_interface(Some("RegionOne"), Some("public"))
+            .unwrap();
+        assert_eq!(ep.url_str(), "http://compute.example.com/v2.1");
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_read_auth_catalog_async_empty_catalog() {
+        let server = httpmock::MockServer::start_async().await;
+
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/auth/catalog");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body("{}");
+            })
+            .await;
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        cat.read_auth_catalog_async(&_client).await.unwrap();
+
+        assert!(!cat.catalog_endpoints.contains_key("compute"));
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_read_auth_catalog_sync_empty_catalog() {
+        let server = httpmock::MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/auth/catalog");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{}");
+        });
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        cat.read_auth_catalog(&_client).unwrap();
+
+        assert!(!cat.catalog_endpoints.contains_key("compute"));
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_read_auth_catalog_async_error_401() {
+        let server = httpmock::MockServer::start_async().await;
+
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/auth/catalog");
+                then.status(401)
+                    .header("content-type", "application/json")
+                    .body(r#"{"Error": "Unauthorized"}"#);
+            })
+            .await;
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        let err = cat.read_auth_catalog_async(&_client).await.unwrap_err();
+        assert!(matches!(err, CatalogError::Http { .. }));
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_read_auth_catalog_sync_error_401() {
+        let server = httpmock::MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/auth/catalog");
+            then.status(401)
+                .header("content-type", "application/json")
+                .body(r#"{"Error": "Unauthorized"}"#);
+        });
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        let err = cat.read_auth_catalog(&_client).unwrap_err();
+        assert!(matches!(err, CatalogError::Http { .. }));
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_read_auth_catalog_async_no_identity_endpoint() {
+        let mut cat = Catalog::default();
+        let _client = FakeOpenStackClient::new("http://localhost:0");
+        let err = cat.read_auth_catalog_async(&_client).await.unwrap_err();
+        assert!(matches!(err, CatalogError::ServiceNotConfigured { .. }));
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_read_auth_catalog_sync_no_identity_endpoint() {
+        let mut cat = Catalog::default();
+        let _client = FakeOpenStackClient::new("http://localhost:0");
+        let err = cat.read_auth_catalog(&_client).unwrap_err();
+        assert!(matches!(err, CatalogError::ServiceNotConfigured { .. }));
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_read_auth_catalog_async_multiple_services() {
+        let server = httpmock::MockServer::start_async().await;
+        let catalog_json = json!({
+            "catalog": [
+                {
+                    "type": "compute",
+                    "name": "nova",
+                    "endpoints": [
+                        {
+                            "id": "ep1",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://compute.example.com/v2.1",
+                            "availability_zone_hints": ["nova"]
+                        }
+                    ]
+                },
+                {
+                    "type": "object-store",
+                    "name": "swift",
+                    "endpoints": [
+                        {
+                            "id": "ep2",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://swift.example.com/v1/AUTH_test",
+                            "availability_zone_hints": []
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET).path("/auth/catalog");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(catalog_json.to_string());
+            })
+            .await;
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        cat.read_auth_catalog_async(&_client).await.unwrap();
+
+        let compute_eps = cat.catalog_endpoints.get("compute").unwrap();
+        assert!(
+            compute_eps
+                .get_by_region_and_interface(Some("RegionOne"), Some("public"))
+                .is_some()
+        );
+
+        let swift_eps = cat.catalog_endpoints.get("object-store").unwrap();
+        assert!(
+            swift_eps
+                .get_by_region_and_interface(Some("RegionOne"), Some("public"))
+                .is_some()
+        );
+    }
+
+    #[cfg(feature = "sync")]
+    #[test]
+    fn test_read_auth_catalog_sync_multiple_services() {
+        let server = httpmock::MockServer::start();
+        let catalog_json = json!({
+            "catalog": [
+                {
+                    "type": "compute",
+                    "name": "nova",
+                    "endpoints": [
+                        {
+                            "id": "ep1",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://compute.example.com/v2.1",
+                            "availability_zone_hints": ["nova"]
+                        }
+                    ]
+                },
+                {
+                    "type": "object-store",
+                    "name": "swift",
+                    "endpoints": [
+                        {
+                            "id": "ep2",
+                            "region_id": "RegionOne",
+                            "region": "RegionOne",
+                            "interface": "public",
+                            "url": "http://swift.example.com/v1/AUTH_test",
+                            "availability_zone_hints": []
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/auth/catalog");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(catalog_json.to_string());
+        });
+
+        let mut cat = Catalog::default();
+        cat.register_catalog_endpoint(
+            "identity",
+            &server.base_url(),
+            None::<String>,
+            Some("public"),
+        )
+        .unwrap();
+
+        let _client = FakeOpenStackClient::new(server.base_url());
+        cat.read_auth_catalog(&_client).unwrap();
+
+        let compute_eps = cat.catalog_endpoints.get("compute").unwrap();
+        assert!(
+            compute_eps
+                .get_by_region_and_interface(Some("RegionOne"), Some("public"))
+                .is_some()
+        );
+
+        let swift_eps = cat.catalog_endpoints.get("object-store").unwrap();
+        assert!(
+            swift_eps
+                .get_by_region_and_interface(Some("RegionOne"), Some("public"))
+                .is_some()
+        );
     }
 
     #[test]

--- a/sdk/core/src/catalog/error.rs
+++ b/sdk/core/src/catalog/error.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::boxed::Box;
 use thiserror::Error;
 use url::Url;
 
@@ -22,6 +23,11 @@ use crate::types::api_version::{ApiVersion, ApiVersionError};
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum CatalogError {
+    #[error("Cannot parse catalog data: {}", source)]
+    Json {
+        #[from]
+        source: serde_json::Error,
+    },
     #[error("Cannot parse Api Version: {}", source)]
     ApiVersion {
         #[from]
@@ -47,11 +53,11 @@ pub enum CatalogError {
         url: String,
     },
 
-    /// A transparent url::ParseError error for unwrapped cases
-    #[error("Failed to parse url: `{}`", source)]
-    UrlParseError {
+    /// Invalid URI
+    #[error("Invalid URI: `{}`", source)]
+    InvalidUri {
         #[from]
-        source: url::ParseError,
+        source: http::uri::InvalidUri,
     },
 
     /// Invalid URL scheme
@@ -88,6 +94,19 @@ pub enum CatalogError {
         ver
     )]
     VersionUnsupported { ver: ApiVersion },
+
+    /// HTTP error with status code
+    #[error("HTTP request failed with status {}: {}", status, body)]
+    Http {
+        status: http::StatusCode,
+        body: String,
+    },
+
+    /// Generic API error wrapper
+    #[error("API error: {err}")]
+    ApiError {
+        err: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 impl CatalogError {
@@ -100,5 +119,13 @@ impl CatalogError {
 
     pub fn cannot_be_base(url: &Url) -> Self {
         Self::UrlCannotBeBase(url.as_str().into())
+    }
+
+    /// Wrap an ApiError in CatalogError for generic error types
+    pub fn api_error<E>(err: crate::api::ApiError<E>) -> Self
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        Self::ApiError { err: Box::new(err) }
     }
 }


### PR DESCRIPTION
Do speculative request to the auth catalog when the requested endpoint
cannot be found in the catalog.
