### PR TITLE
fix(tui): Remove unsafe pointer cast in confirm popup

### DIFF
--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -570,9 +570,8 @@ impl App {
                     self.active_popup = Some(Popup::Confirm);
                     if let Some(popup) = self.popups.get_mut(&Popup::Confirm) {
                         // ConfirmPopup already exists, reuse by downcasting
-                        unsafe {
-                            let ptr = popup as *mut Box<dyn Component> as *mut ConfirmPopup;
-                            (*ptr).update_request(request);
+                        if let Some(confirm_popup) = popup.as_any_mut().downcast_mut::<ConfirmPopup>() {
+                            confirm_popup.update_request(request);
                         }
                     } else {
                         let mut confirm_popup = ConfirmPopup::new(request);

--- a/openstack_tui/src/components.rs
+++ b/openstack_tui/src/components.rs
@@ -54,6 +54,10 @@ pub use crate::widgets::popup::Popup;
 /// update state, and be rendered on the screen.
 #[async_trait]
 pub trait Component {
+    /// Return `self` as `&mut dyn Any` so callers can safely downcast to a concrete
+    /// component type (e.g. to reuse an existing popup instance).
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+
     /// Register an action handler that can send actions for processing if necessary.
     ///
     /// # Arguments

--- a/openstack_tui/src/components/auth_helper.rs
+++ b/openstack_tui/src/components/auth_helper.rs
@@ -109,6 +109,10 @@ impl AuthHelper {
 }
 
 impl Component for AuthHelper {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
         self.config = config;
         Ok(())

--- a/openstack_tui/src/components/cloud_select_popup.rs
+++ b/openstack_tui/src/components/cloud_select_popup.rs
@@ -52,6 +52,10 @@ impl CloudSelect {
 }
 
 impl Component for CloudSelect {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<(), TuiError> {
         self.action_tx = Some(tx);
         Ok(())

--- a/openstack_tui/src/components/confirm_popup.rs
+++ b/openstack_tui/src/components/confirm_popup.rs
@@ -62,6 +62,10 @@ impl ConfirmPopup {
 }
 
 impl Component for ConfirmPopup {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
         self.config = config;
         Ok(())

--- a/openstack_tui/src/components/describe.rs
+++ b/openstack_tui/src/components/describe.rs
@@ -246,6 +246,10 @@ impl Describe {
 }
 
 impl Component for Describe {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn handle_key_events(&mut self, key: KeyEvent) -> Result<Option<Action>, TuiError> {
         if key.kind == KeyEventKind::Press {
             match key.code {

--- a/openstack_tui/src/components/error_popup.rs
+++ b/openstack_tui/src/components/error_popup.rs
@@ -125,6 +125,10 @@ impl ErrorPopup {
 }
 
 impl Component for ErrorPopup {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
         self.config = config;
         Ok(())

--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -65,10 +65,15 @@ where
 
 impl<'a, B> Component for GenericResourceView<'a, B>
 where
-    B: ResourceBehaviour,
+    'a: 'static,
+    B: ResourceBehaviour + 'static,
     B::Item: StructTable,
     for<'b> &'b B::Item: StructTable,
 {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
         self.base.set_config(config)
     }

--- a/openstack_tui/src/components/header.rs
+++ b/openstack_tui/src/components/header.rs
@@ -136,6 +136,10 @@ impl Header {
 }
 
 impl Component for Header {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_config_handler(&mut self, config: Config) -> Result<(), TuiError> {
         self.config = config;
         Ok(())

--- a/openstack_tui/src/components/home.rs
+++ b/openstack_tui/src/components/home.rs
@@ -131,6 +131,10 @@ impl Home {
 }
 
 impl Component for Home {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<(), TuiError> {
         self.command_tx = Some(tx);
         Ok(())

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -75,6 +75,10 @@ impl ProjectSelect {
 }
 
 impl Component for ProjectSelect {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<(), TuiError> {
         self.action_tx = Some(tx);
         Ok(())

--- a/openstack_tui/src/components/region_select_popup.rs
+++ b/openstack_tui/src/components/region_select_popup.rs
@@ -56,6 +56,10 @@ impl RegionSelect {
 }
 
 impl Component for RegionSelect {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<(), TuiError> {
         self.action_tx = Some(tx);
         Ok(())

--- a/openstack_tui/src/components/resource_select_popup.rs
+++ b/openstack_tui/src/components/resource_select_popup.rs
@@ -47,6 +47,10 @@ impl ApiRequestSelect {
 }
 
 impl Component for ApiRequestSelect {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_action_handler(&mut self, _tx: UnboundedSender<Action>) -> Result<(), TuiError> {
         Ok(())
     }

--- a/openstack_tui/src/widgets/popup.rs
+++ b/openstack_tui/src/widgets/popup.rs
@@ -74,8 +74,12 @@ where
 
 impl<C> Component for Popup<C>
 where
-    C: Widget + Clone,
+    C: Widget + Clone + 'static,
 {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
     fn register_config_handler(&mut self, config: Config) -> Result<(), crate::error::TuiError> {
         self.config = config;
         Ok(())


### PR DESCRIPTION
Confirm action cast &mut Box<dyn Component> directly to
*mut ConfirmPopup, reinterpreting the trait object's fat-pointer
bytes as the concrete struct — real UB, not just risky style.

Add as_any_mut() to Component and use downcast_mut::<ConfirmPopup>()
instead. Required implementing as_any_mut on every Component impl,
which forced explicit 'static bounds on the two generic ones
(GenericResourceView, Popup<C>) since dyn Any needs 'static.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
