### PR TITLE
fix(tui): Fix cloud and project select popups

### DIFF
--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -438,6 +438,9 @@ impl App {
                     self.active_popup = Some(Popup::SwitchProject);
                     self.render(tui)?;
                 }
+                Action::ListClouds => {
+                    self.cloud_worker_tx.send(Action::ListClouds)?;
+                }
                 Action::AuthDataRequired { .. } => {
                     self.active_popup = Some(Popup::AuthHelper);
                     self.render(tui)?;

--- a/openstack_tui/src/components/cloud_select_popup.rs
+++ b/openstack_tui/src/components/cloud_select_popup.rs
@@ -15,6 +15,7 @@
 use crossterm::event::{KeyCode, KeyEvent};
 use eyre::Result;
 use ratatui::prelude::*;
+use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
     action::Action,
@@ -29,6 +30,8 @@ const TITLE: &str = " Select cloud to connect: ";
 pub struct CloudSelect {
     config: Config,
     popup_state: FuzzySelectState,
+    action_tx: Option<UnboundedSender<Action>>,
+    items_fetched: bool,
 }
 
 impl Default for CloudSelect {
@@ -42,11 +45,18 @@ impl CloudSelect {
         Self {
             config: Config::default(),
             popup_state: FuzzySelectState::new(),
+            action_tx: None,
+            items_fetched: false,
         }
     }
 }
 
 impl Component for CloudSelect {
+    fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<(), TuiError> {
+        self.action_tx = Some(tx);
+        Ok(())
+    }
+
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
         self.config = config.clone();
         Ok(())
@@ -57,6 +67,11 @@ impl Component for CloudSelect {
             let mut items: Vec<String> = clouds.to_vec();
             items.sort_by_key(|a| a.to_lowercase());
             self.popup_state.set_items(items);
+            self.items_fetched = true;
+        } else if action == Action::CloudSelect && !self.items_fetched {
+            if let Some(tx) = &self.action_tx {
+                tx.send(Action::ListClouds)?;
+            }
         }
         Ok(None)
     }

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -51,6 +51,8 @@ pub struct ProjectSelect {
     items: Vec<ProjectData>,
     popup_state: FuzzySelectState,
     is_loading: bool,
+    action_tx: Option<UnboundedSender<Action>>,
+    items_fetched: bool,
 }
 
 impl Default for ProjectSelect {
@@ -66,12 +68,15 @@ impl ProjectSelect {
             items: Vec::new(),
             popup_state: FuzzySelectState::new(),
             is_loading: true,
+            action_tx: None,
+            items_fetched: false,
         }
     }
 }
 
 impl Component for ProjectSelect {
-    fn register_action_handler(&mut self, _tx: UnboundedSender<Action>) -> Result<(), TuiError> {
+    fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<(), TuiError> {
+        self.action_tx = Some(tx);
         Ok(())
     }
 
@@ -82,15 +87,20 @@ impl Component for ProjectSelect {
 
     fn update(&mut self, action: Action, _current_mode: Mode) -> Result<Option<Action>, TuiError> {
         match &action {
-            Action::ConnectToCloud(_) | Action::CloudChangeScope(_) => self.is_loading = true,
-            Action::ConnectedToCloud(_) => {
+            Action::ConnectToCloud(_) | Action::CloudChangeScope(_) => {
                 self.is_loading = true;
-                let req = IdentityAuthProjectListBuilder::default()
-                    .build()
-                    .wrap_err("cannot prepare auth project list request")?;
-                return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
-                    IdentityAuthProjectApiRequest::List(Box::new(req)),
-                ))));
+                self.items_fetched = false;
+            }
+            Action::ConnectedToCloud(_) | Action::SelectProject => {
+                if !self.items_fetched {
+                    self.is_loading = true;
+                    let req = IdentityAuthProjectListBuilder::default()
+                        .build()
+                        .wrap_err("cannot prepare auth project list request")?;
+                    return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                        IdentityAuthProjectApiRequest::List(Box::new(req)),
+                    ))));
+                }
             }
             Action::ApiResponsesData {
                 data,
@@ -141,6 +151,7 @@ impl ProjectSelect {
         let names: Vec<String> = items.iter().map(|p| p.name.clone()).collect();
         self.items = items;
         self.popup_state.set_items(names);
+        self.items_fetched = true;
         self.is_loading = false;
         Ok(())
     }


### PR DESCRIPTION
In last refactor project and cloud select popups accidentally lost
ability to properly react on and request data since the dispatch
mechanism was changed from broadcast to "active only".

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
