### PR TITLE
feat(cli,sdk): Diverse UX improvements

### DIFF
--- a/cli/auth/src/lib.rs
+++ b/cli/auth/src/lib.rs
@@ -16,11 +16,15 @@
 
 use clap::{Parser, Subcommand};
 
-use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_cli_core::{
+    cli::{CliArgs, ConnectionRequirements, ConnectionRequirementsProvider},
+    error::OpenStackCliError,
+};
 use openstack_sdk::AsyncOpenStack;
 
 pub mod login;
 pub mod show;
+pub mod status;
 
 /// Cloud Authentication operations
 ///
@@ -38,6 +42,25 @@ pub struct AuthCommand {
 pub enum AuthCommands {
     Login(login::LoginCommand),
     Show(show::ShowCommand),
+    Status(status::StatusCommand),
+}
+
+impl ConnectionRequirementsProvider for AuthCommands {
+    fn connection_requirements(&self) -> ConnectionRequirements {
+        match self {
+            AuthCommands::Login(login::LoginCommand { renew: true, .. }) => {
+                ConnectionRequirements {
+                    needs_auth: true,
+                    renew: true,
+                }
+            }
+            AuthCommands::Status(_) => ConnectionRequirements {
+                needs_auth: false,
+                renew: false,
+            },
+            _ => ConnectionRequirements::connected(),
+        }
+    }
 }
 
 impl AuthCommand {
@@ -50,6 +73,7 @@ impl AuthCommand {
         match &self.command {
             AuthCommands::Show(cmd) => cmd.take_action(parsed_args, client).await,
             AuthCommands::Login(cmd) => cmd.take_action(parsed_args, client).await,
+            AuthCommands::Status(cmd) => cmd.take_action(parsed_args, client).await,
         }
     }
 }

--- a/cli/auth/src/status.rs
+++ b/cli/auth/src/status.rs
@@ -1,0 +1,128 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Show current authentication status without requiring a fresh authorization
+use chrono::prelude::*;
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use openstack_cli_core::output::{OutputFor, OutputProcessor};
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+use openstack_sdk::auth::AuthState as SdkAuthState;
+use structable::{StructTable, StructTableOptions};
+
+/// Show current authentication status.
+///
+/// This command reports the currently known (locally cached) authentication
+/// state for the connection: scope, token validity/expiry, and the on-disk
+/// cache file used, without forcing a token renewal.
+///
+/// This command does not require a fully valid/unexpired authorization to run.
+#[derive(Debug, Parser)]
+pub struct StatusCommand {}
+
+/// Authentication status information.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, StructTable)]
+pub struct Status {
+    /// Whether a token is present at all.
+    #[structable()]
+    pub authenticated: bool,
+
+    /// Human readable auth scope (unscoped/project/domain/system) with name/id.
+    #[structable(optional)]
+    pub scope: Option<String>,
+
+    /// Token validity state.
+    #[structable(optional)]
+    pub state: Option<String>,
+
+    /// Token expiration time.
+    #[structable(optional)]
+    pub expires_at: Option<DateTime<Utc>>,
+
+    /// On-disk auth cache file in use, if the cache is enabled.
+    #[structable(optional)]
+    pub cache_file: Option<String>,
+}
+
+impl StatusCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        info!("Show auth status");
+
+        let op = OutputProcessor::from_args(parsed_args, Some("auth"), Some("status"));
+
+        let auth_info = client.get_auth_info();
+        let auth_state = client.get_auth_state(None);
+        let cache_file = client
+            .get_auth_cache_file()
+            .map(|p| p.display().to_string());
+
+        let scope = auth_info.as_ref().map(|info| {
+            if let Some(project) = &info.token.project {
+                format!(
+                    "project: {}",
+                    project
+                        .name
+                        .clone()
+                        .or_else(|| project.id.clone())
+                        .unwrap_or_default()
+                )
+            } else if let Some(domain) = &info.token.domain {
+                format!(
+                    "domain: {}",
+                    domain
+                        .name
+                        .clone()
+                        .or_else(|| domain.id.clone())
+                        .unwrap_or_default()
+                )
+            } else if let Some(system) = &info.token.system {
+                format!("system: {:?}", system)
+            } else {
+                "unscoped".to_string()
+            }
+        });
+
+        let status = Status {
+            authenticated: auth_info.is_some(),
+            scope,
+            state: auth_state.map(|s| match s {
+                SdkAuthState::Valid => "valid".to_string(),
+                SdkAuthState::Expired => "expired".to_string(),
+                SdkAuthState::AboutToExpire => "about to expire".to_string(),
+                SdkAuthState::Unset => "unset".to_string(),
+            }),
+            expires_at: auth_info.as_ref().map(|info| info.token.expires_at),
+            cache_file,
+        };
+
+        match op.target {
+            OutputFor::Human => {
+                op.output_human(&status)?;
+            }
+            _ => {
+                op.output_machine(serde_json::to_value(&status)?)?;
+            }
+        }
+        op.show_command_hint()?;
+        Ok(())
+    }
+}

