### PR TITLE
chore(tui): Wrap remaining resources' wiring

### DIFF
--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -141,32 +141,49 @@ pub enum Action {
     },
 
     // Compute (Nova)
+    // BEGIN GENERATED rust-tui-view action compute.server
+    /// Set compute.server filters
     SetComputeServerListFilters(Box<cloud_types::ComputeServerList>),
+    // END GENERATED rust-tui-view action compute.server
+    // BEGIN GENERATED rust-tui-view action compute.server/instance_action
+    /// Set compute.server/instance_action filters
     SetComputeServerInstanceActionListFilters(Box<cloud_types::ComputeServerInstanceActionList>),
+    // END GENERATED rust-tui-view action compute.server/instance_action
+    // BEGIN GENERATED rust-tui-view action compute.server/instance_action/event
+    /// Set compute.server/instance_action/event filters
     SetComputeServerInstanceActionShowFilters(Box<cloud_types::ComputeServerInstanceActionShow>),
+    // END GENERATED rust-tui-view action compute.server/instance_action/event
     /// Show console output of the selected entry
     ShowServerConsoleOutput,
 
     // DNS (Designate)
-    /// Set DNS Zone filters
+    // BEGIN GENERATED rust-tui-view action dns.zone
+    /// Set dns.zone filters
     SetDnsZoneListFilters(cloud_types::DnsZoneList),
-    /// Set DNS Recordset filters
+    // END GENERATED rust-tui-view action dns.zone
+    // BEGIN GENERATED rust-tui-view action dns.recordset
+    /// Set dns.recordset filters
     SetDnsRecordsetListFilters(cloud_types::DnsRecordsetList),
+    // END GENERATED rust-tui-view action dns.recordset
 
     // Identity (keystone)
     //  Groups
     /// Create new identity group
     IdentityGroupCreate,
     //  Group users
-    /// Set GroupUser filters
+    // BEGIN GENERATED rust-tui-view action identity.group_user
+    /// Set identity.group_user filters
     SetIdentityGroupUserListFilters(cloud_types::IdentityGroupUserList),
+    // END GENERATED rust-tui-view action identity.group_user
     /// Add user into the group
     IdentityGroupUserAdd,
     /// Remove user from the group
     IdentityGroupUserRemove,
     //  Users
-    // Set ApplicationCredentials filters
+    // BEGIN GENERATED rust-tui-view action identity.user/application_credential
+    /// Set identity.user/application_credential filters
     SetIdentityApplicationCredentialListFilters(cloud_types::IdentityUserApplicationCredentialList),
+    // END GENERATED rust-tui-view action identity.user/application_credential
     /// Create new user
     IdentityUserCreate,
     /// Update user password
