### PR TITLE
chore(tui): Extract mechanical ResourceBehaviour tier

### DIFF
--- a/openstack_tui/src/components/network.rs
+++ b/openstack_tui/src/components/network.rs
@@ -12,6 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod generated;
 pub mod networks;
 pub mod routers;
 pub mod security_group_rules;

--- a/openstack_tui/src/components/network/generated.rs
+++ b/openstack_tui/src/components/network/generated.rs
@@ -1,0 +1,25 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// WARNING: Individual `pub(crate) mod <resource>;` lines below are automatically generated
+// from OpenAPI schema using `openstack-codegenerator`. This scaffold line itself is hand-added,
+// once per service, as the anchor new resources' lines get inserted after.
+
+// GENERATED-ANCHOR: resource mods
+// BEGIN GENERATED rust-resource-behaviour mod security_group
+pub(crate) mod security_group;
+// END GENERATED rust-resource-behaviour mod security_group
+// BEGIN GENERATED rust-resource-behaviour mod security_group_rule
+pub(crate) mod security_group_rule;
+// END GENERATED rust-resource-behaviour mod security_group_rule

--- a/openstack_tui/src/components/network/generated/security_group.rs
+++ b/openstack_tui/src/components/network/generated/security_group.rs
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hand-authored for now: mirrors the shape a planned `RustResourceBehaviourGenerator`
+// (openstack-codegenerator, Track 2) is expected to emit. Replace with generated output once
+// that generator lands.
+
+use crate::cloud_worker::network::v2::{
+    NetworkApiRequest, NetworkSecurityGroupApiRequest, NetworkSecurityGroupList,
+};
+use crate::cloud_worker::types::ApiRequest;
+use crate::components::resource_behaviour::GeneratedResourceBehaviour;
+use crate::mode::Mode;
+use openstack_types::network::v2::security_group::response::list::SecurityGroupResponse;
+
+pub(crate) struct Generated;
+
+impl GeneratedResourceBehaviour for Generated {
+    type Item = SecurityGroupResponse;
+    type Filter = NetworkSecurityGroupList;
+
+    fn view_key() -> &'static str {
+        crate::mode::NETWORK_SECURITY_GROUP
+    }
+    fn title() -> &'static str {
+        "Security Groups"
+    }
+    fn mode() -> Mode {
+        Mode::Resource(Self::view_key())
+    }
+    fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
+        ApiRequest::from(NetworkSecurityGroupApiRequest::List(Box::new(
+            filter.clone(),
+        )))
+    }
+    fn matches_request(request: &ApiRequest) -> bool {
+        matches!(
+            request,
+            ApiRequest::Network(NetworkApiRequest::SecurityGroup(boxreq))
+            if matches!(**boxreq, NetworkSecurityGroupApiRequest::List(_))
+        )
+    }
+}

--- a/openstack_tui/src/components/network/generated/security_group_rule.rs
+++ b/openstack_tui/src/components/network/generated/security_group_rule.rs
@@ -1,0 +1,62 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hand-authored for now: mirrors the shape a planned `RustResourceBehaviourGenerator`
+// (openstack-codegenerator, Track 2) is expected to emit. Replace with generated output once
+// that generator lands.
+
+use crate::action::Action;
+use crate::cloud_worker::network::v2::{
+    NetworkApiRequest, NetworkSecurityGroupRuleApiRequest, NetworkSecurityGroupRuleList,
+};
+use crate::cloud_worker::types::ApiRequest;
+use crate::components::resource_behaviour::GeneratedResourceBehaviour;
+use crate::mode::Mode;
+use openstack_types::network::v2::security_group_rule::response::list::SecurityGroupRuleResponse;
+
+pub(crate) struct Generated;
+
+impl GeneratedResourceBehaviour for Generated {
+    type Item = SecurityGroupRuleResponse;
+    type Filter = NetworkSecurityGroupRuleList;
+
+    fn view_key() -> &'static str {
+        crate::mode::NETWORK_SECURITY_GROUP_RULE
+    }
+    fn title() -> &'static str {
+        "Security Group Rules"
+    }
+    fn mode() -> Mode {
+        Mode::Resource(Self::view_key())
+    }
+    fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
+        ApiRequest::from(NetworkSecurityGroupRuleApiRequest::List(Box::new(
+            filter.clone(),
+        )))
+    }
+    fn matches_request(request: &ApiRequest) -> bool {
+        matches!(
+            request,
+            ApiRequest::Network(NetworkApiRequest::SecurityGroupRule(boxreq))
+            if matches!(**boxreq, NetworkSecurityGroupRuleApiRequest::List(_))
+        )
+    }
+    fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
+        if let Action::SetNetworkSecurityGroupRuleListFilters(f) = action {
+            Some(f.clone())
+        } else {
+            None
+        }
+    }
+}