--- a/cli/core/src/cli.rs
+++ b/cli/core/src/cli.rs
@@ -222,3 +222,46 @@ pub struct CompletionCommand {
     #[arg(default_value_t = Shell::Bash)]
     pub shell: Shell,
 }
+
+/// Pre-connect behavior a parsed command wants from the CLI entry point.
+///
+/// Centralizes the "does this command need a live authenticated connection,
+/// and should the token be force-renewed" decision so the entry point does
+/// not need to hand-inspect the parsed command tree for every case (see
+/// `osc auth login --renew` and `osc auth status`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConnectionRequirements {
+    /// Whether the command requires a live, authenticated connection to the cloud.
+    ///
+    /// Commands that only read local/cached state (e.g. `osc auth status`) can set
+    /// this to `false`.
+    pub needs_auth: bool,
+    /// Whether the auth token should be force-renewed before the command runs.
+    pub renew: bool,
+}
+
+impl ConnectionRequirements {
+    /// Default requirements for a normal, connected command: needs a live
+    /// authenticated session, no forced renewal.
+    pub fn connected() -> Self {
+        Self {
+            needs_auth: true,
+            renew: false,
+        }
+    }
+}
+
+/// Provides pre-connect [`ConnectionRequirements`] for a parsed command.
+///
+/// This is implemented by hand for the top-level `Cli`/`TopLevelCommands` dispatch
+/// and the `auth` subcommand (both hand-written, not codegenerated — see
+/// `grep -r TopLevelCommands`). Should more commands need pre-connect behavior
+/// (e.g. a hypothetical purely-local `osc api-version`), a template-level
+/// `connection_requirements()` hook in the code generator would be the long-term
+/// fix; for now the mechanism is only wired where it is needed.
+pub trait ConnectionRequirementsProvider {
+    /// Return the connection requirements for this parsed command.
+    fn connection_requirements(&self) -> ConnectionRequirements {
+        ConnectionRequirements::connected()
+    }
+}

--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -14,7 +14,10 @@
 //! CLI top level command and processing
 use clap::Parser;
 
-use openstack_cli_core::cli::{CliArgs, CompletionCommand, GlobalOpts, parse_config, styles};
+use openstack_cli_core::cli::{
+    CliArgs, CompletionCommand, ConnectionRequirements, ConnectionRequirementsProvider, GlobalOpts,
+    parse_config, styles,
+};
 use openstack_cli_core::config::Config;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_sdk::AsyncOpenStack;
