### PR TITLE
fix(tui): Restore functionality

### DIFF
--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -495,6 +495,7 @@ impl App {
                         }
                         self.mode_switch_stack.push(mode);
                         self.mode = mode;
+                        self.action_tx.send(Action::Refresh)?;
                         self.render(tui)?;
                     }
                 Action::PerformApiRequest(ref request) => {

--- a/openstack_tui/src/cloud_worker/compute/v2/server/delete.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/delete.rs
@@ -38,21 +38,6 @@ pub struct ComputeServerDelete {
     pub name: Option<String>,
 }
 
-// Conversion from ServerResponse to ComputeServerDelete
-impl TryFrom<&openstack_types::compute::v2::server::response::list_detailed_21::ServerResponse>
-    for ComputeServerDelete
-{
-    type Error = eyre::Report;
-    fn try_from(
-        value: &openstack_types::compute::v2::server::response::list_detailed_21::ServerResponse,
-    ) -> Result<Self, Self::Error> {
-        Ok(ComputeServerDelete {
-            id: value.id.clone(),
-            name: value.name.clone(),
-        })
-    }
-}
-
 impl fmt::Display for ComputeServerDelete {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut parts: Vec<String> = Vec::new();

--- a/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
@@ -45,22 +45,6 @@ pub struct ComputeServerInstanceActionList {
     pub server_name: Option<String>,
 }
 
-// Conversion from ServerResponse to ComputeServerInstanceActionList
-impl TryFrom<&openstack_types::compute::v2::server::response::list_detailed_21::ServerResponse>
-    for ComputeServerInstanceActionList
-{
-    type Error = eyre::Report;
-    fn try_from(
-        value: &openstack_types::compute::v2::server::response::list_detailed_21::ServerResponse,
-    ) -> Result<Self, Self::Error> {
-        Ok(ComputeServerInstanceActionList {
-            server_id: value.id.clone(),
-            server_name: value.name.clone(),
-            ..Default::default()
-        })
-    }
-}
-
 impl fmt::Display for ComputeServerInstanceActionList {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut parts: Vec<String> = Vec::new();

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -88,11 +88,11 @@ impl ResourceBehaviour for ComputeFlavorsBehaviour {
                 .build()
         {
             return vec![
-                Action::SetComputeServerListFilters(Box::new(server_list)),
                 Action::Mode {
                     mode: Mode::ComputeServers,
                     stack: true,
                 },
+                Action::SetComputeServerListFilters(Box::new(server_list)),
             ];
         }
         Vec::new()
@@ -197,17 +197,17 @@ mod tests {
         );
         assert_eq!(actions.len(), 2);
         match &actions[0] {
-            Action::SetComputeServerListFilters(f) => {
-                assert_eq!(f.flavor, Some("flavor-123".into()));
-            }
-            _ => panic!("Expected SetComputeServerListFilters, got {:?}", actions[0]),
-        }
-        match &actions[1] {
             Action::Mode { mode, stack } => {
                 assert_eq!(*mode, crate::mode::Mode::ComputeServers);
                 assert!(*stack);
             }
-            _ => panic!("Expected Mode switch, got {:?}", actions[1]),
+            _ => panic!("Expected Mode switch, got {:?}", actions[0]),
+        }
+        match &actions[1] {
+            Action::SetComputeServerListFilters(f) => {
+                assert_eq!(f.flavor, Some("flavor-123".into()));
+            }
+            _ => panic!("Expected SetComputeServerListFilters, got {:?}", actions[1]),
         }
     }
 

--- a/openstack_tui/src/components/compute/server_instance_actions.rs
+++ b/openstack_tui/src/components/compute/server_instance_actions.rs
@@ -83,11 +83,11 @@ impl ResourceBehaviour for ComputeServerInstanceActionsBehaviour {
             }
             if let Ok(list) = req.build() {
                 return vec![
-                    Action::SetComputeServerInstanceActionShowFilters(Box::new(list)),
                     Action::Mode {
                         mode: Mode::ComputeServerInstanceActionEvents,
                         stack: true,
                     },
+                    Action::SetComputeServerInstanceActionShowFilters(Box::new(list)),
                 ];
             }
         }
@@ -205,14 +205,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetComputeServerInstanceActionShowFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::ComputeServerInstanceActionEvents,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetComputeServerInstanceActionShowFilters(_)
         ));
     }
 

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -14,8 +14,8 @@
 
 use crate::action::Action;
 use crate::cloud_worker::compute::v2::{
-    ComputeServerApiRequest, ComputeServerDelete, ComputeServerGetConsoleOutputBuilder,
-    ComputeServerInstanceActionList, ComputeServerList,
+    ComputeServerApiRequest, ComputeServerDeleteBuilder, ComputeServerGetConsoleOutputBuilder,
+    ComputeServerInstanceActionListBuilder, ComputeServerList,
 };
 use crate::cloud_worker::types::{ApiRequest, ComputeApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
@@ -65,15 +65,20 @@ impl ResourceBehaviour for ComputeServersBehaviour {
             None
         }
     }
