### PR TITLE
fix(sdk): Fix microversion header negotiation

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -11,11 +11,12 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/functional.yml'
-      - 'auth-*/**'
-      - 'cli-*/**'
+      - 'cli/**'
       - 'openstack_cli/**'
       - 'openstack_sdk/**'
-      - 'sdk-*/**'
+      - 'openstack_types/**'
+      - 'sdk/**'
+      - 'types/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/sdk/core/src/api/error.rs
+++ b/sdk/core/src/api/error.rs
@@ -191,6 +191,27 @@ where
         #[from]
         source: http::uri::InvalidUri,
     },
+
+    /// The endpoint requires a microversion outside the range supported by the cloud.
+    #[error(
+        "requested microversion {required_major}.{required_minor} is not supported by the cloud (range: {range})",
+        range = match (&cloud_min, &cloud_max) {
+            (Some(mn), Some(mx)) => format!("{mn}..={mx}"),
+            (Some(mn), None) => format!("{mn}..*"),
+            (None, Some(mx)) => format!("*..={mx}"),
+            (None, None) => "*..*".to_string(),
+        }
+    )]
+    MicroversionIncompatible {
+        /// The required microversion major.
+        required_major: u8,
+        /// The required microversion minor.
+        required_minor: u8,
+        /// Cloud's reported minimum microversion, if known.
+        cloud_min: Option<String>,
+        /// Cloud's reported maximum microversion, if known.
+        cloud_max: Option<String>,
+    },
 }
 
 impl<E> ApiError<E>
@@ -307,6 +328,21 @@ where
     pub fn endpoint_builder<EX: Error + Send>(error: EX) -> Self {
         ApiError::EndpointBuilder {
             message: error.to_string(),
+        }
+    }
+
+    /// Create a MicroversionIncompatible error.
+    pub fn microversion_incompatible(
+        required_major: u8,
+        required_minor: u8,
+        cloud_min: Option<String>,
+        cloud_max: Option<String>,
+    ) -> Self {
+        ApiError::MicroversionIncompatible {
+            required_major,
+            required_minor,
+            cloud_min,
+            cloud_max,
         }
     }
 }

--- a/sdk/core/src/api/paged.rs
+++ b/sdk/core/src/api/paged.rs
@@ -27,7 +27,7 @@ use serde::de::DeserializeOwned;
 
 pub use self::pagination::{Pagination, PaginationError};
 
-use crate::api::rest_endpoint::set_latest_microversion;
+use crate::api::rest_endpoint::set_request_microversion_header;
 use crate::api::{ApiError, RestEndpoint, query};
 
 #[cfg(feature = "async")]
@@ -135,7 +135,7 @@ where
                 .method(self.endpoint.method())
                 .uri(query::url_to_http_uri(page_url.clone())?)
                 .header(header::ACCEPT, HeaderValue::from_static("application/json"));
-            set_latest_microversion(&mut req, &ep, &self.endpoint);
+            set_request_microversion_header::<C, E>(&mut req, &ep, &self.endpoint)?;
             // Set endpoint headers
             if let Some(request_headers) = self.endpoint.request_headers()
                 && let Some(headers) = req.headers_mut()

--- a/sdk/core/src/api/paged/iter.rs
+++ b/sdk/core/src/api/paged/iter.rs
@@ -26,7 +26,7 @@ use serde::de::DeserializeOwned;
 use url::Url;
 
 use crate::api::paged::{Pageable, Paged, Pagination, next_page};
-use crate::api::rest_endpoint::set_latest_microversion;
+use crate::api::rest_endpoint::set_request_microversion_header;
 use crate::api::{ApiError, RestClient, RestEndpoint, query};
 #[cfg(feature = "async")]
 use crate::api::{AsyncClient, QueryAsync};
@@ -369,7 +369,7 @@ where
             return Ok(Vec::new());
         };
         let (mut req, data) = self.build_request::<C>(url.clone())?;
-        set_latest_microversion(&mut req, &ep, &self.paged.endpoint);
+        set_request_microversion_header::<C, E>(&mut req, &ep, &self.paged.endpoint)?;
         let rsp = client.rest(req, data)?;
         self.process_response::<C, _>(rsp, url.clone())
     }
@@ -399,7 +399,7 @@ where
             return Ok(Vec::new());
         };
         let (mut req, data) = self.build_request::<C>(url.clone())?;