@@ -129,6 +132,15 @@ pub enum TopLevelCommands {
     ObjectStore(openstack_cli_object_store::ObjectStoreCommand),
     Placement(openstack_cli_placement::PlacementCommand),
     Completion(CompletionCommand),
+}
+
+impl ConnectionRequirementsProvider for TopLevelCommands {
+    fn connection_requirements(&self) -> ConnectionRequirements {
+        if let TopLevelCommands::Auth(args) = self {
+            return args.command.connection_requirements();
+        }
+        ConnectionRequirements::connected()
+    }
 }
 
 impl Cli {

--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -32,7 +32,7 @@ use tracing::warn;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{Layer, prelude::*};
 
-use openstack_cli_auth as auth;
+use openstack_cli_core::cli::ConnectionRequirementsProvider;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::{
     build_http_requests_timing_table,
@@ -136,42 +136,49 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         cloud_config.region_name = Some(region_name.clone());
     }
 
-    let mut renew_auth: bool = false;
+    // Certain commands (e.g. `auth login --renew`, `auth status`) need different
+    // pre-connect behavior than the default "connect with a live authenticated
+    // session". See `ConnectionRequirementsProvider`.
+    let connection_requirements = cli.command.connection_requirements();
+    let renew_auth = connection_requirements.renew;
 
-    // Login command need to be analyzed before authorization
-    if let TopLevelCommands::Auth(args) = &cli.command
-        && let auth::AuthCommands::Login(login_args) = &args.command
-        && login_args.renew
-    {
-        renew_auth = true;
-    }
-
-    // Connect to the selected cloud with the possible AuthHelper
-    let mut session = if let Some(external_auth_helper) =
-        &cli.global_opts.connection.auth_helper_cmd
-    {
-        AsyncOpenStack::new_with_authentication_helper(
-            &cloud_config,
-            ExternalCmd::new(external_auth_helper.clone()),
-            renew_auth,
-        )
-        .await
-    } else if std::io::stdin().is_terminal() {
-        AsyncOpenStack::new_with_authentication_helper(
-            &cloud_config,
-            Dialoguer::default(),
-            renew_auth,
-        )
-        .await
+    // Connect to the selected cloud with the possible AuthHelper. Commands that
+    // don't need a live/valid session (e.g. `auth status`) use a cache-only,
+    // network-free path so they keep working even with an expired token or an
+    // unreachable cloud.
+    let mut session = if !connection_requirements.needs_auth {
+        AsyncOpenStack::new_cache_only(&cloud_config)
+            .map_err(|err| OpenStackCliError::Auth { source: err })?
     } else {
-        AsyncOpenStack::new_with_authentication_helper(&cloud_config, Noop::default(), renew_auth)
+        if let Some(external_auth_helper) = &cli.global_opts.connection.auth_helper_cmd {
+            AsyncOpenStack::new_with_authentication_helper(
+                &cloud_config,
+                ExternalCmd::new(external_auth_helper.clone()),
+                renew_auth,
+            )
             .await
-    }
-    .map_err(|err| OpenStackCliError::Auth { source: err })?;
+        } else if std::io::stdin().is_terminal() {
+            AsyncOpenStack::new_with_authentication_helper(
+                &cloud_config,
+                Dialoguer::default(),
+                renew_auth,
+            )
+            .await
+        } else {
+            AsyncOpenStack::new_with_authentication_helper(
+                &cloud_config,
+                Noop::default(),
+                renew_auth,
+            )
+            .await
+        }
+        .map_err(|err| OpenStackCliError::Auth { source: err })?
+    };
 
     // Does the user want to connect to different project?
-    if cli.global_opts.connection.os_project_id.is_some()
-        || cli.global_opts.connection.os_project_name.is_some()
+    if connection_requirements.needs_auth
+        && (cli.global_opts.connection.os_project_id.is_some()
+            || cli.global_opts.connection.os_project_name.is_some())
     {
         warn!(
             "Cloud config is being chosen with arguments overriding project. Result may be not as expected."
@@ -183,14 +190,11 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         let project = Project {
             id: cli.global_opts.connection.os_project_id.clone(),
             name: cli.global_opts.connection.os_project_name.clone(),
-            domain: match (current_auth.project, current_auth.domain) {
-                // New project is in the same domain as the original
-                (Some(project), _) => project.domain,
-                // domain scope was used
-                (None, Some(domain)) => Some(domain),
-                // There was no scope thus using user domain
-                _ => current_auth.user.domain,
-            },
+            domain: infer_project_override_domain(
+                current_auth.project,
+                current_auth.domain,
+                current_auth.user.domain,
+            ),
         };
         let scope = AuthTokenScope::Project(project.clone());
         session
@@ -216,4 +220,64 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
     }
 
     res
+}
+
+/// Infer the domain to scope a CLI-provided `--os-project-id`/`--os-project-name`
+/// override to, based on the currently authenticated (unscoped/differently-scoped)
+/// token.
+///
+/// Fallback chain (first match wins):
+/// 1. Same domain as the currently scoped project, if any.
+/// 2. The domain of the current domain-scoped token, if any.
+/// 3. The authenticated user's own domain.
+fn infer_project_override_domain(
+    current_project: Option<openstack_sdk::types::identity::v3::Project>,
+    current_domain: Option<openstack_sdk::types::identity::v3::Domain>,
+    user_domain: Option<openstack_sdk::types::identity::v3::Domain>,
+) -> Option<openstack_sdk::types::identity::v3::Domain> {
+    match (current_project, current_domain) {
+        // New project is in the same domain as the original
+        (Some(project), _) => project.domain,
+        // domain scope was used
+        (None, Some(domain)) => Some(domain),
+        // There was no scope thus using user domain
+        _ => user_domain,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openstack_sdk::types::identity::v3::Domain;
+    use openstack_sdk::types::identity::v3::Project as AuthProject;
+
+    fn domain(id: &str) -> Domain {
+        Domain {
+            id: Some(id.to_string()),
+            name: None,
+        }
+    }
+
+    #[test]
+    fn test_infer_domain_from_current_project() {
+        let project = AuthProject {
+            id: Some("p1".into()),
+            name: None,
+            domain: Some(domain("from-project")),
+        };
+        let result = infer_project_override_domain(Some(project), Some(domain("from-token")), None);
+        assert_eq!(result.unwrap().id.as_deref(), Some("from-project"));
+    }
+
+    #[test]
+    fn test_infer_domain_from_domain_scope() {
+        let result = infer_project_override_domain(None, Some(domain("from-token")), None);
+        assert_eq!(result.unwrap().id.as_deref(), Some("from-token"));
+    }
+
+    #[test]
+    fn test_infer_domain_falls_back_to_user_domain() {
+        let result = infer_project_override_domain(None, None, Some(domain("user-domain")));
+        assert_eq!(result.unwrap().id.as_deref(), Some("user-domain"));
+    }
 }

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -77,6 +77,7 @@ futures.workspace = true
 futures-util.workspace = true
 http.workspace = true
 inventory.workspace = true
+url.workspace = true
 openstack-sdk-auth-applicationcredential = { version = "0.22", path = "../sdk/auth-application-credential/" }
 openstack-sdk-auth-core.workspace = true
 openstack-sdk-auth-federation = { version = "0.22", path = "../sdk/auth-federation/", optional = true }
@@ -118,7 +119,6 @@ reqwest = { workspace = true, features = ["rustls", "blocking"] }
 secrecy.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-test.workspace = true
-url.workspace = true
 
 [[test]]
 name = "functional"

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -460,6 +460,32 @@ impl AsyncOpenStack {
 
         Ok(session)
     }
+
+    /// Create a new OpenStack API session from `CloudConfig`, loading any
+    /// already-cached authorization but never performing network I/O to
+    /// discover endpoints or obtain a fresh token.
+    ///
+    /// Intended for commands that only need to *report* on locally known
+    /// auth state (e.g. `osc auth status`) and must keep working even when
+    /// the cloud is unreachable or the cached token has expired.
+    #[instrument(name = "connect_cache_only", level = "trace", skip(config))]
+    pub fn new_cache_only(config: &CloudConfig) -> OpenStackResult<Self> {
+        let session = Self::new_impl(config, Auth::None)?;
+
+        let requested_scope = AuthTokenScope::try_from(&session.config).ok();
+        let cached = {
+            let mut inner = session.session_write("new_cache_only: get cache auth");
+            match &requested_scope {
+                Some(scope) => inner.state.get_scope_auth(scope),
+                None => inner.state.get_any_valid_auth(),
+            }
+        };
+        if let Some(auth) = cached {
+            session.set_auth(Auth::AuthToken(Box::new(auth)), true)?;
+        }
+
+        Ok(session)
+    }
     #[instrument(name = "connect", level = "trace", skip(config))]
     #[deprecated(
         since = "0.22.0",
@@ -905,7 +931,7 @@ impl AsyncOpenStack {
                     .auth_info
                     .as_ref()
                     .map(AuthTokenScope::from)
-                    .is_some_and(|scope| requested_scope == scope)
+                    .is_some_and(|scope| requested_scope.matches(&scope))
             {
                 // And now time to rescope the token
                 let token_auth = self.reauth(token_auth, &requested_scope).await?;
@@ -985,6 +1011,57 @@ impl AsyncOpenStack {
             return Ok(());
         }
 
+        let region = {
+            let session = self.session_read("discover_service_endpoint: get region for cache");
+            session
+                .region_name
+                .as_deref()
+                .or(self.config.region_name.as_deref())
+                .map(|s| s.to_string())
+        };
+        let interface = self.config.interface.clone();
+
+        // Try the on-disk discovery cache first: version discovery results almost
+        // never change for a given cloud, so a fresh cache hit lets a one-shot CLI
+        // invocation skip the HTTP round-trip entirely.
+        let cached = {
+            let session = self.session_read("discover_service_endpoint: check cache");
+            session.state.get_discovery_cache(
+                &service_type.to_string(),
+                region.as_deref(),
+                interface.as_deref(),
+            )
+        };
+        if let Some((cached_url, cached_data)) = cached
+            && let Ok(url) = url::Url::parse(&cached_url)
+        {
+            let ok = {
+                let mut session =
+                    self.session_write("discover_service_endpoint: process cached catalog");
+                session
+                    .catalog
+                    .process_endpoint_discovery(
+                        service_type,
+                        &url,
+                        &Bytes::from(cached_data),
+                        region.as_deref(),
+                        interface.as_deref(),
+                    )
+                    .is_ok()
+            };
+            if ok {
+                debug!(
+                    "Restored `{}` endpoint version discovery from cache",
+                    service_type
+                );
+                return Ok(());
+            }
+            debug!(
+                "Discovery cache entry for `{}` was unusable; falling back to live discovery",
+                service_type
+            );
+        }
+
         info!("Performing `{}` endpoint version discovery", service_type);
 
         let orig_url = ep.url().clone();
@@ -1036,6 +1113,17 @@ impl AsyncOpenStack {
                         if ok {
                             debug!("Finished service version discovery at {}", try_url.as_str());
                             debug!("catalog {:?}", self.session.read().catalog.clone());
+                            {
+                                let session =
+                                    self.session_read("discover_service_endpoint: persist cache");
+                                session.state.set_discovery_cache(
+                                    &service_type.to_string(),
+                                    region.as_deref(),
+                                    interface.as_deref(),
+                                    try_url.as_str(),
+                                    rsp.body().to_vec(),
+                                );
+                            }
                             return Ok(());
                         }
                     }
@@ -1153,6 +1241,13 @@ impl AsyncOpenStack {
             return Some(token.get_state(offset));
         }
         None
+    }
+
+    /// Return the path to the on-disk auth cache file in use for the current
+    /// connection, if the on-disk cache is enabled.
+    pub fn get_auth_cache_file(&self) -> Option<std::path::PathBuf> {
+        let session = self.session.read();
+        session.state.cache_file_path()
     }
 
     /// Set the region name for endpoint resolution.

--- a/openstack_sdk/src/test.rs
+++ b/openstack_sdk/src/test.rs
@@ -290,6 +290,85 @@ mod tests {
         );
     }
 
+    /// Regression test for a bug where a scoped login (project requested by
+    /// `project_id` only) triggered a *second*, redundant `POST
+    /// /v3/auth/tokens` rescope call immediately after the first successful
+    /// auth, because the requested scope (partial: id set, name `None`) was
+    /// compared with `==` against the scope resolved from the full token
+    /// response (id + name + domain all set). Since project_id-only configs
+    /// never structurally equal the fully-populated resolved scope, this
+    /// forced a network reauth on every single connect, defeating the auth
+    /// cache. The fix uses `AuthTokenScope::matches()` (wildcard-aware)
+    /// instead of strict equality.
+    #[cfg(all(feature = "sync", feature = "async"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_scoped_login_does_not_trigger_redundant_reauth() {
+        let server = MockServer::start_async().await;
+        let base_url = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/");
+            then.status(StatusCode::OK).json_body(serde_json::json!({
+                "versions": [{
+                    "id": "v3", "status": "SUPPORTED",
+                    "links": [{ "rel": "self", "href": format!("{base_url}/v3/") }]
+                }]
+            }));
+        });
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/v3/");
+            then.status(StatusCode::OK).json_body(serde_json::json!({
+                "versions": [{
+                    "id": "v3", "status": "SUPPORTED",
+                    "links": [{ "rel": "self", "href": format!("{base_url}/v3/") }]
+                }]
+            }));
+        });
+
+        let expires = (chrono::Utc::now() + chrono::TimeDelta::hours(1)).to_rfc3339();
+        // Token response resolves to a *fully populated* scope (id + name +
+        // domain), while the request config below only sets `project_id`.
+        let token_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::POST).path("/v3/auth/tokens");
+            then.status(StatusCode::CREATED)
+                .header("x-subject-token", "test-token-scoped")
+                .json_body(serde_json::json!({
+                    "token": {
+                        "id": "token-id", "expires_at": expires,
+                        "project": {
+                            "id": "test-project", "name": "TestProject",
+                            "domain": { "id": "default", "name": "Default" }
+                        },
+                        "user": { "id": "test-user", "name": "test-user" },
+                        "methods": ["password"], "audit_ids": ["audit-1"],
+                        "catalog": [
+                            { "type": "identity", "name": "keystone", "endpoints": [{
+                                "id": "identity-1", "url": format!("{}/v3", base_url),
+                                "region": "RegionOne", "interface": "public"
+                            }] }
+                        ]
+                    }
+                }));
+        });
+
+        let config = helpers::create_test_cloud_config(&server);
+
+        let _client = AsyncOpenStack::new_with_authentication_helper(
+            &config,
+            crate::auth::auth_helper::Noop::default(),
+            false,
+        )
+        .await
+        .expect("AsyncOpenStack client creation failed");
+
+        assert_eq!(
+            token_mock.calls_async().await,
+            1,
+            "scoped login must obtain the token in a single request; a second \
+             hit means an unnecessary rescope reauth was triggered"
+        );
+    }
+
     /// Test 401 re-auth through the full  flow.
     ///
     /// Simulates a real-world scenario: token is valid at  time, but a subsequent

