### PR TITLE
chore: Stop use deprecated RawQuery/RawQueryAsync

### DIFF
--- a/cli/block-storage/src/v3/cgsnapshot/delete.rs
+++ b/cli/block-storage/src/v3/cgsnapshot/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::cgsnapshot::delete;
+use openstack_sdk::api::raw;
 
 /// Delete a cgsnapshot.
 #[derive(Args)]

--- a/cli/block-storage/src/v3/consistencygroup/delete.rs
+++ b/cli/block-storage/src/v3/consistencygroup/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::consistencygroup::delete;
+use openstack_sdk::api::raw;
 
 /// Delete a consistency group.
 #[derive(Args)]

--- a/cli/block-storage/src/v3/snapshot/metadata/delete.rs
+++ b/cli/block-storage/src/v3/snapshot/metadata/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::snapshot::metadata::delete;
+use openstack_sdk::api::raw;
 
 /// Deletes an existing metadata.
 #[derive(Args)]

--- a/cli/compute/src/v2/floating_ip/delete_21.rs
+++ b/cli/compute/src/v2/floating_ip/delete_21.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::floating_ip::delete_21;
+use openstack_sdk::api::raw;
 
 /// Deletes, or deallocates, a floating IP address from the current project and
 /// returns it to the pool from which it was allocated.

--- a/cli/compute/src/v2/server/share/delete_297.rs
+++ b/cli/compute/src/v2/server/share/delete_297.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::server::share::delete_297;
+use openstack_sdk::api::raw;
 
 /// Detach a share from an instance.
 ///

--- a/cli/dns/src/v2/blacklist/delete.rs
+++ b/cli/dns/src/v2/blacklist/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::blacklist::delete;
+use openstack_sdk::api::raw;
 
 /// Delete a blacklist
 #[derive(Args)]

--- a/cli/dns/src/v2/pool/delete.rs
+++ b/cli/dns/src/v2/pool/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::pool::delete;
+use openstack_sdk::api::raw;
 
 /// Delete the specific pool
 #[derive(Args)]

--- a/cli/dns/src/v2/tld/delete.rs
+++ b/cli/dns/src/v2/tld/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::tld::delete;
+use openstack_sdk::api::raw;
 
 /// Delete a tld
 #[derive(Args)]

--- a/cli/dns/src/v2/tsigkey/delete.rs
+++ b/cli/dns/src/v2/tsigkey/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::tsigkey::delete;
+use openstack_sdk::api::raw;
 
 /// Delete a tsigkey
 #[derive(Args)]

--- a/cli/dns/src/v2/zone/share/delete.rs
+++ b/cli/dns/src/v2/zone/share/delete.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::zone::find as find_zone;
 use openstack_sdk::api::dns::v2::zone::share::delete;
 use openstack_sdk::api::find_by_name;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Delete a zone share.

--- a/cli/dns/src/v2/zone/task/export/delete.rs
+++ b/cli/dns/src/v2/zone/task/export/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::zone::task::export::delete;
+use openstack_sdk::api::raw;
 
 /// This will just delete the record of the zone export, not the exported zone.
 ///

--- a/cli/dns/src/v2/zone/task/import/delete.rs
+++ b/cli/dns/src/v2/zone/task/import/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::zone::task::import::delete;
+use openstack_sdk::api::raw;
 
 /// This will just delete the record of the zone import, not the imported zone.
 ///

--- a/cli/dns/src/v2/zone/task/transfer_request/delete.rs
+++ b/cli/dns/src/v2/zone/task/transfer_request/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::dns::v2::zone::task::transfer_request::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/identity/src/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
+++ b/cli/identity/src/v3/os_inherit/domain/group/role/inherited_to_project/delete.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::os_inherit::domain::group::role::inherited_to_project::delete;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Revokes an inherited project role from a group in a domain.

--- a/cli/identity/src/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
+++ b/cli/identity/src/v3/os_inherit/domain/user/role/inherited_to_project/delete.rs
@@ -29,11 +29,13 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::domain::find as find_domain;
 use openstack_sdk::api::identity::v3::os_inherit::domain::user::role::inherited_to_project::delete;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Revokes an inherited project role from a user in a domain.

