### PR TITLE
fix(tui): graceful error handling, stale-data cleanup, concurrent discovery

### DIFF
--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -425,6 +425,10 @@ impl App {
                         // Hide popup
                         self.active_popup = None;
                     }
+                    // Broadcast to all popups so they can clear stale data
+                    for popup in self.popups.values_mut() {
+                        let _ = popup.update(action.clone(), self.mode);
+                    }
                     self.render(tui)?;
                     self.cloud_worker_tx
                         .send(Action::CloudChangeScope(scope.clone()))?;
@@ -435,6 +439,10 @@ impl App {
                     {
                         // Hide popup
                         self.active_popup = None;
+                    }
+                    // Broadcast to all popups so they can clear stale data
+                    for popup in self.popups.values_mut() {
+                        let _ = popup.update(action.clone(), self.mode);
                     }
                     self.render(tui)?;
                     self.cloud_worker_tx
@@ -506,9 +514,14 @@ impl App {
                 Action::ConnectToCloud(ref cloud) => {
                     self.cloud_worker_tx
                         .send(Action::ConnectToCloud(cloud.clone()))?;
-                    // Hide popup
                     self.active_popup = None;
                     self.cloud_connected = false;
+                    // Broadcast to all popups so they can clear stale data
+                    for popup in self.popups.values_mut() {
+                        let _ = popup.update(action.clone(), self.mode);
+                    }
+                    // Let the active mode component know to refresh
+                    self.action_tx.send(Action::Refresh)?;
                     self.render(tui)?;
                 }
                 Action::Confirm(ref request) => {

--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -18,12 +18,11 @@
 
 use async_trait::async_trait;
 use chrono::TimeDelta;
-use eyre::{Report, Result, eyre};
+use eyre::{Result, eyre};
 use openstack_sdk::{
     AsyncOpenStack, RenewHandle,
     auth::auth_helper::{AuthHelper, AuthHelperError},
     config::ConfigFile,
-    types::identity::v3::AuthResponse,
 };
 use secrecy::SecretString;
 use std::path::PathBuf;
@@ -31,7 +30,19 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tracing::{debug, instrument, trace};
 
+use futures::future::try_join_all;
+
 use crate::action::Action;
+
+/// Services the TUI needs version-discovered endpoints for.
+const TUI_SERVICES: [openstack_sdk::types::ServiceType; 6] = [
+    openstack_sdk::types::ServiceType::Compute,
+    openstack_sdk::types::ServiceType::BlockStorage,
+    openstack_sdk::types::ServiceType::Dns,
+    openstack_sdk::types::ServiceType::Image,
+    openstack_sdk::types::ServiceType::LoadBalancer,
+    openstack_sdk::types::ServiceType::Network,
+];
 
 pub mod block_storage;
 mod common;
@@ -103,24 +114,7 @@ impl Cloud {
         )
         .await?;
 
-        session
-            .discover_service_endpoint(&openstack_sdk::types::ServiceType::Compute)
-            .await?;
-        session
-            .discover_service_endpoint(&openstack_sdk::types::ServiceType::BlockStorage)
-            .await?;
-        session
-            .discover_service_endpoint(&openstack_sdk::types::ServiceType::Dns)
-            .await?;
-        session
-            .discover_service_endpoint(&openstack_sdk::types::ServiceType::Image)
-            .await?;
-        session
-            .discover_service_endpoint(&openstack_sdk::types::ServiceType::LoadBalancer)
-            .await?;
-        session
-            .discover_service_endpoint(&openstack_sdk::types::ServiceType::Network)
-            .await?;
+        Self::discover_services(&session, &TUI_SERVICES).await?;
 
         // Replacing `self.cloud` also happens here; assigning a new
         // `_renew_handle` first drops (aborts) any renewal task for the
@@ -134,10 +128,60 @@ impl Cloud {
         Ok(())
     }
 
+    /// Concurrently discover version endpoints for the given services.
+    async fn discover_services(
+        session: &AsyncOpenStack,
+        services: &[openstack_sdk::types::ServiceType],
+    ) -> Result<()> {
+        try_join_all(services.iter().map(|st| {
+            let session = session.clone();
+            async move {
+                session.discover_service_endpoint(st).await?;
+                Ok::<_, openstack_sdk::OpenStackError>(())
+            }
+        }))
+        .await?;
+        Ok(())
+    }
+
+    /// Re-authorise and rediscovers service endpoints for the given session,
+    /// sending [`Action::Error`] on failure instead of propagating the error
+    /// out of the worker loop.
+    ///
+    /// Returns `true` when the whole sequence completed without errors,
+    /// `false` when an [`Action::Error`] was already emitted.
+    async fn prepare_session_for_work(
+        session: &mut AsyncOpenStack,
+        services: &[openstack_sdk::types::ServiceType],
+        app_tx: &UnboundedSender<Action>,
+        action: &Action,
+    ) -> bool {
+        // Re-authorise with current scope so a stale/expired session gets
+        // refreshed before we blow up on the first endpoint request.
+        if let Err(err) = session.authorize(None, false, true).await {
+            let _ = app_tx.send(Action::Error {
+                msg: format!("Re-authorisation failed: {err:?}"),
+                action: Some(Box::new(action.clone())),
+            });
+            return false;
+        }
+
+        if let Err(err) = Cloud::discover_services(session, services).await {
+            let _ = app_tx.send(Action::Error {
+                msg: format!("Service discovery failed: {err:?}"),
+                action: Some(Box::new(action.clone())),
+            });
+            return false;
+        }
+        true
+    }
+
     pub async fn switch_auth_scope(
         &mut self,
         scope: &openstack_sdk::auth::authtoken::AuthTokenScope,
-    ) -> Result<Option<AuthResponse>, Report> {
+        app_tx: &UnboundedSender<Action>,
+        action: &Action,
+    ) -> bool {
         // Deliberately doesn't touch `_renew_handle`: rescoping goes
         // through token-exchange, which preserves the original token's
         // expiry, so the background task's already-computed sleep target
@@ -148,26 +192,44 @@ impl Cloud {
         match self.cloud {
             Some(ref mut session) => {
                 debug!("Switching connection scope to {:?}", scope);
-                session.authorize(Some(scope.clone()), true, false).await?;
+                // Re-authorise with current scope so a stale/expired session gets
+                // refreshed before attempting the scope change.
+                if let Err(err) = session.authorize(None, false, true).await {
+                    let _ = app_tx.send(Action::Error {
+                        msg: format!("Re-authorisation failed: {err:?}"),
+                        action: Some(Box::new(action.clone())),
+                    });
+                    return false;
+                }
+                if let Err(err) = session.authorize(Some(scope.clone()), true, false).await {
+                    let _ = app_tx.send(Action::Error {
+                        msg: format!("Cannot switch session scope: {err:?}"),
+                        action: Some(Box::new(action.clone())),
+                    });
+                    return false;
+                }
                 debug!("Authed as {:?}", session.get_auth_info());
 
-                session
-                    .discover_service_endpoint(&openstack_sdk::types::ServiceType::Compute)
-                    .await?;
-                session
-                    .discover_service_endpoint(&openstack_sdk::types::ServiceType::BlockStorage)
-                    .await?;
-                session
-                    .discover_service_endpoint(&openstack_sdk::types::ServiceType::Image)
-                    .await?;
+                if let Err(err) = Cloud::discover_services(session, &TUI_SERVICES).await {
+                    let _ = app_tx.send(Action::Error {
+                        msg: format!("Service discovery failed: {err:?}"),
+                        action: Some(Box::new(action.clone())),
+                    });
+                    return false;
+                }
 
-                session
-                    .discover_service_endpoint(&openstack_sdk::types::ServiceType::Network)
-                    .await?;
-
-                Ok(session.get_auth_info())
+                if let Some(auth_info) = session.get_auth_info() {
+                    let _ = app_tx.send(Action::ConnectedToCloud(Box::new(auth_info.token)));
+                }
+                true
             }
-            _ => Err(eyre!("Cannot change scope without being connected first")),
+            _ => {
+                let _ = app_tx.send(Action::Error {
+                    msg: String::from("Cannot change scope without being connected first"),
+                    action: Some(Box::new(action.clone())),
+                });
+                false
+            }
         }
     }
 
@@ -188,6 +250,12 @@ impl Cloud {
                             {
                                 app_tx.send(Action::ConnectedToCloud(Box::new(auth_info.token)))?;
                             }
+                            // Re-issue region list now that a new cloud is connected
+                            if let Some(ref session) = self.cloud
+                                && let Some(regions) = session.get_available_regions()
+                            {
+                                app_tx.send(Action::Regions(regions))?;
+                            }
                         }
                         Err(err) => app_tx.send(Action::Error {
                             msg: format!("Failed to connect to the cloud: {err:?}"),
@@ -198,17 +266,15 @@ impl Cloud {
                 Action::ListClouds => {
                     app_tx.send(Action::Clouds(self.cloud_configs.get_available_clouds()))?;
                 }
-                Action::CloudChangeScope(ref scope) => match self.switch_auth_scope(scope).await {
-                    Ok(auth_response) => {
-                        if let Some(auth_info) = auth_response {
-                            app_tx.send(Action::ConnectedToCloud(Box::new(auth_info.token)))?;
-                        }
+                Action::CloudChangeScope(ref scope) => {
+                    let _ = self.switch_auth_scope(scope, &app_tx, &action).await;
+                    // Re-issue region list now that the scope has changed
+                    if let Some(ref session) = self.cloud
+                        && let Some(regions) = session.get_available_regions()
+                    {
+                        app_tx.send(Action::Regions(regions))?;
                     }
-                    Err(err) => app_tx.send(Action::Error {
-                        msg: format!("Cannot switch session scope: {err:?}"),
-                        action: Some(Box::new(action.clone())),
-                    })?,
-                },
+                }
                 Action::SwitchToRegion(ref region) => match self.cloud {
                     Some(ref mut session) => {
                         debug!("Switching region to {}", region);
@@ -217,30 +283,22 @@ impl Cloud {
                                 msg: format!("Cannot switch region: {err:?}"),
                                 action: Some(Box::new(action.clone())),
                             })?;
-                        } else {
-                            session
-                                .discover_service_endpoint(
-                                    &openstack_sdk::types::ServiceType::Compute,
-                                )
-                                .await?;
-                            session
-                                .discover_service_endpoint(
-                                    &openstack_sdk::types::ServiceType::BlockStorage,
-                                )
-                                .await?;
-                            session
-                                .discover_service_endpoint(
-                                    &openstack_sdk::types::ServiceType::Image,
-                                )
-                                .await?;
-                            session
-                                .discover_service_endpoint(
-                                    &openstack_sdk::types::ServiceType::Network,
-                                )
-                                .await?;
-                            if let Some(auth_info) = session.get_auth_info() {
-                                app_tx.send(Action::ConnectedToCloud(Box::new(auth_info.token)))?;
-                            }
+                        } else if Cloud::prepare_session_for_work(
+                            session,
+                            &TUI_SERVICES,
+                            &app_tx,
+                            &action,
+                        )
+                        .await
+                            && let Some(auth_info) = session.get_auth_info()
+                        {
+                            app_tx.send(Action::ConnectedToCloud(Box::new(auth_info.token)))?;
+                        }
+                        // Re-issue region list after region switch completes
+                        if let Some(ref session) = self.cloud
+                            && let Some(regions) = session.get_available_regions()
+                        {
+                            app_tx.send(Action::Regions(regions))?;
                         }
                     }
                     _ => app_tx.send(Action::Error {

--- a/openstack_tui/src/components/cloud_select_popup.rs
+++ b/openstack_tui/src/components/cloud_select_popup.rs
@@ -68,6 +68,15 @@ impl Component for CloudSelect {
             items.sort_by_key(|a| a.to_lowercase());
             self.popup_state.set_items(items);
             self.items_fetched = true;
+        } else if matches!(
+            action,
+            Action::ConnectToCloud(_)
+                | Action::CloudChangeScope(_)
+                | Action::SwitchToRegion(_)
+                | Action::ConnectedToCloud(_)
+        ) {
+            self.items_fetched = false;
+            self.popup_state.set_items(Vec::<String>::new());
         } else if action == Action::CloudSelect
             && !self.items_fetched
             && let Some(tx) = &self.action_tx

--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -99,15 +99,12 @@ where
             _ => {}
         }
 
-        // --- Cloud change scope: reset loading state ---
-        if let Action::CloudChangeScope(_) = &action {
+        // --- Connect / re-scope / region switch: clear stale data ---
+        if let Action::ConnectToCloud(_) | Action::CloudChangeScope(_) | Action::SwitchToRegion(_) =
+            &action
+        {
             self.base.set_loading(true);
-            return Ok(None);
-        }
-
-        // --- Region switch: reload data for the new region ---
-        if let Action::SwitchToRegion(_) = &action {
-            self.base.set_loading(true);
+            self.base.set_data(Vec::new())?;
             return Ok(None);
         }
 

--- a/openstack_tui/src/components/home.rs
+++ b/openstack_tui/src/components/home.rs
@@ -143,9 +143,17 @@ impl Component for Home {
 
     fn update(&mut self, action: Action, current_mode: Mode) -> Result<Option<Action>, TuiError> {
         match action {
-            Action::CloudChangeScope(_) => {
+            Action::ConnectToCloud(_) => {
                 self.is_error = false;
                 self.set_loading(true);
+                self.compute_quota = None;
+                self.network_quota = None;
+            }
+            Action::CloudChangeScope(_) | Action::SwitchToRegion(_) => {
+                self.is_error = false;
+                self.set_loading(true);
+                self.compute_quota = None;
+                self.network_quota = None;
             }
             Action::ConnectedToCloud(auth) => {
                 self.is_error = false;

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -90,16 +90,36 @@ impl Component for ProjectSelect {
             Action::ConnectToCloud(_) | Action::CloudChangeScope(_) => {
                 self.is_loading = true;
                 self.items_fetched = false;
+                self.items.clear();
+                self.popup_state.set_items(Vec::<String>::new());
             }
-            Action::ConnectedToCloud(_) | Action::SelectProject => {
-                if !self.items_fetched {
-                    self.is_loading = true;
+            Action::ConnectedToCloud(_) => {
+                // Mark items_fetched=true so the generic is_loading guard at
+                // the bottom doesn't re-issue. Issue the fetch directly so we
+                // refresh after cloud change.
+                self.items_fetched = true;
+                self.items.clear();
+                self.popup_state.set_items(Vec::<String>::new());
+                self.is_loading = true;
+                if let Some(tx) = &self.action_tx {
                     let req = IdentityAuthProjectListBuilder::default()
                         .build()
                         .wrap_err("cannot prepare auth project list request")?;
-                    return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                    tx.send(Action::PerformApiRequest(ApiRequest::from(
                         IdentityAuthProjectApiRequest::List(Box::new(req)),
-                    ))));
+                    )))?;
+                }
+                self.is_loading = false;
+            }
+
+            Action::SelectProject => {
+                // Only trigger a fetch when there's no data, nothing in-flight,
+                // and no refresh already initiated by ConnectedToCloud.
+                if !self.items_fetched && self.items.is_empty() && !self.is_loading {
+                    self.is_loading = true;
+                    self.items_fetched = false;
+                    self.items.clear();
+                    self.popup_state.set_items(Vec::<String>::new());
                 }
             }
             Action::ApiResponsesData {
@@ -108,6 +128,17 @@ impl Component for ProjectSelect {
             } => self.on_data(data.clone())?,
             _ => {}
         }
+
+        if self.is_loading && self.action_tx.is_some() && !self.items_fetched {
+            let req = IdentityAuthProjectListBuilder::default()
+                .build()
+                .wrap_err("cannot prepare auth project list request")?;
+            self.is_loading = false;
+            return Ok(Some(Action::PerformApiRequest(ApiRequest::from(
+                IdentityAuthProjectApiRequest::List(Box::new(req)),
+            ))));
+        }
+
         Ok(None)
     }
 

--- a/openstack_tui/src/components/region_select_popup.rs
+++ b/openstack_tui/src/components/region_select_popup.rs
@@ -72,7 +72,13 @@ impl Component for RegionSelect {
                 self.items_fetched = false;
                 self.is_loading = true;
             }
-            Action::ConnectedToCloud(_) | Action::SelectRegion => {
+            Action::ConnectedToCloud(_) => {
+                self.is_loading = true;
+                self.items_fetched = true;
+                self.regions.clear();
+                self.popup_state.set_items(Vec::<String>::new());
+            }
+            Action::SelectRegion => {
                 if !self.items_fetched {
                     self.is_loading = true;
                     if let Some(tx) = &self.action_tx {
@@ -87,6 +93,12 @@ impl Component for RegionSelect {
                 self.is_loading = false;
             }
             _ => {}
+        }
+        if self.is_loading && self.action_tx.is_some() {
+            if let Some(tx) = &self.action_tx {
+                tx.send(Action::ListRegions)?;
+            }
+            self.is_loading = false;
         }
         Ok(None)
     }


### PR DESCRIPTION
- Make SwitchToRegion, CloudChangeScope and ConnectToCloud emit
  Action::Error instead of panicking when auth or service discovery
  fails, keeping the worker loop alive.

- Broadcast ConnectToCloud, CloudChangeScope, and SwitchToRegion to
  all registered popups (not just the active one) so they can
  immediately clear stale data.

- Add stale-data clearing to project_select_popup, region_select_popup,
  home, and generic_resource_view on cloud/scope/region changes.

- Emit Action::Regions after ConnectToCloud and CloudChangeScope so
  the region popup stays in sync.

- Guard project_select_popup fetch logic with is_loading and
  items_fetched to prevent duplicate PerformApiRequest calls on every
  popup open while guaranteeing a fresh fetch after cloud switches.

- Discover service endpoints concurrently using try_join_all.
  Connect time now depends on the slowest service rather than the
  sum of all six. TUI_SERVICES constant drives all call sites.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
