### PR TITLE
refactor: Replace RawQueryAsync trait with combinators

### DIFF
--- a/cli/image/src/v2/image/file/download.rs
+++ b/cli/image/src/v2/image/file/download.rs
@@ -29,7 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_cli_core::common::download_file;
 use openstack_sdk::api::QueryAsync;
-use openstack_sdk::api::RawQueryAsync;
+use openstack_sdk::api::download;
 use openstack_sdk::api::find;
 use openstack_sdk::api::image::v2::image::file::download;
 use openstack_sdk::api::image::v2::image::find;
@@ -128,7 +128,7 @@ impl FileCommand {
             .image_id(image_id)
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let (headers, data) = ep.download_async(client).await?;
+        let (headers, data) = download(ep).query_async(client).await?;
 
         let size: u64 = headers
             .get("content-length")

--- a/cli/image/src/v2/image/file/upload.rs
+++ b/cli/image/src/v2/image/file/upload.rs
@@ -28,8 +28,9 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use openstack_cli_core::common::build_upload_asyncread;
-use openstack_sdk::api::RawQueryAsync;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::image::file::upload;
+use openstack_sdk::api::raw_with_body;
 
 /// Uploads binary image data. *(Since Image API v2.0)*
 ///
@@ -159,7 +160,7 @@ impl FileCommand {
         let dst = self.file.clone();
         let data = build_upload_asyncread(dst).await?;
 
-        let _rsp = ep.raw_query_read_body_async(client, data).await?;
+        let _rsp = raw_with_body(ep, data).query_async(client).await?;
         // TODO: what if there is an interesting response
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/object-store/src/v1/account/set.rs
+++ b/cli/object-store/src/v1/account/set.rs
@@ -45,7 +45,7 @@ use openstack_sdk::api::object_store::v1::account::head::Request as GetRequest;
 use openstack_sdk::api::object_store::v1::account::set::Request;
 use openstack_sdk::{
     AsyncOpenStack,
-    api::{AsyncClient, RawQueryAsync},
+    api::{AsyncClient, QueryAsync, raw},
     types::{ApiVersion, ServiceType},
 };
 use structable::{StructTable, StructTableOptions};
@@ -124,7 +124,7 @@ impl AccountCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let _rsp: Response<Bytes> = raw(ep).query_async(client).await?;
 
         // Refetch the container with the actual data
         let mut ep_builder = GetRequest::builder();
@@ -136,7 +136,7 @@ impl AccountCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let rsp: Response<Bytes> = raw(ep).query_async(client).await?;
         let mut metadata: HashMap<String, String> = HashMap::new();
         let headers = rsp.headers();
 

--- a/cli/object-store/src/v1/account/show.rs
+++ b/cli/object-store/src/v1/account/show.rs
@@ -34,7 +34,7 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::api::object_store::v1::account::head::Request;
 use openstack_sdk::{
     AsyncOpenStack,
-    api::{AsyncClient, RawQueryAsync},
+    api::{AsyncClient, QueryAsync, raw},
     types::{ApiVersion, ServiceType},
 };
 
@@ -80,7 +80,7 @@ impl AccountCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let rsp: Response<Bytes> = raw(ep).query_async(client).await?;
         let mut metadata: HashMap<String, String> = HashMap::new();
         let headers = rsp.headers();
 

--- a/cli/object-store/src/v1/container/create.rs
+++ b/cli/object-store/src/v1/container/create.rs
@@ -16,13 +16,10 @@
 //! You do not need to check whether a container already exists before issuing
 //! a PUT operation because the operation is idempotent: It creates a container
 //! or updates an existing container, as appropriate.
-use std::collections::HashMap;
-
-use bytes::Bytes;
 use clap::Args;
 use eyre::{WrapErr, eyre};
-use http::Response;
 use regex::Regex;
+use std::collections::HashMap;
 use tracing::info;
 
 use openstack_cli_core::cli::CliArgs;
@@ -33,7 +30,7 @@ use openstack_sdk::api::object_store::v1::container::create::Request;
 use openstack_sdk::api::object_store::v1::container::head::Request as GetRequest;
 use openstack_sdk::{
     AsyncOpenStack,
-    api::{AsyncClient, RawQueryAsync},
+    api::{self, AsyncClient, QueryAsync},
     types::{ApiVersion, ServiceType},
 };
 
@@ -88,7 +85,7 @@ impl ContainerCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let _rsp = api::raw(ep).query_async(client).await?;
 
         let mut ep_builder = GetRequest::builder();
         if let Some(account) = account {
@@ -100,7 +97,7 @@ impl ContainerCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let rsp = api::raw(ep).query_async(client).await?;
 
         let mut metadata: HashMap<String, String> = HashMap::new();
         let headers = rsp.headers();

--- a/cli/object-store/src/v1/container/delete.rs
+++ b/cli/object-store/src/v1/container/delete.rs
@@ -26,9 +26,9 @@ use openstack_cli_core::cli::CliArgs;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::api::object_store::v1::container::delete::Request;
+use openstack_sdk::api::{AsyncClient, QueryAsync, raw};
 use openstack_sdk::{
     AsyncOpenStack,
-    api::{AsyncClient, RawQueryAsync},
     types::{ApiVersion, ServiceType},
 };
 use structable::{StructTable, StructTableOptions};
@@ -87,7 +87,7 @@ impl ContainerCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let _rsp: Response<Bytes> = raw(ep).query_async(client).await?;
         op.show_command_hint()?;
         Ok(())
     }

--- a/cli/object-store/src/v1/container/set.rs
+++ b/cli/object-store/src/v1/container/set.rs
@@ -13,10 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Creates, updates, or deletes custom metadata for a container.
-use bytes::Bytes;
 use clap::Args;
 use eyre::{WrapErr, eyre};
-use http::Response;
 use http::{HeaderName, HeaderValue};
 use regex::Regex;
 use std::collections::HashMap;
@@ -29,7 +27,7 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::api::object_store::v1::container::head::Request as GetRequest;
 use openstack_sdk::api::object_store::v1::container::set::Request;
-use openstack_sdk::api::{AsyncClient, RawQueryAsync};
+use openstack_sdk::api::{AsyncClient, QueryAsync, raw};
 use openstack_sdk::{
     AsyncOpenStack,
     types::{ApiVersion, ServiceType},
@@ -104,7 +102,7 @@ impl ContainerCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let _rsp = raw(ep).query_async(client).await?;
 
         // Refetch the container with the actual data
         let mut ep_builder = GetRequest::builder();
@@ -115,7 +113,7 @@ impl ContainerCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let rsp = raw(ep).query_async(client).await?;
 
         let mut metadata: HashMap<String, String> = HashMap::new();
         let headers = rsp.headers();

--- a/cli/object-store/src/v1/container/show.rs
+++ b/cli/object-store/src/v1/container/show.rs
@@ -16,10 +16,8 @@
 //! bytes of all objects stored in the container.
 use std::collections::HashMap;
 
-use bytes::Bytes;
 use clap::Args;
 use eyre::{WrapErr, eyre};
-use http::Response;
 use regex::Regex;
 use tracing::info;
 
@@ -28,7 +26,7 @@ use openstack_cli_core::common::HashMapStringString;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::api::object_store::v1::container::head::Request;
-use openstack_sdk::api::{AsyncClient, RawQueryAsync};
+use openstack_sdk::api::{AsyncClient, QueryAsync, raw};
 use openstack_sdk::{
     AsyncOpenStack,
     types::{ApiVersion, ServiceType},
@@ -83,7 +81,7 @@ impl ContainerCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let rsp = raw(ep).query_async(client).await?;
         let mut metadata: HashMap<String, String> = HashMap::new();
         let headers = rsp.headers();
 

--- a/cli/object-store/src/v1/object/delete.rs
+++ b/cli/object-store/src/v1/object/delete.rs
@@ -33,7 +33,7 @@ use openstack_cli_core::cli::CliArgs;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::api::object_store::v1::object::delete::Request;
-use openstack_sdk::api::{AsyncClient, RawQueryAsync};
+use openstack_sdk::api::{AsyncClient, QueryAsync, raw};
 use openstack_sdk::{
     AsyncOpenStack,
     types::{ApiVersion, ServiceType},
@@ -112,7 +112,7 @@ impl ObjectCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let _rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let _rsp: Response<Bytes> = raw(ep).query_async(client).await?;
         op.show_command_hint()?;
         Ok(())
     }

--- a/cli/object-store/src/v1/object/download.rs
+++ b/cli/object-store/src/v1/object/download.rs
@@ -26,7 +26,7 @@ use openstack_cli_core::common::download_file;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::api::object_store::v1::object::get::Request;
-use openstack_sdk::api::{AsyncClient, RawQueryAsync};
+use openstack_sdk::api::{AsyncClient, QueryAsync, download};
 use openstack_sdk::{
     AsyncOpenStack,
     types::{ApiVersion, ServiceType},
@@ -146,7 +146,7 @@ impl ObjectCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
-        let (headers, data) = ep.download_async(client).await?;
+        let (headers, data) = download(ep).query_async(client).await?;
 
         let size: u64 = headers
             .get("content-length")

--- a/cli/object-store/src/v1/object/show.rs
+++ b/cli/object-store/src/v1/object/show.rs
@@ -26,7 +26,7 @@ use openstack_cli_core::common::HashMapStringString;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::api::object_store::v1::object::head::Request;
-use openstack_sdk::api::{AsyncClient, RawQueryAsync};
+use openstack_sdk::api::{AsyncClient, QueryAsync, raw};
 use openstack_sdk::{
     AsyncOpenStack,
     types::{ApiVersion, ServiceType},
@@ -133,7 +133,7 @@ impl ObjectCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let rsp: Response<Bytes> = ep.raw_query_async(client).await?;
+        let rsp: Response<Bytes> = raw(ep).query_async(client).await?;
         let mut metadata: HashMap<String, String> = HashMap::new();
         let headers = rsp.headers();
 

--- a/cli/object-store/src/v1/object/upload.rs
+++ b/cli/object-store/src/v1/object/upload.rs
@@ -39,11 +39,10 @@ use openstack_cli_core::cli::CliArgs;
 use openstack_cli_core::common::build_upload_asyncread;
 use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
-use openstack_sdk::api::RawQueryAsync;
 use openstack_sdk::api::object_store::v1::object::put::Request;
+use openstack_sdk::api::{AsyncClient, QueryAsync, raw_with_body};
 use openstack_sdk::{
     AsyncOpenStack,
-    api::AsyncClient,
     types::{ApiVersion, ServiceType},
 };
 use structable::{StructTable, StructTableOptions};
@@ -178,7 +177,7 @@ impl ObjectCommand {
         let dst = self.file.clone();
         let data = build_upload_asyncread(dst).await?;
 
-        let _rsp: Response<Bytes> = ep.raw_query_read_body_async(client, data).await?;
+        let _rsp: Response<Bytes> = raw_with_body(ep, data).query_async(client).await?;
         // TODO: what if there is an interesting response
         op.show_command_hint()?;
         Ok(())

--- a/openstack_sdk/src/api.rs
+++ b/openstack_sdk/src/api.rs
@@ -32,22 +32,24 @@
 //!    # Ok(())
 //!    # }
 //! ```
-//! ## RawQuery/RawQueryAsync trait
+//! ## Raw response combinator
 //!
-//! It may be sometimes desired to get the raw API response for example to access headers. It is
-//! possible using [RawQuery]/[RawQueryAsync] trait on such endpoints.
+//! For cases where the raw HTTP response is needed (to inspect headers or
+//! handle non-JSON bodies), use the [`raw`](fn@raw) combinator. It implements
+//! the standard [Query]/[QueryAsync] trait and returns [http::Response<Bytes>].
 //!
 //! ```
-//!    use openstack_sdk::api::RawQueryAsync;
+//!    use openstack_sdk::api::{raw, QueryAsync};
+//!    use http::Response;
+//!    use bytes::Bytes;
 //!    # use openstack_sdk::{AsyncOpenStack, config::ConfigFile, OpenStackError};
-//!    # use http::{Response};
-//!    # use bytes::Bytes;
 //!    # async fn func() -> Result<(), OpenStackError> {
 //!    # let cfg = ConfigFile::new().unwrap();
 //!    # let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
 //!    # let client = AsyncOpenStack::new(&profile).await?;
 //!    # let ep = openstack_sdk::api::compute::v2::flavor::get::Request::builder().build().unwrap();
-//!    let rsp: Response<Bytes> = ep.raw_query_async(&client).await?;
+//!    // let rsp: Response<Bytes> = raw(ep).query_async(&client).await?;
+//!    // let rsp: Response<Bytes> = raw(ep).skip_error_check(true).query_async(&client).await?;
 //!    # Ok(())
 //!    # }
 //! ```

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -50,10 +50,7 @@ use openstack_sdk_auth_token as token_auth;
 use crate::auth::authtoken::{AuthType, build_token_info_endpoint};
 use crate::session;
 
-use openstack_sdk_core::api::{
-    self, AsyncClient,
-    query::{self, RawQueryAsync},
-};
+use openstack_sdk_core::api::{self, AsyncClient, QueryAsync, query, raw};
 use openstack_sdk_core::auth::{
     AuthState,
     auth_helper::{AuthHelper, Dialoguer, Noop},
@@ -1302,7 +1299,7 @@ impl AsyncOpenStack {
         token: SecretString,
     ) -> Result<AuthResponse, OpenStackError> {
         let auth_ep = build_token_info_endpoint(token.expose_secret())?;
-        let rsp = auth_ep.raw_query_async(self).await?;
+        let rsp = raw(auth_ep).query_async(self).await?;
         let data: AuthResponse = serde_json::from_slice(rsp.body())?;
         Ok(data)
     }

--- a/openstack_sdk/tests/connection/catalog.rs
+++ b/openstack_sdk/tests/connection/catalog.rs
@@ -23,7 +23,7 @@ use openstack_sdk::api::identity::v3::endpoint::create;
 use openstack_sdk::api::identity::v3::endpoint::delete;
 use openstack_sdk::api::identity::v3::service::create as service_create;
 use openstack_sdk::api::identity::v3::service::delete as service_delete;
-use openstack_sdk::api::{AsyncClient, Client, Query, QueryAsync, RawQuery, RawQueryAsync};
+use openstack_sdk::api::{AsyncClient, Client, Query, QueryAsync, raw};
 use openstack_sdk::types::ServiceType;
 use openstack_sdk::{AsyncOpenStack, OpenStack, config::ConfigFile};
 use std::borrow::Cow;
@@ -108,14 +108,14 @@ fn sync_catalog_refresh_with_new_service() -> Result<(), Box<dyn std::error::Err
     let _del_ep = delete::Request::builder()
         .id(endpoint_id)
         .build()
-        .expect("delete request builder")
-        .raw_query(&session)?;
+        .expect("delete request builder");
+    let _del_ep = raw(_del_ep).query(&session)?;
 
     let _del_svc = service_delete::Request::builder()
         .id(service_id)
         .build()
-        .expect("delete request builder")
-        .raw_query(&session)?;
+        .expect("delete request builder");
+    let _del_svc = raw(_del_svc).query(&session)?;
 
     Ok(())
 }
@@ -178,19 +178,17 @@ async fn async_catalog_refresh_with_new_service() -> Result<(), Box<dyn std::err
         .is_ok();
 
     // Cleanup
-    let _del_ep = delete::Request::builder()
+    let del_ep = delete::Request::builder()
         .id(endpoint_id)
         .build()
-        .expect("delete request builder")
-        .raw_query_async(&session)
-        .await?;
+        .expect("delete request builder");
+    let _del_ep = raw(del_ep).query_async(&session).await?;
 
-    let _del_svc = service_delete::Request::builder()
+    let del_svc = service_delete::Request::builder()
         .id(service_id)
         .build()
-        .expect("delete request builder")
-        .raw_query_async(&session)
-        .await?;
+        .expect("delete request builder");
+    let _del_svc = raw(del_svc).query_async(&session).await?;
 
     assert!(
         found,

--- a/openstack_sdk/tests/connection/reauth.rs
+++ b/openstack_sdk/tests/connection/reauth.rs
@@ -26,7 +26,7 @@ use std::env;
 use http::{HeaderName, HeaderValue, StatusCode};
 use openstack_sdk::api::compute::v2::server::list;
 use openstack_sdk::api::identity::v3::auth::token::delete;
-use openstack_sdk::api::{Pagination, Query, QueryAsync, RawQuery, RawQueryAsync, paged};
+use openstack_sdk::api::{Pagination, Query, QueryAsync, paged, raw};
 use openstack_sdk::config::ConfigFile;
 use openstack_sdk::types::ServiceType;
 use openstack_sdk::{AsyncOpenStack, OpenStack};
@@ -57,7 +57,10 @@ async fn async_reauth_after_token_revocation() -> Result<(), Box<dyn std::error:
         )
         .build()
         .unwrap();
-    let response = endpoint.raw_query_async_ll(&session, Some(false)).await?;
+    let response = raw(endpoint)
+        .skip_error_check(true)
+        .query_async(&session)
+        .await?;
     // 403 means the token was already revoked by a parallel test — same end result.
     assert!(
         response.status().is_success() || response.status() == StatusCode::FORBIDDEN,
@@ -102,7 +105,7 @@ fn sync_reauth_after_token_revocation() -> Result<(), Box<dyn std::error::Error>
         )
         .build()
         .unwrap();
-    let response = endpoint.raw_query(&session)?;
+    let response = raw(endpoint).query(&session)?;
     // 403 means the token was already revoked by a parallel test — same end result.
     assert!(
         response.status().is_success() || response.status() == StatusCode::FORBIDDEN,

--- a/sdk/core/src/api.rs
+++ b/sdk/core/src/api.rs
@@ -56,17 +56,18 @@
 //!    # Ok(())
 //!    # }
 //! ```
-//! ## RawQuery/RawQueryAsync trait
+//! ## Raw response combinator
 //!
-//! It may be sometimes desired to get the raw API response for example to access headers. It is
-//! possible using [RawQuery]/[RawQueryAsync] trait on such endpoints.
+//! For cases where the raw HTTP response is needed (to inspect headers or
+//! handle non-JSON bodies), use the [`raw`](fn@raw) combinator. It implements
+//! the standard [Query]/[QueryAsync] trait and returns [http::Response<Bytes>].
 //!
 //! ```
-//!    use openstack_sdk_core::api::RawQueryAsync;
+//!    use openstack_sdk_core::api::{raw, QueryAsync};
 //!    use openstack_sdk_core::{config::ConfigFile, OpenStackError};
 //!    use std::borrow::Cow;
 //!    use openstack_sdk_core::{api::RestEndpoint, types::ServiceType};
-//!    use http::{Response};
+//!    use http::Response;
 //!    use bytes::Bytes;
 //!    async fn func() -> Result<(), OpenStackError> {
 //!    let cfg = ConfigFile::new().unwrap();
@@ -76,26 +77,50 @@
 //!    pub struct Request<'a> {
 //!        id: Cow<'a, str>,
 //!    }
-//!    
+//!
 //!    impl RestEndpoint for Request<'_> {
 //!        fn method(&self) -> http::Method {
 //!            http::Method::GET
 //!        }
-//!    
+//!
 //!        fn endpoint(&self) -> Cow<'static, str> {
 //!            format!("flavors/{id}", id = self.id.as_ref(),).into()
 //!        }
-//!    
+//!
 //!        fn service_type(&self) -> ServiceType {
 //!            ServiceType::Compute
 //!        }
-//!    
-//!        fn response_key(&self) -> Option<Cow<'static, str>> {
-//!            Some("flavor".into())
-//!        }
 //!    }
 //!    let ep = RequestBuilder::default().build().unwrap();
-//!    // let rsp: Response<Bytes> = ep.raw_query_async(&client).await?;
+//!    // let rsp: Response<Bytes> = raw(ep).query_async(&client).await?;
+//!    // let rsp: Response<Bytes> = raw(ep).skip_error_check(true).query_async(&client).await?;
+//!    # Ok(())
+//!    # }
+//! ```
+//!
+//! For streaming downloads use [`download`](fn@download):
+//!
+//! ```
+//!    use openstack_sdk_core::api::{download, QueryAsync};
+//!    use openstack_sdk_core::{config::ConfigFile, OpenStackError};
+//!    async fn func() -> Result<(), OpenStackError> {
+//!    let cfg = ConfigFile::new().unwrap();
+//!    let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
+//!    // let client = AsyncOpenStack::new(&profile).await?;
+//!    // let (headers, stream) = download(ep).query_async(&client).await?;
+//!    # Ok(())
+//!    # }
+//! ```
+//!
+//! For uploads with a streamed request body use [`raw_with_body`](fn@raw_with_body):
+//!
+//! ```
+//!    use openstack_sdk_core::api::{raw_with_body, QueryAsync};
+//!    use openstack_sdk_core::{config::ConfigFile, OpenStackError};
+//!    use openstack_sdk_core::types::BoxedAsyncRead;
+//!    async fn func() -> Result<(), OpenStackError> {
+//!    // let body: BoxedAsyncRead = /* ... */;
+//!    // let rsp = raw_with_body(ep, body).query_async(&client).await?;
 //!    # Ok(())
 //!    # }
 //! ```
@@ -426,10 +451,10 @@ pub mod common;
 mod error;
 mod find;
 mod ignore;
-#[allow(dead_code)]
 mod paged;
 mod params;
 pub mod query;
+mod raw;
 pub mod rest_endpoint;
 
 pub use self::error::ApiError;
@@ -469,3 +494,9 @@ pub use self::params::QueryParams;
 
 pub use self::ignore::Ignore;
 pub use self::ignore::ignore;
+
+pub use self::raw::Download;
+pub use self::raw::Raw;
+pub use self::raw::download;
+pub use self::raw::raw;
+pub use self::raw::raw_with_body;

--- a/sdk/core/src/api/query.rs
+++ b/sdk/core/src/api/query.rs
@@ -63,7 +63,10 @@ where
 /// nothing about required authorization, which is handled by the client. It
 /// can be used for special cases where headers must be captured, response
 /// is not json, etc.
+///
+/// **Deprecated**: Use [`raw`](crate::api::raw) combinator instead.
 #[cfg(feature = "sync")]
+#[deprecated(since = "0.23.0", note = "Use `raw(endpoint).query(client)` instead")]
 pub trait RawQuery<C>
 where
     C: Client,
@@ -75,6 +78,10 @@ where
 /// A trait which represents an asynchronous query which may be made to a
 /// OpenStack service API client and return http response. It does know
 /// nothing about required authorization, which is handled by the client.
+#[deprecated(
+    since = "0.23.0",
+    note = "Use `raw(endpoint).query_async(client)` instead"
+)]
 #[cfg(feature = "async")]
 #[async_trait]
 pub trait RawQueryAsync<C>

--- a/sdk/core/src/api/raw.rs
+++ b/sdk/core/src/api/raw.rs
@@ -1,0 +1,324 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Raw query wrappers that implement [Query] / [QueryAsync] and return the
+//! undecorated HTTP response. Use these instead of the deprecated
+//! [RawQuery] / [RawQueryAsync] traits.
+
+use crate::api::rest_endpoint::{check_response_error, prepare_request};
+use crate::api::{ApiError, RestEndpoint};
+use crate::types::BoxedAsyncRead;
+
+#[cfg(feature = "async")]
+use crate::api::{AsyncClient, QueryAsync};
+#[cfg(feature = "sync")]
+use crate::api::{Client, Query};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::{HeaderMap, Response};
+use std::sync::{Arc, Mutex};
+use tracing::instrument;
+
+/// A query modifier that returns the raw [Response] from an endpoint.
+///
+/// By default the wrapper checks the response for errors. To obtain the raw
+/// response regardless of status code, chain `.skip_error_check(true)`.
+pub struct Raw<E> {
+    endpoint: E,
+    /// Stored in Arc<Mutex<Option>> so that `QueryAsync::query_async(&self)`
+    /// can consume the body despite taking `&self`.
+    body: Option<Arc<Mutex<Option<BoxedAsyncRead>>>>,
+    skip_error_check: bool,
+}
+
+/// A query modifier that streams the response body as [BoxedAsyncRead].
+///
+/// Returns a tuple of (response headers, async-readable body stream). Useful
+/// for downloading large objects without buffering the entire body into
+/// memory.
+pub struct Download<E> {
+    endpoint: E,
+}
+
+/// Create a raw query wrapper for an endpoint.
+///
+/// This is the replacement for the deprecated [RawQueryAsync::raw_query_async].
+///
+/// ```
+/// use openstack_sdk_core::api::{raw, QueryAsync};
+/// // let rsp: Response<Bytes> = raw(ep).query_async(&client).await?;
+/// ```
+pub fn raw<E>(endpoint: E) -> Raw<E> {
+    Raw {
+        endpoint,
+        body: None,
+        skip_error_check: false,
+    }
+}
+
+/// Create a raw query wrapper that sends a streamed body.
+///
+/// This is the replacement for the deprecated
+/// [RawQueryAsync::raw_query_read_body_async].
+///
+/// ```
+/// use openstack_sdk_core::api::{raw_with_body, QueryAsync};
+/// use openstack_sdk_core::types::BoxedAsyncRead;
+/// // let body: BoxedAsyncRead = /* ... */;
+/// // let rsp = raw_with_body(ep, body).query_async(&client).await?;
+/// ```
+pub fn raw_with_body<E>(endpoint: E, body: BoxedAsyncRead) -> Raw<E> {
+    Raw {
+        endpoint,
+        body: Some(Arc::new(Mutex::new(Some(body)))),
+        skip_error_check: false,
+    }
+}
+
+/// Create a streaming download wrapper for an endpoint.
+///
+/// This is the replacement for the deprecated
+/// [RawQueryAsync::download_async].
+///
+/// ```
+/// use openstack_sdk_core::api::{download, QueryAsync};
+/// // let (headers, stream) = download(ep).query_async(&client).await?;
+/// ```
+pub fn download<E>(endpoint: E) -> Download<E> {
+    Download { endpoint }
+}
+
+impl<E> Raw<E> {
+    /// Configure whether to check the response for errors.
+    ///
+    /// When `false` (default), error status codes are returned as [ApiError].
+    /// When `true`, the raw response is returned regardless of status code.
+    ///
+    /// This is the replacement for the deprecated
+    /// [RawQueryAsync::raw_query_async_ll].
+    ///
+    /// ```
+    /// use openstack_sdk_core::api::{raw, QueryAsync};
+    /// // let rsp: Response<Bytes> = raw(ep)
+    /// //     .skip_error_check(true)
+    /// //     .query_async(&client)
+    /// //     .await?;
+    /// ```
+    pub fn skip_error_check(mut self, v: bool) -> Self {
+        self.skip_error_check = v;
+        self
+    }
+}
+
+#[cfg(feature = "sync")]
+impl<E, C> Query<Response<Bytes>, C> for Raw<E>
+where
+    E: RestEndpoint,
+    C: Client,
+{
+    fn query(&self, client: &C) -> Result<Response<Bytes>, ApiError<C::Error>> {
+        let ep = client.get_service_endpoint(
+            &self.endpoint.service_type(),
+            self.endpoint.api_version().as_ref(),
+        )?;
+        let (req, data) = prepare_request::<C, E>(
+            &ep,
+            ep.build_request_url(&self.endpoint.endpoint())?,
+            &self.endpoint,
+        )?;
+
+        let query_uri = req.uri_ref().cloned();
+        let rsp = client.rest(req, data)?;
+
+        if !self.skip_error_check {
+            check_response_error::<C>(&rsp, query_uri)?;
+        }
+
+        Ok(rsp)
+    }
+}
+
+#[cfg(feature = "async")]
+#[async_trait]
+impl<E, C> QueryAsync<Response<Bytes>, C> for Raw<E>
+where
+    E: RestEndpoint + Sync,
+    C: AsyncClient + Sync,
+{
+    #[instrument(name = "raw_query", level = "debug", skip_all)]
+    async fn query_async(&self, client: &C) -> Result<Response<Bytes>, ApiError<C::Error>> {
+        let ep = client
+            .get_service_endpoint(
+                &self.endpoint.service_type(),
+                self.endpoint.api_version().as_ref(),
+            )
+            .await?;
+        let (req, data) = prepare_request::<C, E>(
+            &ep,
+            ep.build_request_url(&self.endpoint.endpoint())?,
+            &self.endpoint,
+        )?;
+
+        let query_uri = req.uri_ref().cloned();
+        let rsp = if let Some(ref body_arc) = self.body {
+            let body = body_arc
+                .lock()
+                .map_err(|_| ApiError::poisoned_lock("locking body"))?
+                .take()
+                .ok_or_else(|| ApiError::Session {
+                    msg: "raw_with_body endpoint reused after body consumed".into(),
+                })?;
+            client.rest_read_body_async(req, body).await?
+        } else {
+            client.rest_async(req, data).await?
+        };
+
+        if !self.skip_error_check {
+            check_response_error::<C>(&rsp, query_uri)?;
+        }
+
+        Ok(rsp)
+    }
+}
+
+#[cfg(feature = "async")]
+#[async_trait]
+impl<E, C> QueryAsync<(HeaderMap, BoxedAsyncRead), C> for Download<E>
+where
+    E: RestEndpoint + Sync,
+    C: AsyncClient + Sync,
+{
+    #[instrument(name = "download", level = "debug", skip_all)]
+    async fn query_async(
+        &self,
+        client: &C,
+    ) -> Result<(HeaderMap, BoxedAsyncRead), ApiError<C::Error>> {
+        let ep = client
+            .get_service_endpoint(
+                &self.endpoint.service_type(),
+                self.endpoint.api_version().as_ref(),
+            )
+            .await?;
+        let (req, data) = prepare_request::<C, E>(
+            &ep,
+            ep.build_request_url(&self.endpoint.endpoint())?,
+            &self.endpoint,
+        )?;
+
+        client.download_async(req, data).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::rest_endpoint_prelude::*;
+    use crate::test::client::FakeOpenStackClient;
+    use crate::types::ServiceType;
+    use http::StatusCode;
+    use httpmock::MockServer;
+    use serde_json::json;
+
+    struct Dummy;
+
+    impl RestEndpoint for Dummy {
+        fn method(&self) -> http::Method {
+            http::Method::GET
+        }
+
+        fn endpoint(&self) -> Cow<'static, str> {
+            "dummy".into()
+        }
+
+        fn service_type(&self) -> ServiceType {
+            ServiceType::from("dummy")
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_raw_ok_async() {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/dummy");
+            then.status(StatusCode::OK).body("hello");
+        });
+
+        let rsp: Response<Bytes> = crate::api::raw(Dummy).query_async(&client).await.unwrap();
+        assert!(rsp.status().is_success());
+        assert_eq!(rsp.body(), &Bytes::from_static(b"hello"));
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_raw_error_converted_async() {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/dummy");
+            then.status(StatusCode::CONFLICT)
+                .json_body(json!({"message": "err"}));
+        });
+
+        let err = crate::api::raw(Dummy)
+            .query_async(&client)
+            .await
+            .unwrap_err();
+        if let ApiError::OpenStack { msg, .. } = err {
+            assert_eq!(msg, "err");
+        } else {
+            panic!("unexpected error: {err}");
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_raw_skip_error_check_async() {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/dummy");
+            then.status(StatusCode::FORBIDDEN)
+                .json_body(json!({"message": "denied"}));
+        });
+
+        let rsp: Response<Bytes> = crate::api::raw(Dummy)
+            .skip_error_check(true)
+            .query_async(&client)
+            .await
+            .unwrap();
+        assert_eq!(rsp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[cfg(feature = "async")]
+    #[tokio::test]
+    async fn test_raw_headers_async() {
+        let server = MockServer::start_async().await;
+        let client = FakeOpenStackClient::new(server.base_url());
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/dummy");
+            then.status(StatusCode::OK)
+                .header("x-custom", "value123")
+                .body("hello");
+        });
+
+        let rsp: Response<Bytes> = crate::api::raw(Dummy).query_async(&client).await.unwrap();
+        assert_eq!(
+            rsp.headers().get("x-custom").unwrap().to_str().unwrap(),
+            "value123"
+        );
+    }
+}


### PR DESCRIPTION
Replace the RawQueryAsync trait with wrapper structs (Raw, Download)
that implement QueryAsync, following the same pattern as
paged/find/ignore.

New interface:
- raw(ep) - raw response with error checking
- raw(ep).skip_error_check(true) - raw response without error checking
- raw_with_body(ep, body) - upload with streamed request body
- download(ep) - streaming download returning (HeaderMap,
  BoxedAsyncRead)

This eliminates the confusing raw_query_async_ll + Option<bool> API and
reduces trait surface area by removing RawQueryAsync entirely.
Non-generated code (cli/object-store, cli/image, openstack_async) is
updated.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
