### PR TITLE
chore(tui): Wrap security_group(_rule) wiring in gen markers

### DIFF
--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -192,8 +192,10 @@ pub enum Action {
     SetLoadBalancerHealthMonitorListFilters(cloud_types::LoadBalancerHealthmonitorList),
 
     // Network (neutron)
-    /// Set Security group filters
+    // BEGIN GENERATED rust-tui-view action network.security_group
+    /// Set network.security_group filters
     SetNetworkSecurityGroupListFilters(cloud_types::NetworkSecurityGroupList),
+    // END GENERATED rust-tui-view action network.security_group
     /// Show a resource view, addressed by `ViewKey`.
     ShowResource(#[serde(deserialize_with = "deserialize_view_key")] crate::mode::ViewKey),
     /// Create/Delete a resource, addressed by `ViewKey`.
@@ -210,8 +212,11 @@ pub enum Action {
     },
     /// Switch to routers view
     ShowNetworkRouters,
-    /// Set Security group rule filters
+    // BEGIN GENERATED rust-tui-view action network.security_group_rule
+    /// Set network.security_group_rule filters
     SetNetworkSecurityGroupRuleListFilters(cloud_types::NetworkSecurityGroupRuleList),
+    // END GENERATED rust-tui-view action network.security_group_rule
+    // GENERATED-ANCHOR: action variants
     SetNetworkSubnetListFilters(cloud_types::NetworkSubnetList),
 }
 

--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -54,14 +54,7 @@ use crate::{
             loadbalancers::LoadBalancers, pool_members::LoadBalancerPoolMembers,
             pools::LoadBalancerPools,
         },
-        network::{
-            networks::NetworkNetworks,
-            routers::NetworkRouters,
-            //security_group_rule_create::CreateSecurityGroupRuleComponent,
-            security_group_rules::NetworkSecurityGroupRules,
-            security_groups::NetworkSecurityGroups,
-            subnets::NetworkSubnets,
-        },
+        network::{networks::NetworkNetworks, routers::NetworkRouters, subnets::NetworkSubnets},
         project_select_popup::ProjectSelect,
         region_select_popup::RegionSelect,
         resource_select_popup::ApiRequestSelect,
@@ -225,14 +218,21 @@ impl App {
             Mode::Resource(crate::mode::NETWORK_ROUTER),
             Box::new(NetworkRouters::new()),
         );
+        // BEGIN GENERATED rust-tui-view app-insert network.security_group
         components.insert(
             Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP),
-            Box::new(NetworkSecurityGroups::new()),
+            Box::new(crate::components::network::security_groups::NetworkSecurityGroups::new()),
         );
+        // END GENERATED rust-tui-view app-insert network.security_group
+        // BEGIN GENERATED rust-tui-view app-insert network.security_group_rule
         components.insert(
             Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP_RULE),
-            Box::new(NetworkSecurityGroupRules::new()),
+            Box::new(
+                crate::components::network::security_group_rules::NetworkSecurityGroupRules::new(),
+            ),
         );
+        // END GENERATED rust-tui-view app-insert network.security_group_rule
+        // GENERATED-ANCHOR: component insert
         components.insert(
             Mode::Resource(crate::mode::NETWORK_SUBNET),
             Box::new(NetworkSubnets::new()),

--- a/openstack_tui/src/mode.rs
+++ b/openstack_tui/src/mode.rs
@@ -18,8 +18,13 @@ use serde::{Deserialize, Serialize};
 /// `ResourceBehaviour::view_key()` (e.g. `"network.security_group_rule"`).
 pub type ViewKey = &'static str;
 
+// BEGIN GENERATED rust-tui-view mode-const network.security_group
 pub const NETWORK_SECURITY_GROUP: ViewKey = "network.security_group";
+// END GENERATED rust-tui-view mode-const network.security_group
+// BEGIN GENERATED rust-tui-view mode-const network.security_group_rule
 pub const NETWORK_SECURITY_GROUP_RULE: ViewKey = "network.security_group_rule";
+// END GENERATED rust-tui-view mode-const network.security_group_rule
+// GENERATED-ANCHOR: view-key consts
 pub const NETWORK_NETWORK: ViewKey = "network.network";
 pub const NETWORK_ROUTER: ViewKey = "network.router";
 pub const NETWORK_SUBNET: ViewKey = "network.subnet";
@@ -51,8 +56,13 @@ pub const LB_HEALTHMONITOR: ViewKey = "load-balancer.healthmonitor";
 /// check `app.rs` and `.config/config.yaml` stay in sync with this list — add a new
 /// resource's `(name, const)` pair here too.
 pub(crate) const ALL_VIEW_KEYS: &[(&str, ViewKey)] = &[
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys network.security_group
     ("NETWORK_SECURITY_GROUP", NETWORK_SECURITY_GROUP),
+    // END GENERATED rust-tui-view mode-all_view_keys network.security_group
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys network.security_group_rule
     ("NETWORK_SECURITY_GROUP_RULE", NETWORK_SECURITY_GROUP_RULE),
+    // END GENERATED rust-tui-view mode-all_view_keys network.security_group_rule
+    // GENERATED-ANCHOR: ALL_VIEW_KEYS entries
     ("NETWORK_NETWORK", NETWORK_NETWORK),
     ("NETWORK_ROUTER", NETWORK_ROUTER),
     ("NETWORK_SUBNET", NETWORK_SUBNET),
@@ -93,8 +103,13 @@ pub(crate) const ALL_VIEW_KEYS: &[(&str, ViewKey)] = &[
 /// Add an arm here when migrating another resource to `Mode::Resource`.
 pub(crate) fn resolve_view_key(s: &str) -> Option<ViewKey> {
     match s {
+        // BEGIN GENERATED rust-tui-view mode-resolve network.security_group
         "network.security_group" => Some(NETWORK_SECURITY_GROUP),
+        // END GENERATED rust-tui-view mode-resolve network.security_group
+        // BEGIN GENERATED rust-tui-view mode-resolve network.security_group_rule
         "network.security_group_rule" => Some(NETWORK_SECURITY_GROUP_RULE),
+        // END GENERATED rust-tui-view mode-resolve network.security_group_rule
+        // GENERATED-ANCHOR: resolve_view_key arms
         "network.network" => Some(NETWORK_NETWORK),
         "network.router" => Some(NETWORK_ROUTER),
         "network.subnet" => Some(NETWORK_SUBNET),


### PR DESCRIPTION
Scaffolds mode.rs/action.rs/app.rs for the new rust-tui-view
codegenerator target: wraps the two pilot resources' existing
lines in BEGIN/END GENERATED markers and adds GENERATED-ANCHOR
points for future resources, so codegen can patch just one
resource's region without touching hand-written neighbors.

app.rs registration now uses fully-qualified component paths
instead of `use` imports, so no separate generated region is
needed for the use-block.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
