### PR TITLE
feat(tui): Replace per-resource Mode variants

### DIFF
--- a/openstack_tui/.config/config.yaml
+++ b/openstack_tui/.config/config.yaml
@@ -1,33 +1,36 @@
 ---
 # Mode keybindings in the following form
-#  <Mode>:
+#  <Mode> or "Resource(<service>.<resource>)" for migrated resource views:
 #    <shortcut>:
 #       action: <ACTION TO PERFORM>
 #       description: <DESCRIPTION USED IN TUI>
 mode_keybindings:
   Home: {}
   # Block Storage views
-  BlockStorageBackups:
+  "Resource(block_storage.backup)":
     "y":
       action: DescribeApiResponse
       description: YAML
-  BlockStorageSnapshots:
+  "Resource(block_storage.snapshot)":
     "y":
       action: DescribeApiResponse
       description: YAML
-  BlockStorageVolumes:
+  "Resource(block_storage.volume)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "ctrl-d":
-      action: DeleteBlockStorageVolume
+      action:
+        ResourceOp:
+          key: "block_storage.volume"
+          op: Delete
       description: Delete
   # Compute views
-  ComputeAggregates:
+  "Resource(compute.aggregate)":
     "y":
       action: DescribeApiResponse
       description: YAML
-  ComputeServers:
+  "Resource(compute.server)":
     "y":
       action: DescribeApiResponse
       description: YAML
@@ -42,34 +45,40 @@ mode_keybindings:
       description: All tenants (admin)
       type: Filter
     "ctrl-d":
-      action: DeleteComputeServer
+      action:
+        ResourceOp:
+          key: "compute.server"
+          op: Delete
       description: Delete
     "c":
       action: ShowServerConsoleOutput
       description: Console output
     "a":
-      action: ShowComputeServerInstanceActions
+      action:
+        ShowResource: "compute.server/instance_action"
       description: Instance actions
-  ComputeServerInstanceActions:
+  "Resource(compute.server/instance_action)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "e":
-      action: ShowComputeServerInstanceActionEvents
+      action:
+        ShowResource: "compute.server/instance_action/event"
       description: Events
-  ComputeFlavors:
+  "Resource(compute.flavor)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "s":
-      action: ShowComputeServersWithFlavor
+      action:
+        ShowResource: "compute.server"
       description: Servers
-  ComputeHypervisors:
+  "Resource(compute.hypervisor)":
     "y":
       action: DescribeApiResponse
       description: YAML
   # DNS views
-  DnsRecordsets:
+  "Resource(dns.recordset)":
     "y":
       action: DescribeApiResponse
       description: YAML
@@ -78,35 +87,43 @@ mode_keybindings:
         SetDnsRecordsetListFilters: {}
       description: Default filters
       type: Filter
-  DnsZones:
+  "Resource(dns.zone)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "<enter>":
-      action: ShowDnsZoneRecordsets
+      action:
+        ShowResource: "dns.recordset"
       description: Recordsets
     "ctrl-d":
-      action: DeleteDnsZone
+      action:
+        ResourceOp:
+          key: "dns.zone"
+          op: Delete
       description: Delete
   # Identity views
-  IdentityApplicationCredentials:
+  "Resource(identity.user/application_credential)":
     "y":
       action: DescribeApiResponse
       description: YAML
-  IdentityGroups:
+  "Resource(identity.group)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "u":
-      action: ShowIdentityGroupUsers
+      action:
+        ShowResource: "identity.group_user"
       description: Group users
     "d":
-      action: IdentityGroupDelete
-      description: Delete (todo!)
+      action:
+        ResourceOp:
+          key: "identity.group"
+          op: Delete
+      description: Delete
     "a":
       action: IdentityGroupCreate
       description: Create new group (todo!)
-  IdentityGroupUsers:
+  "Resource(identity.group_user)":
     "y":
       action: DescribeApiResponse
       description: YAML
@@ -116,22 +133,28 @@ mode_keybindings:
     "r":
       action: IdentityGroupUserRemove
       description: Remove user from group (todo!)
-  IdentityProjects:
+  "Resource(identity.project)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "s":
       action: SwitchToProject
       description: Switch to project
-  IdentityUsers:
+  "Resource(identity.user)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "ctrl-d":
-      action: IdentityUserDelete
+      action:
+        IdentityUserOp:
+          key: "identity.user"
+          op: Delete
       description: Delete
     "e":
-      action: IdentityUserFlipEnable
+      action:
+        IdentityUserOp:
+          key: "identity.user"
+          op: FlipEnable
       description: Enable/Disable user
     "a":
       action: IdentityUserCreate
@@ -140,10 +163,11 @@ mode_keybindings:
       action: IdentityUserSetPassword
       description: Set user password (todo!)
     "c":
-      action: ShowIdentityUserApplicationCredentials
+      action:
+        ShowResource: "identity.user/application_credential"
       description: Application credentials
   # Image views
-  ImageImages:
+  "Resource(image.image)":
     "y":
       action: DescribeApiResponse
       description: YAML
@@ -168,54 +192,62 @@ mode_keybindings:
       description: private
       type: Filter
     "ctrl-d":
-      action: DeleteImage
+      action:
+        ResourceOp:
+          key: "image.image"
+          op: Delete
       description: Delete
   # LoadBalancer views
-  LoadBalancers:
+  "Resource(load-balancer.loadbalancer)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "l":
-      action: ShowLoadBalancerListeners
+      action:
+        ShowResource: "load-balancer.listener"
       description: Listeners
     "p":
-      action: ShowLoadBalancerPools
+      action:
+        ShowResource: "load-balancer.pool"
       description: Pools
-  LoadBalancerListeners:
+  "Resource(load-balancer.listener)":
     "y":
       action: DescribeApiResponse
       description: YAML
-  LoadBalancerPools:
+  "Resource(load-balancer.pool)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "<enter>":
-      action: ShowLoadBalancerPoolMembers
+      action:
+        ShowResource: "load-balancer.pool/member"
       description: Members
     "h":
-      action: ShowLoadBalancerPoolHealthMonitors
+      action:
+        ShowResource: "load-balancer.healthmonitor"
       description: HealthMonitors
-  LoadBalancerPoolMembers:
+  "Resource(load-balancer.pool/member)":
     "y":
       action: DescribeApiResponse
       description: YAML
-  LoadBalancerHealthMonitors:
+  "Resource(load-balancer.healthmonitor)":
     "y":
       action: DescribeApiResponse
       description: YAML
   # Network views
-  NetworkNetworks:
+  "Resource(network.network)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "<enter>":
-      action: ShowNetworkSubnets
+      action:
+        ShowResource: "network.subnet"
       description: Subnets
-  NetworkRouters:
+  "Resource(network.router)":
     "y":
       action: DescribeApiResponse
       description: YAML
-  NetworkSubnets:
+  "Resource(network.subnet)":
     "y":
       action: DescribeApiResponse
       description: YAML
@@ -224,14 +256,15 @@ mode_keybindings:
         SetNetworkSubnetListFilters: {}
       description: All
       type: Filter
-  NetworkSecurityGroups:
+  "Resource(network.security_group)":
     "y":
       action: DescribeApiResponse
       description: YAML
     "<enter>":
-      action: ShowNetworkSecurityGroupRules
+      action:
+        ShowResource: "network.security_group_rule"
       description: Rules
-  NetworkSecurityGroupRules:
+  "Resource(network.security_group_rule)":
     "y":
       action: DescribeApiResponse
       description: YAML
@@ -241,10 +274,16 @@ mode_keybindings:
       description: All
       type: Filter
     "ctrl-n":
-      action: CreateNetworkSecurityGroupRule
+      action:
+        ResourceOp:
+          key: "network.security_group_rule"
+          op: Create
       description: Create
     "ctrl-d":
-      action: DeleteNetworkSecurityGroupRule
+      action:
+        ResourceOp:
+          key: "network.security_group_rule"
+          op: Delete
       description: Delete
 # Global keybindings
 # <KEYBINDING>:
@@ -284,37 +323,37 @@ global_keybindings:
 # Mode aliases
 # <ALIAS>: <MODE>
 mode_aliases:
-  "aggregates (compute)": "ComputeAggregates"
-  "application credentials (identity)": "IdentityApplicationCredentials"
-  "backups": "BlockStorageBackups"
-  "flavors": "ComputeFlavors"
-  "groups (identity)": "IdentityGroups"
-  "host-aggregates (compute)": "ComputeAggregates"
-  "hypervisors (compute)": "ComputeHypervisors"
-  "images": "ImageImages"
-  "loadbalancers": "LoadBalancers"
-  "lb (loadbalancers)": "LoadBalancers"
-  "listeners (loadbalancer)": "LoadBalancerListeners"
-  "lbl (loadbalancer listeners)": "LoadBalancerListeners"
-  "pool (loadbalancer)": "LoadBalancerPools"
-  "lbp (loadbalancer pools)": "LoadBalancerPools"
-  "healthmonitors (loadbalancer)": "LoadBalancerHealthMonitors"
-  "lbhm (loadbalancer health monitors)": "LoadBalancerHealthMonitors"
-  "nets": "NetworkNetworks"
-  "networks": "NetworkNetworks"
-  "projects": "IdentityProjects"
-  "recordsets (dns)": "DnsRecordsets"
-  "routers": "NetworkRouters"
-  "security groups (network)": "NetworkSecurityGroups"
-  "security group rules (network)": "NetworkSecurityGroupRules"
-  "servers": "ComputeServers"
-  "sg": "NetworkSecurityGroups"
-  "sgr": "NetworkSecurityGroupRules"
-  "snapshots": "BlockStorageSnapshots"
-  "subnets (network)": "NetworkSubnets"
-  "volumes": "BlockStorageVolumes"
-  "users": "IdentityUsers"
-  "zones (dns)": "DnsZones"
+  "aggregates (compute)": "Resource(compute.aggregate)"
+  "application credentials (identity)": "Resource(identity.user/application_credential)"
+  "backups": "Resource(block_storage.backup)"
+  "flavors": "Resource(compute.flavor)"
+  "groups (identity)": "Resource(identity.group)"
+  "host-aggregates (compute)": "Resource(compute.aggregate)"
+  "hypervisors (compute)": "Resource(compute.hypervisor)"
+  "images": "Resource(image.image)"
+  "loadbalancers": "Resource(load-balancer.loadbalancer)"
+  "lb (loadbalancers)": "Resource(load-balancer.loadbalancer)"
+  "listeners (loadbalancer)": "Resource(load-balancer.listener)"
+  "lbl (loadbalancer listeners)": "Resource(load-balancer.listener)"
+  "pool (loadbalancer)": "Resource(load-balancer.pool)"
+  "lbp (loadbalancer pools)": "Resource(load-balancer.pool)"
+  "healthmonitors (loadbalancer)": "Resource(load-balancer.healthmonitor)"
+  "lbhm (loadbalancer health monitors)": "Resource(load-balancer.healthmonitor)"
+  "nets": "Resource(network.network)"
+  "networks": "Resource(network.network)"
+  "projects": "Resource(identity.project)"
+  "recordsets (dns)": "Resource(dns.recordset)"
+  "routers": "Resource(network.router)"
+  "security groups (network)": "Resource(network.security_group)"
+  "security group rules (network)": "Resource(network.security_group_rule)"
+  "servers": "Resource(compute.server)"
+  "sg": "Resource(network.security_group)"
+  "sgr": "Resource(network.security_group_rule)"
+  "snapshots": "Resource(block_storage.snapshot)"
+  "subnets (network)": "Resource(network.subnet)"
+  "volumes": "Resource(block_storage.volume)"
+  "users": "Resource(identity.user)"
+  "zones (dns)": "Resource(dns.zone)"
 # View output
 # <RESOURCE_KEY>:
 #   fields: <ARRAY OF COLUMNS TO SHOW>

--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -17,6 +17,36 @@ use strum::Display;
 
 use crate::cloud_worker::types as cloud_types;
 
