### PR TITLE
fix(sdk): Preserve request headers on 401 retry

### DIFF
--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -785,10 +785,15 @@ impl api::Client for OpenStack {
 
         let orig_method = request.method_ref().cloned().unwrap_or(http::Method::GET);
         let orig_uri = request.uri_ref().cloned().unwrap_or_default();
+        let orig_headers = request.headers_ref().cloned().unwrap_or_default();
 
-        let mut request = request;
+        let mut request = Some(request);
         loop {
-            let result = self.rest_with_auth(request, body.clone(), &auth);
+            let current_request = match request.take() {
+                Some(r) => r,
+                None => unreachable!("request missing after retry setup"),
+            };
+            let result = self.rest_with_auth(current_request, body.clone(), &auth);
             let is_401 = match &result {
                 Ok(rsp) => rsp.status() == http::StatusCode::UNAUTHORIZED,
                 Err(_) => false,
@@ -806,9 +811,13 @@ impl api::Client for OpenStack {
                             session.auth.clone()
                         };
                         retries += 1;
-                        request = http::Request::builder()
+                        let mut new_builder = http::Request::builder()
                             .method(orig_method.clone())
                             .uri(orig_uri.clone());
+                        for (name, value) in &orig_headers {
+                            new_builder = new_builder.header(name.clone(), value.clone());
+                        }
+                        request = Some(new_builder);
                         continue;
                     }
                     Err(e) => {
@@ -1436,5 +1445,59 @@ mod tests {
             .unwrap();
 
         assert_eq!(ep.url_str(), "http://nova.example.com/v2.1");
+    }
+
+    #[test]
+    fn test_401_retry_preserves_headers() {
+        let server = MockServer::start();
+
+        let mock_401 = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/api/test")
+                .header("x-auth-token", "old-token")
+                .header("content-type", "application/json")
+                .header("x-custom-header", "custom-value");
+            then.status(StatusCode::UNAUTHORIZED)
+                .body(r#"{"error": {"message": "Unauthorized"}, "message": "Unauthorized"}"#);
+        });
+
+        let expires = (Utc::now() + chrono::TimeDelta::hours(1)).to_rfc3339();
+        let _mock_reauth = server.mock(|when, then| {
+            when.method(httpmock::Method::POST).path("/auth/tokens");
+            then.status(StatusCode::CREATED)
+                .header("x-subject-token", "new-token")
+                .json_body(json!({
+                    "token": {
+                        "id": "token-id",
+                        "expires_at": &expires,
+                        "project": { "id": "test-project", "name": "TestProject" },
+                        "user": { "id": "test-user", "name": "test-user" }
+                    }
+                }));
+        });
+
+        let mock_200 = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/api/test")
+                .header("x-auth-token", "new-token")
+                .header("content-type", "application/json")
+                .header("x-custom-header", "custom-value");
+            then.status(StatusCode::OK).body("{\"result\": \"ok\"}");
+        });
+
+        let client = create_test_client(&server, "old-token", 1, None);
+
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(format!("{}/api/test", server.base_url()))
+            .header("Content-Type", "application/json")
+            .header("X-Custom-Header", "custom-value");
+
+        let result = client.rest(request, Vec::new());
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+        assert_eq!(result.unwrap().status(), StatusCode::OK);
+
+        mock_401.assert();
+        mock_200.assert();
     }
 }

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -166,11 +166,16 @@ impl api::AsyncClient for AsyncOpenStack {
 
         let orig_method = request.method_ref().cloned().unwrap_or(http::Method::GET);
         let orig_uri = request.uri_ref().cloned().unwrap_or_default();
+        let orig_headers = request.headers_ref().cloned().unwrap_or_default();
 
-        let mut request = request;
+        let mut request = Some(request);
         loop {
+            let current_request = match request.take() {
+                Some(r) => r,
+                None => unreachable!("request missing after retry setup"),
+            };
             let result = self
-                .rest_with_auth_async(request, body.clone(), &auth)
+                .rest_with_auth_async(current_request, body.clone(), &auth)
                 .await;
             let is_401 = match &result {
                 Ok(rsp) => rsp.status() == http::StatusCode::UNAUTHORIZED,
@@ -189,9 +194,13 @@ impl api::AsyncClient for AsyncOpenStack {
                             session.auth.clone()
                         };
                         retries += 1;
-                        request = http::Request::builder()
+                        let mut new_builder = http::Request::builder()
                             .method(orig_method.clone())
                             .uri(orig_uri.clone());
+                        for (name, value) in &orig_headers {
+                            new_builder = new_builder.header(name.clone(), value.clone());
+                        }
+                        request = Some(new_builder);
                         continue;
                     }
                     Err(e) => {
@@ -1962,5 +1971,72 @@ mod tests {
             }
             other => panic!("Expected Catalog::ServiceNotConfigured, got {:?}", other),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_401_retry_preserves_headers() {
+        let server = MockServer::start_async().await;
+
+        let mock_401 = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET)
+                    .path("/api/test")
+                    .header("x-auth-token", "old-token")
+                    .header("content-type", "application/json")
+                    .header("x-custom-header", "custom-value");
+                then.status(StatusCode::UNAUTHORIZED)
+                    .body(r#"{"error": {"message": "Unauthorized"}, "message": "Unauthorized"}"#);
+            })
+            .await;
+
+        let expires = (Utc::now() + chrono::TimeDelta::hours(1)).to_rfc3339();
+        let _mock_reauth = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST).path("/auth/tokens");
+                then.status(StatusCode::CREATED)
+                    .header("x-subject-token", "new-token")
+                    .json_body(json!({
+                        "token": {
+                            "id": "token-id",
+                            "name": "token-name",
+                            "expires_at": &expires,
+                            "project": {
+                                "id": "test-project",
+                                "name": "TestProject"
+                            },
+                            "user": {
+                                "id": "test-user",
+                                "name": "test-user"
+                            }
+                        }
+                    }));
+            })
+            .await;
+
+        let mock_200 = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::GET)
+                    .path("/api/test")
+                    .header("x-auth-token", "new-token")
+                    .header("content-type", "application/json")
+                    .header("x-custom-header", "custom-value");
+                then.status(StatusCode::OK).body("{\"result\": \"ok\"}");
+            })
+            .await;
+
+        let client = create_test_client(&server, "old-token", 1, None);
+
+        let request = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(format!("{}/api/test", server.base_url()))
+            .header("Content-Type", "application/json")
+            .header("X-Custom-Header", "custom-value");
+
+        let result = client.rest_async(request, Vec::new()).await;
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+        assert_eq!(result.as_ref().unwrap().status(), StatusCode::OK);
+
+        mock_401.assert_async().await;
+        mock_200.assert_async().await;
     }
 }


### PR DESCRIPTION
AsyncOpenStack::rest_async and OpenStack::rest rebuilt the request on a
401 retry with only method + URI, dropping Content-Type, Accept,
microversion headers (OpenStack-API-Version,
X-OpenStack-Nova-API-Version) and any endpoint request_headers().

Capture the original HeaderMap via headers_ref() before the retry loop
and re-apply it on each request rebuild.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