--- a/openstack_tui/src/components/network/security_group_rules.rs
+++ b/openstack_tui/src/components/network/security_group_rules.rs
@@ -19,7 +19,9 @@ use crate::cloud_worker::network::v2::{
 };
 use crate::cloud_worker::types::ApiRequest;
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::{Mutation, ResourceBehaviour};
+use crate::components::resource_behaviour::{
+    GeneratedResourceBehaviour, Mutation, ResourceBehaviour,
+};
 use crate::mode::Mode;
 use openstack_types::network::v2::security_group_rule::response::list::SecurityGroupRuleResponse;
 use serde_json::Value;
@@ -48,13 +50,22 @@ impl ResourceBehaviour for NetworkSecurityGroupRulesBehaviour {
     type Filter = NetworkSecurityGroupRuleList;
 
     fn view_key() -> &'static str {
-        crate::mode::NETWORK_SECURITY_GROUP_RULE
+        super::generated::security_group_rule::Generated::view_key()
     }
     fn title() -> &'static str {
-        "SecurityGroupRules"
+        super::generated::security_group_rule::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::security_group_rule::Generated::mode()
+    }
+    fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
+        super::generated::security_group_rule::Generated::request_from_filter(filter)
+    }
+    fn matches_request(request: &ApiRequest) -> bool {
+        super::generated::security_group_rule::Generated::matches_request(request)
+    }
+    fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
+        super::generated::security_group_rule::Generated::handle_set_filter_action(action)
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -67,25 +78,6 @@ impl ResourceBehaviour for NetworkSecurityGroupRulesBehaviour {
             filter.sort_dir = Some(vec!["asc".into(), "asc".into(), "asc".into(), "asc".into()]);
         }
         filter