-        set_latest_microversion(&mut req, &ep, &self.paged.endpoint);
+        set_request_microversion_header::<C, E>(&mut req, &ep, &self.paged.endpoint)?;
         let rsp = client.rest_async(req, data).await?;
         self.process_response::<C, _>(rsp, url.clone())
     }

--- a/sdk/core/src/api/rest_endpoint.rs
+++ b/sdk/core/src/api/rest_endpoint.rs
@@ -91,38 +91,147 @@ pub trait RestEndpoint {
     fn api_version(&self) -> Option<ApiVersion> {
         ApiVersion::from_endpoint_url(self.endpoint())
     }
+
+    /// Returns the minimum microversion this endpoint variant requires for
+    /// the `OpenStack-API-Version` header.
+    ///
+    /// - `None` is interpreted as default version
+    /// - `ApiVersion {0, 0}` is interpreted as explicitly unversioned API
+    ///
+    /// Defaults to [`RestEndpoint::api_version`] for backwards compatibility.
+    fn min_version(&self) -> Option<ApiVersion> {
+        self.api_version()
+    }
+
+    /// Returns the maximum microversion this endpoint variant supports, if
+    /// bounded.
+    ///
+    /// Generated code emits a separate struct per microversion break (e.g.
+    /// `create_20`, `create_276`, ...); each variant's `min_version()` is the
+    /// version it was introduced at. `max_version()` is the version of the
+    /// *next* variant minus one, when known. `None` means this variant is
+    /// valid for every version the cloud supports at or above
+    /// `min_version()`.
+    fn max_version(&self) -> Option<ApiVersion> {
+        None
+    }
 }
 