@@ -175,21 +192,34 @@ pub enum Action {
     SwitchToProject,
 
     // Image (glance)
+    // BEGIN GENERATED rust-tui-view action image.image
+    /// Set image.image filters
     SetImageListFilters(cloud_types::ImageImageList),
+    // END GENERATED rust-tui-view action image.image
 
     // LB
-    /// Set LB filters
+    // BEGIN GENERATED rust-tui-view action load-balancer.loadbalancer
+    /// Set load-balancer.loadbalancer filters
     SetLoadBalancerListFilters(cloud_types::LoadBalancerLoadbalancerList),
-    /// Set LB Listener filters
+    // END GENERATED rust-tui-view action load-balancer.loadbalancer
+    // BEGIN GENERATED rust-tui-view action load-balancer.listener
+    /// Set load-balancer.listener filters
     SetLoadBalancerListenerListFilters(cloud_types::LoadBalancerListenerList),
-    /// Set LB Pool filters
+    // END GENERATED rust-tui-view action load-balancer.listener
+    // BEGIN GENERATED rust-tui-view action load-balancer.pool
+    /// Set load-balancer.pool filters
     SetLoadBalancerPoolListFilters(cloud_types::LoadBalancerPoolList),
+    // END GENERATED rust-tui-view action load-balancer.pool
     /// Show LB Listener Pools
     ShowLoadBalancerListenerPools,
-    /// Set LB Member filters
+    // BEGIN GENERATED rust-tui-view action load-balancer.pool/member
+    /// Set load-balancer.pool/member filters
     SetLoadBalancerPoolMemberListFilters(cloud_types::LoadBalancerPoolMemberList),
-    /// Set LB Healthmonitor filters
+    // END GENERATED rust-tui-view action load-balancer.pool/member
+    // BEGIN GENERATED rust-tui-view action load-balancer.healthmonitor
+    /// Set load-balancer.healthmonitor filters
     SetLoadBalancerHealthMonitorListFilters(cloud_types::LoadBalancerHealthmonitorList),
+    // END GENERATED rust-tui-view action load-balancer.healthmonitor
 
     // Network (neutron)
     // BEGIN GENERATED rust-tui-view action network.security_group
@@ -217,7 +247,10 @@ pub enum Action {
     SetNetworkSecurityGroupRuleListFilters(cloud_types::NetworkSecurityGroupRuleList),
     // END GENERATED rust-tui-view action network.security_group_rule
     // GENERATED-ANCHOR: action variants
+    // BEGIN GENERATED rust-tui-view action network.subnet
+    /// Set network.subnet filters
     SetNetworkSubnetListFilters(cloud_types::NetworkSubnetList),
+    // END GENERATED rust-tui-view action network.subnet
 }
 
 #[cfg(test)]

--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -24,39 +24,9 @@ use crate::{
     action::Action,
     cloud_worker::{AuthAction, Cloud},
     components::{
-        Component,
-        auth_helper::AuthHelper,
-        block_storage::{
-            backups::BlockStorageBackups, snapshots::BlockStorageSnapshots,
-            volumes::BlockStorageVolumes,
-        },
-        cloud_select_popup::CloudSelect,
-        compute::{
-            aggregates::ComputeAggregates, flavors::ComputeFlavors,
-            hypervisors::ComputeHypervisors,
-            server_instance_action_events::ComputeServerInstanceActionEvents,
-            server_instance_actions::ComputeServerInstanceActions, servers::ComputeServers,
-        },
-        confirm_popup::ConfirmPopup,
-        describe::Describe,
-        dns::{recordsets::DnsRecordsets, zones::DnsZones},
-        error_popup::ErrorPopup,
-        header::Header,
-        home::Home,
-        identity::{
-            application_credentials::IdentityApplicationCredentials,
-            group_users::IdentityGroupUsers, groups::IdentityGroups, projects::IdentityProjects,
-            users::IdentityUsers,
-        },
-        image::images::Images,
-        load_balancer::{
-            health_monitors::LoadBalancerHealthMonitors, listeners::LoadBalancerListeners,
-            loadbalancers::LoadBalancers, pool_members::LoadBalancerPoolMembers,
-            pools::LoadBalancerPools,
-        },
-        network::{networks::NetworkNetworks, routers::NetworkRouters, subnets::NetworkSubnets},
-        project_select_popup::ProjectSelect,
-        region_select_popup::RegionSelect,
+        Component, auth_helper::AuthHelper, cloud_select_popup::CloudSelect,
+        confirm_popup::ConfirmPopup, describe::Describe, error_popup::ErrorPopup, header::Header,
+        home::Home, project_select_popup::ProjectSelect, region_select_popup::RegionSelect,
         resource_select_popup::ApiRequestSelect,
     },
     config::Config,
@@ -116,108 +86,167 @@ impl App {
         components.insert(Mode::Home, Box::new(Home::new()));
         components.insert(Mode::Describe, Box::new(Describe::new()));
 
+        // BEGIN GENERATED rust-tui-view app-insert block_storage.backup
         components.insert(
             Mode::Resource(crate::mode::BLOCK_STORAGE_BACKUP),
-            Box::new(BlockStorageBackups::new()),
+            Box::new(crate::components::block_storage::backups::BlockStorageBackups::new()),
         );
+        // END GENERATED rust-tui-view app-insert block_storage.backup
+        // BEGIN GENERATED rust-tui-view app-insert block_storage.snapshot
         components.insert(
             Mode::Resource(crate::mode::BLOCK_STORAGE_SNAPSHOT),
-            Box::new(BlockStorageSnapshots::new()),
+            Box::new(crate::components::block_storage::snapshots::BlockStorageSnapshots::new()),
         );
+        // END GENERATED rust-tui-view app-insert block_storage.snapshot
+        // BEGIN GENERATED rust-tui-view app-insert block_storage.volume
         components.insert(
             Mode::Resource(crate::mode::BLOCK_STORAGE_VOLUME),
-            Box::new(BlockStorageVolumes::new()),
+            Box::new(crate::components::block_storage::volumes::BlockStorageVolumes::new()),
         );
+        // END GENERATED rust-tui-view app-insert block_storage.volume
 
+        // BEGIN GENERATED rust-tui-view app-insert compute.server
         components.insert(
             Mode::Resource(crate::mode::COMPUTE_SERVER),
-            Box::new(ComputeServers::new()),
+            Box::new(crate::components::compute::servers::ComputeServers::new()),
         );
+        // END GENERATED rust-tui-view app-insert compute.server
+        // BEGIN GENERATED rust-tui-view app-insert compute.server/instance_action
         components.insert(
             Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION),
-            Box::new(ComputeServerInstanceActions::new()),
+            Box::new(
+                crate::components::compute::server_instance_actions::ComputeServerInstanceActions::new(),
+            ),
         );
+        // END GENERATED rust-tui-view app-insert compute.server/instance_action
+        // BEGIN GENERATED rust-tui-view app-insert compute.server/instance_action/event
         components.insert(
             Mode::Resource(crate::mode::COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
-            Box::new(ComputeServerInstanceActionEvents::new()),
+            Box::new(
+                crate::components::compute::server_instance_action_events::ComputeServerInstanceActionEvents::new(),
+            ),
         );
+        // END GENERATED rust-tui-view app-insert compute.server/instance_action/event
+        // BEGIN GENERATED rust-tui-view app-insert compute.flavor
         components.insert(
             Mode::Resource(crate::mode::COMPUTE_FLAVOR),
-            Box::new(ComputeFlavors::new()),
+            Box::new(crate::components::compute::flavors::ComputeFlavors::new()),
         );
+        // END GENERATED rust-tui-view app-insert compute.flavor
+        // BEGIN GENERATED rust-tui-view app-insert compute.aggregate
         components.insert(
             Mode::Resource(crate::mode::COMPUTE_AGGREGATE),
-            Box::new(ComputeAggregates::new()),
+            Box::new(crate::components::compute::aggregates::ComputeAggregates::new()),
         );
+        // END GENERATED rust-tui-view app-insert compute.aggregate
+        // BEGIN GENERATED rust-tui-view app-insert compute.hypervisor
         components.insert(
             Mode::Resource(crate::mode::COMPUTE_HYPERVISOR),
-            Box::new(ComputeHypervisors::new()),
+            Box::new(crate::components::compute::hypervisors::ComputeHypervisors::new()),
         );
+        // END GENERATED rust-tui-view app-insert compute.hypervisor
 
+        // BEGIN GENERATED rust-tui-view app-insert dns.recordset
         components.insert(
             Mode::Resource(crate::mode::DNS_RECORDSET),
-            Box::new(DnsRecordsets::new()),
+            Box::new(crate::components::dns::recordsets::DnsRecordsets::new()),
         );
+        // END GENERATED rust-tui-view app-insert dns.recordset
+        // BEGIN GENERATED rust-tui-view app-insert dns.zone
         components.insert(
             Mode::Resource(crate::mode::DNS_ZONE),
-            Box::new(DnsZones::new()),
+            Box::new(crate::components::dns::zones::DnsZones::new()),
         );
+        // END GENERATED rust-tui-view app-insert dns.zone
 
+        // BEGIN GENERATED rust-tui-view app-insert identity.user/application_credential
         components.insert(
             Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
-            Box::new(IdentityApplicationCredentials::new()),
+            Box::new(
+                crate::components::identity::application_credentials::IdentityApplicationCredentials::new(),
+            ),
         );
+        // END GENERATED rust-tui-view app-insert identity.user/application_credential
+        // BEGIN GENERATED rust-tui-view app-insert identity.group
         components.insert(
             Mode::Resource(crate::mode::IDENTITY_GROUP),
-            Box::new(IdentityGroups::new()),
+            Box::new(crate::components::identity::groups::IdentityGroups::new()),
         );
+        // END GENERATED rust-tui-view app-insert identity.group
+        // BEGIN GENERATED rust-tui-view app-insert identity.group_user
         components.insert(
             Mode::Resource(crate::mode::IDENTITY_GROUP_USER),
-            Box::new(IdentityGroupUsers::new()),
+            Box::new(crate::components::identity::group_users::IdentityGroupUsers::new()),
         );
+        // END GENERATED rust-tui-view app-insert identity.group_user
+        // BEGIN GENERATED rust-tui-view app-insert identity.project
         components.insert(
             Mode::Resource(crate::mode::IDENTITY_PROJECT),
-            Box::new(IdentityProjects::new()),
+            Box::new(crate::components::identity::projects::IdentityProjects::new()),
         );
+        // END GENERATED rust-tui-view app-insert identity.project
+        // BEGIN GENERATED rust-tui-view app-insert identity.user
         components.insert(
             Mode::Resource(crate::mode::IDENTITY_USER),
-            Box::new(IdentityUsers::new()),
+            Box::new(crate::components::identity::users::IdentityUsers::new()),
         );
+        // END GENERATED rust-tui-view app-insert identity.user
 
+        // BEGIN GENERATED rust-tui-view app-insert image.image
         components.insert(
             Mode::Resource(crate::mode::IMAGE_IMAGE),
-            Box::new(Images::new()),
+            Box::new(crate::components::image::images::Images::new()),
         );
+        // END GENERATED rust-tui-view app-insert image.image
 
+        // BEGIN GENERATED rust-tui-view app-insert load-balancer.loadbalancer
         components.insert(
             Mode::Resource(crate::mode::LB_LOADBALANCER),
-            Box::new(LoadBalancers::new()),
+            Box::new(crate::components::load_balancer::loadbalancers::LoadBalancers::new()),
         );
+        // END GENERATED rust-tui-view app-insert load-balancer.loadbalancer
+        // BEGIN GENERATED rust-tui-view app-insert load-balancer.listener
         components.insert(
             Mode::Resource(crate::mode::LB_LISTENER),
-            Box::new(LoadBalancerListeners::new()),
+            Box::new(crate::components::load_balancer::listeners::LoadBalancerListeners::new()),
         );
+        // END GENERATED rust-tui-view app-insert load-balancer.listener
+        // BEGIN GENERATED rust-tui-view app-insert load-balancer.pool
         components.insert(
             Mode::Resource(crate::mode::LB_POOL),
-            Box::new(LoadBalancerPools::new()),
+            Box::new(crate::components::load_balancer::pools::LoadBalancerPools::new()),
         );
+        // END GENERATED rust-tui-view app-insert load-balancer.pool
+        // BEGIN GENERATED rust-tui-view app-insert load-balancer.pool/member
         components.insert(
             Mode::Resource(crate::mode::LB_POOL_MEMBER),
-            Box::new(LoadBalancerPoolMembers::new()),
+            Box::new(
+                crate::components::load_balancer::pool_members::LoadBalancerPoolMembers::new(),
+            ),
         );
+        // END GENERATED rust-tui-view app-insert load-balancer.pool/member
+        // BEGIN GENERATED rust-tui-view app-insert load-balancer.healthmonitor
         components.insert(
             Mode::Resource(crate::mode::LB_HEALTHMONITOR),
-            Box::new(LoadBalancerHealthMonitors::new()),
+            Box::new(
+                crate::components::load_balancer::health_monitors::LoadBalancerHealthMonitors::new(
+                ),
+            ),
         );
+        // END GENERATED rust-tui-view app-insert load-balancer.healthmonitor
 
+        // BEGIN GENERATED rust-tui-view app-insert network.network
         components.insert(
             Mode::Resource(crate::mode::NETWORK_NETWORK),
-            Box::new(NetworkNetworks::new()),
+            Box::new(crate::components::network::networks::NetworkNetworks::new()),
         );
+        // END GENERATED rust-tui-view app-insert network.network
+        // BEGIN GENERATED rust-tui-view app-insert network.router
         components.insert(
             Mode::Resource(crate::mode::NETWORK_ROUTER),
-            Box::new(NetworkRouters::new()),
+            Box::new(crate::components::network::routers::NetworkRouters::new()),
         );
+        // END GENERATED rust-tui-view app-insert network.router
         // BEGIN GENERATED rust-tui-view app-insert network.security_group
         components.insert(
             Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP),
@@ -233,10 +262,12 @@ impl App {
         );
         // END GENERATED rust-tui-view app-insert network.security_group_rule
         // GENERATED-ANCHOR: component insert
+        // BEGIN GENERATED rust-tui-view app-insert network.subnet
         components.insert(
             Mode::Resource(crate::mode::NETWORK_SUBNET),
-            Box::new(NetworkSubnets::new()),
+            Box::new(crate::components::network::subnets::NetworkSubnets::new()),
         );
+        // END GENERATED rust-tui-view app-insert network.subnet
 
         let (auth_helper_control_channel_tx, auth_helper_control_channel_rx) =
             mpsc::channel::<oneshot::Sender<AuthAction>>(10);

--- a/openstack_tui/src/mode.rs
+++ b/openstack_tui/src/mode.rs
@@ -25,31 +25,81 @@ pub const NETWORK_SECURITY_GROUP: ViewKey = "network.security_group";
 pub const NETWORK_SECURITY_GROUP_RULE: ViewKey = "network.security_group_rule";
 // END GENERATED rust-tui-view mode-const network.security_group_rule
 // GENERATED-ANCHOR: view-key consts
+// BEGIN GENERATED rust-tui-view mode-const network.network
 pub const NETWORK_NETWORK: ViewKey = "network.network";
+// END GENERATED rust-tui-view mode-const network.network
+// BEGIN GENERATED rust-tui-view mode-const network.router
 pub const NETWORK_ROUTER: ViewKey = "network.router";
+// END GENERATED rust-tui-view mode-const network.router
+// BEGIN GENERATED rust-tui-view mode-const network.subnet
 pub const NETWORK_SUBNET: ViewKey = "network.subnet";
+// END GENERATED rust-tui-view mode-const network.subnet
+// BEGIN GENERATED rust-tui-view mode-const block_storage.backup
 pub const BLOCK_STORAGE_BACKUP: ViewKey = "block_storage.backup";
+// END GENERATED rust-tui-view mode-const block_storage.backup
+// BEGIN GENERATED rust-tui-view mode-const block_storage.snapshot
 pub const BLOCK_STORAGE_SNAPSHOT: ViewKey = "block_storage.snapshot";
+// END GENERATED rust-tui-view mode-const block_storage.snapshot
+// BEGIN GENERATED rust-tui-view mode-const block_storage.volume
 pub const BLOCK_STORAGE_VOLUME: ViewKey = "block_storage.volume";
+// END GENERATED rust-tui-view mode-const block_storage.volume
+// BEGIN GENERATED rust-tui-view mode-const dns.zone
 pub const DNS_ZONE: ViewKey = "dns.zone";
+// END GENERATED rust-tui-view mode-const dns.zone
+// BEGIN GENERATED rust-tui-view mode-const dns.recordset
 pub const DNS_RECORDSET: ViewKey = "dns.recordset";
+// END GENERATED rust-tui-view mode-const dns.recordset
+// BEGIN GENERATED rust-tui-view mode-const image.image
 pub const IMAGE_IMAGE: ViewKey = "image.image";
+// END GENERATED rust-tui-view mode-const image.image
+// BEGIN GENERATED rust-tui-view mode-const compute.aggregate
 pub const COMPUTE_AGGREGATE: ViewKey = "compute.aggregate";
+// END GENERATED rust-tui-view mode-const compute.aggregate
+// BEGIN GENERATED rust-tui-view mode-const compute.flavor
 pub const COMPUTE_FLAVOR: ViewKey = "compute.flavor";
+// END GENERATED rust-tui-view mode-const compute.flavor
+// BEGIN GENERATED rust-tui-view mode-const compute.hypervisor
 pub const COMPUTE_HYPERVISOR: ViewKey = "compute.hypervisor";
+// END GENERATED rust-tui-view mode-const compute.hypervisor
+// BEGIN GENERATED rust-tui-view mode-const compute.server
 pub const COMPUTE_SERVER: ViewKey = "compute.server";
+// END GENERATED rust-tui-view mode-const compute.server
+// BEGIN GENERATED rust-tui-view mode-const compute.server/instance_action
 pub const COMPUTE_SERVER_INSTANCE_ACTION: ViewKey = "compute.server/instance_action";
+// END GENERATED rust-tui-view mode-const compute.server/instance_action
+// BEGIN GENERATED rust-tui-view mode-const compute.server/instance_action/event
 pub const COMPUTE_SERVER_INSTANCE_ACTION_EVENT: ViewKey = "compute.server/instance_action/event";
+// END GENERATED rust-tui-view mode-const compute.server/instance_action/event
+// BEGIN GENERATED rust-tui-view mode-const identity.user/application_credential
 pub const IDENTITY_APPLICATION_CREDENTIAL: ViewKey = "identity.user/application_credential";
+// END GENERATED rust-tui-view mode-const identity.user/application_credential
+// BEGIN GENERATED rust-tui-view mode-const identity.group
 pub const IDENTITY_GROUP: ViewKey = "identity.group";
+// END GENERATED rust-tui-view mode-const identity.group
+// BEGIN GENERATED rust-tui-view mode-const identity.group_user
 pub const IDENTITY_GROUP_USER: ViewKey = "identity.group_user";
+// END GENERATED rust-tui-view mode-const identity.group_user
+// BEGIN GENERATED rust-tui-view mode-const identity.project
 pub const IDENTITY_PROJECT: ViewKey = "identity.project";
+// END GENERATED rust-tui-view mode-const identity.project
+// BEGIN GENERATED rust-tui-view mode-const identity.user
 pub const IDENTITY_USER: ViewKey = "identity.user";
+// END GENERATED rust-tui-view mode-const identity.user
+// BEGIN GENERATED rust-tui-view mode-const load-balancer.loadbalancer
 pub const LB_LOADBALANCER: ViewKey = "load-balancer.loadbalancer";
+// END GENERATED rust-tui-view mode-const load-balancer.loadbalancer
+// BEGIN GENERATED rust-tui-view mode-const load-balancer.listener
 pub const LB_LISTENER: ViewKey = "load-balancer.listener";
+// END GENERATED rust-tui-view mode-const load-balancer.listener
+// BEGIN GENERATED rust-tui-view mode-const load-balancer.pool
 pub const LB_POOL: ViewKey = "load-balancer.pool";
+// END GENERATED rust-tui-view mode-const load-balancer.pool
+// BEGIN GENERATED rust-tui-view mode-const load-balancer.pool/member
 pub const LB_POOL_MEMBER: ViewKey = "load-balancer.pool/member";
+// END GENERATED rust-tui-view mode-const load-balancer.pool/member
+// BEGIN GENERATED rust-tui-view mode-const load-balancer.healthmonitor
 pub const LB_HEALTHMONITOR: ViewKey = "load-balancer.healthmonitor";
+// END GENERATED rust-tui-view mode-const load-balancer.healthmonitor
 
 /// Every `ViewKey` migrated to `Mode::Resource`, paired with its const name. Single source
 /// of truth used both by the `resolve_view_key` round-trip test and by coverage tests that
@@ -63,40 +113,90 @@ pub(crate) const ALL_VIEW_KEYS: &[(&str, ViewKey)] = &[
     ("NETWORK_SECURITY_GROUP_RULE", NETWORK_SECURITY_GROUP_RULE),
     // END GENERATED rust-tui-view mode-all_view_keys network.security_group_rule
     // GENERATED-ANCHOR: ALL_VIEW_KEYS entries
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys network.network
     ("NETWORK_NETWORK", NETWORK_NETWORK),
+    // END GENERATED rust-tui-view mode-all_view_keys network.network
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys network.router
     ("NETWORK_ROUTER", NETWORK_ROUTER),
+    // END GENERATED rust-tui-view mode-all_view_keys network.router
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys network.subnet
     ("NETWORK_SUBNET", NETWORK_SUBNET),
+    // END GENERATED rust-tui-view mode-all_view_keys network.subnet
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys block_storage.backup
     ("BLOCK_STORAGE_BACKUP", BLOCK_STORAGE_BACKUP),
+    // END GENERATED rust-tui-view mode-all_view_keys block_storage.backup
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys block_storage.snapshot
     ("BLOCK_STORAGE_SNAPSHOT", BLOCK_STORAGE_SNAPSHOT),
+    // END GENERATED rust-tui-view mode-all_view_keys block_storage.snapshot
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys block_storage.volume
     ("BLOCK_STORAGE_VOLUME", BLOCK_STORAGE_VOLUME),
+    // END GENERATED rust-tui-view mode-all_view_keys block_storage.volume
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys dns.zone
     ("DNS_ZONE", DNS_ZONE),
+    // END GENERATED rust-tui-view mode-all_view_keys dns.zone
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys dns.recordset
     ("DNS_RECORDSET", DNS_RECORDSET),
+    // END GENERATED rust-tui-view mode-all_view_keys dns.recordset
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys image.image
     ("IMAGE_IMAGE", IMAGE_IMAGE),
+    // END GENERATED rust-tui-view mode-all_view_keys image.image
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys compute.aggregate
     ("COMPUTE_AGGREGATE", COMPUTE_AGGREGATE),
+    // END GENERATED rust-tui-view mode-all_view_keys compute.aggregate
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys compute.flavor
     ("COMPUTE_FLAVOR", COMPUTE_FLAVOR),
+    // END GENERATED rust-tui-view mode-all_view_keys compute.flavor
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys compute.hypervisor
     ("COMPUTE_HYPERVISOR", COMPUTE_HYPERVISOR),
+    // END GENERATED rust-tui-view mode-all_view_keys compute.hypervisor
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys compute.server
     ("COMPUTE_SERVER", COMPUTE_SERVER),
+    // END GENERATED rust-tui-view mode-all_view_keys compute.server
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys compute.server/instance_action
     (
         "COMPUTE_SERVER_INSTANCE_ACTION",
         COMPUTE_SERVER_INSTANCE_ACTION,
     ),
+    // END GENERATED rust-tui-view mode-all_view_keys compute.server/instance_action
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys compute.server/instance_action/event
     (
         "COMPUTE_SERVER_INSTANCE_ACTION_EVENT",
         COMPUTE_SERVER_INSTANCE_ACTION_EVENT,
     ),
+    // END GENERATED rust-tui-view mode-all_view_keys compute.server/instance_action/event
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys identity.user/application_credential
     (
         "IDENTITY_APPLICATION_CREDENTIAL",
         IDENTITY_APPLICATION_CREDENTIAL,
     ),
+    // END GENERATED rust-tui-view mode-all_view_keys identity.user/application_credential
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys identity.group
     ("IDENTITY_GROUP", IDENTITY_GROUP),
+    // END GENERATED rust-tui-view mode-all_view_keys identity.group
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys identity.group_user
     ("IDENTITY_GROUP_USER", IDENTITY_GROUP_USER),
+    // END GENERATED rust-tui-view mode-all_view_keys identity.group_user
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys identity.project
     ("IDENTITY_PROJECT", IDENTITY_PROJECT),
+    // END GENERATED rust-tui-view mode-all_view_keys identity.project
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys identity.user
     ("IDENTITY_USER", IDENTITY_USER),
+    // END GENERATED rust-tui-view mode-all_view_keys identity.user
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys load-balancer.loadbalancer
     ("LB_LOADBALANCER", LB_LOADBALANCER),
+    // END GENERATED rust-tui-view mode-all_view_keys load-balancer.loadbalancer
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys load-balancer.listener
     ("LB_LISTENER", LB_LISTENER),
+    // END GENERATED rust-tui-view mode-all_view_keys load-balancer.listener
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys load-balancer.pool
     ("LB_POOL", LB_POOL),
+    // END GENERATED rust-tui-view mode-all_view_keys load-balancer.pool
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys load-balancer.pool/member
     ("LB_POOL_MEMBER", LB_POOL_MEMBER),
+    // END GENERATED rust-tui-view mode-all_view_keys load-balancer.pool/member
+    // BEGIN GENERATED rust-tui-view mode-all_view_keys load-balancer.healthmonitor
     ("LB_HEALTHMONITOR", LB_HEALTHMONITOR),
+    // END GENERATED rust-tui-view mode-all_view_keys load-balancer.healthmonitor
 ];
 
 /// Resolve a config-supplied view-key string to the canonical `'static` `ViewKey`.
@@ -110,31 +210,81 @@ pub(crate) fn resolve_view_key(s: &str) -> Option<ViewKey> {
         "network.security_group_rule" => Some(NETWORK_SECURITY_GROUP_RULE),
         // END GENERATED rust-tui-view mode-resolve network.security_group_rule
         // GENERATED-ANCHOR: resolve_view_key arms
+        // BEGIN GENERATED rust-tui-view mode-resolve network.network
         "network.network" => Some(NETWORK_NETWORK),
+        // END GENERATED rust-tui-view mode-resolve network.network
+        // BEGIN GENERATED rust-tui-view mode-resolve network.router
         "network.router" => Some(NETWORK_ROUTER),
+        // END GENERATED rust-tui-view mode-resolve network.router
+        // BEGIN GENERATED rust-tui-view mode-resolve network.subnet
         "network.subnet" => Some(NETWORK_SUBNET),
+        // END GENERATED rust-tui-view mode-resolve network.subnet
+        // BEGIN GENERATED rust-tui-view mode-resolve block_storage.backup
         "block_storage.backup" => Some(BLOCK_STORAGE_BACKUP),
+        // END GENERATED rust-tui-view mode-resolve block_storage.backup
+        // BEGIN GENERATED rust-tui-view mode-resolve block_storage.snapshot
         "block_storage.snapshot" => Some(BLOCK_STORAGE_SNAPSHOT),
+        // END GENERATED rust-tui-view mode-resolve block_storage.snapshot
+        // BEGIN GENERATED rust-tui-view mode-resolve block_storage.volume
         "block_storage.volume" => Some(BLOCK_STORAGE_VOLUME),
+        // END GENERATED rust-tui-view mode-resolve block_storage.volume
+        // BEGIN GENERATED rust-tui-view mode-resolve dns.zone
         "dns.zone" => Some(DNS_ZONE),
+        // END GENERATED rust-tui-view mode-resolve dns.zone
+        // BEGIN GENERATED rust-tui-view mode-resolve dns.recordset
         "dns.recordset" => Some(DNS_RECORDSET),
+        // END GENERATED rust-tui-view mode-resolve dns.recordset
+        // BEGIN GENERATED rust-tui-view mode-resolve image.image
         "image.image" => Some(IMAGE_IMAGE),
+        // END GENERATED rust-tui-view mode-resolve image.image
+        // BEGIN GENERATED rust-tui-view mode-resolve compute.aggregate
         "compute.aggregate" => Some(COMPUTE_AGGREGATE),
+        // END GENERATED rust-tui-view mode-resolve compute.aggregate
+        // BEGIN GENERATED rust-tui-view mode-resolve compute.flavor
         "compute.flavor" => Some(COMPUTE_FLAVOR),
+        // END GENERATED rust-tui-view mode-resolve compute.flavor
+        // BEGIN GENERATED rust-tui-view mode-resolve compute.hypervisor
         "compute.hypervisor" => Some(COMPUTE_HYPERVISOR),
+        // END GENERATED rust-tui-view mode-resolve compute.hypervisor
+        // BEGIN GENERATED rust-tui-view mode-resolve compute.server
         "compute.server" => Some(COMPUTE_SERVER),
+        // END GENERATED rust-tui-view mode-resolve compute.server
+        // BEGIN GENERATED rust-tui-view mode-resolve compute.server/instance_action
         "compute.server/instance_action" => Some(COMPUTE_SERVER_INSTANCE_ACTION),
+        // END GENERATED rust-tui-view mode-resolve compute.server/instance_action
+        // BEGIN GENERATED rust-tui-view mode-resolve compute.server/instance_action/event
         "compute.server/instance_action/event" => Some(COMPUTE_SERVER_INSTANCE_ACTION_EVENT),
+        // END GENERATED rust-tui-view mode-resolve compute.server/instance_action/event
+        // BEGIN GENERATED rust-tui-view mode-resolve identity.user/application_credential
         "identity.user/application_credential" => Some(IDENTITY_APPLICATION_CREDENTIAL),
+        // END GENERATED rust-tui-view mode-resolve identity.user/application_credential
+        // BEGIN GENERATED rust-tui-view mode-resolve identity.group
         "identity.group" => Some(IDENTITY_GROUP),
+        // END GENERATED rust-tui-view mode-resolve identity.group
+        // BEGIN GENERATED rust-tui-view mode-resolve identity.group_user
         "identity.group_user" => Some(IDENTITY_GROUP_USER),
+        // END GENERATED rust-tui-view mode-resolve identity.group_user
+        // BEGIN GENERATED rust-tui-view mode-resolve identity.project
         "identity.project" => Some(IDENTITY_PROJECT),
+        // END GENERATED rust-tui-view mode-resolve identity.project
+        // BEGIN GENERATED rust-tui-view mode-resolve identity.user
         "identity.user" => Some(IDENTITY_USER),
+        // END GENERATED rust-tui-view mode-resolve identity.user
+        // BEGIN GENERATED rust-tui-view mode-resolve load-balancer.loadbalancer
         "load-balancer.loadbalancer" => Some(LB_LOADBALANCER),
+        // END GENERATED rust-tui-view mode-resolve load-balancer.loadbalancer
+        // BEGIN GENERATED rust-tui-view mode-resolve load-balancer.listener
         "load-balancer.listener" => Some(LB_LISTENER),
+        // END GENERATED rust-tui-view mode-resolve load-balancer.listener
+        // BEGIN GENERATED rust-tui-view mode-resolve load-balancer.pool
         "load-balancer.pool" => Some(LB_POOL),
+        // END GENERATED rust-tui-view mode-resolve load-balancer.pool
+        // BEGIN GENERATED rust-tui-view mode-resolve load-balancer.pool/member
         "load-balancer.pool/member" => Some(LB_POOL_MEMBER),
+        // END GENERATED rust-tui-view mode-resolve load-balancer.pool/member
+        // BEGIN GENERATED rust-tui-view mode-resolve load-balancer.healthmonitor
         "load-balancer.healthmonitor" => Some(LB_HEALTHMONITOR),
+        // END GENERATED rust-tui-view mode-resolve load-balancer.healthmonitor
         _ => None,
     }
 }


### PR DESCRIPTION
Extends the security_group(_rule) pilot to every other migrated
resource, scaffolding for the codegenerator rust-tui-view target:

- mode.rs: all 27 view keys now marker-wrapped (const/resolve
  arm/ALL_VIEW_KEYS entry) per resource.
- app.rs: all 27 component registrations wrapped and switched to
  fully-qualified `crate::components::<mod>::<Type>::new()` paths,
  dropping the now-superseded per-service use groups.
- action.rs: the 14 resources with a Set*Filters action wrapped
  (the other 13 have no filter action at all, matching their
  absence from config.yaml, so nothing to wrap).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
