### PR TITLE
fix: Fix sha2 0.11 LowerHex removal in config hash

### DIFF
--- a/sdk/core/src/config.rs
+++ b/sdk/core/src/config.rs
@@ -492,7 +492,14 @@ pub fn get_config_identity_hash(config: &CloudConfig) -> String {
 
     let mut hasher = Sha256::new();
     hasher.update(canonical.as_bytes());
-    format!("{:x}", hasher.finalize())
+    hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut s, b| {
+            use std::fmt::Write;
+            let _ = write!(s, "{:02x}", b);
+            s
+        })
 }
 
 /// CloudConfig struct implementation.


### PR DESCRIPTION
Array<u8, N> lost LowerHex impl in sha2 0.11. Iterate bytes and format
manually.

Signed-off-by: gtema <artem.goncharov@gmail.com>
