### PR TITLE
feat(sdk): Add background token auto-renewal

### DIFF
--- a/openstack_sdk/src/lib.rs
+++ b/openstack_sdk/src/lib.rs
@@ -27,7 +27,7 @@ mod session;
 #[cfg(feature = "async")]
 mod openstack_async;
 #[cfg(feature = "async")]
-pub use openstack_async::AsyncOpenStack;
+pub use openstack_async::{AsyncOpenStack, RenewHandle};
 #[cfg(all(feature = "sync", feature = "async"))]
 mod openstack;
 #[cfg(all(feature = "sync", feature = "async"))]

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, SystemTime};
 use std::{fs::File, io::Read};
 
@@ -327,6 +327,18 @@ impl Drop for SessionWriteGuard<'_> {
     }
 }
 
+/// Handle to a background token-renewal task started by
+/// [`AsyncOpenStack::enable_auto_renew`]. Dropping it stops the task; the
+/// task also stops on its own once every `AsyncOpenStack` sharing the
+/// session it was spawned for has been dropped.
+pub struct RenewHandle(tokio::task::JoinHandle<()>);
+
+impl Drop for RenewHandle {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 impl AsyncOpenStack {
     /// Lock the session for reading. `location` is kept as a parameter for
     /// call-site self-documentation (parking_lot never poisons, so it no
@@ -570,6 +582,165 @@ impl AsyncOpenStack {
     pub fn disable_auth_cache(&self) -> &Self {
         self.session.write().state.disable_auth_cache();
         self
+    }
+
+    /// Spawn a background task that proactively re-authenticates `margin`
+    /// before the current token expires, so the request hot path rarely
+    /// hits a 401 to begin with.
+    ///
+    /// This performs a full, non-interactive re-authentication — *not*
+    /// token-exchange (`Self::reauth`, method=`token`). Keystone bakes the
+    /// original token's expiry into any token minted via token-exchange
+    /// (`keystone/auth/plugins/token.py`: `response_data.setdefault(
+    /// 'expires_at', token.expires_at)`, deliberately, to stop callers from
+    /// bumping expiry without reproving identity), so exchanging a token
+    /// for a token never actually extends the session — it would produce a
+    /// new token id with the exact same expiry as the one it replaced.
+    /// Reproving identity is required, so this clears cached auth state and
+    /// replays the credentials in `CloudConfig` (password / application
+    /// credential / client credentials) through [`Self::authorize_with_auth_helper`]
+    /// with [`Noop`] — deliberately never the configured interactive
+    /// `auth_helper`, since a background task cannot block on a prompt.
+    /// Clouds that need MFA/SSO/interactive input therefore don't renew
+    /// here; they keep relying on the interactive 401 retry path when a
+    /// user is actually present.
+    ///
+    /// Re-authentication is single-flighted with the 401 retry path through
+    /// `reauth_lock`, so a concurrent 401 and a renewal wakeup never both
+    /// re-authenticate at once.
+    ///
+    /// The task exits once it observes there is no `Auth::AuthToken` to
+    /// renew (unauthenticated session), once the last `AsyncOpenStack`
+    /// sharing this session is dropped, or when the returned handle is
+    /// dropped.
+    pub fn enable_auto_renew(&self, margin: TimeDelta) -> RenewHandle {
+        // Only `session` is held weakly — it's the field whose refcount
+        // marks "is any AsyncOpenStack for this session still alive".
+        // Everything else is cloned strong: none of it keeps `session`
+        // alive, and the task needs it to build a short-lived client for
+        // each wake-up without holding a strong `session` ref across the
+        // (possibly hours-long) sleep in between.
+        let weak_session: Weak<RwLock<session::SessionContext>> = Arc::downgrade(&self.session);
+        let reqwest_client = self.client.clone();
+        let config = self.config.clone();
+        let auth_snapshot = Arc::clone(&self.auth_snapshot);
+        let auth_helper = self.auth_helper.clone();
+        let max_auth_retries = self.max_auth_retries;
+        let reauth_lock = Arc::clone(&self.reauth_lock);
+
+        let join = tokio::spawn(async move {
+            // Rebuilds a client around the currently-live `session` Arc, or
+            // `None` once the last real `AsyncOpenStack` has been dropped.
+            let upgrade = || {
+                weak_session.upgrade().map(|session| AsyncOpenStack {
+                    client: reqwest_client.clone(),
+                    config: config.clone(),
+                    session,
+                    auth_snapshot: Arc::clone(&auth_snapshot),
+                    auth_helper: auth_helper.clone(),
+                    max_auth_retries,
+                    reauth_lock: Arc::clone(&reauth_lock),
+                })
+            };
+
+            loop {
+                let sleep_for = {
+                    let Some(client) = upgrade() else { return };
+                    let Auth::AuthToken(token) = &client.auth_snapshot.load().auth else {
+                        return;
+                    };
+                    let Some(auth_info) = &token.auth_info else {
+                        return;
+                    };
+                    (auth_info.token.expires_at - margin - chrono::Utc::now())
+                        .to_std()
+                        .unwrap_or(Duration::ZERO)
+                    // `client` (and its strong `session` ref) drops here,
+                    // before the sleep below.
+                };
+                tokio::time::sleep(sleep_for).await;
+
+                let Some(client) = upgrade() else { return };
+
+                let seen_generation = client.auth_snapshot.load().auth_generation;
+                let _guard = client.reauth_lock.lock().await;
+                if client.auth_snapshot.load().auth_generation != seen_generation {
+                    // Another task (401 retry or a previous renewal wakeup)
+                    // already refreshed the token while we waited.
+                    continue;
+                }
+
+                let scope = match AuthTokenScope::try_from(&client.config) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!("background token renewal: cannot determine scope: {e}");
+                        return;
+                    }
+                };
+
+                // `authorize_with_auth_helper` re-processes the token
+                // catalog, which wipes all previously-discovered service
+                // endpoint versions (identity excepted) since a rescope may
+                // land on a different project_id. This renewal keeps the
+                // same scope, so remember what was discovered and redo it
+                // below rather than silently losing it.
+                let discovered_services = {
+                    let session =
+                        client.session_read("enable_auto_renew: snapshot discovered services");
+                    session.catalog.discovered_service_types()
+                };
+
+                // Clear cached auth first: `authorize_with_auth_helper`
+                // would otherwise happily rescope a still-cached token via
+                // token-exchange, which (see doc comment above) preserves
+                // the old expiry instead of extending it. Clearing forces
+                // it down the real-credential path.
+                {
+                    let mut session = client.session_write("enable_auto_renew: clear state");
+                    session.state.clear_all_auth();
+                }
+                match client
+                    .authorize_with_auth_helper(Some(scope), &Noop::default(), true)
+                    .await
+                {
+                    Ok(()) => {
+                        for service_type in &discovered_services {
+                            if let Err(e) = client
+                                .discover_service_endpoint(&ServiceType::from(
+                                    service_type.as_str(),
+                                ))
+                                .await
+                            {
+                                warn!(
+                                    "background token renewal: failed to re-discover endpoint for {service_type}: {e}"
+                                );
+                            }
+                        }
+                        let expires_at =
+                            if let Auth::AuthToken(t) = &client.auth_snapshot.load().auth {
+                                t.auth_info
+                                    .as_ref()
+                                    .map(|i| i.token.expires_at.to_rfc3339())
+                            } else {
+                                None
+                            };
+                        event!(
+                            name: "token_renewed",
+                            Level::DEBUG,
+                            expires_at,
+                            "Background token renewal succeeded"
+                        )
+                    }
+                    Err(e) => {
+                        warn!("background token renewal failed: {e}");
+                        // Rate-limit retries; a subsequent 401 still falls
+                        // back to the normal retry path in the meantime.
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                    }
+                }
+            }
+        });
+        RenewHandle(join)
     }
 
     /// Set the maximum number of retries on 401 responses.
@@ -2076,5 +2247,107 @@ mod tests {
 
         mock_401.assert_async().await;
         mock_200.assert_async().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_auto_renew_success() {
+        let server = MockServer::start_async().await;
+
+        // Match only on method/path/body-shape ("application_credential"
+        // identity method), so this mock exercises the real-credential
+        // re-authentication path `enable_auto_renew` must take — not
+        // token-exchange (method=`token`), which Keystone pins to the
+        // *original* token's expiry and therefore can never actually renew
+        // a session (see the doc comment on `enable_auto_renew`).
+        let expires = (Utc::now() + chrono::TimeDelta::hours(1)).to_rfc3339();
+        let mock_reauth = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST)
+                    .path("/auth/tokens")
+                    .body_includes("application_credential");
+                then.status(StatusCode::CREATED)
+                    .header("x-subject-token", "renewed-token")
+                    .json_body(json!({
+                        "token": {
+                            "id": "token-id",
+                            "name": "token-name",
+                            "expires_at": &expires,
+                            "project": {
+                                "id": "test-project",
+                                "name": "TestProject"
+                            },
+                            "user": {
+                                "id": "test-user",
+                                "name": "test-user"
+                            }
+                        }
+                    }));
+            })
+            .await;
+
+        let mut client = create_test_client(&server, "old-token", 1, None);
+        // Renewal must actually replay real credentials (app-cred here),
+        // not exchange the still-cached token.
+        client.config.auth_type = Some("v3applicationcredential".into());
+        if let Some(auth) = &mut client.config.auth {
+            auth.application_credential_id = Some("app-cred-id".into());
+            auth.application_credential_secret = Some("app-cred-secret".into());
+        }
+        // Make the token expire almost immediately so the renewal task wakes
+        // right away instead of waiting out the 1h default in the fixture.
+        {
+            let mut guard = client.session_write("test: force near expiry");
+            if let Auth::AuthToken(t) = &mut guard.auth
+                && let Some(info) = &mut t.auth_info
+            {
+                info.token.expires_at = Utc::now() + chrono::TimeDelta::milliseconds(100);
+            }
+        }
+        let generation_before = client.auth_snapshot.load().auth_generation;
+
+        let _handle = client.enable_auto_renew(TimeDelta::milliseconds(50));
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        mock_reauth.assert_async().await;
+        let snap = client.auth_snapshot.load();
+        assert_eq!(snap.auth_generation, generation_before + 1);
+        match &snap.auth {
+            Auth::AuthToken(t) => assert_eq!(t.token.expose_secret(), "renewed-token"),
+            _ => panic!("expected AuthToken after renewal"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_auto_renew_stops_when_client_dropped() {
+        let server = MockServer::start_async().await;
+
+        // If the renewal task fires after the client is gone, this mock
+        // would be hit; asserting it was never called proves the task
+        // stopped instead of renewing against a dropped session.
+        let mock_reauth = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST).path("/auth/tokens");
+                then.status(StatusCode::CREATED)
+                    .header("x-subject-token", "renewed-token")
+                    .json_body(json!({"token": {}}));
+            })
+            .await;
+
+        let client = create_test_client(&server, "old-token", 1, None);
+        {
+            let mut guard = client.session_write("test: force near expiry");
+            if let Auth::AuthToken(t) = &mut guard.auth
+                && let Some(info) = &mut t.auth_info
+            {
+                info.token.expires_at = Utc::now() + chrono::TimeDelta::milliseconds(150);
+            }
+        }
+
+        let handle = client.enable_auto_renew(TimeDelta::milliseconds(50));
+        drop(client);
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        mock_reauth.assert_calls_async(0).await;
+        drop(handle);
     }
 }

