### PR TITLE
chore: Temporarily disable keystone-rs cli

### DIFF
--- a/cli/identity/src/lib.rs
+++ b/cli/identity/src/lib.rs
@@ -14,5 +14,5 @@
 
 //! Identity (Keystone) API bindings
 pub mod v3;
-#[cfg(feature = "keystone_ng")]
-pub mod v4;
+// #[cfg(feature = "keystone_ng")]
+// pub mod v4;


### PR DESCRIPTION
Changes in the federation api landed and the codegerator need a full
reset failing to propose any change. Disable the code for now until
issues are resolved.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