-    }
-    fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(NetworkSecurityGroupRuleApiRequest::List(Box::new(
-            filter.clone(),
-        )))
-    }
-    fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Network(NetworkApiRequest::SecurityGroupRule(boxreq))
-            if matches!(**boxreq, NetworkSecurityGroupRuleApiRequest::List(_))
-        )
-    }
-    fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetNetworkSecurityGroupRuleListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
     }
     fn confirm_request(action: &Action, selected: Option<&Self::Item>) -> Option<ApiRequest> {
         if let Action::ResourceOp {
@@ -143,7 +135,7 @@ mod tests {
         );
         assert_eq!(
             NetworkSecurityGroupRulesBehaviour::title(),
-            "SecurityGroupRules"
+            "Security Group Rules"
         );
         assert_eq!(
             NetworkSecurityGroupRulesBehaviour::mode(),

--- a/openstack_tui/src/components/network/security_groups.rs
+++ b/openstack_tui/src/components/network/security_groups.rs
@@ -14,12 +14,11 @@
 
 use crate::action::Action;
 use crate::cloud_worker::network::v2::{
-    NetworkApiRequest, NetworkSecurityGroupApiRequest, NetworkSecurityGroupList,
-    NetworkSecurityGroupRuleList, NetworkSecurityGroupRuleListBuilder,
+    NetworkSecurityGroupList, NetworkSecurityGroupRuleList, NetworkSecurityGroupRuleListBuilder,
 };
 use crate::cloud_worker::types::ApiRequest;
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
 use openstack_types::network::v2::security_group::response::list::SecurityGroupResponse;
 
@@ -50,13 +49,19 @@ impl ResourceBehaviour for NetworkSecurityGroupsBehaviour {
     type Filter = NetworkSecurityGroupList;
 
     fn view_key() -> &'static str {
-        crate::mode::NETWORK_SECURITY_GROUP
+        super::generated::security_group::Generated::view_key()
     }
     fn title() -> &'static str {
-        "SecurityGroups"
+        super::generated::security_group::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::security_group::Generated::mode()
+    }
+    fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
+        super::generated::security_group::Generated::request_from_filter(filter)
+    }
+    fn matches_request(request: &ApiRequest) -> bool {
+        super::generated::security_group::Generated::matches_request(request)
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -64,18 +69,6 @@ impl ResourceBehaviour for NetworkSecurityGroupsBehaviour {
             filter.sort_dir = Some(Vec::from(["asc".into()]));
         }
         filter
-    }
-    fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(NetworkSecurityGroupApiRequest::List(Box::new(
-            filter.clone(),
-        )))
-    }
-    fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Network(NetworkApiRequest::SecurityGroup(boxreq))
-            if matches!(**boxreq, NetworkSecurityGroupApiRequest::List(_))
-        )
     }
     fn filter_carry_action(
         action: &Action,
@@ -104,6 +97,7 @@ pub type NetworkSecurityGroups = GenericResourceView<'static, NetworkSecurityGro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cloud_worker::network::v2::{NetworkApiRequest, NetworkSecurityGroupApiRequest};
     use crate::components::resource_behaviour::ResourceBehaviour;
     use openstack_types::network::v2::security_group::response::list::SecurityGroupResponse;
 
@@ -126,7 +120,7 @@ mod tests {
             NetworkSecurityGroupsBehaviour::view_key(),
             "network.security_group"
         );
-        assert_eq!(NetworkSecurityGroupsBehaviour::title(), "SecurityGroups");
+        assert_eq!(NetworkSecurityGroupsBehaviour::title(), "Security Groups");
         assert_eq!(
             NetworkSecurityGroupsBehaviour::mode(),
             Mode::Resource(crate::mode::NETWORK_SECURITY_GROUP)

--- a/openstack_tui/src/components/resource_behaviour.rs
+++ b/openstack_tui/src/components/resource_behaviour.rs
@@ -20,8 +20,40 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::fmt::Display;
 
+/// The mechanical subset of `ResourceBehaviour`: methods fully derivable from a resource's
+/// metadata (view key, request/filter types, mode). Intended to be implemented by a generated
+/// `Generated` companion type per resource; `ResourceBehaviour`'s defaults delegate to it.
+pub trait GeneratedResourceBehaviour {
+    type Item: ResourceKey + DeserializeOwned;
+    type Filter: Default + Display + Clone;
+
+    /// The view configuration key used for persisting column/field settings.
+    fn view_key() -> &'static str;
+    /// Human readable title for the view.
+    fn title() -> &'static str;
+    /// The Mode that corresponds to this component (when shown, data should be loaded).
+    fn mode() -> Mode;
+    /// Build the ApiRequest to list resources, given the current (normalised) filters.
+    fn request_from_filter(filter: &Self::Filter) -> ApiRequest;
+    /// Check whether the given ApiRequest is the list-detailed request this component handles.
+    fn matches_request(request: &ApiRequest) -> bool;
+    /// Return the filter from a Set*Filters action. Return None if the action does not apply.
+    fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
+        let _ = action;
+        None
+    }
+}
+
 /// Behaviour specifics for a particular OpenStack resource.
 /// Implementors provide the concrete item type, filter type and any custom actions.
+///
+/// The `view_key`/`title`/`mode`/`request_from_filter`/`matches_request`/`handle_set_filter_action`
+/// methods below are the "mechanical" tier also described by `GeneratedResourceBehaviour`: for
+/// resources that have a generated companion module, implementors should give each of these a
+/// one-line body that forwards to it (e.g. `fn view_key() -> &'static str {
+/// generated::security_group::Generated::view_key() }`) rather than duplicating the logic here.
+/// They stay required, non-default methods on this trait itself so that resources without a
+/// generated companion module yet are unaffected.
 pub trait ResourceBehaviour {
     type Item: ResourceKey + DeserializeOwned;
     type Filter: Default + Display + Clone;


### PR DESCRIPTION
Introduces GeneratedResourceBehaviour, the mechanical subset of
ResourceBehaviour
(view_key/title/mode/request_from_filter/matches_request/
handle_set_filter_action), and moves that logic into per-resource
components/<service>/generated/<resource>.rs companion modules. The two
pilot resources (network.security_group, network.security_group_rule)
now forward those six methods to their Generated module; all hand-tuned
methods (normalise_filter, filter_carry_action, confirm_request,
handle_mutation_response, clear_data_on_filter_change) are unchanged.

The generated/ files are hand-authored for now, in the shape a planned
codegenerator generator is expected to emit later.  ResourceBehaviour's
own method signatures are otherwise untouched so the other 25 resources'
impls keep compiling as-is.

title() values for the two migrated resources were renormalized to
spaced Title Case ("Security Groups", "Security Group Rules") to match
what a mechanical component_type-derived title would produce.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