--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -20,8 +20,7 @@ use async_trait::async_trait;
 use chrono::TimeDelta;
 use eyre::{Report, Result, eyre};
 use openstack_sdk::{
-    AsyncOpenStack,
-    auth::AuthState,
+    AsyncOpenStack, RenewHandle,
     auth::auth_helper::{AuthHelper, AuthHelperError},
     config::ConfigFile,
     types::identity::v3::AuthResponse,
@@ -49,11 +48,20 @@ pub use crate::cloud_worker::common::CloudWorkerError;
 use crate::cloud_worker::types::*;
 use crate::error::TuiError;
 
+/// How long before token expiry the background renewal task re-authenticates.
+/// The TUI is long-running, so it enables proactive renewal unconditionally
+/// instead of checking/renewing per-request.
+const AUTO_RENEW_MARGIN: TimeDelta = TimeDelta::seconds(59 * 60);
+
 /// Cloud worker struct
 pub(crate) struct Cloud {
     cloud_configs: ConfigFile,
     pub(crate) cloud: Option<AsyncOpenStack>,
     auth_helper: TuiAuthHelper,
+    /// Handle to the background token-renewal task for `cloud`. Dropped
+    /// (stopping the task) when replaced by a new connection/scope change,
+    /// or when `Cloud` itself is dropped.
+    _renew_handle: Option<RenewHandle>,
 }
 
 #[derive(Debug)]
@@ -78,6 +86,7 @@ impl Cloud {
             cloud_configs: cfg,
             cloud: None,
             auth_helper: TuiAuthHelper::new(auth_helper_control_tx),
+            _renew_handle: None,
         })
     }
 