+/// Deserialize a `ViewKey` field from an owned string, resolving it to the
+/// canonical `'static` constant. Needed because `#[derive(Deserialize)]`
+/// cannot produce a `&'static str` directly (see `crate::mode::resolve_view_key`).
+fn deserialize_view_key<'de, D>(deserializer: D) -> Result<crate::mode::ViewKey, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    crate::mode::resolve_view_key(&s)
+        .ok_or_else(|| serde::de::Error::custom(format!("unknown resource view key: {s}")))
+}
+
+/// Identity-only operation on a resource, addressed by `ViewKey`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResourceOp {
+    Create,
+    Delete,
+}
+
+/// Operations on Identity Users, addressed by `ViewKey`.
+/// Kept separate from `ResourceOp` because:
+/// 1. `FlipEnable` is a toggle with no Create/Delete analogue.
+/// 2. `FlipEnable` dispatches via `action_to_request` (immediate, no confirmation),
+///    while `Delete` dispatches via `confirm_request` (requires confirmation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IdentityUserOp {
+    Delete,
+    FlipEnable,
+}
+
 /// TUI action
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
 pub enum Action {
@@ -110,44 +140,24 @@ pub enum Action {
         original_action: Box<Action>,
     },
 
-    // Block Storage (Cinder)
-    /// Delete volume
-    DeleteBlockStorageVolume,
-
     // Compute (Nova)
     SetComputeServerListFilters(Box<cloud_types::ComputeServerList>),
     SetComputeServerInstanceActionListFilters(Box<cloud_types::ComputeServerInstanceActionList>),
     SetComputeServerInstanceActionShowFilters(Box<cloud_types::ComputeServerInstanceActionShow>),
-    /// Show servers provisioned with selected flavor
-    ShowComputeServersWithFlavor,
-    /// Delete selected server
-    DeleteComputeServer,
     /// Show console output of the selected entry
     ShowServerConsoleOutput,
-    /// Show selected server instance actions
-    ShowComputeServerInstanceActions,
-    /// Show selected server instance action events
-    ShowComputeServerInstanceActionEvents,
 
     // DNS (Designate)
     /// Set DNS Zone filters
     SetDnsZoneListFilters(cloud_types::DnsZoneList),
-    /// Delete DNS zone
-    DeleteDnsZone,
     /// Set DNS Recordset filters
     SetDnsRecordsetListFilters(cloud_types::DnsRecordsetList),
-    /// Zone recordsets
-    ShowDnsZoneRecordsets,
 
     // Identity (keystone)
     //  Groups
     /// Create new identity group
     IdentityGroupCreate,
-    /// Delete identity group
-    IdentityGroupDelete,
     //  Group users
-    /// Action user invokes to switch mode for selected entity
-    ShowIdentityGroupUsers,
     /// Set GroupUser filters
     SetIdentityGroupUserListFilters(cloud_types::IdentityGroupUserList),
     /// Add user into the group
@@ -156,12 +166,7 @@ pub enum Action {
     IdentityGroupUserRemove,
     //  Users
     // Set ApplicationCredentials filters
-    ShowIdentityUserApplicationCredentials,
     SetIdentityApplicationCredentialListFilters(cloud_types::IdentityUserApplicationCredentialList),
-    /// Toggle user enabled property
-    IdentityUserFlipEnable,
-    /// Remove user
-    IdentityUserDelete,
     /// Create new user
     IdentityUserCreate,
     /// Update user password
@@ -171,46 +176,101 @@ pub enum Action {
 
     // Image (glance)
     SetImageListFilters(cloud_types::ImageImageList),
-    /// Delete image
-    DeleteImage,
 
     // LB
     /// Set LB filters
     SetLoadBalancerListFilters(cloud_types::LoadBalancerLoadbalancerList),
     /// Set LB Listener filters
     SetLoadBalancerListenerListFilters(cloud_types::LoadBalancerListenerList),
-    /// Show LB Listeners
-    ShowLoadBalancerListeners,
-    /// Show LB Pools
-    ShowLoadBalancerPools,
     /// Set LB Pool filters
     SetLoadBalancerPoolListFilters(cloud_types::LoadBalancerPoolList),
     /// Show LB Listener Pools
     ShowLoadBalancerListenerPools,
     /// Set LB Member filters
     SetLoadBalancerPoolMemberListFilters(cloud_types::LoadBalancerPoolMemberList),
-    /// Show LB Pool members
-    ShowLoadBalancerPoolMembers,
     /// Set LB Healthmonitor filters
     SetLoadBalancerHealthMonitorListFilters(cloud_types::LoadBalancerHealthmonitorList),
-    /// Show LB Listener Pools
-    ShowLoadBalancerPoolHealthMonitors,
 
     // Network (neutron)
     /// Set Security group filters
     SetNetworkSecurityGroupListFilters(cloud_types::NetworkSecurityGroupList),
-    /// Switch to NetworkSecurityGroupRules
-    ShowNetworkSecurityGroupRules,
-    /// Create the security group rule.
-    CreateNetworkSecurityGroupRule,
-    //CreateNetworkSecurityGroupRuleData(serde_json::Value),
-    /// Delete the security group rule.
-    DeleteNetworkSecurityGroupRule,
+    /// Show a resource view, addressed by `ViewKey`.
+    ShowResource(#[serde(deserialize_with = "deserialize_view_key")] crate::mode::ViewKey),
+    /// Create/Delete a resource, addressed by `ViewKey`.
+    ResourceOp {
+        #[serde(deserialize_with = "deserialize_view_key")]
+        key: crate::mode::ViewKey,
+        op: ResourceOp,
+    },
+    /// Identity-user-specific operation, addressed by `ViewKey`.
+    IdentityUserOp {
+        #[serde(deserialize_with = "deserialize_view_key")]
+        key: crate::mode::ViewKey,
+        op: IdentityUserOp,
+    },
     /// Switch to routers view
     ShowNetworkRouters,
     /// Set Security group rule filters
     SetNetworkSecurityGroupRuleListFilters(cloud_types::NetworkSecurityGroupRuleList),
     SetNetworkSubnetListFilters(cloud_types::NetworkSubnetList),
-    /// Show Subnetworks of a network
-    ShowNetworkSubnets,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mode::NETWORK_SECURITY_GROUP_RULE;
+
+    /// serde_yaml 0.9 serializes/deserializes non-unit enum variants using a
+    /// YAML tag (`!VariantName`) by default, not the `{VariantName: ...}`
+    /// mapping form that `serde_json`/`toml` use for externally tagged
+    /// enums. Parsing that mapping form (which is what our config files and
+    /// these tests use) requires opting into `serde_yaml`'s
+    /// `singleton_map_recursive` adapter, which walks the whole value tree
+    /// applying the "single-key map" convention to every nested enum too
+    /// (`Action`'s content contains further enums like `ResourceOp`). See
+    /// https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html.
+    fn action_from_yaml_str(yaml: &str) -> Result<Action, serde_yaml::Error> {
+        let deserializer = serde_yaml::Deserializer::from_str(yaml);
+        serde_yaml::with::singleton_map_recursive::deserialize(deserializer)
+    }
+
+    #[test]
+    fn show_resource_round_trips_through_yaml() {
+        let yaml = "ShowResource: \"network.security_group_rule\"";
+        let action: Action = action_from_yaml_str(yaml).unwrap();
+        assert_eq!(action, Action::ShowResource(NETWORK_SECURITY_GROUP_RULE));
+    }
+
+    #[test]
+    fn resource_op_round_trips_through_yaml() {
+        let yaml = "ResourceOp:\n  key: \"network.security_group_rule\"\n  op: Delete";
+        let action: Action = action_from_yaml_str(yaml).unwrap();
+        assert_eq!(
+            action,
+            Action::ResourceOp {
+                key: NETWORK_SECURITY_GROUP_RULE,
+                op: ResourceOp::Delete,
+            }
+        );
+    }
+
+    #[test]
+    fn resource_op_variants_are_distinct() {
+        assert_ne!(
+            Action::ResourceOp {
+                key: NETWORK_SECURITY_GROUP_RULE,
+                op: ResourceOp::Create,
+            },
+            Action::ResourceOp {
+                key: NETWORK_SECURITY_GROUP_RULE,
+                op: ResourceOp::Delete,
+            }
+        );
+    }
+
+    #[test]
+    fn unit_variant_action_deserializes_from_bare_string() {
+        let action: Action = serde_yaml::from_str("Quit").unwrap();
+        assert_eq!(action, Action::Quit);
+    }
 }

--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -81,7 +81,6 @@ enum Popup {
     SwitchCloud,
     SwitchProject,
     SwitchRegion,
-    //CreateNetworkSecurityGroupRule,
     Confirm,
 }
 
@@ -125,77 +124,119 @@ impl App {
         components.insert(Mode::Describe, Box::new(Describe::new()));
 
         components.insert(
-            Mode::BlockStorageBackups,
+            Mode::Resource(crate::mode::BLOCK_STORAGE_BACKUP),
             Box::new(BlockStorageBackups::new()),
         );
         components.insert(
-            Mode::BlockStorageSnapshots,
+            Mode::Resource(crate::mode::BLOCK_STORAGE_SNAPSHOT),
             Box::new(BlockStorageSnapshots::new()),
         );
         components.insert(
-            Mode::BlockStorageVolumes,
+            Mode::Resource(crate::mode::BLOCK_STORAGE_VOLUME),
             Box::new(BlockStorageVolumes::new()),
         );
 
-        components.insert(Mode::ComputeServers, Box::new(ComputeServers::new()));
         components.insert(
-            Mode::ComputeServerInstanceActions,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
+            Box::new(ComputeServers::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION),
             Box::new(ComputeServerInstanceActions::new()),
         );
         components.insert(
-            Mode::ComputeServerInstanceActionEvents,
+            Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
             Box::new(ComputeServerInstanceActionEvents::new()),
         );
-        components.insert(Mode::ComputeFlavors, Box::new(ComputeFlavors::new()));
-        components.insert(Mode::ComputeAggregates, Box::new(ComputeAggregates::new()));
         components.insert(
-            Mode::ComputeHypervisors,
+            Mode::Resource(crate::mode::COMPUTE_FLAVOR),
+            Box::new(ComputeFlavors::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::COMPUTE_AGGREGATE),
+            Box::new(ComputeAggregates::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::COMPUTE_HYPERVISOR),
             Box::new(ComputeHypervisors::new()),
         );
 
-        components.insert(Mode::DnsRecordsets, Box::new(DnsRecordsets::new()));
-        components.insert(Mode::DnsZones, Box::new(DnsZones::new()));
+        components.insert(
+            Mode::Resource(crate::mode::DNS_RECORDSET),
+            Box::new(DnsRecordsets::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::DNS_ZONE),
+            Box::new(DnsZones::new()),
+        );
 
         components.insert(
-            Mode::IdentityApplicationCredentials,
+            Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
             Box::new(IdentityApplicationCredentials::new()),
         );
-        components.insert(Mode::IdentityGroups, Box::new(IdentityGroups::new()));
         components.insert(
-            Mode::IdentityGroupUsers,
+            Mode::Resource(crate::mode::IDENTITY_GROUP),
+            Box::new(IdentityGroups::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::IDENTITY_GROUP_USER),
             Box::new(IdentityGroupUsers::new()),
         );
-        components.insert(Mode::IdentityProjects, Box::new(IdentityProjects::new()));
-        components.insert(Mode::IdentityUsers, Box::new(IdentityUsers::new()));
-
-        components.insert(Mode::ImageImages, Box::new(Images::new()));
-
-        components.insert(Mode::LoadBalancers, Box::new(LoadBalancers::new()));
         components.insert(
-            Mode::LoadBalancerListeners,
+            Mode::Resource(crate::mode::IDENTITY_PROJECT),
+            Box::new(IdentityProjects::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::IDENTITY_USER),
+            Box::new(IdentityUsers::new()),
+        );
+
+        components.insert(
+            Mode::Resource(crate::mode::IMAGE_IMAGE),
+            Box::new(Images::new()),
+        );
+
+        components.insert(
+            Mode::Resource(crate::mode::LB_LOADBALANCER),
+            Box::new(LoadBalancers::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::LB_LISTENER),
             Box::new(LoadBalancerListeners::new()),
         );
-        components.insert(Mode::LoadBalancerPools, Box::new(LoadBalancerPools::new()));
         components.insert(
-            Mode::LoadBalancerPoolMembers,
+            Mode::Resource(crate::mode::LB_POOL),
+            Box::new(LoadBalancerPools::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::LB_POOL_MEMBER),
             Box::new(LoadBalancerPoolMembers::new()),
         );
         components.insert(
-            Mode::LoadBalancerHealthMonitors,
+            Mode::Resource(crate::mode::LB_HEALTHMONITOR),
             Box::new(LoadBalancerHealthMonitors::new()),
         );
 
-        components.insert(Mode::NetworkNetworks, Box::new(NetworkNetworks::new()));
-        components.insert(Mode::NetworkRouters, Box::new(NetworkRouters::new()));
         components.insert(
-            Mode::NetworkSecurityGroups,
+            Mode::Resource(crate::mode::NETWORK_NETWORK),
+            Box::new(NetworkNetworks::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::NETWORK_ROUTER),
+            Box::new(NetworkRouters::new()),
+        );
+        components.insert(
+            Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP),
             Box::new(NetworkSecurityGroups::new()),
         );
         components.insert(
-            Mode::NetworkSecurityGroupRules,
+            Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP_RULE),
             Box::new(NetworkSecurityGroupRules::new()),
         );
-        components.insert(Mode::NetworkSubnets, Box::new(NetworkSubnets::new()));
+        components.insert(
+            Mode::Resource(crate::mode::NETWORK_SUBNET),
+            Box::new(NetworkSubnets::new()),
+        );
 
         let (auth_helper_control_channel_tx, auth_helper_control_channel_rx) =
             mpsc::channel::<oneshot::Sender<AuthAction>>(10);

--- a/openstack_tui/src/components/block_storage/backups.rs
+++ b/openstack_tui/src/components/block_storage/backups.rs
@@ -35,7 +35,7 @@ impl ResourceBehaviour for BlockStorageBackupsBehaviour {
         "Backups"
     }
     fn mode() -> Mode {
-        Mode::BlockStorageBackups
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(BlockStorageBackupApiRequest::ListDetailed(Box::new(
@@ -68,7 +68,7 @@ mod tests {
         assert_eq!(BlockStorageBackupsBehaviour::title(), "Backups");
         assert_eq!(
             BlockStorageBackupsBehaviour::mode(),
-            Mode::BlockStorageBackups
+            Mode::Resource(crate::mode::BLOCK_STORAGE_BACKUP)
         );
     }
 

--- a/openstack_tui/src/components/block_storage/snapshots.rs
+++ b/openstack_tui/src/components/block_storage/snapshots.rs
@@ -35,7 +35,7 @@ impl ResourceBehaviour for BlockStorageSnapshotsBehaviour {
         "Snapshots"
     }
     fn mode() -> Mode {
-        Mode::BlockStorageSnapshots
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(BlockStorageSnapshotApiRequest::ListDetailed(Box::new(
@@ -68,7 +68,7 @@ mod tests {
         assert_eq!(BlockStorageSnapshotsBehaviour::title(), "Snapshots");
         assert_eq!(
             BlockStorageSnapshotsBehaviour::mode(),
-            Mode::BlockStorageSnapshots
+            Mode::Resource(crate::mode::BLOCK_STORAGE_SNAPSHOT)
         );
     }
 

--- a/openstack_tui/src/components/block_storage/volumes.rs
+++ b/openstack_tui/src/components/block_storage/volumes.rs
@@ -56,7 +56,7 @@ impl ResourceBehaviour for BlockStorageVolumesBehaviour {
         "Volumes"
     }
     fn mode() -> Mode {
-        Mode::BlockStorageVolumes
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(BlockStorageVolumeApiRequest::ListDetailed(Box::new(
@@ -71,7 +71,12 @@ impl ResourceBehaviour for BlockStorageVolumesBehaviour {
         )
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::DeleteBlockStorageVolume = action {
+        if let Action::ResourceOp {
+            key,
+            op: crate::action::ResourceOp::Delete,
+        } = action
+            && *key == Self::view_key()
+        {
             let del = BlockStorageVolumeDelete::try_from(selected?).ok()?;
             Some(ApiRequest::from(BlockStorageVolumeApiRequest::Delete(
                 Box::new(del),
@@ -127,7 +132,7 @@ mod tests {
         assert_eq!(BlockStorageVolumesBehaviour::title(), "Volumes");
         assert_eq!(
             BlockStorageVolumesBehaviour::mode(),
-            Mode::BlockStorageVolumes
+            Mode::Resource(crate::mode::BLOCK_STORAGE_VOLUME)
         );
     }
 
@@ -163,7 +168,10 @@ mod tests {
     fn confirm_request_delete_with_selected() {
         let vol = make_volume("vol-1", "test-vol");
         let result = BlockStorageVolumesBehaviour::confirm_request(
-            &Action::DeleteBlockStorageVolume,
+            &Action::ResourceOp {
+                key: crate::mode::BLOCK_STORAGE_VOLUME,
+                op: crate::action::ResourceOp::Delete,
+            },
             Some(&vol),
         );
         assert!(result.is_some());
@@ -177,8 +185,13 @@ mod tests {
 
     #[test]
     fn confirm_request_delete_without_selected() {
-        let result =
-            BlockStorageVolumesBehaviour::confirm_request(&Action::DeleteBlockStorageVolume, None);
+        let result = BlockStorageVolumesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::BLOCK_STORAGE_VOLUME,
+                op: crate::action::ResourceOp::Delete,
+            },
+            None,
+        );
         assert!(result.is_none());
     }
 
@@ -186,6 +199,19 @@ mod tests {
     fn confirm_request_returns_none_for_unrelated() {
         let vol = make_volume("vol-1", "test-vol");
         let result = BlockStorageVolumesBehaviour::confirm_request(&Action::Tick, Some(&vol));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn confirm_request_ignores_delete_for_other_resource() {
+        let vol = make_volume("vol-1", "test-vol");
+        let result = BlockStorageVolumesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::BLOCK_STORAGE_SNAPSHOT,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&vol),
+        );
         assert!(result.is_none());
     }
 }

--- a/openstack_tui/src/components/compute/aggregates.rs
+++ b/openstack_tui/src/components/compute/aggregates.rs
@@ -35,7 +35,7 @@ impl ResourceBehaviour for ComputeAggregatesBehaviour {
         "Compute Aggregates"
     }
     fn mode() -> Mode {
-        Mode::ComputeAggregates
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(ComputeAggregateApiRequest::List(Box::new(filter.clone())))
@@ -61,7 +61,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(ComputeAggregatesBehaviour::view_key(), "compute.aggregate");
         assert_eq!(ComputeAggregatesBehaviour::title(), "Compute Aggregates");
-        assert_eq!(ComputeAggregatesBehaviour::mode(), Mode::ComputeAggregates);
+        assert_eq!(
+            ComputeAggregatesBehaviour::mode(),
+            Mode::Resource(crate::mode::COMPUTE_AGGREGATE)
+        );
     }
 
     #[test]

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -50,7 +50,7 @@ impl ResourceBehaviour for ComputeFlavorsBehaviour {
     }
 
     fn mode() -> Mode {
-        Mode::ComputeFlavors
+        Mode::Resource(Self::view_key())
     }
 
     fn normalise_filter(filter: Self::Filter) -> Self::Filter {
@@ -81,7 +81,8 @@ impl ResourceBehaviour for ComputeFlavorsBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowComputeServersWithFlavor = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::COMPUTE_SERVER
             && let Some(sel) = selected
             && let Ok(server_list) = ComputeServerListBuilder::default()
                 .flavor(sel.id.clone())
@@ -89,7 +90,7 @@ impl ResourceBehaviour for ComputeFlavorsBehaviour {
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::ComputeServers,
+                    mode: Mode::Resource(crate::mode::COMPUTE_SERVER),
                     stack: true,
                 },
                 Action::SetComputeServerListFilters(Box::new(server_list)),
@@ -153,7 +154,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(ComputeFlavorsBehaviour::view_key(), "compute.flavor");
         assert_eq!(ComputeFlavorsBehaviour::title(), "Compute Flavors");
-        assert_eq!(ComputeFlavorsBehaviour::mode(), Mode::ComputeFlavors);
+        assert_eq!(
+            ComputeFlavorsBehaviour::mode(),
+            Mode::Resource(crate::mode::COMPUTE_FLAVOR)
+        );
     }
 
     #[test]
@@ -189,14 +193,17 @@ mod tests {
     fn filter_carry_action_show_servers_with_flavor() {
         let flavor = make_flavor("flavor-123");
         let actions = ComputeFlavorsBehaviour::filter_carry_action(
-            &Action::ShowComputeServersWithFlavor,
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER),
             Some(&flavor),
             &ComputeFlavorList::default(),
         );
         assert_eq!(actions.len(), 2);
         match &actions[0] {
             Action::Mode { mode, stack } => {
-                assert_eq!(*mode, crate::mode::Mode::ComputeServers);
+                assert_eq!(
+                    *mode,
+                    crate::mode::Mode::Resource(crate::mode::COMPUTE_SERVER)
+                );
                 assert!(*stack);
             }
             _ => panic!("Expected Mode switch, got {:?}", actions[0]),
@@ -212,8 +219,19 @@ mod tests {
     #[test]
     fn filter_carry_action_no_selected() {
         let actions = ComputeFlavorsBehaviour::filter_carry_action(
-            &Action::ShowComputeServersWithFlavor,
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER),
             None,
+            &ComputeFlavorList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let flavor = make_flavor("flavor-123");
+        let actions = ComputeFlavorsBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::COMPUTE_FLAVOR),
+            Some(&flavor),
             &ComputeFlavorList::default(),
         );
         assert!(actions.is_empty());

--- a/openstack_tui/src/components/compute/hypervisors.rs
+++ b/openstack_tui/src/components/compute/hypervisors.rs
@@ -35,7 +35,7 @@ impl ResourceBehaviour for ComputeHypervisorsBehaviour {
         "Compute Hypervisors"
     }
     fn mode() -> Mode {
-        Mode::ComputeHypervisors
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(ComputeHypervisorApiRequest::ListDetailed(Box::new(
@@ -68,7 +68,7 @@ mod tests {
         assert_eq!(ComputeHypervisorsBehaviour::title(), "Compute Hypervisors");
         assert_eq!(
             ComputeHypervisorsBehaviour::mode(),
-            Mode::ComputeHypervisors
+            Mode::Resource(crate::mode::COMPUTE_HYPERVISOR)
         );
     }
 

--- a/openstack_tui/src/components/compute/server_instance_action_events.rs
+++ b/openstack_tui/src/components/compute/server_instance_action_events.rs
@@ -81,7 +81,7 @@ impl ResourceBehaviour for ComputeServerInstanceActionEventsBehaviour {
         "InstanceAction Events"
     }
     fn mode() -> Mode {
-        Mode::ComputeServerInstanceActionEvents
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(ComputeServerInstanceActionApiRequest::Get(Box::new(
@@ -151,7 +151,7 @@ mod tests {
         );
         assert_eq!(
             ComputeServerInstanceActionEventsBehaviour::mode(),
-            Mode::ComputeServerInstanceActionEvents
+            Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT)
         );
     }
 

--- a/openstack_tui/src/components/compute/server_instance_actions.rs
+++ b/openstack_tui/src/components/compute/server_instance_actions.rs
@@ -44,7 +44,7 @@ impl ResourceBehaviour for ComputeServerInstanceActionsBehaviour {
         "ServerInstanceAction Actions"
     }
     fn mode() -> Mode {
-        Mode::ComputeServerInstanceActions
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(ComputeServerInstanceActionApiRequest::List(Box::new(
@@ -72,7 +72,8 @@ impl ResourceBehaviour for ComputeServerInstanceActionsBehaviour {
         selected: Option<&Self::Item>,
         filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowComputeServerInstanceActionEvents = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT
             && let Some(sel) = selected
         {
             let mut req = ComputeServerInstanceActionShowBuilder::default();
@@ -84,7 +85,7 @@ impl ResourceBehaviour for ComputeServerInstanceActionsBehaviour {
             if let Ok(list) = req.build() {
                 return vec![
                     Action::Mode {
-                        mode: Mode::ComputeServerInstanceActionEvents,
+                        mode: Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
                         stack: true,
                     },
                     Action::SetComputeServerInstanceActionShowFilters(Box::new(list)),
@@ -141,7 +142,7 @@ mod tests {
         );
         assert_eq!(
             ComputeServerInstanceActionsBehaviour::mode(),
-            Mode::ComputeServerInstanceActions
+            Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION)
         );
     }
 
@@ -198,7 +199,7 @@ mod tests {
         let action_item = make_instance_action();
         let filter = make_filter();
         let actions = ComputeServerInstanceActionsBehaviour::filter_carry_action(
-            &Action::ShowComputeServerInstanceActionEvents,
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
             Some(&action_item),
             &filter,
         );
@@ -206,7 +207,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::ComputeServerInstanceActionEvents,
+                mode: Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
                 stack: true
             }
         ));
@@ -219,9 +220,21 @@ mod tests {
     #[test]
     fn filter_carry_action_without_selected() {
         let actions = ComputeServerInstanceActionsBehaviour::filter_carry_action(
-            &Action::ShowComputeServerInstanceActionEvents,
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
             None,
             &make_filter(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let action_item = make_instance_action();
+        let filter = make_filter();
+        let actions = ComputeServerInstanceActionsBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION),
+            Some(&action_item),
+            &filter,
         );
         assert!(actions.is_empty());
     }

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -37,7 +37,7 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         "Compute Servers"
     }
     fn mode() -> Mode {
-        Mode::ComputeServers
+        Mode::Resource(Self::view_key())
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -66,7 +66,12 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         }
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::DeleteComputeServer = action {
+        if let Action::ResourceOp {
+            key,
+            op: crate::action::ResourceOp::Delete,
+        } = action
+            && *key == Self::view_key()
+        {
             let sel = selected?;
             let mut del_builder = ComputeServerDeleteBuilder::default();
             del_builder.id(sel.id.clone());
@@ -133,7 +138,8 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowComputeServerInstanceActions = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::COMPUTE_SERVER_INSTANCE_ACTION
             && let Some(sel) = selected
         {
             let mut list_builder = ComputeServerInstanceActionListBuilder::default();
@@ -144,7 +150,7 @@ impl ResourceBehaviour for ComputeServersBehaviour {
             if let Ok(list) = list_builder.build() {
                 return vec![
                     Action::Mode {
-                        mode: Mode::ComputeServerInstanceActions,
+                        mode: Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION),
                         stack: true,
                     },
                     Action::SetComputeServerInstanceActionListFilters(Box::new(list)),
@@ -216,7 +222,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(ComputeServersBehaviour::view_key(), "compute.server");
         assert_eq!(ComputeServersBehaviour::title(), "Compute Servers");
-        assert_eq!(ComputeServersBehaviour::mode(), Mode::ComputeServers);
+        assert_eq!(
+            ComputeServersBehaviour::mode(),
+            Mode::Resource(crate::mode::COMPUTE_SERVER)
+        );
     }
 
     #[test]
@@ -270,8 +279,13 @@ mod tests {
     #[test]
     fn confirm_request_delete_with_selected_server() {
         let server = make_server("server-1", "test-server");
-        let result =
-            ComputeServersBehaviour::confirm_request(&Action::DeleteComputeServer, Some(&server));
+        let result = ComputeServersBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::COMPUTE_SERVER,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&server),
+        );
         assert!(result.is_some());
         let request = result.unwrap();
         assert!(matches!(
@@ -283,7 +297,26 @@ mod tests {
 
     #[test]
     fn confirm_request_delete_without_selected_server() {
-        let result = ComputeServersBehaviour::confirm_request(&Action::DeleteComputeServer, None);
+        let result = ComputeServersBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::COMPUTE_SERVER,
+                op: crate::action::ResourceOp::Delete,
+            },
+            None,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn confirm_request_ignores_delete_for_other_resource() {
+        let server = make_server("server-1", "test-server");
+        let result = ComputeServersBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::COMPUTE_AGGREGATE,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&server),
+        );
         assert!(result.is_none());
     }
 
@@ -383,7 +416,7 @@ mod tests {
     fn filter_carry_action_instance_actions_with_server() {
         let server = make_server("server-1", "test-server");
         let result = ComputeServersBehaviour::filter_carry_action(
-            &Action::ShowComputeServerInstanceActions,
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION),
             Some(&server),
             &ComputeServerList::default(),
         );
@@ -391,7 +424,7 @@ mod tests {
         assert!(matches!(
             result[0],
             Action::Mode {
-                mode: Mode::ComputeServerInstanceActions,
+                mode: Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION),
                 stack: true
             }
         ));
@@ -404,8 +437,19 @@ mod tests {
     #[test]
     fn filter_carry_action_instance_actions_without_server() {
         let result = ComputeServersBehaviour::filter_carry_action(
-            &Action::ShowComputeServerInstanceActions,
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION),
             None,
+            &ComputeServerList::default(),
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let server = make_server("server-1", "test-server");
+        let result = ComputeServersBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::COMPUTE_SERVER),
+            Some(&server),
             &ComputeServerList::default(),
         );
         assert!(result.is_empty());

--- a/openstack_tui/src/components/dns/recordsets.rs
+++ b/openstack_tui/src/components/dns/recordsets.rs
@@ -63,7 +63,7 @@ impl ResourceBehaviour for DnsRecordsetsBehaviour {
         "DNS Recordsets"
     }
     fn mode() -> Mode {
-        Mode::DnsRecordsets
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         if filter.zone_id.is_some() {
@@ -114,7 +114,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(DnsRecordsetsBehaviour::view_key(), "dns.recordset");
         assert_eq!(DnsRecordsetsBehaviour::title(), "DNS Recordsets");
-        assert_eq!(DnsRecordsetsBehaviour::mode(), Mode::DnsRecordsets);
+        assert_eq!(
+            DnsRecordsetsBehaviour::mode(),
+            Mode::Resource(crate::mode::DNS_RECORDSET)
+        );
     }
 
     #[test]

--- a/openstack_tui/src/components/dns/zones.rs
+++ b/openstack_tui/src/components/dns/zones.rs
@@ -72,7 +72,7 @@ impl ResourceBehaviour for DnsZonesBehaviour {
         "DNS Zones"
     }
     fn mode() -> Mode {
-        Mode::DnsZones
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(DnsZoneApiRequest::List(Box::new(filter.clone())))
@@ -92,7 +92,12 @@ impl ResourceBehaviour for DnsZonesBehaviour {
         }
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::DeleteDnsZone = action {
+        if let Action::ResourceOp {
+            key,
+            op: crate::action::ResourceOp::Delete,
+        } = action
+            && *key == Self::view_key()
+        {
             let del = DnsZoneDelete::try_from(selected?).ok()?;
             Some(ApiRequest::from(DnsZoneApiRequest::Delete(Box::new(del))))
         } else {
@@ -104,13 +109,14 @@ impl ResourceBehaviour for DnsZonesBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowDnsZoneRecordsets = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::DNS_RECORDSET
             && let Some(sel) = selected
             && let Ok(list) = DnsRecordsetList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::DnsRecordsets,
+                    mode: Mode::Resource(crate::mode::DNS_RECORDSET),
                     stack: true,
                 },
                 Action::SetDnsRecordsetListFilters(list),
@@ -153,7 +159,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(DnsZonesBehaviour::view_key(), "dns.zone");
         assert_eq!(DnsZonesBehaviour::title(), "DNS Zones");
-        assert_eq!(DnsZonesBehaviour::mode(), Mode::DnsZones);
+        assert_eq!(
+            DnsZonesBehaviour::mode(),
+            Mode::Resource(crate::mode::DNS_ZONE)
+        );
     }
 
     #[test]
@@ -199,7 +208,13 @@ mod tests {
     #[test]
     fn confirm_request_delete_with_selected() {
         let zone = make_zone("zone-1", "example.com");
-        let result = DnsZonesBehaviour::confirm_request(&Action::DeleteDnsZone, Some(&zone));
+        let result = DnsZonesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::DNS_ZONE,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&zone),
+        );
         assert!(result.is_some());
         let request = result.unwrap();
         assert!(matches!(
@@ -211,7 +226,13 @@ mod tests {
 
     #[test]
     fn confirm_request_delete_without_selected() {
-        let result = DnsZonesBehaviour::confirm_request(&Action::DeleteDnsZone, None);
+        let result = DnsZonesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::DNS_ZONE,
+                op: crate::action::ResourceOp::Delete,
+            },
+            None,
+        );
         assert!(result.is_none());
     }
 
@@ -223,10 +244,23 @@ mod tests {
     }
 
     #[test]
+    fn confirm_request_ignores_delete_for_other_resource() {
+        let zone = make_zone("zone-1", "example.com");
+        let result = DnsZonesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::DNS_RECORDSET,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&zone),
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
     fn filter_carry_action_show_recordsets_with_selected() {
         let zone = make_zone("zone-1", "example.com");
         let actions = DnsZonesBehaviour::filter_carry_action(
-            &Action::ShowDnsZoneRecordsets,
+            &Action::ShowResource(crate::mode::DNS_RECORDSET),
             Some(&zone),
             &DnsZoneList::default(),
         );
@@ -234,7 +268,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::DnsRecordsets,
+                mode: Mode::Resource(crate::mode::DNS_RECORDSET),
                 stack: true
             }
         ));
@@ -244,7 +278,7 @@ mod tests {
     #[test]
     fn filter_carry_action_without_selected() {
         let actions = DnsZonesBehaviour::filter_carry_action(
-            &Action::ShowDnsZoneRecordsets,
+            &Action::ShowResource(crate::mode::DNS_RECORDSET),
             None,
             &DnsZoneList::default(),
         );
@@ -256,6 +290,17 @@ mod tests {
         let zone = make_zone("zone-1", "example.com");
         let actions = DnsZonesBehaviour::filter_carry_action(
             &Action::Tick,
+            Some(&zone),
+            &DnsZoneList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let zone = make_zone("zone-1", "example.com");
+        let actions = DnsZonesBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::DNS_ZONE),
             Some(&zone),
             &DnsZoneList::default(),
         );

--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn tick_returns_none() {
         let mut comp: ComputeServers = GenericResourceView::new();
-        let result = comp.update(Action::Tick, Mode::ComputeServers);
+        let result = comp.update(Action::Tick, Mode::Resource(crate::mode::COMPUTE_SERVER));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
     }
@@ -280,7 +280,7 @@ mod tests {
     #[test]
     fn render_returns_none() {
         let mut comp: ComputeServers = GenericResourceView::new();
-        let result = comp.update(Action::Render, Mode::ComputeServers);
+        let result = comp.update(Action::Render, Mode::Resource(crate::mode::COMPUTE_SERVER));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
     }
@@ -288,7 +288,7 @@ mod tests {
     #[test]
     fn refresh_returns_perform_api_request() {
         let mut comp: ComputeServers = GenericResourceView::new();
-        let result = comp.update(Action::Refresh, Mode::ComputeServers);
+        let result = comp.update(Action::Refresh, Mode::Resource(crate::mode::COMPUTE_SERVER));
         assert!(result.is_ok());
         assert!(matches!(
             result.unwrap(),
@@ -301,10 +301,10 @@ mod tests {
         let mut comp: ComputeServers = GenericResourceView::new();
         let result = comp.update(
             Action::Mode {
-                mode: Mode::ComputeServers,
+                mode: Mode::Resource(crate::mode::COMPUTE_SERVER),
                 stack: false,
             },
-            Mode::ComputeServers,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
@@ -315,10 +315,10 @@ mod tests {
         let mut comp: ComputeServers = GenericResourceView::new();
         let result = comp.update(
             Action::Mode {
-                mode: Mode::ComputeFlavors,
+                mode: Mode::Resource(crate::mode::COMPUTE_FLAVOR),
                 stack: false,
             },
-            Mode::ComputeFlavors,
+            Mode::Resource(crate::mode::COMPUTE_FLAVOR),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
@@ -332,7 +332,7 @@ mod tests {
             ..Default::default()
         };
         let action = Action::SetComputeServerListFilters(Box::new(filter));
-        let result = comp.update(action, Mode::ComputeServers);
+        let result = comp.update(action, Mode::Resource(crate::mode::COMPUTE_SERVER));
         assert!(result.is_ok());
         assert!(matches!(
             result.unwrap(),
@@ -350,7 +350,7 @@ mod tests {
         let data: Vec<Value> = Vec::new();
         let result = comp.update(
             Action::ApiResponsesData { request, data },
-            Mode::ComputeServers,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
@@ -370,7 +370,7 @@ mod tests {
         let data: Vec<Value> = Vec::new();
         let result = comp.update(
             Action::ApiResponsesData { request, data },
-            Mode::ComputeServers,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
@@ -382,7 +382,7 @@ mod tests {
         let scope = openstack_sdk::auth::authtoken::AuthTokenScope::Unscoped;
         let result = comp.update(
             Action::CloudChangeScope(Box::new(scope)),
-            Mode::ComputeServers,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
@@ -394,7 +394,7 @@ mod tests {
         let token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
         let result = comp.update(
             Action::ConnectedToCloud(Box::new(token_info)),
-            Mode::ComputeServers,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
         assert!(matches!(
@@ -409,7 +409,7 @@ mod tests {
         let token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
         let result = comp.update(
             Action::ConnectedToCloud(Box::new(token_info)),
-            Mode::ComputeFlavors,
+            Mode::Resource(crate::mode::COMPUTE_FLAVOR),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
@@ -449,7 +449,7 @@ mod tests {
         )));
         comp.update(
             Action::ApiResponsesData { request, data },
-            Mode::ComputeServers,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
         )
         .unwrap();
         comp.handle_key_events(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
@@ -476,7 +476,7 @@ mod tests {
         let data = vec![console_data];
         let result = comp.update(
             Action::ApiResponsesData { request, data },
-            Mode::ComputeServers,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
         assert!(matches!(
@@ -488,7 +488,13 @@ mod tests {
     #[test]
     fn confirm_request_dispatches_confirm_action() {
         let mut comp = setup_comp_with_selected_server();
-        let result = comp.update(Action::DeleteComputeServer, Mode::ComputeServers);
+        let result = comp.update(
+            Action::ResourceOp {
+                key: crate::mode::COMPUTE_SERVER,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
+        );
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), Some(Action::Confirm(_))));
     }
@@ -533,12 +539,18 @@ mod tests {
                 request,
                 data: vec![volume_json],
             },
-            Mode::BlockStorageVolumes,
+            Mode::Resource(crate::mode::BLOCK_STORAGE_VOLUME),
         )
         .unwrap();
         comp.handle_key_events(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
             .unwrap();
-        let result = comp.update(Action::DeleteBlockStorageVolume, Mode::BlockStorageVolumes);
+        let result = comp.update(
+            Action::ResourceOp {
+                key: crate::mode::BLOCK_STORAGE_VOLUME,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Mode::Resource(crate::mode::BLOCK_STORAGE_VOLUME),
+        );
         assert!(result.is_ok());
         assert!(matches!(result.unwrap(), Some(Action::Confirm(_))));
     }
@@ -546,7 +558,10 @@ mod tests {
     #[test]
     fn action_to_singular_request_dispatches_via_tx_and_returns_perform() {
         let mut comp = setup_comp_with_selected_server();
-        let result = comp.update(Action::ShowServerConsoleOutput, Mode::ComputeServers);
+        let result = comp.update(
+            Action::ShowServerConsoleOutput,
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
+        );
         assert!(result.is_ok());
         assert!(matches!(
             result.unwrap(),
@@ -581,12 +596,15 @@ mod tests {
                 request,
                 data: vec![flavor_json],
             },
-            Mode::ComputeFlavors,
+            Mode::Resource(crate::mode::COMPUTE_FLAVOR),
         )
         .unwrap();
         comp.handle_key_events(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()))
             .unwrap();
-        let result = comp.update(Action::ShowComputeServersWithFlavor, Mode::ComputeFlavors);
+        let result = comp.update(
+            Action::ShowResource(crate::mode::COMPUTE_SERVER),
+            Mode::Resource(crate::mode::COMPUTE_FLAVOR),
+        );
         assert!(result.is_ok());
         assert!(matches!(
             result.unwrap(),

--- a/openstack_tui/src/components/identity/application_credentials.rs
+++ b/openstack_tui/src/components/identity/application_credentials.rs
@@ -44,7 +44,7 @@ impl ResourceBehaviour for IdentityApplicationCredentialsBehaviour {
         "Application Credentials"
     }
     fn mode() -> Mode {
-        Mode::IdentityApplicationCredentials
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(IdentityUserApplicationCredentialApiRequest::List(Box::new(
@@ -89,7 +89,7 @@ mod tests {
         );
         assert_eq!(
             IdentityApplicationCredentialsBehaviour::mode(),
-            Mode::IdentityApplicationCredentials
+            Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL)
         );
     }
 

--- a/openstack_tui/src/components/identity/group_users.rs
+++ b/openstack_tui/src/components/identity/group_users.rs
@@ -43,7 +43,12 @@ impl ResourceBehaviour for IdentityGroupUsersBehaviour {
         "Identity Group Users"
     }
     fn mode() -> Mode {
-        Mode::IdentityGroupUsers
+        // NOTE: intentionally NOT `Mode::Resource(Self::view_key())` — `view_key()` returns
+        // "identity.user" (shared with `IdentityUsersBehaviour`, both render `UserResponse`-shaped
+        // rows via the same `views: identity.user:` config). Using it here would collide with
+        // `IdentityUsers`' own `Mode::Resource("identity.user")` key in the `app.rs` component
+        // registry, so this resource uses the synthetic `IDENTITY_GROUP_USER` key instead.
+        Mode::Resource(crate::mode::IDENTITY_GROUP_USER)
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(IdentityGroupUserApiRequest::List(Box::new(filter.clone())))
@@ -79,7 +84,7 @@ mod tests {
         assert_eq!(IdentityGroupUsersBehaviour::title(), "Identity Group Users");
         assert_eq!(
             IdentityGroupUsersBehaviour::mode(),
-            Mode::IdentityGroupUsers
+            Mode::Resource(crate::mode::IDENTITY_GROUP_USER)
         );
     }
 

--- a/openstack_tui/src/components/identity/groups.rs
+++ b/openstack_tui/src/components/identity/groups.rs
@@ -72,7 +72,7 @@ impl ResourceBehaviour for IdentityGroupsBehaviour {
         "Identity Groups"
     }
     fn mode() -> Mode {
-        Mode::IdentityGroups
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(IdentityGroupApiRequest::List(Box::new(filter.clone())))
@@ -85,7 +85,12 @@ impl ResourceBehaviour for IdentityGroupsBehaviour {
         )
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::IdentityGroupDelete = action {
+        if let Action::ResourceOp {
+            key,
+            op: crate::action::ResourceOp::Delete,
+        } = action
+            && *key == Self::view_key()
+        {
             let del = IdentityGroupDelete::try_from(selected?).ok()?;
             Some(ApiRequest::from(IdentityGroupApiRequest::Delete(Box::new(
                 del,
@@ -99,13 +104,14 @@ impl ResourceBehaviour for IdentityGroupsBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowIdentityGroupUsers = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::IDENTITY_GROUP_USER
             && let Some(sel) = selected
             && let Ok(list) = IdentityGroupUserList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::IdentityGroupUsers,
+                    mode: Mode::Resource(crate::mode::IDENTITY_GROUP_USER),
                     stack: true,
                 },
                 Action::SetIdentityGroupUserListFilters(list),
@@ -137,7 +143,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(IdentityGroupsBehaviour::view_key(), "identity.group");
         assert_eq!(IdentityGroupsBehaviour::title(), "Identity Groups");
-        assert_eq!(IdentityGroupsBehaviour::mode(), Mode::IdentityGroups);
+        assert_eq!(
+            IdentityGroupsBehaviour::mode(),
+            Mode::Resource(crate::mode::IDENTITY_GROUP)
+        );
     }
 
     #[test]
@@ -171,8 +180,13 @@ mod tests {
     #[test]
     fn confirm_request_delete_with_selected() {
         let group = make_group("group-1", "test-group");
-        let result =
-            IdentityGroupsBehaviour::confirm_request(&Action::IdentityGroupDelete, Some(&group));
+        let result = IdentityGroupsBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::IDENTITY_GROUP,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&group),
+        );
         assert!(result.is_some());
         let request = result.unwrap();
         assert!(matches!(
@@ -184,7 +198,26 @@ mod tests {
 
     #[test]
     fn confirm_request_delete_without_selected() {
-        let result = IdentityGroupsBehaviour::confirm_request(&Action::IdentityGroupDelete, None);
+        let result = IdentityGroupsBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::IDENTITY_GROUP,
+                op: crate::action::ResourceOp::Delete,
+            },
+            None,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn confirm_request_ignores_delete_for_other_resource() {
+        let group = make_group("group-1", "test-group");
+        let result = IdentityGroupsBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::IDENTITY_PROJECT,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&group),
+        );
         assert!(result.is_none());
     }
 
@@ -199,7 +232,7 @@ mod tests {
     fn filter_carry_action_show_group_users_with_selected() {
         let group = make_group("group-1", "test-group");
         let actions = IdentityGroupsBehaviour::filter_carry_action(
-            &Action::ShowIdentityGroupUsers,
+            &Action::ShowResource(crate::mode::IDENTITY_GROUP_USER),
             Some(&group),
             &IdentityGroupList::default(),
         );
@@ -207,7 +240,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::IdentityGroupUsers,
+                mode: Mode::Resource(crate::mode::IDENTITY_GROUP_USER),
                 stack: true
             }
         ));
@@ -220,8 +253,19 @@ mod tests {
     #[test]
     fn filter_carry_action_without_selected() {
         let actions = IdentityGroupsBehaviour::filter_carry_action(
-            &Action::ShowIdentityGroupUsers,
+            &Action::ShowResource(crate::mode::IDENTITY_GROUP_USER),
             None,
+            &IdentityGroupList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let group = make_group("group-1", "test-group");
+        let actions = IdentityGroupsBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::IDENTITY_GROUP),
+            Some(&group),
             &IdentityGroupList::default(),
         );
         assert!(actions.is_empty());

--- a/openstack_tui/src/components/identity/projects.rs
+++ b/openstack_tui/src/components/identity/projects.rs
@@ -43,7 +43,7 @@ impl ResourceBehaviour for IdentityProjectsBehaviour {
         "Identity Projects"
     }
     fn mode() -> Mode {
-        Mode::IdentityProjects
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(IdentityProjectApiRequest::List(Box::new(filter.clone())))
@@ -102,7 +102,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(IdentityProjectsBehaviour::view_key(), "identity.project");
         assert_eq!(IdentityProjectsBehaviour::title(), "Identity Projects");
-        assert_eq!(IdentityProjectsBehaviour::mode(), Mode::IdentityProjects);
+        assert_eq!(
+            IdentityProjectsBehaviour::mode(),
+            Mode::Resource(crate::mode::IDENTITY_PROJECT)
+        );
     }
 
     #[test]

--- a/openstack_tui/src/components/identity/users.rs
+++ b/openstack_tui/src/components/identity/users.rs
@@ -67,7 +67,7 @@ impl ResourceBehaviour for IdentityUsersBehaviour {
         "Identity Users"
     }
     fn mode() -> Mode {
-        Mode::IdentityUsers
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(IdentityUserApiRequest::List(Box::new(filter.clone())))
@@ -80,7 +80,12 @@ impl ResourceBehaviour for IdentityUsersBehaviour {
         )
     }
     fn action_to_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::IdentityUserFlipEnable = action {
+        if let Action::IdentityUserOp {
+            key,
+            op: crate::action::IdentityUserOp::FlipEnable,
+        } = action
+            && *key == Self::view_key()
+        {
             let sel = selected?;
             let req: crate::cloud_worker::identity::v3::user::set::User =
                 crate::cloud_worker::identity::v3::user::set::UserBuilder::default()
@@ -100,7 +105,12 @@ impl ResourceBehaviour for IdentityUsersBehaviour {
         }
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::IdentityUserDelete = action {
+        if let Action::IdentityUserOp {
+            key,
+            op: crate::action::IdentityUserOp::Delete,
+        } = action
+            && *key == Self::view_key()
+        {
             let del = IdentityUserDelete::try_from(selected?).ok()?;
             Some(ApiRequest::from(IdentityUserApiRequest::Delete(Box::new(
                 del,
@@ -114,13 +124,14 @@ impl ResourceBehaviour for IdentityUsersBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowIdentityUserApplicationCredentials = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::IDENTITY_APPLICATION_CREDENTIAL
             && let Some(sel) = selected
             && let Ok(list) = IdentityUserApplicationCredentialList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::IdentityApplicationCredentials,
+                    mode: Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
                     stack: true,
                 },
                 Action::SetIdentityApplicationCredentialListFilters(list),
@@ -165,7 +176,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(IdentityUsersBehaviour::view_key(), "identity.user");
         assert_eq!(IdentityUsersBehaviour::title(), "Identity Users");
-        assert_eq!(IdentityUsersBehaviour::mode(), Mode::IdentityUsers);
+        assert_eq!(
+            IdentityUsersBehaviour::mode(),
+            Mode::Resource(crate::mode::IDENTITY_USER)
+        );
     }
 
     #[test]
@@ -213,8 +227,13 @@ mod tests {
     #[test]
     fn action_to_request_flip_enable_with_selected() {
         let user = make_user("user-1", "test-user", true);
-        let result =
-            IdentityUsersBehaviour::action_to_request(&Action::IdentityUserFlipEnable, Some(&user));
+        let result = IdentityUsersBehaviour::action_to_request(
+            &Action::IdentityUserOp {
+                key: crate::mode::IDENTITY_USER,
+                op: crate::action::IdentityUserOp::FlipEnable,
+            },
+            Some(&user),
+        );
         assert!(result.is_some());
         let request = result.unwrap();
         assert!(matches!(
@@ -226,8 +245,26 @@ mod tests {
 
     #[test]
     fn action_to_request_flip_enable_without_selected() {
-        let result =
-            IdentityUsersBehaviour::action_to_request(&Action::IdentityUserFlipEnable, None);
+        let result = IdentityUsersBehaviour::action_to_request(
+            &Action::IdentityUserOp {
+                key: crate::mode::IDENTITY_USER,
+                op: crate::action::IdentityUserOp::FlipEnable,
+            },
+            None,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn action_to_request_ignores_flip_enable_for_other_resource() {
+        let user = make_user("user-1", "test-user", true);
+        let result = IdentityUsersBehaviour::action_to_request(
+            &Action::IdentityUserOp {
+                key: crate::mode::IDENTITY_GROUP,
+                op: crate::action::IdentityUserOp::FlipEnable,
+            },
+            Some(&user),
+        );
         assert!(result.is_none());
     }
 
@@ -241,8 +278,13 @@ mod tests {
     #[test]
     fn confirm_request_delete_with_selected() {
         let user = make_user("user-1", "test-user", true);
-        let result =
-            IdentityUsersBehaviour::confirm_request(&Action::IdentityUserDelete, Some(&user));
+        let result = IdentityUsersBehaviour::confirm_request(
+            &Action::IdentityUserOp {
+                key: crate::mode::IDENTITY_USER,
+                op: crate::action::IdentityUserOp::Delete,
+            },
+            Some(&user),
+        );
         assert!(result.is_some());
         let request = result.unwrap();
         assert!(matches!(
@@ -254,7 +296,26 @@ mod tests {
 
     #[test]
     fn confirm_request_delete_without_selected() {
-        let result = IdentityUsersBehaviour::confirm_request(&Action::IdentityUserDelete, None);
+        let result = IdentityUsersBehaviour::confirm_request(
+            &Action::IdentityUserOp {
+                key: crate::mode::IDENTITY_USER,
+                op: crate::action::IdentityUserOp::Delete,
+            },
+            None,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn confirm_request_ignores_delete_for_other_resource() {
+        let user = make_user("user-1", "test-user", true);
+        let result = IdentityUsersBehaviour::confirm_request(
+            &Action::IdentityUserOp {
+                key: crate::mode::IDENTITY_GROUP,
+                op: crate::action::IdentityUserOp::Delete,
+            },
+            Some(&user),
+        );
         assert!(result.is_none());
     }
 
@@ -269,7 +330,7 @@ mod tests {
     fn filter_carry_action_show_credentials_with_selected() {
         let user = make_user("user-1", "test-user", true);
         let actions = IdentityUsersBehaviour::filter_carry_action(
-            &Action::ShowIdentityUserApplicationCredentials,
+            &Action::ShowResource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
             Some(&user),
             &IdentityUserList::default(),
         );
@@ -277,7 +338,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::IdentityApplicationCredentials,
+                mode: Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
                 stack: true
             }
         ));
@@ -290,8 +351,19 @@ mod tests {
     #[test]
     fn filter_carry_action_show_credentials_without_selected() {
         let actions = IdentityUsersBehaviour::filter_carry_action(
-            &Action::ShowIdentityUserApplicationCredentials,
+            &Action::ShowResource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
             None,
+            &IdentityUserList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let user = make_user("user-1", "test-user", true);
+        let actions = IdentityUsersBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::IDENTITY_USER),
+            Some(&user),
             &IdentityUserList::default(),
         );
         assert!(actions.is_empty());

--- a/openstack_tui/src/components/image/images.rs
+++ b/openstack_tui/src/components/image/images.rs
@@ -59,7 +59,7 @@ impl ResourceBehaviour for ImageImagesBehaviour {
         "Images"
     }
     fn mode() -> Mode {
-        Mode::ImageImages
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(ImageImageApiRequest::List(Box::new(filter.clone())))
@@ -79,7 +79,12 @@ impl ResourceBehaviour for ImageImagesBehaviour {
         }
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::DeleteImage = action {
+        if let Action::ResourceOp {
+            key,
+            op: crate::action::ResourceOp::Delete,
+        } = action
+            && *key == Self::view_key()
+        {
             let del = ImageImageDelete::try_from(selected?).ok()?;
             Some(ApiRequest::from(ImageImageApiRequest::Delete(Box::new(
                 del,
@@ -128,7 +133,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(ImageImagesBehaviour::view_key(), "image.image");
         assert_eq!(ImageImagesBehaviour::title(), "Images");
-        assert_eq!(ImageImagesBehaviour::mode(), Mode::ImageImages);
+        assert_eq!(
+            ImageImagesBehaviour::mode(),
+            Mode::Resource(crate::mode::IMAGE_IMAGE)
+        );
     }
 
     #[test]
@@ -176,7 +184,13 @@ mod tests {
     #[test]
     fn confirm_request_delete_with_selected() {
         let img = make_image("img-1", "test-image");
-        let result = ImageImagesBehaviour::confirm_request(&Action::DeleteImage, Some(&img));
+        let result = ImageImagesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::IMAGE_IMAGE,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&img),
+        );
         assert!(result.is_some());
         let request = result.unwrap();
         assert!(matches!(
@@ -188,7 +202,26 @@ mod tests {
 
     #[test]
     fn confirm_request_delete_without_selected() {
-        let result = ImageImagesBehaviour::confirm_request(&Action::DeleteImage, None);
+        let result = ImageImagesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::IMAGE_IMAGE,
+                op: crate::action::ResourceOp::Delete,
+            },
+            None,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn confirm_request_ignores_delete_for_other_resource() {
+        let img = make_image("img-1", "test-image");
+        let result = ImageImagesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::COMPUTE_SERVER,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&img),
+        );
         assert!(result.is_none());
     }
 

--- a/openstack_tui/src/components/load_balancer/health_monitors.rs
+++ b/openstack_tui/src/components/load_balancer/health_monitors.rs
@@ -43,7 +43,7 @@ impl ResourceBehaviour for LoadBalancerHealthMonitorsBehaviour {
         "LB HealthMonitors"
     }
     fn mode() -> Mode {
-        Mode::LoadBalancerHealthMonitors
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(LoadBalancerHealthmonitorApiRequest::List(Box::new(
@@ -86,7 +86,7 @@ mod tests {
         );
         assert_eq!(
             LoadBalancerHealthMonitorsBehaviour::mode(),
-            Mode::LoadBalancerHealthMonitors
+            Mode::Resource(crate::mode::LB_HEALTHMONITOR)
         );
     }
 

--- a/openstack_tui/src/components/load_balancer/listeners.rs
+++ b/openstack_tui/src/components/load_balancer/listeners.rs
@@ -43,7 +43,7 @@ impl ResourceBehaviour for LoadBalancerListenersBehaviour {
         "LB Listeners"
     }
     fn mode() -> Mode {
-        Mode::LoadBalancerListeners
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(LoadBalancerListenerApiRequest::List(Box::new(
@@ -82,7 +82,7 @@ mod tests {
         assert_eq!(LoadBalancerListenersBehaviour::title(), "LB Listeners");
         assert_eq!(
             LoadBalancerListenersBehaviour::mode(),
-            Mode::LoadBalancerListeners
+            Mode::Resource(crate::mode::LB_LISTENER)
         );
     }
 

--- a/openstack_tui/src/components/load_balancer/loadbalancers.rs
+++ b/openstack_tui/src/components/load_balancer/loadbalancers.rs
@@ -73,7 +73,7 @@ impl ResourceBehaviour for LoadBalancersBehaviour {
         "LoadBalancers"
     }
     fn mode() -> Mode {
-        Mode::LoadBalancers
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(LoadBalancerLoadbalancerApiRequest::List(Box::new(
@@ -99,25 +99,27 @@ impl ResourceBehaviour for LoadBalancersBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowLoadBalancerListeners = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::LB_LISTENER
             && let Some(sel) = selected
             && let Ok(list) = LoadBalancerListenerList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::LoadBalancerListeners,
+                    mode: Mode::Resource(crate::mode::LB_LISTENER),
                     stack: true,
                 },
                 Action::SetLoadBalancerListenerListFilters(list),
             ];
         }
-        if let Action::ShowLoadBalancerPools = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::LB_POOL
             && let Some(sel) = selected
             && let Ok(list) = LoadBalancerPoolList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::LoadBalancerPools,
+                    mode: Mode::Resource(crate::mode::LB_POOL),
                     stack: true,
                 },
                 Action::SetLoadBalancerPoolListFilters(list),
@@ -164,7 +166,10 @@ mod tests {
             "load-balancer.loadbalancer"
         );
         assert_eq!(LoadBalancersBehaviour::title(), "LoadBalancers");
-        assert_eq!(LoadBalancersBehaviour::mode(), Mode::LoadBalancers);
+        assert_eq!(
+            LoadBalancersBehaviour::mode(),
+            Mode::Resource(crate::mode::LB_LOADBALANCER)
+        );
     }
 
     #[test]
@@ -213,7 +218,7 @@ mod tests {
     fn filter_carry_action_show_listeners_with_selected() {
         let lb = make_lb("lb-1", "test-lb");
         let actions = LoadBalancersBehaviour::filter_carry_action(
-            &Action::ShowLoadBalancerListeners,
+            &Action::ShowResource(crate::mode::LB_LISTENER),
             Some(&lb),
             &LoadBalancerLoadbalancerList::default(),
         );
@@ -221,7 +226,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::LoadBalancerListeners,
+                mode: Mode::Resource(crate::mode::LB_LISTENER),
                 stack: true
             }
         ));
@@ -235,7 +240,7 @@ mod tests {
     fn filter_carry_action_show_pools_with_selected() {
         let lb = make_lb("lb-1", "test-lb");
         let actions = LoadBalancersBehaviour::filter_carry_action(
-            &Action::ShowLoadBalancerPools,
+            &Action::ShowResource(crate::mode::LB_POOL),
             Some(&lb),
             &LoadBalancerLoadbalancerList::default(),
         );
@@ -243,7 +248,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::LoadBalancerPools,
+                mode: Mode::Resource(crate::mode::LB_POOL),
                 stack: true
             }
         ));
@@ -256,8 +261,19 @@ mod tests {
     #[test]
     fn filter_carry_action_without_selected() {
         let actions = LoadBalancersBehaviour::filter_carry_action(
-            &Action::ShowLoadBalancerListeners,
+            &Action::ShowResource(crate::mode::LB_LISTENER),
             None,
+            &LoadBalancerLoadbalancerList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let lb = make_lb("lb-1", "test-lb");
+        let actions = LoadBalancersBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::LB_LOADBALANCER),
+            Some(&lb),
             &LoadBalancerLoadbalancerList::default(),
         );
         assert!(actions.is_empty());

--- a/openstack_tui/src/components/load_balancer/pool_members.rs
+++ b/openstack_tui/src/components/load_balancer/pool_members.rs
@@ -44,7 +44,7 @@ impl ResourceBehaviour for LoadBalancerPoolMembersBehaviour {
         "LB Pool Members"
     }
     fn mode() -> Mode {
-        Mode::LoadBalancerPoolMembers
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(LoadBalancerPoolMemberApiRequest::List(Box::new(
@@ -85,7 +85,7 @@ mod tests {
         assert_eq!(LoadBalancerPoolMembersBehaviour::title(), "LB Pool Members");
         assert_eq!(
             LoadBalancerPoolMembersBehaviour::mode(),
-            Mode::LoadBalancerPoolMembers
+            Mode::Resource(crate::mode::LB_POOL_MEMBER)
         );
     }
 

--- a/openstack_tui/src/components/load_balancer/pools.rs
+++ b/openstack_tui/src/components/load_balancer/pools.rs
@@ -73,7 +73,7 @@ impl ResourceBehaviour for LoadBalancerPoolsBehaviour {
         "LB Pools"
     }
     fn mode() -> Mode {
-        Mode::LoadBalancerPools
+        Mode::Resource(Self::view_key())
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         ApiRequest::from(LoadBalancerPoolApiRequest::List(Box::new(filter.clone())))
@@ -97,25 +97,27 @@ impl ResourceBehaviour for LoadBalancerPoolsBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowLoadBalancerPoolMembers = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::LB_POOL_MEMBER
             && let Some(sel) = selected
             && let Ok(list) = LoadBalancerPoolMemberList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::LoadBalancerPoolMembers,
+                    mode: Mode::Resource(crate::mode::LB_POOL_MEMBER),
                     stack: true,
                 },
                 Action::SetLoadBalancerPoolMemberListFilters(list),
             ];
         }
-        if let Action::ShowLoadBalancerPoolHealthMonitors = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::LB_HEALTHMONITOR
             && let Some(sel) = selected
             && let Ok(list) = LoadBalancerHealthmonitorList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::LoadBalancerHealthMonitors,
+                    mode: Mode::Resource(crate::mode::LB_HEALTHMONITOR),
                     stack: true,
                 },
                 Action::SetLoadBalancerHealthMonitorListFilters(list),
@@ -160,7 +162,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(LoadBalancerPoolsBehaviour::view_key(), "load-balancer.pool");
         assert_eq!(LoadBalancerPoolsBehaviour::title(), "LB Pools");
-        assert_eq!(LoadBalancerPoolsBehaviour::mode(), Mode::LoadBalancerPools);
+        assert_eq!(
+            LoadBalancerPoolsBehaviour::mode(),
+            Mode::Resource(crate::mode::LB_POOL)
+        );
     }
 
     #[test]
@@ -209,7 +214,7 @@ mod tests {
     fn filter_carry_action_show_members_with_selected() {
         let pool = make_pool("pool-1", "test-pool");
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
-            &Action::ShowLoadBalancerPoolMembers,
+            &Action::ShowResource(crate::mode::LB_POOL_MEMBER),
             Some(&pool),
             &LoadBalancerPoolList::default(),
         );
@@ -217,7 +222,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::LoadBalancerPoolMembers,
+                mode: Mode::Resource(crate::mode::LB_POOL_MEMBER),
                 stack: true
             }
         ));
@@ -231,7 +236,7 @@ mod tests {
     fn filter_carry_action_show_health_monitors_with_selected() {
         let pool = make_pool("pool-1", "test-pool");
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
-            &Action::ShowLoadBalancerPoolHealthMonitors,
+            &Action::ShowResource(crate::mode::LB_HEALTHMONITOR),
             Some(&pool),
             &LoadBalancerPoolList::default(),
         );
@@ -239,7 +244,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::LoadBalancerHealthMonitors,
+                mode: Mode::Resource(crate::mode::LB_HEALTHMONITOR),
                 stack: true
             }
         ));
@@ -252,8 +257,19 @@ mod tests {
     #[test]
     fn filter_carry_action_without_selected() {
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
-            &Action::ShowLoadBalancerPoolMembers,
+            &Action::ShowResource(crate::mode::LB_POOL_MEMBER),
             None,
+            &LoadBalancerPoolList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let pool = make_pool("pool-1", "test-pool");
+        let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::LB_POOL),
+            Some(&pool),
             &LoadBalancerPoolList::default(),
         );
         assert!(actions.is_empty());

--- a/openstack_tui/src/components/network/networks.rs
+++ b/openstack_tui/src/components/network/networks.rs
@@ -23,11 +23,9 @@ use crate::components::resource_behaviour::ResourceBehaviour;
 use crate::mode::Mode;
 use openstack_types::network::v2::network::response::list::NetworkResponse;
 
-const VIEW_CONFIG_KEY: &str = "network.network";
-
 impl crate::utils::ResourceKey for NetworkResponse {
     fn get_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_NETWORK
     }
 }
 
@@ -52,13 +50,13 @@ impl ResourceBehaviour for NetworkNetworksBehaviour {
     type Filter = NetworkNetworkList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_NETWORK
     }
     fn title() -> &'static str {
         "Networks"
     }
     fn mode() -> Mode {
-        Mode::NetworkNetworks
+        Mode::Resource(Self::view_key())
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -82,13 +80,14 @@ impl ResourceBehaviour for NetworkNetworksBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowNetworkSubnets = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::NETWORK_SUBNET
             && let Some(sel) = selected
             && let Ok(list) = NetworkSubnetList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::NetworkSubnets,
+                    mode: Mode::Resource(crate::mode::NETWORK_SUBNET),
                     stack: true,
                 },
                 Action::SetNetworkSubnetListFilters(list),
@@ -125,7 +124,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(NetworkNetworksBehaviour::view_key(), "network.network");
         assert_eq!(NetworkNetworksBehaviour::title(), "Networks");
-        assert_eq!(NetworkNetworksBehaviour::mode(), Mode::NetworkNetworks);
+        assert_eq!(
+            NetworkNetworksBehaviour::mode(),
+            Mode::Resource(crate::mode::NETWORK_NETWORK)
+        );
     }
 
     #[test]
@@ -174,7 +176,7 @@ mod tests {
     fn filter_carry_action_show_subnets_with_selected() {
         let net = make_network("net-1", "test-net");
         let actions = NetworkNetworksBehaviour::filter_carry_action(
-            &Action::ShowNetworkSubnets,
+            &Action::ShowResource(crate::mode::NETWORK_SUBNET),
             Some(&net),
             &NetworkNetworkList::default(),
         );
@@ -182,7 +184,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::NetworkSubnets,
+                mode: Mode::Resource(crate::mode::NETWORK_SUBNET),
                 stack: true
             }
         ));
@@ -192,8 +194,19 @@ mod tests {
     #[test]
     fn filter_carry_action_without_selected() {
         let actions = NetworkNetworksBehaviour::filter_carry_action(
-            &Action::ShowNetworkSubnets,
+            &Action::ShowResource(crate::mode::NETWORK_SUBNET),
             None,
+            &NetworkNetworkList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let net = make_network("net-1", "test-net");
+        let actions = NetworkNetworksBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::NETWORK_NETWORK),
+            Some(&net),
             &NetworkNetworkList::default(),
         );
         assert!(actions.is_empty());

--- a/openstack_tui/src/components/network/routers.rs
+++ b/openstack_tui/src/components/network/routers.rs
@@ -20,11 +20,9 @@ use crate::components::resource_behaviour::ResourceBehaviour;
 use crate::mode::Mode;
 use openstack_types::network::v2::router::response::list::RouterResponse;
 
-const VIEW_CONFIG_KEY: &str = "network.router";
-
 impl crate::utils::ResourceKey for RouterResponse {
     fn get_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_ROUTER
     }
 }
 
@@ -35,13 +33,13 @@ impl ResourceBehaviour for NetworkRoutersBehaviour {
     type Filter = NetworkRouterList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_ROUTER
     }
     fn title() -> &'static str {
         "Routers"
     }
     fn mode() -> Mode {
-        Mode::NetworkRouters
+        Mode::Resource(Self::view_key())
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -73,7 +71,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(NetworkRoutersBehaviour::view_key(), "network.router");
         assert_eq!(NetworkRoutersBehaviour::title(), "Routers");
-        assert_eq!(NetworkRoutersBehaviour::mode(), Mode::NetworkRouters);
+        assert_eq!(
+            NetworkRoutersBehaviour::mode(),
+            Mode::Resource(crate::mode::NETWORK_ROUTER)
+        );
     }
 
     #[test]

--- a/openstack_tui/src/components/network/security_group_rules.rs
+++ b/openstack_tui/src/components/network/security_group_rules.rs
@@ -24,11 +24,9 @@ use crate::mode::Mode;
 use openstack_types::network::v2::security_group_rule::response::list::SecurityGroupRuleResponse;
 use serde_json::Value;
 
-const VIEW_CONFIG_KEY: &str = "network.security_group_rule";
-
 impl crate::utils::ResourceKey for SecurityGroupRuleResponse {
     fn get_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_SECURITY_GROUP_RULE
     }
 }
 
@@ -50,13 +48,13 @@ impl ResourceBehaviour for NetworkSecurityGroupRulesBehaviour {
     type Filter = NetworkSecurityGroupRuleList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_SECURITY_GROUP_RULE
     }
     fn title() -> &'static str {
         "SecurityGroupRules"
     }
     fn mode() -> Mode {
-        Mode::NetworkSecurityGroupRules
+        Mode::Resource(Self::view_key())
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -90,7 +88,12 @@ impl ResourceBehaviour for NetworkSecurityGroupRulesBehaviour {
         }
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
-        if let Action::DeleteNetworkSecurityGroupRule = action {
+        if let Action::ResourceOp {
+            key,
+            op: crate::action::ResourceOp::Delete,
+        } = action
+            && *key == Self::view_key()
+        {
             let del = NetworkSecurityGroupRuleDelete::try_from(selected?).ok()?;
             Some(ApiRequest::from(
                 NetworkSecurityGroupRuleApiRequest::Delete(Box::new(del)),
@@ -144,7 +147,7 @@ mod tests {
         );
         assert_eq!(
             NetworkSecurityGroupRulesBehaviour::mode(),
-            Mode::NetworkSecurityGroupRules
+            Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP_RULE)
         );
     }
 
@@ -225,7 +228,10 @@ mod tests {
     fn confirm_request_delete_with_selected() {
         let rule = make_rule("rule-1");
         let result = NetworkSecurityGroupRulesBehaviour::confirm_request(
-            &Action::DeleteNetworkSecurityGroupRule,
+            &Action::ResourceOp {
+                key: crate::mode::NETWORK_SECURITY_GROUP_RULE,
+                op: crate::action::ResourceOp::Delete,
+            },
             Some(&rule),
         );
         assert!(result.is_some());
@@ -240,8 +246,24 @@ mod tests {
     #[test]
     fn confirm_request_delete_without_selected() {
         let result = NetworkSecurityGroupRulesBehaviour::confirm_request(
-            &Action::DeleteNetworkSecurityGroupRule,
+            &Action::ResourceOp {
+                key: crate::mode::NETWORK_SECURITY_GROUP_RULE,
+                op: crate::action::ResourceOp::Delete,
+            },
             None,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn confirm_request_ignores_delete_for_other_resource() {
+        let rule = make_rule("rule-1");
+        let result = NetworkSecurityGroupRulesBehaviour::confirm_request(
+            &Action::ResourceOp {
+                key: crate::mode::NETWORK_SECURITY_GROUP,
+                op: crate::action::ResourceOp::Delete,
+            },
+            Some(&rule),
         );
         assert!(result.is_none());
     }

--- a/openstack_tui/src/components/network/security_groups.rs
+++ b/openstack_tui/src/components/network/security_groups.rs
@@ -23,11 +23,9 @@ use crate::components::resource_behaviour::ResourceBehaviour;
 use crate::mode::Mode;
 use openstack_types::network::v2::security_group::response::list::SecurityGroupResponse;
 
-const VIEW_CONFIG_KEY: &str = "network.security_group";
-
 impl crate::utils::ResourceKey for SecurityGroupResponse {
     fn get_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_SECURITY_GROUP
     }
 }
 
@@ -52,13 +50,13 @@ impl ResourceBehaviour for NetworkSecurityGroupsBehaviour {
     type Filter = NetworkSecurityGroupList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_SECURITY_GROUP
     }
     fn title() -> &'static str {
         "SecurityGroups"
     }
     fn mode() -> Mode {
-        Mode::NetworkSecurityGroups
+        Mode::Resource(Self::view_key())
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -84,13 +82,14 @@ impl ResourceBehaviour for NetworkSecurityGroupsBehaviour {
         selected: Option<&Self::Item>,
         _filter: &Self::Filter,
     ) -> Vec<Action> {
-        if let Action::ShowNetworkSecurityGroupRules = action
+        if let Action::ShowResource(key) = action
+            && *key == crate::mode::NETWORK_SECURITY_GROUP_RULE
             && let Some(sel) = selected
             && let Ok(list) = NetworkSecurityGroupRuleList::try_from(sel)
         {
             return vec![
                 Action::Mode {
-                    mode: Mode::NetworkSecurityGroupRules,
+                    mode: Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP_RULE),
                     stack: true,
                 },
                 Action::SetNetworkSecurityGroupRuleListFilters(list),
@@ -130,7 +129,7 @@ mod tests {
         assert_eq!(NetworkSecurityGroupsBehaviour::title(), "SecurityGroups");
         assert_eq!(
             NetworkSecurityGroupsBehaviour::mode(),
-            Mode::NetworkSecurityGroups
+            Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP)
         );
     }
 
@@ -180,7 +179,7 @@ mod tests {
     fn filter_carry_action_show_rules_with_selected() {
         let sg = make_sg("sg-1", "test-sg");
         let actions = NetworkSecurityGroupsBehaviour::filter_carry_action(
-            &Action::ShowNetworkSecurityGroupRules,
+            &Action::ShowResource(crate::mode::NETWORK_SECURITY_GROUP_RULE),
             Some(&sg),
             &NetworkSecurityGroupList::default(),
         );
@@ -188,7 +187,7 @@ mod tests {
         assert!(matches!(
             actions[0],
             Action::Mode {
-                mode: Mode::NetworkSecurityGroupRules,
+                mode: Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP_RULE),
                 stack: true
             }
         ));
@@ -201,8 +200,19 @@ mod tests {
     #[test]
     fn filter_carry_action_without_selected() {
         let actions = NetworkSecurityGroupsBehaviour::filter_carry_action(
-            &Action::ShowNetworkSecurityGroupRules,
+            &Action::ShowResource(crate::mode::NETWORK_SECURITY_GROUP_RULE),
             None,
+            &NetworkSecurityGroupList::default(),
+        );
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn filter_carry_action_ignores_show_resource_for_other_key() {
+        let sg = make_sg("sg-1", "test-sg");
+        let actions = NetworkSecurityGroupsBehaviour::filter_carry_action(
+            &Action::ShowResource(crate::mode::NETWORK_SECURITY_GROUP),
+            Some(&sg),
             &NetworkSecurityGroupList::default(),
         );
         assert!(actions.is_empty());

--- a/openstack_tui/src/components/network/subnets.rs
+++ b/openstack_tui/src/components/network/subnets.rs
@@ -22,11 +22,9 @@ use crate::components::resource_behaviour::ResourceBehaviour;
 use crate::mode::Mode;
 use openstack_types::network::v2::subnet::response::list::SubnetResponse;
 
-const VIEW_CONFIG_KEY: &str = "network.subnet";
-
 impl crate::utils::ResourceKey for SubnetResponse {
     fn get_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_SUBNET
     }
 }
 
@@ -37,13 +35,13 @@ impl ResourceBehaviour for NetworkSubnetsBehaviour {
     type Filter = NetworkSubnetList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        crate::mode::NETWORK_SUBNET
     }
     fn title() -> &'static str {
         "Subnets"
     }
     fn mode() -> Mode {
-        Mode::NetworkSubnets
+        Mode::Resource(Self::view_key())
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -82,7 +80,10 @@ mod tests {
     fn view_key_and_title() {
         assert_eq!(NetworkSubnetsBehaviour::view_key(), "network.subnet");
         assert_eq!(NetworkSubnetsBehaviour::title(), "Subnets");
-        assert_eq!(NetworkSubnetsBehaviour::mode(), Mode::NetworkSubnets);
+        assert_eq!(
+            NetworkSubnetsBehaviour::mode(),
+            Mode::Resource(crate::mode::NETWORK_SUBNET)
+        );
     }
 
     #[test]

--- a/openstack_tui/src/config.rs
+++ b/openstack_tui/src/config.rs
@@ -735,4 +735,307 @@ mod tests {
             KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT)
         );
     }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_security_group_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let rule_mode = Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP_RULE);
+        let bindings = config
+            .mode_keybindings
+            .get(&rule_mode)
+            .expect("Resource(network.security_group_rule) keybindings must be present");
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ResourceOp {
+                    key,
+                    op: crate::action::ResourceOp::Delete,
+                } if key == crate::mode::NETWORK_SECURITY_GROUP_RULE
+            )),
+            "expected a ResourceOp{{key, op: Delete}} binding for the security group rule view"
+        );
+    }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_network_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let network_mode = Mode::Resource(crate::mode::NETWORK_NETWORK);
+        let bindings = config
+            .mode_keybindings
+            .get(&network_mode)
+            .expect("Resource(network.network) keybindings must be present");
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::NETWORK_SUBNET
+            )),
+            "expected a ShowResource(network.subnet) binding for the network view"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::NETWORK_ROUTER)),
+            "Resource(network.router) keybindings must be present"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::NETWORK_SUBNET)),
+            "Resource(network.subnet) keybindings must be present"
+        );
+    }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_block_storage_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let volume_mode = Mode::Resource(crate::mode::BLOCK_STORAGE_VOLUME);
+        let bindings = config
+            .mode_keybindings
+            .get(&volume_mode)
+            .expect("Resource(block_storage.volume) keybindings must be present");
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ResourceOp { key, op: crate::action::ResourceOp::Delete }
+                if key == crate::mode::BLOCK_STORAGE_VOLUME
+            )),
+            "expected a ResourceOp{{key, op: Delete}} binding for the block_storage.volume view"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::BLOCK_STORAGE_BACKUP)),
+            "Resource(block_storage.backup) keybindings must be present"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::BLOCK_STORAGE_SNAPSHOT)),
+            "Resource(block_storage.snapshot) keybindings must be present"
+        );
+    }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_dns_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let zone_mode = Mode::Resource(crate::mode::DNS_ZONE);
+        let bindings = config
+            .mode_keybindings
+            .get(&zone_mode)
+            .expect("Resource(dns.zone) keybindings must be present");
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ResourceOp { key, op: crate::action::ResourceOp::Delete }
+                if key == crate::mode::DNS_ZONE
+            )),
+            "expected a ResourceOp{{key, op: Delete}} binding for the dns.zone view"
+        );
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::DNS_RECORDSET
+            )),
+            "expected a ShowResource(dns.recordset) binding for the dns.zone view"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::DNS_RECORDSET)),
+            "Resource(dns.recordset) keybindings must be present"
+        );
+    }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_image_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let image_mode = Mode::Resource(crate::mode::IMAGE_IMAGE);
+        let bindings = config
+            .mode_keybindings
+            .get(&image_mode)
+            .expect("Resource(image.image) keybindings must be present");
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ResourceOp { key, op: crate::action::ResourceOp::Delete }
+                if key == crate::mode::IMAGE_IMAGE
+            )),
+            "expected a ResourceOp{{key, op: Delete}} binding for the image.image view"
+        );
+    }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_compute_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let server_mode = Mode::Resource(crate::mode::COMPUTE_SERVER);
+        let bindings = config
+            .mode_keybindings
+            .get(&server_mode)
+            .expect("Resource(compute.server) keybindings must be present");
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ResourceOp { key, op: crate::action::ResourceOp::Delete }
+                if key == crate::mode::COMPUTE_SERVER
+            )),
+            "expected a ResourceOp{{key, op: Delete}} binding for the compute.server view"
+        );
+        assert!(
+            bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::COMPUTE_SERVER_INSTANCE_ACTION
+            )),
+            "expected a ShowResource(compute.server/instance_action) binding for the compute.server view"
+        );
+        let flavor_mode = Mode::Resource(crate::mode::COMPUTE_FLAVOR);
+        let flavor_bindings = config
+            .mode_keybindings
+            .get(&flavor_mode)
+            .expect("Resource(compute.flavor) keybindings must be present");
+        assert!(
+            flavor_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::COMPUTE_SERVER
+            )),
+            "expected a ShowResource(compute.server) binding for the compute.flavor view"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION)),
+            "Resource(compute.server/instance_action) keybindings must be present"
+        );
+    }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_identity_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let group_mode = Mode::Resource(crate::mode::IDENTITY_GROUP);
+        let group_bindings = config
+            .mode_keybindings
+            .get(&group_mode)
+            .expect("Resource(identity.group) keybindings must be present");
+        assert!(
+            group_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ResourceOp { key, op: crate::action::ResourceOp::Delete }
+                if key == crate::mode::IDENTITY_GROUP
+            )),
+            "expected a ResourceOp{{key, op: Delete}} binding for the identity.group view"
+        );
+        assert!(
+            group_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::IDENTITY_GROUP_USER
+            )),
+            "expected a ShowResource(identity.group_user) binding for the identity.group view"
+        );
+        let user_mode = Mode::Resource(crate::mode::IDENTITY_USER);
+        let user_bindings = config
+            .mode_keybindings
+            .get(&user_mode)
+            .expect("Resource(identity.user) keybindings must be present");
+        assert!(
+            user_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::IdentityUserOp { key, op: crate::action::IdentityUserOp::Delete }
+                if key == crate::mode::IDENTITY_USER
+            )),
+            "expected an IdentityUserOp{{key, op: Delete}} binding for the identity.user view"
+        );
+        assert!(
+            user_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::IdentityUserOp { key, op: crate::action::IdentityUserOp::FlipEnable }
+                if key == crate::mode::IDENTITY_USER
+            )),
+            "expected an IdentityUserOp{{key, op: FlipEnable}} binding for the identity.user view"
+        );
+        assert!(
+            user_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::IDENTITY_APPLICATION_CREDENTIAL
+            )),
+            "expected a ShowResource(identity.user/application_credential) binding for the identity.user view"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::IDENTITY_GROUP_USER)),
+            "Resource(identity.group_user) keybindings must be present"
+        );
+        assert!(
+            config.mode_keybindings.contains_key(&Mode::Resource(
+                crate::mode::IDENTITY_APPLICATION_CREDENTIAL
+            )),
+            "Resource(identity.user/application_credential) keybindings must be present"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::IDENTITY_PROJECT)),
+            "Resource(identity.project) keybindings must be present"
+        );
+    }
+
+    #[test]
+    fn default_config_yaml_loads_and_has_migrated_loadbalancer_keybindings() {
+        let config = Config::new().expect("default config.yaml must load");
+        let lb_mode = Mode::Resource(crate::mode::LB_LOADBALANCER);
+        let lb_bindings = config
+            .mode_keybindings
+            .get(&lb_mode)
+            .expect("Resource(load-balancer.loadbalancer) keybindings must be present");
+        assert!(
+            lb_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::LB_LISTENER
+            )),
+            "expected a ShowResource(load-balancer.listener) binding for the loadbalancer view"
+        );
+        assert!(
+            lb_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::LB_POOL
+            )),
+            "expected a ShowResource(load-balancer.pool) binding for the loadbalancer view"
+        );
+        let pool_mode = Mode::Resource(crate::mode::LB_POOL);
+        let pool_bindings = config
+            .mode_keybindings
+            .get(&pool_mode)
+            .expect("Resource(load-balancer.pool) keybindings must be present");
+        assert!(
+            pool_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::LB_POOL_MEMBER
+            )),
+            "expected a ShowResource(load-balancer.pool/member) binding for the pool view"
+        );
+        assert!(
+            pool_bindings.0.values().any(|cmd| matches!(
+                cmd.action,
+                Action::ShowResource(key) if key == crate::mode::LB_HEALTHMONITOR
+            )),
+            "expected a ShowResource(load-balancer.healthmonitor) binding for the pool view"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::LB_LISTENER)),
+            "Resource(load-balancer.listener) keybindings must be present"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::LB_POOL_MEMBER)),
+            "Resource(load-balancer.pool/member) keybindings must be present"
+        );
+        assert!(
+            config
+                .mode_keybindings
+                .contains_key(&Mode::Resource(crate::mode::LB_HEALTHMONITOR)),
+            "Resource(load-balancer.healthmonitor) keybindings must be present"
+        );
+    }
 }

--- a/openstack_tui/src/mode.rs
+++ b/openstack_tui/src/mode.rs
@@ -14,63 +14,226 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Stable string identifier for a resource view, reused from
+/// `ResourceBehaviour::view_key()` (e.g. `"network.security_group_rule"`).
+pub type ViewKey = &'static str;
+
+pub const NETWORK_SECURITY_GROUP: ViewKey = "network.security_group";
+pub const NETWORK_SECURITY_GROUP_RULE: ViewKey = "network.security_group_rule";
+pub const NETWORK_NETWORK: ViewKey = "network.network";
+pub const NETWORK_ROUTER: ViewKey = "network.router";
+pub const NETWORK_SUBNET: ViewKey = "network.subnet";
+pub const BLOCK_STORAGE_BACKUP: ViewKey = "block_storage.backup";
+pub const BLOCK_STORAGE_SNAPSHOT: ViewKey = "block_storage.snapshot";
+pub const BLOCK_STORAGE_VOLUME: ViewKey = "block_storage.volume";
+pub const DNS_ZONE: ViewKey = "dns.zone";
+pub const DNS_RECORDSET: ViewKey = "dns.recordset";
+pub const IMAGE_IMAGE: ViewKey = "image.image";
+pub const COMPUTE_AGGREGATE: ViewKey = "compute.aggregate";
+pub const COMPUTE_FLAVOR: ViewKey = "compute.flavor";
+pub const COMPUTE_HYPERVISOR: ViewKey = "compute.hypervisor";
+pub const COMPUTE_SERVER: ViewKey = "compute.server";
+pub const COMPUTE_SERVER_INSTANCE_ACTION: ViewKey = "compute.server/instance_action";
+pub const COMPUTE_SERVER_INSTANCE_ACTION_EVENT: ViewKey = "compute.server/instance_action/event";
+pub const IDENTITY_APPLICATION_CREDENTIAL: ViewKey = "identity.user/application_credential";
+pub const IDENTITY_GROUP: ViewKey = "identity.group";
+pub const IDENTITY_GROUP_USER: ViewKey = "identity.group_user";
+pub const IDENTITY_PROJECT: ViewKey = "identity.project";
+pub const IDENTITY_USER: ViewKey = "identity.user";
+pub const LB_LOADBALANCER: ViewKey = "load-balancer.loadbalancer";
+pub const LB_LISTENER: ViewKey = "load-balancer.listener";
+pub const LB_POOL: ViewKey = "load-balancer.pool";
+pub const LB_POOL_MEMBER: ViewKey = "load-balancer.pool/member";
+pub const LB_HEALTHMONITOR: ViewKey = "load-balancer.healthmonitor";
+
+/// Resolve a config-supplied view-key string to the canonical `'static` `ViewKey`.
+/// Add an arm here when migrating another resource to `Mode::Resource`.
+pub(crate) fn resolve_view_key(s: &str) -> Option<ViewKey> {
+    match s {
+        "network.security_group" => Some(NETWORK_SECURITY_GROUP),
+        "network.security_group_rule" => Some(NETWORK_SECURITY_GROUP_RULE),
+        "network.network" => Some(NETWORK_NETWORK),
+        "network.router" => Some(NETWORK_ROUTER),
+        "network.subnet" => Some(NETWORK_SUBNET),
+        "block_storage.backup" => Some(BLOCK_STORAGE_BACKUP),
+        "block_storage.snapshot" => Some(BLOCK_STORAGE_SNAPSHOT),
+        "block_storage.volume" => Some(BLOCK_STORAGE_VOLUME),
+        "dns.zone" => Some(DNS_ZONE),
+        "dns.recordset" => Some(DNS_RECORDSET),
+        "image.image" => Some(IMAGE_IMAGE),
+        "compute.aggregate" => Some(COMPUTE_AGGREGATE),
+        "compute.flavor" => Some(COMPUTE_FLAVOR),
+        "compute.hypervisor" => Some(COMPUTE_HYPERVISOR),
+        "compute.server" => Some(COMPUTE_SERVER),
+        "compute.server/instance_action" => Some(COMPUTE_SERVER_INSTANCE_ACTION),
+        "compute.server/instance_action/event" => Some(COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
+        "identity.user/application_credential" => Some(IDENTITY_APPLICATION_CREDENTIAL),
+        "identity.group" => Some(IDENTITY_GROUP),
+        "identity.group_user" => Some(IDENTITY_GROUP_USER),
+        "identity.project" => Some(IDENTITY_PROJECT),
+        "identity.user" => Some(IDENTITY_USER),
+        "load-balancer.loadbalancer" => Some(LB_LOADBALANCER),
+        "load-balancer.listener" => Some(LB_LISTENER),
+        "load-balancer.pool" => Some(LB_POOL),
+        "load-balancer.pool/member" => Some(LB_POOL_MEMBER),
+        "load-balancer.healthmonitor" => Some(LB_HEALTHMONITOR),
+        _ => None,
+    }
+}
+
 /// TUI Modes (screens)
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+// NOTE: `Serialize` (derived) and `Deserialize` (hand-written below) are asymmetric for
+// the `Resource` variant — derive emits `{"Resource": "<key>"}`, but `Deserialize` only
+// accepts `"Resource(<key>)"`. Fine today since nothing serializes `Mode`; fix if that changes.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, strum::VariantNames)]
 pub enum Mode {
     #[default]
     Home,
     Describe,
 
-    // Cinder
-    /// Cinder backups
-    BlockStorageBackups,
-    /// Cinder snapshots
-    BlockStorageSnapshots,
-    /// Cinder volumes
-    BlockStorageVolumes,
+    /// A resource view identified by its `ViewKey` (e.g. `"network.security_group"`).
+    /// Migrated resources use this instead of a dedicated unit variant.
+    Resource(ViewKey),
+}
 
-    // Nova
-    ComputeAggregates,
-    ComputeFlavors,
-    ComputeHypervisors,
-    ComputeServers,
-    /// Server os-instance-actions
-    ComputeServerInstanceActions,
-    /// Server os-instance-action events
-    ComputeServerInstanceActionEvents,
+impl<'de> Deserialize<'de> for Mode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ModeVisitor;
 
-    // DNS
-    /// DNS Zones
-    DnsZones,
-    /// DNS Zone recordsets
-    DnsRecordsets,
+        impl serde::de::Visitor<'_> for ModeVisitor {
+            type Value = Mode;
 
-    // Keystone
-    IdentityApplicationCredentials,
-    IdentityGroups,
-    IdentityGroupUsers,
-    IdentityProjects,
-    IdentityUsers,
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(
+                    "a Mode name (e.g. \"Home\") or \"Resource(<view_key>)\" (e.g. \"Resource(network.security_group)\")",
+                )
+            }
 
-    // Glance
-    ImageImages,
+            fn visit_str<E>(self, v: &str) -> Result<Mode, E>
+            where
+                E: serde::de::Error,
+            {
+                if let Some(inner) = v
+                    .strip_prefix("Resource(")
+                    .and_then(|s| s.strip_suffix(')'))
+                {
+                    return resolve_view_key(inner)
+                        .map(Mode::Resource)
+                        .ok_or_else(|| E::custom(format!("unknown resource view key: {inner}")));
+                }
+                match v {
+                    "Home" => Ok(Mode::Home),
+                    "Describe" => Ok(Mode::Describe),
+                    other => Err(E::custom(format!("unknown Mode: {other}"))),
+                }
+            }
 
-    // Octavia
-    /// LB Loadbalancers
-    LoadBalancers,
-    /// LB Listeners
-    LoadBalancerListeners,
-    /// LB Pools
-    LoadBalancerPools,
-    /// LB pool members
-    LoadBalancerPoolMembers,
-    /// LB HealthMonitors
-    LoadBalancerHealthMonitors,
+            fn visit_string<E>(self, v: String) -> Result<Mode, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_str(&v)
+            }
+        }
 
-    // Neutron
-    NetworkNetworks,
-    NetworkRouters,
-    NetworkSecurityGroups,
-    NetworkSecurityGroupRules,
-    NetworkSubnets,
+        deserializer.deserialize_str(ModeVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_unit_variant_from_bare_string() {
+        let mode: Mode = serde_yaml::from_str("Home").unwrap();
+        assert_eq!(mode, Mode::Home);
+    }
+
+    #[test]
+    fn deserializes_resource_variant_from_parenthesised_string() {
+        let mode: Mode = serde_yaml::from_str("Resource(network.security_group)").unwrap();
+        assert_eq!(mode, Mode::Resource(NETWORK_SECURITY_GROUP));
+
+        let mode: Mode = serde_yaml::from_str("Resource(network.security_group_rule)").unwrap();
+        assert_eq!(mode, Mode::Resource(NETWORK_SECURITY_GROUP_RULE));
+    }
+
+    #[test]
+    fn rejects_unknown_resource_view_key() {
+        let result: Result<Mode, _> = serde_yaml::from_str("Resource(bogus.key)");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_mode_name() {
+        let result: Result<Mode, _> = serde_yaml::from_str("TotallyNotAMode");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn every_non_resource_variant_name_is_deserializable() {
+        use strum::VariantNames;
+        for name in Mode::VARIANTS {
+            if *name == "Resource" {
+                continue;
+            }
+            let result: Result<Mode, _> = serde_yaml::from_str(name);
+            assert!(
+                result.is_ok(),
+                "variant name {name:?} failed to deserialize"
+            );
+        }
+    }
+
+    #[test]
+    fn resource_mode_is_hashable_and_copy() {
+        use std::collections::HashMap;
+        let mut map: HashMap<Mode, &str> = HashMap::new();
+        map.insert(Mode::Resource(NETWORK_SECURITY_GROUP_RULE), "rules view");
+        let key = Mode::Resource(NETWORK_SECURITY_GROUP_RULE); // Copy, not moved from map insertion
+        assert_eq!(map.get(&key), Some(&"rules view"));
+    }
+
+    #[test]
+    fn every_view_key_roundtrips_through_resolve() {
+        for &key in &[
+            NETWORK_SECURITY_GROUP,
+            NETWORK_SECURITY_GROUP_RULE,
+            NETWORK_NETWORK,
+            NETWORK_ROUTER,
+            NETWORK_SUBNET,
+            BLOCK_STORAGE_BACKUP,
+            BLOCK_STORAGE_SNAPSHOT,
+            BLOCK_STORAGE_VOLUME,
+            DNS_ZONE,
+            DNS_RECORDSET,
+            IMAGE_IMAGE,
+            COMPUTE_AGGREGATE,
+            COMPUTE_FLAVOR,
+            COMPUTE_HYPERVISOR,
+            COMPUTE_SERVER,
+            COMPUTE_SERVER_INSTANCE_ACTION,
+            COMPUTE_SERVER_INSTANCE_ACTION_EVENT,
+            IDENTITY_APPLICATION_CREDENTIAL,
+            IDENTITY_GROUP,
+            IDENTITY_GROUP_USER,
+            IDENTITY_PROJECT,
+            IDENTITY_USER,
+            LB_LOADBALANCER,
+            LB_LISTENER,
+            LB_POOL,
+            LB_POOL_MEMBER,
+            LB_HEALTHMONITOR,
+        ] {
+            assert_eq!(
+                resolve_view_key(key),
+                Some(key),
+                "{key:?} missing from resolve_view_key"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Mode enum had one unit variant per resource type; each new resource
required touching mode.rs, action.rs, app.rs, and its component.
Collapse migrated resources into Mode::Resource(ViewKey), a stable
string id resolved via resolve_view_key(), cutting boilerplate for
future resource additions.

Serialize stays derived; Deserialize is hand-written since derive
can't express the ViewKey resolution. Serialize/Deserialize are
asymmetric as a result (derive emits `{"Resource": "<key>"}`,
Deserialize only accepts `"Resource(<key>)"`) — fine while Mode is
never serialized.

Migrates network, block_storage, dns, image, compute, identity, and
load-balancer resource views. Adds de-enum migration plan docs for
remaining batches.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