--- a/sdk/core/src/state.rs
+++ b/sdk/core/src/state.rs
@@ -68,6 +68,51 @@ const MAX_CACHE_FILE_AGE: std::time::Duration = std::time::Duration::from_secs(7
 /// (and logged as such) instead of both looking like "corrupted → removed".
 const CACHE_FORMAT_VERSION: u8 = 1;
 
+/// Discovered service endpoints almost never change for a given cloud, so a
+/// fairly long TTL is used here (unlike the short [`VALIDITY_MARGIN`] applied
+/// to auth tokens). Entries older than this are treated as a cache miss and
+/// re-discovered over HTTP.
+const MAX_DISCOVERY_CACHE_AGE: chrono::TimeDelta = chrono::TimeDelta::hours(24);
+
+/// On-disk format version for the discovery cache file. Kept separate from
+/// [`CACHE_FORMAT_VERSION`] since the two caches evolve independently.
+const DISCOVERY_CACHE_FORMAT_VERSION: u8 = 1;
+
+/// A single cached version-discovery result.
+///
+/// Rather than caching the parsed [`ServiceEndpoint`](crate::catalog::ServiceEndpoint)
+/// (which is not `Serialize`), the raw discovery document response body is cached
+/// together with the URL it was fetched from. On a cache hit the caller re-parses
+/// the document locally (no network I/O), reusing the exact same parsing path as a
+/// live discovery.
+#[derive(Clone, Deserialize, Serialize, Debug)]
+struct DiscoveryEntry {
+    /// URL the discovery document was fetched from.
+    url: String,
+    /// Raw discovery document response body.
+    data: Vec<u8>,
+    /// Unix timestamp (seconds) when this entry was written.
+    discovered_at: i64,
+}
+
+/// On-disk discovery cache: keyed by `"<service_type>|<region>|<interface>"`.
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+struct DiscoveryEntries(HashMap<String, DiscoveryEntry>);
+
+/// Build the cache key for a discovery cache entry.
+fn discovery_cache_key(
+    service_type: &str,
+    region: Option<&str>,
+    interface: Option<&str>,
+) -> String {
+    format!(
+        "{}|{}|{}",
+        service_type,
+        region.unwrap_or(""),
+        interface.unwrap_or("")
+    )
+}
+
 /// Relative priority of a scope when several cached tokens could serve as a
 /// generic "any valid auth" seed for re-scoping. Lower is preferred.
 fn scope_priority(scope: &AuthTokenScope) -> u8 {
@@ -250,6 +295,16 @@ impl State {
         None
     }
 
+    /// Returns the path to the on-disk auth cache file that would be used for the
+    /// current auth hash, if the on-disk cache is enabled.
+    pub fn cache_file_path(&self) -> Option<PathBuf> {
+        if self.auth_cache_enabled {
+            Some(self.get_auth_state_filename(&self.auth_hash))
+        } else {
+            None
+        }
+    }
+
     /// Removes all cached auth tokens from memory and disk.
     ///
     /// When the cache is enabled, both the data file and the companion lock file
@@ -262,6 +317,232 @@ impl State {
             let _ = std::fs::remove_file(self.get_auth_state_lock_filename(&self.auth_hash));
         }
         self.auth_state.0.clear();
+    }
+
+    /// Returns the discovery document body previously cached for
+    /// `(service_type, region, interface)`, along with the URL it was fetched from,
+    /// if a fresh (within [`MAX_DISCOVERY_CACHE_AGE`]) entry exists.
+    ///
+    /// Returns `None` when the cache is disabled, the file is missing/corrupt, or
+    /// the entry is stale.
+    pub fn get_discovery_cache(
+        &self,
+        service_type: &str,
+        region: Option<&str>,
+        interface: Option<&str>,
+    ) -> Option<(String, Vec<u8>)> {
+        if !self.auth_cache_enabled {
+            return None;
+        }
+        let entries = self.load_discovery_state()?;
+        let key = discovery_cache_key(service_type, region, interface);
+        let entry = entries.0.get(&key)?;
+        let now = chrono::Utc::now().timestamp();
+        if now - entry.discovered_at > MAX_DISCOVERY_CACHE_AGE.num_seconds() {
+            trace!("Discovery cache entry for `{}` is stale", key);
+            return None;
+        }
+        Some((entry.url.clone(), entry.data.clone()))
+    }
+
+    /// Persists a discovery document body for `(service_type, region, interface)`
+    /// to the on-disk discovery cache.
+    ///
+    /// Best-effort: locking/IO failures are logged and otherwise ignored.
+    pub fn set_discovery_cache(
+        &self,
+        service_type: &str,
+        region: Option<&str>,
+        interface: Option<&str>,
+        url: &str,
+        data: Vec<u8>,
+    ) {
+        if !self.auth_cache_enabled {
+            return;
+        }
+        let key = discovery_cache_key(service_type, region, interface);
+        let entry = DiscoveryEntry {
+            url: url.to_string(),
+            data,
+            discovered_at: chrono::Utc::now().timestamp(),
+        };
+        self.save_discovery_entry_to_file(&key, &entry);
+    }
+
+    /// Returns the path to the on-disk discovery cache file for the current auth hash.
+    fn get_discovery_state_filename(&self) -> PathBuf {
+        let mut fname_buf = self.base_dir.clone();
+        fname_buf.push(format!("{}.discovery", self.auth_hash));
+        fname_buf
+    }
+
+    /// Returns the path to the lock file guarding the discovery cache file.
+    fn get_discovery_state_lock_filename(&self) -> PathBuf {
+        let mut fname_buf = self.get_discovery_state_filename();
+        fname_buf.set_extension("discovery.lock");
+        fname_buf
+    }
+
+    /// Reads and deserializes the discovery cache file, if present and valid.
+    fn read_discovery_state_from_file(
+        &self,
+        file: &mut File,
+        path: &PathBuf,
+    ) -> Option<DiscoveryEntries> {
+        let mut contents = vec![];
+        match file.read_to_end(&mut contents) {
+            Ok(_) => {
+                let (&version, payload) = contents.split_first()?;
+                if version != DISCOVERY_CACHE_FORMAT_VERSION {
+                    info!(
+                        "Discovery cache file `{}` has format version {} (expected {}); removing.",
+                        path.display(),
+                        version,
+                        DISCOVERY_CACHE_FORMAT_VERSION
+                    );
+                    let _ = std::fs::remove_file(path);
+                    return None;
+                }
+                match postcard::from_bytes::<DiscoveryEntries>(payload) {
+                    Ok(entries) => Some(entries),
+                    Err(x) => {
+                        info!(
+                            "Corrupted discovery cache file `{}`: {:?}. Removing",
+                            path.display(),
+                            x
+                        );
+                        let _ = std::fs::remove_file(path);
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                info!(
+                    "Error reading discovery cache file `{}`: {:?}",
+                    path.display(),
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    /// Loads the discovery cache with a shared lock (mirrors [`State::load_auth_state`]).
+    fn load_discovery_state(&self) -> Option<DiscoveryEntries> {
+        let fname = self.get_discovery_state_filename();
+        let lock_fname = self.get_discovery_state_lock_filename();
+
+        match File::open(&fname) {
+            Ok(mut file) => {
+                if let Ok(lock_file) = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(false)
+                    .read(true)
+                    .open(&lock_fname)
+                    && let Err(e) = lock_file.lock_shared()
+                {
+                    warn!(
+                        "Failed to acquire shared lock on `{}`: {:?}",
+                        lock_fname.display(),
+                        e
+                    );
+                }
+                self.read_discovery_state_from_file(&mut file, &fname)
+            }
+            Err(e) => {
+                debug!(
+                    "Error opening discovery cache file `{}`: {:?}",
+                    fname.display(),
+                    e
+                );
+                None
+            }
+        }
+    }
+
+    /// Persists a single discovery entry to the on-disk cache (mirrors
+    /// [`State::save_scope_auth_to_file`]: exclusive lock, read-modify-write, atomic
+    /// replace via [`NamedTempFile::persist`], with a direct-write fallback).
+    fn save_discovery_entry_to_file(&self, key: &str, entry: &DiscoveryEntry) {
+        let fname = self.get_discovery_state_filename();
+        let lock_fname = self.get_discovery_state_lock_filename();
+
+        let lock_file = match OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_fname)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                warn!(
+                    "Failed to open discovery cache lock file `{}`: {:?}",
+                    lock_fname.display(),
+                    e
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = lock_file.lock() {
+            warn!(
+                "Failed to acquire exclusive lock on `{}`: {:?}",
+                lock_fname.display(),
+                e
+            );
+            return;
+        }
+
+        let opt_loaded = if let Ok(mut f) = File::open(&fname) {
+            if let Err(e) = f.lock_shared() {
+                warn!(
+                    "Failed to acquire shared lock on `{}`: {:?}",
+                    fname.display(),
+                    e
+                );
+            }
+            self.read_discovery_state_from_file(&mut f, &fname)
+        } else {
+            None
+        };
+
+        let mut state = opt_loaded.unwrap_or_default();
+        state.0.insert(key.to_string(), entry.clone());
+
+        if let Ok(mut temp_file) = NamedTempFile::new_in(&self.base_dir) {
+            if temp_file
+                .write_all(&[DISCOVERY_CACHE_FORMAT_VERSION])
+                .is_ok()
+                && postcard::to_io(&state, &mut temp_file).is_ok()
+                && self.set_file_permissions(temp_file.as_file())
+            {
+                if temp_file.persist(&fname).is_err() {
+                    warn!(
+                        "Error persisting discovery cache file to `{}`",
+                        fname.display()
+                    );
+                }
+                return;
+            }
+        } else {
+            warn!("Error creating temp file for discovery cache");
+        }
+
+        // Fallback: direct write
+        if let Ok(mut write_file) = File::create(&fname) {
+            if !self.set_file_permissions(&write_file) {
+                warn!("Cannot set permissions for the discovery cache file");
+                return;
+            }
+            if let Err(e) = write_file.write_all(&[DISCOVERY_CACHE_FORMAT_VERSION]) {
+                warn!("Error writing discovery cache format version: {:?}", e);
+            } else if let Err(e) = postcard::to_io(&state, &mut write_file) {
+                warn!("Error serializing discovery cache state: {:?}", e);
+            }
+        } else {
+            warn!("Error writing discovery cache file");
+        }
     }
 
     /// Locate authz for requested scope in the state
@@ -891,5 +1172,71 @@ mod tests {
         assert!(td.is_some());
         assert_eq!(tp.unwrap().token.expose_secret(), "tok-p-coexist");
         assert_eq!(td.unwrap().token.expose_secret(), "tok-d-coexist");
+    }
+
+    #[test]
+    fn test_discovery_cache_roundtrip() {
+        let dir = make_state_dir();
+        let s = new_state_in(&dir, 100);
+        assert!(
+            s.get_discovery_cache("compute", Some("RegionOne"), Some("public"))
+                .is_none()
+        );
+        s.set_discovery_cache(
+            "compute",
+            Some("RegionOne"),
+            Some("public"),
+            "http://example.com/v2.1/",
+            b"{\"version\": {}}".to_vec(),
+        );
+        let cached = s.get_discovery_cache("compute", Some("RegionOne"), Some("public"));
+        assert!(cached.is_some());
+        let (url, data) = cached.unwrap();
+        assert_eq!(url, "http://example.com/v2.1/");
+        assert_eq!(data, b"{\"version\": {}}".to_vec());
+
+        // A different key (region) must miss.
+        assert!(
+            s.get_discovery_cache("compute", Some("RegionTwo"), Some("public"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_discovery_cache_disabled_is_noop() {
+        let dir = make_state_dir();
+        let mut s = new_state_in(&dir, 101);
+        s.disable_auth_cache();
+        s.set_discovery_cache("compute", None, None, "http://example.com/", vec![1, 2, 3]);
+        assert!(s.get_discovery_cache("compute", None, None).is_none());
+        // No file should have been written.
+        assert!(!s.get_discovery_state_filename().exists());
+    }
+
+    #[test]
+    fn test_discovery_cache_stale_entry_ignored() {
+        let dir = make_state_dir();
+        let s = new_state_in(&dir, 102);
+        let key = discovery_cache_key("compute", None, None);
+        let entry = DiscoveryEntry {
+            url: "http://example.com/".into(),
+            data: vec![9, 9, 9],
+            discovered_at: chrono::Utc::now().timestamp()
+                - MAX_DISCOVERY_CACHE_AGE.num_seconds()
+                - 10,
+        };
+        s.save_discovery_entry_to_file(&key, &entry);
+        assert!(s.get_discovery_cache("compute", None, None).is_none());
+    }
+
+    #[test]
+    fn test_discovery_cache_persists_across_instances() {
+        let dir = make_state_dir();
+        let s1 = new_state_in(&dir, 103);
+        s1.set_discovery_cache("identity", None, None, "http://example.com/v3/", vec![7, 7]);
+        let s2 = new_state_in(&dir, 103);
+        let cached = s2.get_discovery_cache("identity", None, None);
+        assert!(cached.is_some());
+        assert_eq!(cached.unwrap().1, vec![7, 7]);
     }
 }


### PR DESCRIPTION
Add discovery cache, connection-requirements hook, and `osc auth status`

- Cache service version-discovery documents on disk
  (~/.osc/<hash>.discovery, 24h TTL) alongside the existing auth-token
  cache, cutting one HTTP round-trip per service on osc's one-shot
  invocations.
- Add ConnectionRequirementsProvider so commands can declare whether
  they need a live/renewed session, replacing a hand-rolled command-tree
  check in entry_point.
- Add `osc auth status`, reporting locally cached auth
  scope/state/expiry via a new network-free
  AsyncOpenStack::new_cache_only path so it works even with an expired
  token or unreachable cloud.
- Extract project-override domain inference into a tested helper
  function.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