@@ -113,7 +122,14 @@ impl Cloud {
             .discover_service_endpoint(&openstack_sdk::types::ServiceType::Network)
             .await?;
 
+        // Replacing `self.cloud` also happens here; assigning a new
+        // `_renew_handle` first drops (aborts) any renewal task for the
+        // previous session.
+        self._renew_handle = None;
         self.cloud = Some(session);
+        if let Some(cloud) = &self.cloud {
+            self._renew_handle = Some(cloud.enable_auto_renew(AUTO_RENEW_MARGIN));
+        }
 
         Ok(())
     }
@@ -122,6 +138,13 @@ impl Cloud {
         &mut self,
         scope: &openstack_sdk::auth::authtoken::AuthTokenScope,
     ) -> Result<Option<AuthResponse>, Report> {
+        // Deliberately doesn't touch `_renew_handle`: rescoping goes
+        // through token-exchange, which preserves the original token's
+        // expiry, so the background task's already-computed sleep target
+        // is still correct. It reads live `auth_snapshot` state (shared
+        // via the same session `Arc`) on each wakeup and is guarded by
+        // `auth_generation`, so it naturally observes the new scope
+        // without needing to be respawned.
         match self.cloud {
             Some(ref mut session) => {
                 debug!("Switching connection scope to {:?}", scope);
@@ -234,14 +257,13 @@ impl Cloud {
                 }
                 ref ac @ Action::PerformApiRequest(ref request) => {
                     if let Some(ref mut conn) = self.cloud {
-                        // Check if reauth is necessary
-                        match &conn.get_auth_state(Some(TimeDelta::seconds(10))) {
-                            Some(AuthState::Expired) | Some(AuthState::AboutToExpire) => {
-                                conn.authorize(None, false, true).await?;
-                            }
-                            _ => {}
-                        }
-
+                        // No pre-request expiry check needed: the
+                        // background task from `enable_auto_renew`
+                        // (spawned in `connect_to_cloud`) keeps the token
+                        // fresh proactively. If it can't (e.g. interactive
+                        // MFA/SSO cloud with no stored credentials),
+                        // `rest_async`'s own 401 retry falls back to
+                        // `TuiAuthHelper` and prompts the user.
                         request
                             .execute_request(conn, request, &app_tx)
                             .await

--- a/sdk/core/src/catalog.rs
+++ b/sdk/core/src/catalog.rs
@@ -381,7 +381,23 @@ impl Catalog {
         self.consume_discovered_endpoints(service_type, discovered_endpoints)
     }
 
-    /// Return catalog endpoints as returned in the authorization response
+    /// Return catalog endpoints as returned in the authorization response for
+    /// service types for which endpoint version discovery has previously
+    /// succeeded.
+    ///
+    /// `process_catalog_endpoints` wipes discovered endpoint info on every
+    /// re-auth (a rescope may land on a different project_id, invalidating
+    /// prior discovery). Callers that re-auth without a scope change (e.g.
+    /// background token renewal) can use this beforehand to know what to
+    /// re-discover afterwards so version info isn't silently lost.
+    pub fn discovered_service_types(&self) -> Vec<String> {
+        self.service_endpoints
+            .iter()
+            .filter(|(_, eps)| !eps.get_all().is_empty())
+            .map(|(k, _)| k.clone())
+            .collect()
+    }
+
     pub fn get_token_catalog(&self) -> Option<Vec<ApiServiceEndpoints>> {
         self.token_catalog.clone()
     }


### PR DESCRIPTION
Keystone token-exchange (`reauth`) preserves the original token's
expires_at by design, so it can't extend session lifetime. Real
renewal requires a full non-interactive re-auth (credential replay)
via `authorize_with_auth_helper`, single-flighted with the existing
401-retry path through `reauth_lock`.

- AsyncOpenStack::enable_auto_renew spawns a task holding only a
  Weak<SessionContext>, self-terminating once the last client for
  that session is dropped; RenewHandle aborts it on Drop as an
  explicit stop.
- authorize_with_auth_helper's catalog processing wipes all
  discovered endpoint versions on every re-auth (a rescope may land
  on a different project_id). Renewal keeps the same scope, so
  Catalog::discovered_service_types() snapshots what was discovered
  beforehand and enable_auto_renew re-discovers it after a
  successful renewal instead of silently losing it.
- openstack_tui/cloud_worker.rs: spawn enable_auto_renew(60s margin)
  on connect, dropping/replacing the handle on reconnect; drop the
  old reactive per-request expiry check now that renewal is
  proactive (interactive/MFA clouds still fall back to the 401 ->
  TuiAuthHelper prompt path, since background renewal is
  non-interactive-only).

Closes: #1218
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