--- a/cli/identity/src/v3/os_inherit/project/group/role/inherited_to_project/delete.rs
+++ b/cli/identity/src/v3/os_inherit/project/group/role/inherited_to_project/delete.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_inherit::project::group::role::inherited_to_project::delete;
 use openstack_sdk::api::identity::v3::project::find as find_project;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Relationship:

--- a/cli/identity/src/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
+++ b/cli/identity/src/v3/os_inherit/project/user/role/inherited_to_project/delete.rs
@@ -29,11 +29,13 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::os_inherit::project::user::role::inherited_to_project::delete;
 use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Relationship:

--- a/cli/identity/src/v3/os_oauth1/consumer/delete.rs
+++ b/cli/identity/src/v3/os_oauth1/consumer/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::os_oauth1::consumer::delete;
+use openstack_sdk::api::raw;
 
 /// DELETE operation on /v3/OS-OAUTH1/consumers/{consumer_id}
 #[derive(Args)]

--- a/cli/identity/src/v3/os_oauth2/token/delete.rs
+++ b/cli/identity/src/v3/os_oauth2/token/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::os_oauth2::token::delete;
+use openstack_sdk::api::raw;
 
 /// The method is not allowed.
 #[derive(Args)]

--- a/cli/identity/src/v3/os_trust/trust/delete.rs
+++ b/cli/identity/src/v3/os_trust/trust/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::os_trust::trust::delete;
+use openstack_sdk::api::raw;
 
 /// Delete trust.
 ///

--- a/cli/identity/src/v3/policy/delete.rs
+++ b/cli/identity/src/v3/policy/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::policy::delete;
+use openstack_sdk::api::raw;
 
 /// Deletes a policy.
 ///

--- a/cli/identity/src/v3/policy/os_endpoint_policy/endpoint/delete.rs
+++ b/cli/identity/src/v3/policy/os_endpoint_policy/endpoint/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::policy::os_endpoint_policy::endpoint::delete;
+use openstack_sdk::api::raw;
 
 /// DELETE operation on
 /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/endpoints/{endpoint_id}

--- a/cli/identity/src/v3/policy/os_endpoint_policy/service/delete.rs
+++ b/cli/identity/src/v3/policy/os_endpoint_policy/service/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::policy::os_endpoint_policy::service::delete;
+use openstack_sdk::api::raw;
 
 /// DELETE operation on
 /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}

--- a/cli/identity/src/v3/policy/os_endpoint_policy/service/region/delete.rs
+++ b/cli/identity/src/v3/policy/os_endpoint_policy/service/region/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::policy::os_endpoint_policy::service::region::delete;
+use openstack_sdk::api::raw;
 
 /// DELETE operation on
 /// /v3/policies/{policy_id}/OS-ENDPOINT-POLICY/services/{service_id}/regions/{region_id}

--- a/cli/identity/src/v3/project/tag/delete.rs
+++ b/cli/identity/src/v3/project/tag/delete.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::identity::v3::project::tag::delete;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Remove a single tag from a project.

--- a/cli/identity/src/v3/project/tag/delete_all.rs
+++ b/cli/identity/src/v3/project/tag/delete_all.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::identity::v3::project::tag::delete_all;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Remove all tags from a given project.

--- a/cli/identity/src/v3/system/group/role/delete.rs
+++ b/cli/identity/src/v3/system/group/role/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::identity::v3::system::group::role::delete;
+use openstack_sdk::api::raw;
 
 /// Remove a system role assignment from a group.
 ///

--- a/cli/identity/src/v3/system/user/role/delete.rs
+++ b/cli/identity/src/v3/system/user/role/delete.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::system::user::role::delete;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Remove a system role assignment from a user.

--- a/cli/identity/src/v3/user/credential/os_ec2/delete.rs
+++ b/cli/identity/src/v3/user/credential/os_ec2/delete.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::credential::os_ec2::delete;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Delete a specific EC2 credential.

--- a/cli/identity/src/v3/user/os_oauth1/access_token/delete.rs
+++ b/cli/identity/src/v3/user/os_oauth1/access_token/delete.rs
@@ -29,10 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use eyre::eyre;
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::find as find_user;
 use openstack_sdk::api::identity::v3::user::os_oauth1::access_token::delete;
