### PR TITLE
feat(cli): Add service command version dispatch

### DIFF
--- a/cli/block-storage/src/lib.rs
+++ b/cli/block-storage/src/lib.rs
@@ -13,4 +13,79 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Block storage commands.
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v3;
+
+const API_VERSION_ARG_ID: &str = "os_block_storage_api_version";
+const API_VERSION_LONG: &str = "os-block-storage-api-version";
+const API_VERSION_ENV: &str = "OS_BLOCK_STORAGE_API_VERSION";
+const DEFAULT_BLOCK_STORAGE_API_VERSION: &str = "3";
+
+/// Block Storage (Volume) service (Cinder) commands
+pub enum BlockStorageCommand {
+    V3(v3::BlockStorageCommand),
+}
+
+impl Args for BlockStorageCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_BLOCK_STORAGE_API_VERSION)
+                .help("Block Storage API version to use (default: 3)"),
+        );
+        v3::BlockStorageCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for BlockStorageCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_BLOCK_STORAGE_API_VERSION);
+        match version {
+            "3" => Ok(Self::V3(v3::BlockStorageCommand::from_arg_matches(
+                matches,
+            )?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported Block Storage API version: {other}. Supported: 3\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl BlockStorageCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V3(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/compute/src/lib.rs
+++ b/cli/compute/src/lib.rs
@@ -13,4 +13,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Compute API command
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v2;
+
+const API_VERSION_ARG_ID: &str = "os_compute_api_version";
+const API_VERSION_LONG: &str = "os-compute-api-version";
+const API_VERSION_ENV: &str = "OS_COMPUTE_API_VERSION";
+const DEFAULT_COMPUTE_API_VERSION: &str = "2";
+
+/// Compute service (Nova) operations
+pub enum ComputeCommand {
+    V2(v2::ComputeCommand),
+}
+
+impl Args for ComputeCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_COMPUTE_API_VERSION)
+                .help("Compute API version to use (default: 2)"),
+        );
+        v2::ComputeCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for ComputeCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_COMPUTE_API_VERSION);
+        match version {
+            "2" => Ok(Self::V2(v2::ComputeCommand::from_arg_matches(matches)?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported Compute API version: {other}. Supported: 2\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl ComputeCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V2(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/container-infrastructure-management/src/lib.rs
+++ b/cli/container-infrastructure-management/src/lib.rs
@@ -13,4 +13,81 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Container Infrastructure Management API command
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v1;
+
+const API_VERSION_ARG_ID: &str = "os_container_infrastructure_api_version";
+const API_VERSION_LONG: &str = "os-container-infrastructure-api-version";
+const API_VERSION_ENV: &str = "OS_CONTAINER_INFRASTRUCTURE_API_VERSION";
+const DEFAULT_CONTAINER_INFRASTRUCTURE_API_VERSION: &str = "1";
+
+/// Container Infra service (Magnum) operations
+pub enum ContainerInfrastructureCommand {
+    V1(v1::ContainerInfrastructureCommand),
+}
+
+impl Args for ContainerInfrastructureCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_CONTAINER_INFRASTRUCTURE_API_VERSION)
+                .help("Container Infrastructure API version to use (default: 1)"),
+        );
+        v1::ContainerInfrastructureCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for ContainerInfrastructureCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_CONTAINER_INFRASTRUCTURE_API_VERSION);
+        match version {
+            "1" => Ok(Self::V1(
+                v1::ContainerInfrastructureCommand::from_arg_matches(matches)?,
+            )),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!(
+                    "unsupported Container Infrastructure API version: {other}. Supported: 1\n"
+                ),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl ContainerInfrastructureCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V1(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/core/src/cli.rs
+++ b/cli/core/src/cli.rs
@@ -154,6 +154,32 @@ pub struct GlobalOpts {
     pub output: OutputOpts,
 }
 
+/// Resolve a per-service API version selector by scanning the real process
+/// arguments directly. This has to happen before clap builds the `Command`
+/// tree (inside `Args::augment_args`), i.e. before any `ArgMatches` exist —
+/// so it can't go through clap itself. Once the tree is built, the actual
+/// (clap-parsed, env-aware, default-applying) value is read normally from
+/// `ArgMatches` in `FromArgMatches::from_arg_matches`; this function is only
+/// ever used to decide *which* version's subcommand tree to attach.
+pub fn resolve_api_version(long_flag: &str, env_var: &str, default: &str) -> String {
+    let needle_eq = format!("--{long_flag}=");
+    let needle = format!("--{long_flag}");
+    let mut result = None;
+    let mut args = std::env::args();
+    while let Some(a) = args.next() {
+        if let Some(v) = a.strip_prefix(&needle_eq) {
+            result = Some(v.to_string());
+        } else if a == needle
+            && let Some(v) = args.next()
+        {
+            result = Some(v);
+        }
+    }
+    result
+        .or_else(|| std::env::var(env_var).ok())
+        .unwrap_or_else(|| default.to_string())
+}
+
 /// Output format.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum OutputFormat {

--- a/cli/dns/src/lib.rs
+++ b/cli/dns/src/lib.rs
@@ -13,4 +13,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! DNS API command.
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v2;
+
+const API_VERSION_ARG_ID: &str = "os_dns_api_version";
+const API_VERSION_LONG: &str = "os-dns-api-version";
+const API_VERSION_ENV: &str = "OS_DNS_API_VERSION";
+const DEFAULT_DNS_API_VERSION: &str = "2";
+
+/// DNS service (Designate) operations
+pub enum DnsCommand {
+    V2(v2::DnsCommand),
+}
+
+impl Args for DnsCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_DNS_API_VERSION)
+                .help("DNS API version to use (default: 2)"),
+        );
+        v2::DnsCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for DnsCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_DNS_API_VERSION);
+        match version {
+            "2" => Ok(Self::V2(v2::DnsCommand::from_arg_matches(matches)?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported DNS API version: {other}. Supported: 2\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl DnsCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V2(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/identity/src/lib.rs
+++ b/cli/identity/src/lib.rs
@@ -13,6 +13,110 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Identity (Keystone) API bindings
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{
+    cli::{CliArgs, resolve_api_version},
+    error::OpenStackCliError,
+};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v3;
-// #[cfg(feature = "keystone_ng")]
-// pub mod v4;
+#[cfg(feature = "keystone_ng")]
+pub mod v4;
+
+const API_VERSION_ARG_ID: &str = "os_identity_api_version";
+const API_VERSION_LONG: &str = "os-identity-api-version";
+const API_VERSION_ENV: &str = "OS_IDENTITY_API_VERSION";
+const DEFAULT_IDENTITY_API_VERSION: &str = "3";
+
+/// Identity (Keystone) commands
+pub enum IdentityCommand {
+    V3(Box<v3::IdentityCommand>),
+    #[cfg(feature = "keystone_ng")]
+    V4(Box<v4::IdentityCommand>),
+}
+
+impl Args for IdentityCommand {
+    fn augment_args(cmd: Command) -> Command {
+        let version = resolve_api_version(
+            API_VERSION_LONG,
+            API_VERSION_ENV,
+            DEFAULT_IDENTITY_API_VERSION,
+        );
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_IDENTITY_API_VERSION)
+                .help("Identity API version to use (default: 3)"),
+        );
+        match version.as_str() {
+            #[cfg(feature = "keystone_ng")]
+            "4" => v4::IdentityCommand::augment_args(cmd),
+            // Any other value (including the default "3") falls back to
+            // v3's tree, so an invalid version still parses cleanly and
+            // `from_arg_matches` below reports a proper "unsupported
+            // version" error instead of clap's generic "unexpected
+            // argument" (which would fire first if no subcommand tree
+            // were attached at all).
+            _ => v3::IdentityCommand::augment_args(cmd),
+        }
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for IdentityCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_IDENTITY_API_VERSION);
+        match version {
+            "3" => Ok(Self::V3(Box::new(v3::IdentityCommand::from_arg_matches(
+                matches,
+            )?))),
+            #[cfg(feature = "keystone_ng")]
+            "4" => Ok(Self::V4(Box::new(v4::IdentityCommand::from_arg_matches(
+                matches,
+            )?))),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!(
+                    "unsupported Identity API version: {other}. Supported: 3{}\n",
+                    if cfg!(feature = "keystone_ng") {
+                        ", 4"
+                    } else {
+                        ""
+                    }
+                ),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl IdentityCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V3(cmd) => cmd.take_action(parsed_args, client).await,
+            #[cfg(feature = "keystone_ng")]
+            Self::V4(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/identity/src/v4/federation/mod.rs
+++ b/cli/identity/src/v4/federation/mod.rs
@@ -21,7 +21,7 @@ use openstack_sdk::AsyncOpenStack;
 use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
 
 pub mod identity_provider;
-pub mod mapping;
+//pub mod mapping;
 
 /// Federated login commands
 ///
@@ -36,7 +36,7 @@ pub struct FederationCommand {
 #[derive(Subcommand)]
 pub enum FederationCommands {
     IdentityProvider(identity_provider::IdentityProviderCommand),
-    Mapping(mapping::MappingCommand),
+    //    Mapping(mapping::MappingCommand),
 }
 
 impl FederationCommand {
@@ -49,8 +49,7 @@ impl FederationCommand {
         match &self.command {
             FederationCommands::IdentityProvider(cmd) => {
                 cmd.take_action(parsed_args, session).await
-            }
-            FederationCommands::Mapping(cmd) => cmd.take_action(parsed_args, session).await,
+            } //            FederationCommands::Mapping(cmd) => cmd.take_action(parsed_args, session).await,
         }
     }
 }

--- a/cli/image/src/lib.rs
+++ b/cli/image/src/lib.rs
@@ -13,4 +13,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Image (Glance) commands
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v2;
+
+const API_VERSION_ARG_ID: &str = "os_image_api_version";
+const API_VERSION_LONG: &str = "os-image-api-version";
+const API_VERSION_ENV: &str = "OS_IMAGE_API_VERSION";
+const DEFAULT_IMAGE_API_VERSION: &str = "2";
+
+/// Image service operations
+pub enum ImageCommand {
+    V2(v2::ImageCommand),
+}
+
+impl Args for ImageCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_IMAGE_API_VERSION)
+                .help("Image API version to use (default: 2)"),
+        );
+        v2::ImageCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for ImageCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_IMAGE_API_VERSION);
+        match version {
+            "2" => Ok(Self::V2(v2::ImageCommand::from_arg_matches(matches)?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported Image API version: {other}. Supported: 2\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl ImageCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V2(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/load-balancer/src/lib.rs
+++ b/cli/load-balancer/src/lib.rs
@@ -13,4 +13,79 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Load Balancer commands.
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v2;
+
+const API_VERSION_ARG_ID: &str = "os_load_balancer_api_version";
+const API_VERSION_LONG: &str = "os-load-balancer-api-version";
+const API_VERSION_ENV: &str = "OS_LOAD_BALANCER_API_VERSION";
+const DEFAULT_LOAD_BALANCER_API_VERSION: &str = "2";
+
+/// Load Balancer service operations
+pub enum LoadBalancerCommand {
+    V2(v2::LoadBalancerCommand),
+}
+
+impl Args for LoadBalancerCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_LOAD_BALANCER_API_VERSION)
+                .help("Load Balancer API version to use (default: 2)"),
+        );
+        v2::LoadBalancerCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for LoadBalancerCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_LOAD_BALANCER_API_VERSION);
+        match version {
+            "2" => Ok(Self::V2(v2::LoadBalancerCommand::from_arg_matches(
+                matches,
+            )?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported Load Balancer API version: {other}. Supported: 2\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl LoadBalancerCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V2(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/network/src/lib.rs
+++ b/cli/network/src/lib.rs
@@ -13,4 +13,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Networking commands
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v2;
+
+const API_VERSION_ARG_ID: &str = "os_network_api_version";
+const API_VERSION_LONG: &str = "os-network-api-version";
+const API_VERSION_ENV: &str = "OS_NETWORK_API_VERSION";
+const DEFAULT_NETWORK_API_VERSION: &str = "2";
+
+/// Network (Neutron) commands
+pub enum NetworkCommand {
+    V2(v2::NetworkCommand),
+}
+
+impl Args for NetworkCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_NETWORK_API_VERSION)
+                .help("Network API version to use (default: 2)"),
+        );
+        v2::NetworkCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for NetworkCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_NETWORK_API_VERSION);
+        match version {
+            "2" => Ok(Self::V2(v2::NetworkCommand::from_arg_matches(matches)?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported Network API version: {other}. Supported: 2\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl NetworkCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V2(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/object-store/src/lib.rs
+++ b/cli/object-store/src/lib.rs
@@ -13,4 +13,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Object Store commands
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v1;
+
+const API_VERSION_ARG_ID: &str = "os_object_store_api_version";
+const API_VERSION_LONG: &str = "os-object-store-api-version";
+const API_VERSION_ENV: &str = "OS_OBJECT_STORE_API_VERSION";
+const DEFAULT_OBJECT_STORE_API_VERSION: &str = "1";
+
+/// Object Store service (Swift) commands
+pub enum ObjectStoreCommand {
+    V1(v1::ObjectStoreCommand),
+}
+
+impl Args for ObjectStoreCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_OBJECT_STORE_API_VERSION)
+                .help("Object Store API version to use (default: 1)"),
+        );
+        v1::ObjectStoreCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for ObjectStoreCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_OBJECT_STORE_API_VERSION);
+        match version {
+            "1" => Ok(Self::V1(v1::ObjectStoreCommand::from_arg_matches(matches)?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported Object Store API version: {other}. Supported: 1\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl ObjectStoreCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V1(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/placement/src/lib.rs
+++ b/cli/placement/src/lib.rs
@@ -13,4 +13,77 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Placement commands.
+use clap::error::{Error, ErrorKind};
+use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches};
+
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+
 pub mod v1;
+
+const API_VERSION_ARG_ID: &str = "os_placement_api_version";
+const API_VERSION_LONG: &str = "os-placement-api-version";
+const API_VERSION_ENV: &str = "OS_PLACEMENT_API_VERSION";
+const DEFAULT_PLACEMENT_API_VERSION: &str = "1";
+
+/// Placement service commands
+pub enum PlacementCommand {
+    V1(v1::PlacementCommand),
+}
+
+impl Args for PlacementCommand {
+    fn augment_args(cmd: Command) -> Command {
+        // Only one version currently exists, so there's nothing to branch
+        // on here; `from_arg_matches` below still validates the flag's
+        // actual value and reports a proper "unsupported version" error
+        // for anything else.
+        let cmd = cmd.arg(
+            Arg::new(API_VERSION_ARG_ID)
+                .long(API_VERSION_LONG)
+                .env(API_VERSION_ENV)
+                .global(true)
+                .action(ArgAction::Set)
+                .default_value(DEFAULT_PLACEMENT_API_VERSION)
+                .help("Placement API version to use (default: 1)"),
+        );
+        v1::PlacementCommand::augment_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: Command) -> Command {
+        Self::augment_args(cmd)
+    }
+}
+
+impl FromArgMatches for PlacementCommand {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, Error> {
+        let version = matches
+            .get_one::<String>(API_VERSION_ARG_ID)
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_PLACEMENT_API_VERSION);
+        match version {
+            "1" => Ok(Self::V1(v1::PlacementCommand::from_arg_matches(matches)?)),
+            other => Err(Error::raw(
+                ErrorKind::InvalidValue,
+                format!("unsupported Placement API version: {other}. Supported: 1\n"),
+            )),
+        }
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), Error> {
+        *self = Self::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl PlacementCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match self {
+            Self::V1(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -114,22 +114,20 @@ impl CliArgs for Cli {
 pub enum TopLevelCommands {
     Api(openstack_cli_api::ApiCommand),
     Auth(openstack_cli_auth::AuthCommand),
-    BlockStorage(openstack_cli_block_storage::v3::BlockStorageCommand),
+    BlockStorage(openstack_cli_block_storage::BlockStorageCommand),
     Catalog(openstack_cli_catalog::CatalogCommand),
-    Compute(openstack_cli_compute::v2::ComputeCommand),
+    Compute(openstack_cli_compute::ComputeCommand),
     #[command(aliases = ["container-infrastructure-management", "container"])]
     ContainerInfrastructure(
-        openstack_cli_container_infrastructure_management::v1::ContainerInfrastructureCommand,
+        openstack_cli_container_infrastructure_management::ContainerInfrastructureCommand,
     ),
-    Dns(openstack_cli_dns::v2::DnsCommand),
-    Identity(openstack_cli_identity::v3::IdentityCommand),
-    //#[cfg(feature = "keystone_ng")]
-    //Identity4(openstack_cli_identity::v4::IdentityCommand),
-    Image(openstack_cli_image::v2::ImageCommand),
-    LoadBalancer(openstack_cli_load_balancer::v2::LoadBalancerCommand),
-    Network(openstack_cli_network::v2::NetworkCommand),
-    ObjectStore(openstack_cli_object_store::v1::ObjectStoreCommand),
-    Placement(openstack_cli_placement::v1::PlacementCommand),
+    Dns(openstack_cli_dns::DnsCommand),
+    Identity(openstack_cli_identity::IdentityCommand),
+    Image(openstack_cli_image::ImageCommand),
+    LoadBalancer(openstack_cli_load_balancer::LoadBalancerCommand),
+    Network(openstack_cli_network::NetworkCommand),
+    ObjectStore(openstack_cli_object_store::ObjectStoreCommand),
+    Placement(openstack_cli_placement::PlacementCommand),
     Completion(CompletionCommand),
 }
 
@@ -145,8 +143,6 @@ impl Cli {
             TopLevelCommands::ContainerInfrastructure(args) => args.take_action(self, client).await,
             TopLevelCommands::Dns(args) => args.take_action(self, client).await,
             TopLevelCommands::Identity(args) => args.take_action(self, client).await,
-            //#[cfg(feature = "keystone_ng")]
-            //TopLevelCommands::Identity4(args) => args.take_action(self, client).await,
             TopLevelCommands::Image(args) => args.take_action(self, client).await,
             TopLevelCommands::LoadBalancer(args) => args.take_action(self, client).await,
             TopLevelCommands::Network(args) => args.take_action(self, client).await,

--- a/openstack_cli/tests/identity/v4/federation/identity_provider/mod.rs
+++ b/openstack_cli/tests/identity/v4/federation/identity_provider/mod.rs
@@ -25,7 +25,14 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["identity4", "federation", "identity-provider", "--help"]);
+    cmd.args([
+        "identity",
+        "--os-identity-api-version",
+        "4",
+        "federation",
+        "identity-provider",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v4/federation/mapping/mod.rs
+++ b/openstack_cli/tests/identity/v4/federation/mapping/mod.rs
@@ -25,7 +25,14 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["identity4", "federation", "mapping", "--help"]);
+    cmd.args([
+        "identity",
+        "--os-identity-api-version",
+        "4",
+        "federation",
+        "mapping",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v4/federation/mod.rs
+++ b/openstack_cli/tests/identity/v4/federation/mod.rs
@@ -22,7 +22,13 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["identity4", "federation", "--help"]);
+    cmd.args([
+        "identity",
+        "--os-identity-api-version",
+        "4",
+        "federation",
+        "--help",
+    ]);
     cmd.assert().success();
 
     Ok(())

--- a/openstack_cli/tests/identity/v4/mod.rs
+++ b/openstack_cli/tests/identity/v4/mod.rs
@@ -21,7 +21,7 @@ use std::process::Command;
 fn help() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("osc")?;
 
-    cmd.args(["identity4", "--help"]);
+    cmd.args(["identity", "--os-identity-api-version", "4", "--help"]);
     cmd.assert().success();
 
     Ok(())


### PR DESCRIPTION
Each crate's wrapper type now hand-implements clap::Args and
clap::FromArgMatches (the pattern clap itself documents in
examples/derive_ref/hand_subcommand.rs and flatten_hand_args.rs)
instead of deriving Parser over a trailing_var_arg capture. A small
shared resolve_api_version() helper in cli/core scans the real process
args once to decide which version's subcommand tree to merge into the
single Command clap builds; from_arg_matches then reads the
clap-parsed (env/default-aware) value to pick the matching variant.
Since there is only ever one tree now, GlobalOpts (flattened once, as
before, on the top-level Cli) is naturally visible in --help
everywhere, with no per-crate duplication.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