-/// Set latest microversion information into the request
-/// for services that support that.
-pub fn set_latest_microversion<E>(
+/// Compute the microversion to send for this endpoint against a cloud's
+/// discovered range, without touching any request.
+///
+/// - `endpoint.min_version()` is a floor, not a hard requirement: codegen's
+///   `min-ver` just marks when a struct variant was introduced, so a cloud
+///   whose discovered `min_version` is higher doesn't make the variant
+///   unsupported — the sent version is bumped up to the cloud's floor
+///   instead (`max(endpoint.min_version(), cloud.min_version())`).
+/// - `endpoint.max_version()`, when set, is a genuine ceiling: the variant
+///   stops applying once the cloud's floor moves past it.
+///
+/// Returns `Ok(None)` for unversioned endpoints (nothing to negotiate).
+/// Returns `Err` when no version can satisfy both the endpoint's and the
+/// cloud's constraints.
+///
+/// Exposed as `pub` so callers that already hold `client` + the endpoint
+/// (e.g. to pick a version-appropriate response schema) can learn the
+/// negotiated version via `client.get_service_endpoint(...)` without
+/// duplicating this bounds-check logic.
+pub fn negotiate_microversion<C, E>(
+    service_endpoint: &ServiceEndpoint,
+    endpoint: &E,
+) -> Result<Option<ApiVersion>, ApiError<C::Error>>
+where
+    C: RestClient,
+    E: RestEndpoint,
+{
+    let ep_min = match endpoint.min_version() {
+        Some(v) if v.major != 0 => v,
+        _ => return Ok(None),
+    };
+    let ep_max = endpoint.max_version();
+
+    let cloud_min: Option<ApiVersion> = service_endpoint
+        .min_version()
+        .as_deref()
+        .and_then(|s| ApiVersion::from_apiver_str(s, false).ok());
+    let cloud_max: Option<ApiVersion> = service_endpoint
+        .max_version()
+        .as_deref()
+        .and_then(|s| ApiVersion::from_apiver_str(s, false).ok());
+
+    let incompatible = |required: ApiVersion| {
+        ApiError::microversion_incompatible(
+            required.major,
+            required.minor,
+            service_endpoint.min_version().clone(),
+            service_endpoint.max_version().clone(),
+        )
+    };
+
+    // The endpoint's floor is newer than anything this cloud will ever
+    // support.
+    if let Some(cmax) = cloud_max
+        && ep_min > cmax
+    {
+        return Err(incompatible(ep_min));
+    }
+
+    // The variant's ceiling is older than what this cloud's floor requires
+    // — it's been superseded by a newer variant on this cloud.
+    if let Some(emax) = ep_max
+        && let Some(cmin) = cloud_min
+        && emax < cmin
+    {
+        return Err(incompatible(emax));
+    }
+
+    // Send the highest version both sides agree is valid: raise the
+    // endpoint's floor to the cloud's floor when the cloud requires newer.
+    let req_ver = match cloud_min {
+        Some(cmin) if cmin > ep_min => cmin,
+        _ => ep_min,
+    };
+
+    Ok(Some(req_ver))
+}
+
+/// Validate the endpoint's microversion against the cloud's discovered
+/// range and set the `OpenStack-API-Version` header.
+///
+/// See [`negotiate_microversion`] for how the sent version is picked.
+/// Returns `Ok(())` when the header was set (or skipped for unversioned
+/// endpoints, or an unrecognized service type). Returns `Err` when no
+/// version can satisfy both the endpoint's and the cloud's constraints.
+pub fn set_request_microversion_header<C, E>(
     request: &mut Builder,
     service_endpoint: &ServiceEndpoint,
     endpoint: &E,
-) where
+) -> Result<(), ApiError<C::Error>>
+where
+    C: RestClient,
     E: RestEndpoint,
 {
-    let mh_service_type = match endpoint.service_type() {
+    let Some(req_ver) = negotiate_microversion::<C, E>(service_endpoint, endpoint)? else {
+        return Ok(());
+    };
+
+    let Some(st) = (match endpoint.service_type() {
         ServiceType::BlockStorage => Some("volume"),
         ServiceType::Compute => Some("compute"),
         ServiceType::ContainerInfrastructureManagement => Some("container-infra"),
         ServiceType::Placement => Some("placement"),
         _ => None,
+    }) else {
+        return Ok(());
     };
-    if let Some(st) = mh_service_type {
-        // TODO(gtema) switch to `get_api_version` method since version may be missing
-        if let Some(hdrs) = request.headers_mut() {
-            let ver = service_endpoint.version();
-            if ver.major == 0 {
-                return;
-            }
-            if let Ok(val) =
-                HeaderValue::from_str(format!("{} {}.{}", st, ver.major, ver.minor).as_str())
-            {
-                hdrs.insert("Openstack-API-Version", val);
-            }
+
+    if let Some(hdrs) = request.headers_mut()
+        && let Ok(val) =
+            HeaderValue::from_str(format!("{} {}", st, req_ver).as_str())
+        {
+            hdrs.insert("OpenStack-API-Version", val);
         }
-    }
+    Ok(())
 }
 
 pub fn prepare_request<C, E>(
@@ -139,7 +248,7 @@ where
         .method(endpoint.method())
         .uri(query::url_to_http_uri(url)?)
         .header(header::ACCEPT, HeaderValue::from_static("application/json"));
-    set_latest_microversion(&mut req, service_endpoint, endpoint);
+    set_request_microversion_header::<C, E>(&mut req, service_endpoint, endpoint)?;
     if let Some(request_headers) = endpoint.request_headers()
         && let Some(headers) = req.headers_mut()
     {
@@ -362,7 +471,7 @@ where
         let mut req = Request::builder()
             .method(self.method())
             .uri(query::url_to_http_uri(url)?);
-        set_latest_microversion(&mut req, &ep, self);
+        set_request_microversion_header::<C, E>(&mut req, &ep, self)?;
         if let Some(request_headers) = self.request_headers()
             && let Some(headers) = req.headers_mut()
         {
@@ -664,5 +773,476 @@ mod tests {
         assert!(res.contains(&DummyResult { value: 0 }), "{:?}", res);
         assert!(res.contains(&DummyResult { value: 1 }), "{:?}", res);
         mock.assert();
+    }
+
+    mod microversion {
+        use super::*;
+        use crate::api::rest_endpoint::{negotiate_microversion, set_request_microversion_header};
+        use crate::catalog::ServiceEndpoint;
+        use crate::test::client::FakeOpenStackClient;
+        use url::Url;
+
+        struct VersionedEndpoint {
+            version: Option<ApiVersion>,
+            max_version: Option<ApiVersion>,
+            service_type: ServiceType,
+        }
+
+        impl RestEndpoint for VersionedEndpoint {
+            fn method(&self) -> http::Method {
+                http::Method::GET
+            }
+            fn endpoint(&self) -> Cow<'static, str> {
+                "test".into()
+            }
+            fn service_type(&self) -> ServiceType {
+                self.service_type.clone()
+            }
+            fn api_version(&self) -> Option<ApiVersion> {
+                self.version
+            }
+            fn max_version(&self) -> Option<ApiVersion> {
+                self.max_version
+            }
+        }
+
+        fn make_service_endpoint(
+            min: Option<&str>,
+            max: Option<&str>,
+        ) -> ServiceEndpoint {
+            let mut sep =
+                ServiceEndpoint::new(Url::parse("http://test.com/v2.1/").unwrap(), ApiVersion::new(2, 1));
+            if let Some(m) = min {
+                sep.set_min_version(Some(m));
+            }
+            if let Some(mx) = max {
+                sep.set_max_version(Some(mx));
+            }
+            sep.to_owned()
+        }
+
+        fn make_ep(ver: Option<ApiVersion>, st: ServiceType) -> VersionedEndpoint {
+            VersionedEndpoint {
+                version: ver,
+                max_version: None,
+                service_type: st,
+            }
+        }
+
+        fn make_ep_bounded(
+            ver: Option<ApiVersion>,
+            max_ver: Option<ApiVersion>,
+            st: ServiceType,
+        ) -> VersionedEndpoint {
+            VersionedEndpoint {
+                version: ver,
+                max_version: max_ver,
+                service_type: st,
+            }
+        }
+
+        fn header(req: &http::request::Builder) -> Option<String> {
+            req.headers_ref()
+                .and_then(|h| h.get("OpenStack-API-Version"))
+                .map(|v| v.to_str().unwrap().to_string())
+        }
+
+        // ── core happy path ──────────────────────────────────────────
+
+        #[test]
+        fn within_range_sets_header() {
+            let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.50".into()));
+        }
+
+        // ── service type → header prefix mapping ─────────────────────
+
+        #[test]
+        fn block_storage_uses_volume_prefix() {
+            let ep = make_ep(Some(ApiVersion::new(3, 50)), ServiceType::BlockStorage);
+            let sep = make_service_endpoint(Some("3.0"), Some("3.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("volume 3.50".into()));
+        }
+
+        #[test]
+        fn container_infra_uses_short_prefix() {
+            let ep = make_ep(
+                Some(ApiVersion::new(1, 15)),
+                ServiceType::ContainerInfrastructureManagement,
+            );
+            let sep = make_service_endpoint(Some("1.0"), Some("1.20"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("container-infra 1.15".into()));
+        }
+
+        #[test]
+        fn placement_uses_placement_prefix() {
+            let ep = make_ep(Some(ApiVersion::new(1, 10)), ServiceType::Placement);
+            let sep = make_service_endpoint(Some("1.0"), Some("1.20"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(
+                header(&req),
+                Some("placement 1.10".into())
+            );
+        }
+
+        #[test]
+        fn unsupported_service_type_skips_header() {
+            let ep = make_ep(Some(ApiVersion::new(2, 30)), ServiceType::Network);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert!(header(&req).is_none());
+        }
+
+        #[test]
+        fn other_service_type_skips_header() {
+            let ep =
+                make_ep(Some(ApiVersion::new(2, 30)), ServiceType::Other("custom-service".into()));
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert!(header(&req).is_none());
+        }
+
+        // ── bounds validation ────────────────────────────────────────
+
+        #[test]
+        fn below_min_is_clamped_up() {
+            // endpoint.min_version() below cloud_min is fine: `min-ver` on a
+            // generated variant means "introduced at this version", not a
+            // hard floor the cloud must match. Compute's legacy 2.0 variants
+            // must work against clouds whose discovered min_version is
+            // 2.1+ — the sent version is bumped up to the cloud's floor.
+            let ep = make_ep(Some(ApiVersion::new(2, 5)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.10"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.10".into()));
+        }
+
+        #[test]
+        fn above_max_fails() {
+            let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            let err =
+                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
+                    .unwrap_err();
+            assert!(matches!(
+                err,
+                ApiError::MicroversionIncompatible { .. }
+            ));
+        }
+
+        #[test]
+        fn exact_bound_min_ok() {
+            let ep = make_ep(Some(ApiVersion::new(2, 10)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.10"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.10".into()));
+        }
+
+        #[test]
+        fn exact_bound_max_ok() {
+            let ep = make_ep(Some(ApiVersion::new(2, 60)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.60".into()));
+        }
+
+        // ── single-bound (one side missing) ──────────────────────────
+
+        #[test]
+        fn only_min_set_clamps_up() {
+            let ep = make_ep(Some(ApiVersion::new(2, 5)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.10"), None);
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.10".into()));
+        }
+
+        #[test]
+        fn only_min_set_passes_when_above() {
+            let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.10"), None);
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.99".into()));
+        }
+
+        #[test]
+        fn only_max_set_validates_max_only() {
+            let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
+            let sep = make_service_endpoint(None, Some("2.60"));
+            let mut req = http::Request::builder();
+            let err =
+                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
+                    .unwrap_err();
+            assert!(matches!(
+                err,
+                ApiError::MicroversionIncompatible { .. }
+            ));
+        }
+
+        #[test]
+        fn only_max_set_passes_when_below() {
+            let ep = make_ep(Some(ApiVersion::new(2, 5)), ServiceType::Compute);
+            let sep = make_service_endpoint(None, Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.5".into()));
+        }
+
+        #[test]
+        fn no_cloud_range_skips_validation() {
+            let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
+            let sep = make_service_endpoint(None, None);
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.99".into()));
+        }
+
+        // ── major version mismatch ───────────────────────────────────
+
+        #[test]
+        fn major_version_below_cloud_min_is_clamped_up() {
+            let ep = make_ep(Some(ApiVersion::new(1, 99)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.1".into()));
+        }
+
+        #[test]
+        fn major_version_above_cloud_max_fails() {
+            let ep = make_ep(Some(ApiVersion::new(3, 0)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            let err =
+                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
+                    .unwrap_err();
+            assert!(matches!(
+                err,
+                ApiError::MicroversionIncompatible { .. }
+            ));
+        }
+
+        // ── unversioned / zero-version endpoints ─────────────────────
+
+        #[test]
+        fn unversioned_skips_header() {
+            let ep = make_ep(None, ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert!(header(&req).is_none());
+        }
+
+        #[test]
+        fn major_zero_skips_header() {
+            let ep = make_ep(Some(ApiVersion::new(0, 0)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert!(header(&req).is_none());
+        }
+
+        #[test]
+        fn minor_zero_valid() {
+            let ep = make_ep(Some(ApiVersion::new(2, 0)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("1.0"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.0".into()));
+        }
+
+        // ── cloud range version string formats ───────────────────────
+
+        #[test]
+        fn cloud_min_major_only_parsing() {
+            let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2"), Some("3"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.50".into()));
+        }
+
+        #[test]
+        fn malformed_cloud_range_parses_gracefully() {
+            let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("abc"), Some("def"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.50".into()));
+        }
+
+        #[test]
+        fn malformed_cloud_min_silently_ignored() {
+            let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("bad"), Some("2.99"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.50".into()));
+        }
+
+        // ── error variant contents ───────────────────────────────────
+
+        #[test]
+        fn error_contains_required_version_and_cloud_range() {
+            let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            let err =
+                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
+                    .unwrap_err();
+            match err {
+                ApiError::MicroversionIncompatible {
+                    required_major,
+                    required_minor,
+                    cloud_min,
+                    cloud_max,
+                } => {
+                    assert_eq!(required_major, 2);
+                    assert_eq!(required_minor, 99);
+                    assert_eq!(cloud_min, Some("2.1".into()));
+                    assert_eq!(cloud_max, Some("2.60".into()));
+                }
+                other => panic!("expected MicroversionIncompatible, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn error_display_shows_readable_range() {
+            let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            let err =
+                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
+                    .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("2.99"),
+                "error message should contain required version, got: {msg}"
+            );
+            assert!(
+                msg.contains("2.1..=2.60"),
+                "error message should contain cloud range, got: {msg}"
+            );
+        }
+
+        // ── endpoint max_version (bounded variant) ────────────────────
+
+        #[test]
+        fn bounded_variant_within_cloud_range_uses_cloud_min() {
+            // Endpoint valid for [2.0, 2.75]; cloud floor is 2.30 — send 2.30.
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 75)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(Some("2.30"), Some("2.90"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.30".into()));
+        }
+
+        #[test]
+        fn bounded_variant_obsoleted_by_cloud_floor_fails() {
+            // Endpoint only valid up to 2.75; cloud's floor already moved past
+            // it to 2.80 — a newer variant should have been picked instead.
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 75)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(Some("2.80"), Some("2.90"));
+            let mut req = http::Request::builder();
+            let err =
+                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
+                    .unwrap_err();
+            assert!(matches!(err, ApiError::MicroversionIncompatible { .. }));
+        }
+
+        #[test]
+        fn bounded_variant_exact_ceiling_equals_cloud_floor_ok() {
+            // Boundary: endpoint max == cloud min is still compatible.
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 75)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(Some("2.75"), Some("2.90"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.75".into()));
+        }
+
+        #[test]
+        fn bounded_variant_without_cloud_min_skips_ceiling_check() {
+            // No cloud_min reported at all — nothing to compare max_version
+            // against, so it's not validated (only cloud_max still applies).
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 75)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(None, Some("2.90"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.0".into()));
+        }
+
+        #[test]
+        fn unbounded_variant_ignores_ceiling_check() {
+            // max_version() unset (default None) — no ceiling to violate,
+            // regardless of how high the cloud's floor is.
+            let ep = make_ep(Some(ApiVersion::new(2, 0)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.95"), Some("2.99"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            assert_eq!(header(&req), Some("compute 2.95".into()));
+        }
+
+        // ── negotiate_microversion (standalone, no request/header) ────
+
+        #[test]
+        fn negotiate_clamps_up_to_cloud_min() {
+            let ep = make_ep(Some(ApiVersion::new(2, 5)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.10"), Some("2.60"));
+            let negotiated =
+                negotiate_microversion::<FakeOpenStackClient, _>(&sep, &ep).unwrap();
+            assert_eq!(negotiated, Some(ApiVersion::new(2, 10)));
+        }
+
+        #[test]
+        fn negotiate_bounded_variant_obsoleted_by_cloud_floor_fails() {
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 75)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(Some("2.80"), Some("2.90"));
+            let err = negotiate_microversion::<FakeOpenStackClient, _>(&sep, &ep).unwrap_err();
+            assert!(matches!(err, ApiError::MicroversionIncompatible { .. }));
+        }
+
+        #[test]
+        fn negotiate_unversioned_returns_none() {
+            let ep = make_ep(None, ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let negotiated =
+                negotiate_microversion::<FakeOpenStackClient, _>(&sep, &ep).unwrap();
+            assert_eq!(negotiated, None);
+        }
     }
 }

--- a/sdk/core/src/catalog.rs
+++ b/sdk/core/src/catalog.rs
@@ -225,7 +225,7 @@ impl Catalog {
             if let Some(ver) = api_version {
                 // Specific version requested, version discovery info available, but version is not
                 // present - error
-                return Err(CatalogError::VersionUnsupported { ver: ver.clone() });
+                return Err(CatalogError::VersionUnsupported { ver: *ver });
             }
         }
 

--- a/sdk/core/src/types/api_version.rs
+++ b/sdk/core/src/types/api_version.rs
@@ -70,7 +70,7 @@ impl From<&'static RegexError> for ApiVersionError {
 ///
 /// ApiVersion of the Endpoint as described in
 /// <https://specs.openstack.org/openstack/api-sig/guidelines/consuming-catalog/version-discovery.html>. It is a subset of a SemVer and only includes `major` and `minor` parts.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ApiVersion {
     /// Major version.
     pub major: u8,


### PR DESCRIPTION
Rename set_latest_microversion to set_request_microversion_header and
rewrite to use endpoint.api_version() as the microversion value sent in
the OpenStack-API-Version header. Previously the function used
service_endpoint.version() (URL-parsed, always 2.1 for compute),
ignoring the actual microversion the generated struct requires.

Add bounds validation: if the endpoint's required microversion falls
outside the cloud's discovered min/max range, return a new
ApiError::MicroversionIncompatible error instead of sending a doomed
request.  The error carries required version and cloud range for a
clear user-facing message.

Add Copy, Eq, PartialOrd, Ord derives to ApiVersion to enable direct
comparison.  Reuse ApiVersion::from_apiver_str for parsing cloud
min/max version strings instead of a custom parser.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