+use openstack_sdk::api::raw;
 use tracing::warn;
 
 /// Delete specific access token.

--- a/cli/image/src/v2/cache/delete.rs
+++ b/cli/image/src/v2/cache/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::cache::delete;
+use openstack_sdk::api::raw;
 
 /// Deletes a image from cache. *(Since Image API v2.14)*
 ///

--- a/cli/image/src/v2/cache/delete_all.rs
+++ b/cli/image/src/v2/cache/delete_all.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::cache::delete_all;
+use openstack_sdk::api::raw;
 
 /// Clears the cache and its queue. *(Since Image API v2.14)*
 ///

--- a/cli/image/src/v2/image/file/download.rs
+++ b/cli/image/src/v2/image/file/download.rs
@@ -29,7 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_cli_core::common::download_file;
 use openstack_sdk::api::QueryAsync;
-use openstack_sdk::api::RawQueryAsync;
+use openstack_sdk::api::download;
 use openstack_sdk::api::find;
 use openstack_sdk::api::image::v2::image::file::download;
 use openstack_sdk::api::image::v2::image::find;
@@ -145,7 +145,7 @@ impl FileCommand {
             .image_id(image_id)
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        let (headers, data) = ep.download_async(client).await?;
+        let (headers, data) = download(ep).query_async(client).await?;
 
         let size: u64 = headers
             .get("content-length")

--- a/cli/image/src/v2/image/file/upload.rs
+++ b/cli/image/src/v2/image/file/upload.rs
@@ -28,8 +28,9 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use openstack_cli_core::common::build_upload_asyncread;
-use openstack_sdk::api::RawQueryAsync;
+use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::image::file::upload;
+use openstack_sdk::api::raw_with_body;
 
 /// Uploads binary image data. *(Since Image API v2.0)*
 ///
@@ -159,7 +160,7 @@ impl FileCommand {
         let dst = self.file.clone();
         let data = build_upload_asyncread(dst).await?;
 
-        let _rsp = ep.raw_query_read_body_async(client, data).await?;
+        let _rsp = raw_with_body(ep, data).query_async(client).await?;
         // TODO: what if there is an interesting response
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/image/src/v2/image/member/delete.rs
+++ b/cli/image/src/v2/image/member/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::image::member::delete;
+use openstack_sdk::api::raw;
 
 /// Deletes a tenant ID from the member list of an image. *(Since Image API
 /// v2.1)*

--- a/cli/image/src/v2/image/tag/delete.rs
+++ b/cli/image/src/v2/image/tag/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::image::tag::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/image/src/v2/store/delete.rs
+++ b/cli/image/src/v2/store/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::store::delete;
+use openstack_sdk::api::raw;
 
 /// This API allows you to delete a copy of the image from a specific store.
 /// *(Since Image API v2.10)*

--- a/cli/image/src/v2/task/delete.rs
+++ b/cli/image/src/v2/task/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::image::v2::task::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/flavor/next_provider/delete.rs
+++ b/cli/network/src/v2/flavor/next_provider/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::flavor::next_provider::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/flavor/service_profile/delete.rs
+++ b/cli/network/src/v2/flavor/service_profile/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::flavor::service_profile::delete;
+use openstack_sdk::api::raw;
 
 /// Disassociate a flavor from a service profile.
 ///

--- a/cli/network/src/v2/floatingip_pool/delete.rs
+++ b/cli/network/src/v2/floatingip_pool/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::floatingip_pool::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/log/loggable_resource/delete.rs
+++ b/cli/network/src/v2/log/loggable_resource/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::log::loggable_resource::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/network/dhcp_agent/delete.rs
+++ b/cli/network/src/v2/network/dhcp_agent/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::network::dhcp_agent::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/network_ip_availability/delete.rs
+++ b/cli/network/src/v2/network_ip_availability/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::network_ip_availability::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/policy/packet_rate_limit_rule/delete.rs
+++ b/cli/network/src/v2/policy/packet_rate_limit_rule/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::policy::packet_rate_limit_rule::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/policy/tag/delete.rs
+++ b/cli/network/src/v2/policy/tag/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::policy::tag::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/policy/tag/delete_all.rs
+++ b/cli/network/src/v2/policy/tag/delete_all.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::policy::tag::delete_all;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/qos/rule_type/delete.rs
+++ b/cli/network/src/v2/qos/rule_type/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::qos::rule_type::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/router/l3_agent/delete.rs
+++ b/cli/network/src/v2/router/l3_agent/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::router::l3_agent::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/service_profile/delete.rs
+++ b/cli/network/src/v2/service_profile/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::service_profile::delete;
+use openstack_sdk::api::raw;
 
 /// Deletes a service profile.
 ///

--- a/cli/network/src/v2/service_provider/delete.rs
+++ b/cli/network/src/v2/service_provider/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::service_provider::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/trunk/tag/delete.rs
+++ b/cli/network/src/v2/trunk/tag/delete.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::trunk::tag::delete;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/cli/network/src/v2/trunk/tag/delete_all.rs
+++ b/cli/network/src/v2/trunk/tag/delete_all.rs
@@ -28,8 +28,10 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use http::Response;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::network::v2::trunk::tag::delete_all;
+use openstack_sdk::api::raw;
 
 /// Command without description in OpenAPI
 #[derive(Args)]

--- a/sdk/identity/src/v3/auth/catalog/head.rs
+++ b/sdk/identity/src/v3/auth/catalog/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/domain/head.rs
+++ b/sdk/identity/src/v3/auth/domain/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/os_federation/identity_provider/protocol/websso/head.rs
+++ b/sdk/identity/src/v3/auth/os_federation/identity_provider/protocol/websso/head.rs
@@ -121,7 +121,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -158,7 +158,7 @@ mod tests {
             .protocol_id("protocol_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -195,7 +195,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/os_federation/saml2/ecp/head.rs
+++ b/sdk/identity/src/v3/auth/os_federation/saml2/ecp/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/os_federation/saml2/head.rs
+++ b/sdk/identity/src/v3/auth/os_federation/saml2/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/os_federation/websso/head.rs
+++ b/sdk/identity/src/v3/auth/os_federation/websso/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -147,7 +147,7 @@ mod tests {
             .protocol_id("protocol_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -182,7 +182,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/project/head.rs
+++ b/sdk/identity/src/v3/auth/project/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/system/head.rs
+++ b/sdk/identity/src/v3/auth/system/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/token/head.rs
+++ b/sdk/identity/src/v3/auth/token/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -142,7 +142,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -173,7 +173,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/auth/token/os_pki/revoked/head.rs
+++ b/sdk/identity/src/v3/auth/token/os_pki/revoked/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/credential/head.rs
+++ b/sdk/identity/src/v3/credential/head.rs
@@ -109,7 +109,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -139,7 +139,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().id("id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -171,7 +171,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/domain/config/group/head.rs
+++ b/sdk/identity/src/v3/domain/config/group/head.rs
@@ -121,7 +121,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -161,7 +161,7 @@ mod tests {
             .group("group")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -198,7 +198,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/domain/config/group/option/head.rs
+++ b/sdk/identity/src/v3/domain/config/group/option/head.rs
@@ -127,7 +127,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -169,7 +169,7 @@ mod tests {
             .option("option")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -208,7 +208,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/domain/config/head.rs
+++ b/sdk/identity/src/v3/domain/config/head.rs
@@ -116,7 +116,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -148,7 +148,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().domain_id("domain_id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -183,7 +183,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/domain/group/role/head.rs
+++ b/sdk/identity/src/v3/domain/group/role/head.rs
@@ -127,7 +127,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -166,7 +166,7 @@ mod tests {
             .id("id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -205,7 +205,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/domain/head.rs
+++ b/sdk/identity/src/v3/domain/head.rs
@@ -109,7 +109,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -139,7 +139,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().id("id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -171,7 +171,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/domain/user/role/head.rs
+++ b/sdk/identity/src/v3/domain/user/role/head.rs
@@ -127,7 +127,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -166,7 +166,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -205,7 +205,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/ec2token/head.rs
+++ b/sdk/identity/src/v3/ec2token/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/endpoint/head.rs
+++ b/sdk/identity/src/v3/endpoint/head.rs
@@ -126,7 +126,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -156,7 +156,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -187,7 +187,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/endpoint/os_endpoint_policy/policy/head.rs
+++ b/sdk/identity/src/v3/endpoint/os_endpoint_policy/policy/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -147,7 +147,7 @@ mod tests {
             .endpoint_id("endpoint_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -182,7 +182,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/group/head.rs
+++ b/sdk/identity/src/v3/group/head.rs
@@ -138,7 +138,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -168,7 +168,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -199,7 +199,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/group/user/head.rs
+++ b/sdk/identity/src/v3/group/user/head.rs
@@ -119,7 +119,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -156,7 +156,7 @@ mod tests {
             .id("id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -193,7 +193,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/limit/head.rs
+++ b/sdk/identity/src/v3/limit/head.rs
@@ -109,7 +109,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -139,7 +139,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().id("id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -171,7 +171,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/limit/model/head.rs
+++ b/sdk/identity/src/v3/limit/model/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_ep_filter/endpoint/project/head.rs
+++ b/sdk/identity/src/v3/os_ep_filter/endpoint/project/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -147,7 +147,7 @@ mod tests {
             .endpoint_id("endpoint_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -182,7 +182,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_ep_filter/endpoint_group/endpoint/head.rs
+++ b/sdk/identity/src/v3/os_ep_filter/endpoint_group/endpoint/head.rs
@@ -113,7 +113,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -148,7 +148,7 @@ mod tests {
             .endpoint_group_id("endpoint_group_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -183,7 +183,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_ep_filter/endpoint_group/head.rs
+++ b/sdk/identity/src/v3/os_ep_filter/endpoint_group/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -142,7 +142,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -173,7 +173,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_ep_filter/endpoint_group/project/head.rs
+++ b/sdk/identity/src/v3/os_ep_filter/endpoint_group/project/head.rs
@@ -121,7 +121,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -158,7 +158,7 @@ mod tests {
             .id("id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -195,7 +195,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_ep_filter/project/endpoint/head.rs
+++ b/sdk/identity/src/v3/os_ep_filter/project/endpoint/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -144,7 +144,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().project_id("project_id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -179,7 +179,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_ep_filter/project/endpoint_group/head.rs
+++ b/sdk/identity/src/v3/os_ep_filter/project/endpoint_group/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -144,7 +144,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().project_id("project_id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -179,7 +179,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/domain/head.rs
+++ b/sdk/identity/src/v3/os_federation/domain/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/identity_provider/head.rs
+++ b/sdk/identity/src/v3/os_federation/identity_provider/head.rs
@@ -117,7 +117,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -147,7 +147,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -178,7 +178,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/identity_provider/protocol/auth/head.rs
+++ b/sdk/identity/src/v3/os_federation/identity_provider/protocol/auth/head.rs
@@ -123,7 +123,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -160,7 +160,7 @@ mod tests {
             .protocol_id("protocol_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -197,7 +197,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/identity_provider/protocol/head.rs
+++ b/sdk/identity/src/v3/os_federation/identity_provider/protocol/head.rs
@@ -114,7 +114,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -146,7 +146,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().idp_id("idp_id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -181,7 +181,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/mapping/head.rs
+++ b/sdk/identity/src/v3/os_federation/mapping/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/project/head.rs
+++ b/sdk/identity/src/v3/os_federation/project/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/saml2/metadata/head.rs
+++ b/sdk/identity/src/v3/os_federation/saml2/metadata/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_federation/service_provider/head.rs
+++ b/sdk/identity/src/v3/os_federation/service_provider/head.rs
@@ -117,7 +117,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -147,7 +147,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -178,7 +178,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_inherit/domain/group/role/inherited_to_project/head.rs
+++ b/sdk/identity/src/v3/os_inherit/domain/group/role/inherited_to_project/head.rs
@@ -123,7 +123,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -160,7 +160,7 @@ mod tests {
             .group_id("group_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -197,7 +197,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_inherit/domain/user/role/inherited_to_project/head.rs
+++ b/sdk/identity/src/v3/os_inherit/domain/user/role/inherited_to_project/head.rs
@@ -123,7 +123,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -160,7 +160,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -197,7 +197,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_inherit/project/group/role/inherited_to_project/head.rs
+++ b/sdk/identity/src/v3/os_inherit/project/group/role/inherited_to_project/head.rs
@@ -130,7 +130,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -170,7 +170,7 @@ mod tests {
             .role_id("role_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -209,7 +209,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_inherit/project/user/role/inherited_to_project/head.rs
+++ b/sdk/identity/src/v3/os_inherit/project/user/role/inherited_to_project/head.rs
@@ -130,7 +130,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -170,7 +170,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -209,7 +209,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_oauth1/access_token/head.rs
+++ b/sdk/identity/src/v3/os_oauth1/access_token/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_oauth1/consumer/head.rs
+++ b/sdk/identity/src/v3/os_oauth1/consumer/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_oauth1/request_token/head.rs
+++ b/sdk/identity/src/v3/os_oauth1/request_token/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_oauth2/token/head.rs
+++ b/sdk/identity/src/v3/os_oauth2/token/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_revoke/event/head.rs
+++ b/sdk/identity/src/v3/os_revoke/event/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_simple_cert/ca/head.rs
+++ b/sdk/identity/src/v3/os_simple_cert/ca/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_simple_cert/certificate/head.rs
+++ b/sdk/identity/src/v3/os_simple_cert/certificate/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_trust/trust/head.rs
+++ b/sdk/identity/src/v3/os_trust/trust/head.rs
@@ -118,7 +118,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -148,7 +148,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -179,7 +179,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/os_trust/trust/role/head.rs
+++ b/sdk/identity/src/v3/os_trust/trust/role/head.rs
@@ -118,7 +118,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -155,7 +155,7 @@ mod tests {
             .trust_id("trust_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -192,7 +192,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/policy/head.rs
+++ b/sdk/identity/src/v3/policy/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/policy/os_endpoint_policy/endpoint/head.rs
+++ b/sdk/identity/src/v3/policy/os_endpoint_policy/endpoint/head.rs
@@ -119,7 +119,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -156,7 +156,7 @@ mod tests {
             .policy_id("policy_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -193,7 +193,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/policy/os_endpoint_policy/service/head.rs
+++ b/sdk/identity/src/v3/policy/os_endpoint_policy/service/head.rs
@@ -119,7 +119,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -156,7 +156,7 @@ mod tests {
             .id("id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -193,7 +193,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/policy/os_endpoint_policy/service/region/head.rs
+++ b/sdk/identity/src/v3/policy/os_endpoint_policy/service/region/head.rs
@@ -128,7 +128,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -167,7 +167,7 @@ mod tests {
             .service_id("service_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -206,7 +206,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/project/group/role/head.rs
+++ b/sdk/identity/src/v3/project/group/role/head.rs
@@ -120,7 +120,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -157,7 +157,7 @@ mod tests {
             .project_id("project_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -194,7 +194,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/project/head.rs
+++ b/sdk/identity/src/v3/project/head.rs
@@ -109,7 +109,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -139,7 +139,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().id("id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -171,7 +171,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/project/tag/head.rs
+++ b/sdk/identity/src/v3/project/tag/head.rs
@@ -118,7 +118,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -155,7 +155,7 @@ mod tests {
             .value("value")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -192,7 +192,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/project/user/role/head.rs
+++ b/sdk/identity/src/v3/project/user/role/head.rs
@@ -120,7 +120,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -157,7 +157,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -194,7 +194,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/region/head.rs
+++ b/sdk/identity/src/v3/region/head.rs
@@ -110,7 +110,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -140,7 +140,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -171,7 +171,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/registered_limit/head.rs
+++ b/sdk/identity/src/v3/registered_limit/head.rs
@@ -122,7 +122,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -152,7 +152,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -183,7 +183,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/role/head.rs
+++ b/sdk/identity/src/v3/role/head.rs
@@ -117,7 +117,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -147,7 +147,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -178,7 +178,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/role/imply/head.rs
+++ b/sdk/identity/src/v3/role/imply/head.rs
@@ -121,7 +121,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -158,7 +158,7 @@ mod tests {
             .prior_role_id("prior_role_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -195,7 +195,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/role_assignment/head.rs
+++ b/sdk/identity/src/v3/role_assignment/head.rs
@@ -153,7 +153,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -183,7 +183,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -214,7 +214,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/role_inference/head.rs
+++ b/sdk/identity/src/v3/role_inference/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/s3token/head.rs
+++ b/sdk/identity/src/v3/s3token/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -131,7 +131,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -162,7 +162,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/service/head.rs
+++ b/sdk/identity/src/v3/service/head.rs
@@ -103,7 +103,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -133,7 +133,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -164,7 +164,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/system/group/role/head.rs
+++ b/sdk/identity/src/v3/system/group/role/head.rs
@@ -119,7 +119,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -156,7 +156,7 @@ mod tests {
             .id("id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -193,7 +193,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/system/user/role/head.rs
+++ b/sdk/identity/src/v3/system/user/role/head.rs
@@ -119,7 +119,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -156,7 +156,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -193,7 +193,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/access_rule/head.rs
+++ b/sdk/identity/src/v3/user/access_rule/head.rs
@@ -120,7 +120,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -157,7 +157,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -194,7 +194,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/application_credential/head.rs
+++ b/sdk/identity/src/v3/user/application_credential/head.rs
@@ -123,7 +123,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -160,7 +160,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -197,7 +197,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/credential/os_ec2/head.rs
+++ b/sdk/identity/src/v3/user/credential/os_ec2/head.rs
@@ -120,7 +120,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -157,7 +157,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -194,7 +194,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/group/head.rs
+++ b/sdk/identity/src/v3/user/group/head.rs
@@ -109,7 +109,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -139,7 +139,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().user_id("user_id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -171,7 +171,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/head.rs
+++ b/sdk/identity/src/v3/user/head.rs
@@ -178,7 +178,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -208,7 +208,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -239,7 +239,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/os_oauth1/access_token/head.rs
+++ b/sdk/identity/src/v3/user/os_oauth1/access_token/head.rs
@@ -120,7 +120,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -157,7 +157,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -194,7 +194,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/os_oauth1/access_token/role/head.rs
+++ b/sdk/identity/src/v3/user/os_oauth1/access_token/role/head.rs
@@ -130,7 +130,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -169,7 +169,7 @@ mod tests {
             .user_id("user_id")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -208,7 +208,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/user/project/head.rs
+++ b/sdk/identity/src/v3/user/project/head.rs
@@ -107,7 +107,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -137,7 +137,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().user_id("user_id").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -169,7 +169,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/identity/src/v3/version/head.rs
+++ b/sdk/identity/src/v3/version/head.rs
@@ -101,7 +101,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -130,7 +130,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -161,7 +161,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/object-store/src/v1/account/head.rs
+++ b/sdk/object-store/src/v1/account/head.rs
@@ -112,7 +112,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -142,7 +142,7 @@ mod tests {
         });
 
         let endpoint = Request::builder().account("account").build().unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -174,7 +174,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/object-store/src/v1/container/head.rs
+++ b/sdk/object-store/src/v1/container/head.rs
@@ -124,7 +124,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -161,7 +161,7 @@ mod tests {
             .container("container")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -198,7 +198,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }

--- a/sdk/object-store/src/v1/object/head.rs
+++ b/sdk/object-store/src/v1/object/head.rs
@@ -174,7 +174,7 @@ mod tests {
     use http::{HeaderName, HeaderValue};
     use httpmock::MockServer;
     #[cfg(feature = "sync")]
-    use openstack_sdk_core::api::RawQuery;
+    use openstack_sdk_core::api::{Query, raw};
     use openstack_sdk_core::test::client::FakeOpenStackClient;
     use openstack_sdk_core::types::ServiceType;
 
@@ -213,7 +213,7 @@ mod tests {
             .object("object")
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 
@@ -252,7 +252,7 @@ mod tests {
             )
             .build()
             .unwrap();
-        let _ = endpoint.raw_query(&client).unwrap();
+        let _ = raw(endpoint).query(&client).unwrap();
         mock.assert();
     }
 }


### PR DESCRIPTION
RawQuery/RawQueryAsync are deprecated in openstack_sdk_core in favor
of the raw()/download()/raw_with_body() combinators. Update the
rust_sdk and rust_cli templates plus their import lists to generate
raw(ep).query()/query_async(), download(ep).query_async(), and
raw_with_body(ep, data).query_async() instead.

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/998666
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