-    fn action_to_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        match action {
-            Action::DeleteComputeServer => {
-                let del = ComputeServerDelete::try_from(selected?).ok()?;
-                Some(ApiRequest::from(ComputeServerApiRequest::Delete(Box::new(
-                    del,
-                ))))
+    fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
+        if let Action::DeleteComputeServer = action {
+            let sel = selected?;
+            let mut del_builder = ComputeServerDeleteBuilder::default();
+            del_builder.id(sel.id.clone());
+            if let Some(name) = &sel.name {
+                del_builder.name(name.clone());
             }
-            _ => None,
+            let del = del_builder.build().ok()?;
+            Some(ApiRequest::from(ComputeServerApiRequest::Delete(Box::new(
+                del,
+            ))))
+        } else {
+            None
         }
     }
     fn action_to_singular_request(
@@ -123,18 +128,26 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         }
         None
     }
-    fn custom_action(action: &Action, selected: Option<&Self::Item>) -> Vec<Action> {
+    fn filter_carry_action(
+        action: &Action,
+        selected: Option<&Self::Item>,
+        _filter: &Self::Filter,
+    ) -> Vec<Action> {
         if let Action::ShowComputeServerInstanceActions = action
             && let Some(sel) = selected
         {
-            let sel = sel.clone();
-            if let Ok(list) = ComputeServerInstanceActionList::try_from(&sel) {
+            let mut list_builder = ComputeServerInstanceActionListBuilder::default();
+            list_builder.server_id(sel.id.clone());
+            if let Some(name) = &sel.name {
+                list_builder.server_name(name.clone());
+            }
+            if let Ok(list) = list_builder.build() {
                 return vec![
-                    Action::SetComputeServerInstanceActionListFilters(Box::new(list)),
                     Action::Mode {
                         mode: Mode::ComputeServerInstanceActions,
                         stack: true,
                     },
+                    Action::SetComputeServerInstanceActionListFilters(Box::new(list)),
                 ];
             }
         }
@@ -255,10 +268,10 @@ mod tests {
     }
 
     #[test]
-    fn action_to_request_delete_with_selected_server() {
+    fn confirm_request_delete_with_selected_server() {
         let server = make_server("server-1", "test-server");
         let result =
-            ComputeServersBehaviour::action_to_request(&Action::DeleteComputeServer, Some(&server));
+            ComputeServersBehaviour::confirm_request(&Action::DeleteComputeServer, Some(&server));
         assert!(result.is_some());
         let request = result.unwrap();
         assert!(matches!(
@@ -269,15 +282,15 @@ mod tests {
     }
 
     #[test]
-    fn action_to_request_delete_without_selected_server() {
-        let result = ComputeServersBehaviour::action_to_request(&Action::DeleteComputeServer, None);
+    fn confirm_request_delete_without_selected_server() {
+        let result = ComputeServersBehaviour::confirm_request(&Action::DeleteComputeServer, None);
         assert!(result.is_none());
     }
 
     #[test]
-    fn action_to_request_returns_none_for_unrelated_action() {
+    fn confirm_request_returns_none_for_unrelated_action() {
         let server = make_server("server-1", "test-server");
-        let result = ComputeServersBehaviour::action_to_request(&Action::Tick, Some(&server));
+        let result = ComputeServersBehaviour::confirm_request(&Action::Tick, Some(&server));
         assert!(result.is_none());
     }
 
@@ -367,37 +380,45 @@ mod tests {
     }
 
     #[test]
-    fn custom_action_instance_actions_with_server() {
+    fn filter_carry_action_instance_actions_with_server() {
         let server = make_server("server-1", "test-server");
-        let result = ComputeServersBehaviour::custom_action(
+        let result = ComputeServersBehaviour::filter_carry_action(
             &Action::ShowComputeServerInstanceActions,
             Some(&server),
+            &ComputeServerList::default(),
         );
         assert_eq!(result.len(), 2);
         assert!(matches!(
             result[0],
-            Action::SetComputeServerInstanceActionListFilters(_)
-        ));
-        assert!(matches!(
-            result[1],
             Action::Mode {
                 mode: Mode::ComputeServerInstanceActions,
                 stack: true
             }
         ));
+        assert!(matches!(
+            result[1],
+            Action::SetComputeServerInstanceActionListFilters(_)
+        ));
     }
 
     #[test]
-    fn custom_action_instance_actions_without_server() {
-        let result =
-            ComputeServersBehaviour::custom_action(&Action::ShowComputeServerInstanceActions, None);
+    fn filter_carry_action_instance_actions_without_server() {
+        let result = ComputeServersBehaviour::filter_carry_action(
+            &Action::ShowComputeServerInstanceActions,
+            None,
+            &ComputeServerList::default(),
+        );
         assert!(result.is_empty());
     }
 
     #[test]
-    fn custom_action_returns_empty_for_unrelated_action() {
+    fn filter_carry_action_returns_empty_for_unrelated_action() {
         let server = make_server("server-1", "test-server");
-        let result = ComputeServersBehaviour::custom_action(&Action::Tick, Some(&server));
+        let result = ComputeServersBehaviour::filter_carry_action(
+            &Action::Tick,
+            Some(&server),
+            &ComputeServerList::default(),
+        );
         assert!(result.is_empty());
     }
 }

--- a/openstack_tui/src/components/dns/zones.rs
+++ b/openstack_tui/src/components/dns/zones.rs
@@ -109,11 +109,11 @@ impl ResourceBehaviour for DnsZonesBehaviour {
             && let Ok(list) = DnsRecordsetList::try_from(sel)
         {
             return vec![
-                Action::SetDnsRecordsetListFilters(list),
                 Action::Mode {
                     mode: Mode::DnsRecordsets,
                     stack: true,
                 },
+                Action::SetDnsRecordsetListFilters(list),
             ];
         }
         Vec::new()
@@ -233,14 +233,14 @@ mod tests {
             &DnsZoneList::default(),
         );
         assert_eq!(actions.len(), 2);
-        assert!(matches!(actions[0], Action::SetDnsRecordsetListFilters(_)));
         assert!(matches!(
-            actions[1],
+            actions[0],
             Action::Mode {
                 mode: Mode::DnsRecordsets,
                 stack: true
             }
         ));
+        assert!(matches!(actions[1], Action::SetDnsRecordsetListFilters(_)));
     }
 
     #[test]

--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -135,9 +135,6 @@ where
         if let Action::Mode { mode, .. } = &action {
             if *mode == B::mode() {
                 self.base.set_loading(true);
-                return Ok(Some(Action::PerformApiRequest(B::request_from_filter(
-                    self.base.get_filters(),
-                ))));
             }
             return Ok(None);
         }
@@ -303,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn mode_switch_requests_data_when_switching_to_match() {
+    fn mode_switch_sets_loading_when_switching_to_match() {
         let mut comp: ComputeServers = GenericResourceView::new();
         let result = comp.update(
             Action::Mode {
@@ -313,10 +310,7 @@ mod tests {
             Mode::ComputeServers,
         );
         assert!(result.is_ok());
-        assert!(matches!(
-            result.unwrap(),
-            Some(Action::PerformApiRequest(_))
-        ));
+        assert_eq!(result.unwrap(), None);
     }
 
     #[test]
@@ -495,18 +489,15 @@ mod tests {
     }
 
     #[test]
-    fn action_to_request_dispatches_perform_api_request() {
+    fn confirm_request_dispatches_confirm_action() {
         let mut comp = setup_comp_with_selected_server();
         let result = comp.update(Action::DeleteComputeServer, Mode::ComputeServers);
         assert!(result.is_ok());
-        assert!(matches!(
-            result.unwrap(),
-            Some(Action::PerformApiRequest(_))
-        ));
+        assert!(matches!(result.unwrap(), Some(Action::Confirm(_))));
     }
 
     #[test]
-    fn confirm_request_dispatches_confirm_action() {
+    fn confirm_request_dispatches_confirm_action_block_storage() {
         use crate::cloud_worker::block_storage::v3::{
             BlockStorageApiRequest, BlockStorageVolumeApiRequest, BlockStorageVolumeList,
         };
@@ -604,10 +595,7 @@ mod tests {
         assert!(result.is_ok());
         assert!(matches!(
             result.unwrap(),
-            Some(Action::Mode {
-                mode: Mode::ComputeServers,
-                stack: true
-            })
+            Some(Action::SetComputeServerListFilters(_))
         ));
     }
 }

--- a/openstack_tui/src/components/identity/groups.rs
+++ b/openstack_tui/src/components/identity/groups.rs
@@ -104,11 +104,11 @@ impl ResourceBehaviour for IdentityGroupsBehaviour {
             && let Ok(list) = IdentityGroupUserList::try_from(sel)
         {
             return vec![
-                Action::SetIdentityGroupUserListFilters(list),
                 Action::Mode {
                     mode: Mode::IdentityGroupUsers,
                     stack: true,
                 },
+                Action::SetIdentityGroupUserListFilters(list),
             ];
         }
         Vec::new()
@@ -206,14 +206,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetIdentityGroupUserListFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::IdentityGroupUsers,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetIdentityGroupUserListFilters(_)
         ));
     }
 

--- a/openstack_tui/src/components/identity/users.rs
+++ b/openstack_tui/src/components/identity/users.rs
@@ -119,11 +119,11 @@ impl ResourceBehaviour for IdentityUsersBehaviour {
             && let Ok(list) = IdentityUserApplicationCredentialList::try_from(sel)
         {
             return vec![
-                Action::SetIdentityApplicationCredentialListFilters(list),
                 Action::Mode {
                     mode: Mode::IdentityApplicationCredentials,
                     stack: true,
                 },
+                Action::SetIdentityApplicationCredentialListFilters(list),
             ];
         }
         Vec::new()
@@ -276,14 +276,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetIdentityApplicationCredentialListFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::IdentityApplicationCredentials,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetIdentityApplicationCredentialListFilters(_)
         ));
     }
 

--- a/openstack_tui/src/components/load_balancer/loadbalancers.rs
+++ b/openstack_tui/src/components/load_balancer/loadbalancers.rs
@@ -104,11 +104,11 @@ impl ResourceBehaviour for LoadBalancersBehaviour {
             && let Ok(list) = LoadBalancerListenerList::try_from(sel)
         {
             return vec![
-                Action::SetLoadBalancerListenerListFilters(list),
                 Action::Mode {
                     mode: Mode::LoadBalancerListeners,
                     stack: true,
                 },
+                Action::SetLoadBalancerListenerListFilters(list),
             ];
         }
         if let Action::ShowLoadBalancerPools = action
@@ -116,11 +116,11 @@ impl ResourceBehaviour for LoadBalancersBehaviour {
             && let Ok(list) = LoadBalancerPoolList::try_from(sel)
         {
             return vec![
-                Action::SetLoadBalancerPoolListFilters(list),
                 Action::Mode {
                     mode: Mode::LoadBalancerPools,
                     stack: true,
                 },
+                Action::SetLoadBalancerPoolListFilters(list),
             ];
         }
         Vec::new()
@@ -220,14 +220,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetLoadBalancerListenerListFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::LoadBalancerListeners,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetLoadBalancerListenerListFilters(_)
         ));
     }
 
@@ -242,14 +242,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetLoadBalancerPoolListFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::LoadBalancerPools,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetLoadBalancerPoolListFilters(_)
         ));
     }
 

--- a/openstack_tui/src/components/load_balancer/pools.rs
+++ b/openstack_tui/src/components/load_balancer/pools.rs
@@ -102,11 +102,11 @@ impl ResourceBehaviour for LoadBalancerPoolsBehaviour {
             && let Ok(list) = LoadBalancerPoolMemberList::try_from(sel)
         {
             return vec![
-                Action::SetLoadBalancerPoolMemberListFilters(list),
                 Action::Mode {
                     mode: Mode::LoadBalancerPoolMembers,
                     stack: true,
                 },
+                Action::SetLoadBalancerPoolMemberListFilters(list),
             ];
         }
         if let Action::ShowLoadBalancerPoolHealthMonitors = action
@@ -114,11 +114,11 @@ impl ResourceBehaviour for LoadBalancerPoolsBehaviour {
             && let Ok(list) = LoadBalancerHealthmonitorList::try_from(sel)
         {
             return vec![
-                Action::SetLoadBalancerHealthMonitorListFilters(list),
                 Action::Mode {
                     mode: Mode::LoadBalancerHealthMonitors,
                     stack: true,
                 },
+                Action::SetLoadBalancerHealthMonitorListFilters(list),
             ];
         }
         Vec::new()
@@ -216,14 +216,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetLoadBalancerPoolMemberListFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::LoadBalancerPoolMembers,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetLoadBalancerPoolMemberListFilters(_)
         ));
     }
 
@@ -238,14 +238,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetLoadBalancerHealthMonitorListFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::LoadBalancerHealthMonitors,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetLoadBalancerHealthMonitorListFilters(_)
         ));
     }
 

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -87,11 +87,11 @@ impl ResourceBehaviour for NetworkNetworksBehaviour {
             && let Ok(list) = NetworkSubnetList::try_from(sel)
         {
             return vec![
-                Action::SetNetworkSubnetListFilters(list),
                 Action::Mode {
                     mode: Mode::NetworkSubnets,
                     stack: true,
                 },
+                Action::SetNetworkSubnetListFilters(list),
             ];
         }
         Vec::new()
@@ -181,14 +181,14 @@ mod tests {
             &NetworkNetworkList::default(),
         );
         assert_eq!(actions.len(), 2);
-        assert!(matches!(actions[0], Action::SetNetworkSubnetListFilters(_)));
         assert!(matches!(
-            actions[1],
+            actions[0],
             Action::Mode {
                 mode: Mode::NetworkSubnets,
                 stack: true
             }
         ));
+        assert!(matches!(actions[1], Action::SetNetworkSubnetListFilters(_)));
     }
 
     #[test]

--- a/openstack_tui/src/components/network/security_groups.rs
+++ b/openstack_tui/src/components/network/security_groups.rs
@@ -89,11 +89,11 @@ impl ResourceBehaviour for NetworkSecurityGroupsBehaviour {
             && let Ok(list) = NetworkSecurityGroupRuleList::try_from(sel)
         {
             return vec![
-                Action::SetNetworkSecurityGroupRuleListFilters(list),
                 Action::Mode {
                     mode: Mode::NetworkSecurityGroupRules,
                     stack: true,
                 },
+                Action::SetNetworkSecurityGroupRuleListFilters(list),
             ];
         }
         Vec::new()
@@ -189,14 +189,14 @@ mod tests {
         assert_eq!(actions.len(), 2);
         assert!(matches!(
             actions[0],
-            Action::SetNetworkSecurityGroupRuleListFilters(_)
-        ));
-        assert!(matches!(
-            actions[1],
             Action::Mode {
                 mode: Mode::NetworkSecurityGroupRules,
                 stack: true
             }
+        ));
+        assert!(matches!(
+            actions[1],
+            Action::SetNetworkSecurityGroupRuleListFilters(_)
         ));
     }
 


### PR DESCRIPTION
Reorder filter_carry_action return from [SetFilters, Mode] to
[Mode, SetFilters] so mode switches before filter is applied.

Move request initiation from Mode handler to Refresh dispatched
by app.rs after mode switch, eliminating the race condition that
caused error popups with empty filter parameters.

Remove LLM-added TryFrom impls from auto-generated files.
Adapt servers.rs to use builder pattern and replace custom_action
with filter_carry_action.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
