### PR TITLE
feat(sdk): Add builder for AsyncOpenStack/OpenStack connection options

### DIFF
--- a/openstack_sdk/README.md
+++ b/openstack_sdk/README.md
@@ -66,6 +66,29 @@ async fn list_flavors() -> Result<(), OpenStackError> {
 }
 ```
 
+## Connection options
+
+`AsyncOpenStack::new`/`OpenStack::new` cover the default case. For
+connection-time options (e.g. disabling the on-disk auth cache) use the
+builder instead, via `AsyncOpenStack::builder`/`OpenStack::builder`:
+
+```rust
+use openstack_sdk::{AsyncOpenStack, config::ConfigFile, OpenStackError};
+
+async fn connect_without_cache() -> Result<(), OpenStackError> {
+    let cfg = ConfigFile::new().unwrap();
+    let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
+
+    let session = AsyncOpenStack::builder(&profile)
+        .disable_auth_cache(true)
+        .connect()
+        .await?;
+
+    println!("{:?}", session.get_auth_token());
+    Ok(())
+}
+```
+
 ## Documentation
 
 Current crate documentation is known to be very poor. It will be addressed in

--- a/openstack_sdk/src/lib.rs
+++ b/openstack_sdk/src/lib.rs
@@ -27,7 +27,7 @@ mod session;
 #[cfg(feature = "async")]
 mod openstack_async;
 #[cfg(feature = "async")]
-pub use openstack_async::{AsyncOpenStack, RenewHandle};
+pub use openstack_async::{AsyncOpenStack, AsyncOpenStackBuilder, RenewHandle};
 #[cfg(all(feature = "sync", feature = "async"))]
 mod openstack;
 #[cfg(all(feature = "sync", feature = "async"))]

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -37,7 +37,7 @@ use openstack_sdk_core::error::{OpenStackResult, RestError};
 use openstack_sdk_core::types::ServiceType;
 use secrecy::SecretString;
 
-use crate::{AsyncOpenStack, types::ApiVersion};
+use crate::{AsyncOpenStack, AsyncOpenStackBuilder, types::ApiVersion};
 
 type Runtime = Arc<tokio::runtime::Runtime>;
 
@@ -56,6 +56,23 @@ type Runtime = Arc<tokio::runtime::Runtime>;
 ///     let profile = cfg.get_cloud_config("devstack")?.unwrap();
 ///     let session = openstack_sdk::OpenStack::new(&profile)?;
 ///     session.discover_service_endpoint(&ServiceType::Compute)?;
+///     Ok(())
+/// }
+/// ```
+///
+/// Use [`OpenStack::builder`] instead of [`OpenStack::new`] when
+/// connection-time options are needed, e.g. disabling the on-disk auth
+/// cache:
+/// ```rust
+/// use openstack_sdk::config::ConfigFile;
+///
+/// fn connect_without_cache() -> Result<(), openstack_sdk::OpenStackError> {
+///     let cfg = ConfigFile::new()?;
+///     let profile = cfg.get_cloud_config("devstack")?.unwrap();
+///     let session = openstack_sdk::OpenStack::builder(&profile)
+///         .disable_auth_cache(true)
+///         .build()?;
+///     println!("{:?}", session.get_auth_token());
 ///     Ok(())
 /// }
 /// ```
@@ -119,6 +136,100 @@ impl Client for OpenStack {
     }
 }
 
+/// Builder for connection-time options on [`OpenStack`], obtained via
+/// [`OpenStack::builder`]. Blocking counterpart of [`AsyncOpenStackBuilder`].
+pub struct OpenStackBuilder {
+    inner: AsyncOpenStackBuilder,
+}
+
+impl OpenStackBuilder {
+    /// Disable authentication caching for the session being built. See
+    /// [`AsyncOpenStackBuilder::disable_auth_cache`].
+    pub fn disable_auth_cache(mut self, disable: bool) -> Self {
+        self.inner = self.inner.disable_auth_cache(disable);
+        self
+    }
+
+    /// Set the auth helper used for the initial authorization and for later
+    /// 401 re-authentication.
+    pub fn auth_helper<A>(mut self, auth_helper: A) -> Self
+    where
+        A: AuthHelper + Sync + Send + 'static,
+    {
+        self.inner = self.inner.auth_helper(auth_helper);
+        self
+    }
+
+    /// Force renewal of authorization even if a cached token is available.
+    pub fn renew_auth(mut self, renew_auth: bool) -> Self {
+        self.inner = self.inner.renew_auth(renew_auth);
+        self
+    }
+
+    /// Set the maximum number of retries on 401 responses.
+    pub fn max_auth_retries(mut self, n: u32) -> Self {
+        self.inner = self.inner.max_auth_retries(n);
+        self
+    }
+
+    /// Override the request timeout (default: `CloudConfig.options.api_timeout`, or 30s).
+    pub fn http_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.inner = self.inner.http_timeout(timeout);
+        self
+    }
+
+    /// Override the connect timeout (default: 5s).
+    pub fn http_connect_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.inner = self.inner.http_connect_timeout(timeout);
+        self
+    }
+
+    /// Override the TCP keepalive interval (default: 60s).
+    pub fn http_tcp_keepalive(mut self, interval: std::time::Duration) -> Self {
+        self.inner = self.inner.http_tcp_keepalive(interval);
+        self
+    }
+
+    /// Enable/disable gzip response decompression (default: enabled).
+    pub fn http_gzip(mut self, enable: bool) -> Self {
+        self.inner = self.inner.http_gzip(enable);
+        self
+    }
+
+    /// Enable/disable deflate response decompression (default: enabled).
+    pub fn http_deflate(mut self, enable: bool) -> Self {
+        self.inner = self.inner.http_deflate(enable);
+        self
+    }
+
+    /// Override the maximum idle connections per host (default: 10).
+    pub fn http_pool_max_idle_per_host(mut self, max: usize) -> Self {
+        self.inner = self.inner.http_pool_max_idle_per_host(max);
+        self
+    }
+
+    /// Override the idle connection pool timeout (default: 30s).
+    pub fn http_pool_idle_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.inner = self.inner.http_pool_idle_timeout(timeout);
+        self
+    }
+
+    /// Establish the session, blocking on a freshly created Tokio runtime
+    /// that is then reused by the resulting [`OpenStack`].
+    pub fn build(self) -> OpenStackResult<OpenStack> {
+        let rt: Runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap_or_else(|e| panic!("failed to create tokio runtime: {e}")),
+        );
+        let inner = rt.block_on(self.inner.connect())?;
+        let runtime = Arc::new(OnceLock::new());
+        let _ = runtime.set(rt);
+        Ok(OpenStack { inner, runtime })
+    }
+}
+
 impl OpenStack {
     /// Create a new authenticated session from [`CloudConfig`].
     ///
@@ -157,6 +268,14 @@ impl OpenStack {
             inner,
             runtime: Arc::new(OnceLock::new()),
         })
+    }
+
+    /// Start building a session with connection options (auth cache, auth
+    /// helper, retries, ...). See [`OpenStackBuilder`].
+    pub fn builder(config: &CloudConfig) -> OpenStackBuilder {
+        OpenStackBuilder {
+            inner: AsyncOpenStack::builder(config),
+        }
     }
 
     /// Lazily initialise the shared tokio runtime.

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -97,6 +97,30 @@ use openstack_sdk_core::utils::expand_tilde;
 ///     Ok(())
 /// }
 /// ```
+///
+/// Use [`AsyncOpenStack::builder`] instead of [`AsyncOpenStack::new`] when
+/// connection-time options are needed, e.g. disabling the on-disk auth
+/// cache:
+/// ```rust
+/// use openstack_sdk::{AsyncOpenStack, config::ConfigFile, OpenStackError};
+///
+/// async fn connect_without_cache() -> Result<(), OpenStackError> {
+///     let cfg = ConfigFile::new().unwrap();
+///     let profile = cfg.get_cloud_config("devstack").unwrap().unwrap();
+///
+///     let session = AsyncOpenStack::builder(&profile)
+///         .disable_auth_cache(true)
+///         .connect()
+///         .await?;
+///
+///     println!("{:?}", session.get_auth_token());
+///     Ok(())
+/// }
+/// ```
+/// Default value for `max_auth_retries` when not overridden via
+/// [`AsyncOpenStackBuilder::max_auth_retries`]/[`AsyncOpenStack::set_max_auth_retries`].
+const DEFAULT_MAX_AUTH_RETRIES: u32 = 1;
+
 pub struct AsyncOpenStack {
     /// The client to use for API calls.
     client: reqwest::Client,
@@ -336,6 +360,149 @@ impl Drop for RenewHandle {
     }
 }
 
+/// Overrides for the underlying `reqwest::ClientBuilder`. `None` fields keep
+/// [`AsyncOpenStack::new_impl_with_options`]'s existing defaults.
+#[derive(Default, Clone)]
+struct HttpClientOptions {
+    timeout: Option<Duration>,
+    connect_timeout: Option<Duration>,
+    tcp_keepalive: Option<Duration>,
+    gzip: Option<bool>,
+    deflate: Option<bool>,
+    pool_max_idle_per_host: Option<usize>,
+    pool_idle_timeout: Option<Duration>,
+}
+
+/// Builder for connection-time options on [`AsyncOpenStack`], obtained via
+/// [`AsyncOpenStack::builder`].
+pub struct AsyncOpenStackBuilder {
+    config: CloudConfig,
+    disable_auth_cache: bool,
+    auth_helper: Option<Arc<dyn AuthHelper>>,
+    renew_auth: bool,
+    max_auth_retries: u32,
+    http_options: HttpClientOptions,
+}
+
+impl AsyncOpenStackBuilder {
+    fn new(config: &CloudConfig) -> Self {
+        Self {
+            config: config.clone(),
+            disable_auth_cache: false,
+            auth_helper: None,
+            renew_auth: false,
+            max_auth_retries: DEFAULT_MAX_AUTH_RETRIES,
+            http_options: HttpClientOptions::default(),
+        }
+    }
+
+    /// Disable authentication caching for the session being built. Unlike
+    /// calling [`AsyncOpenStack::disable_auth_cache`] after connecting, this
+    /// takes effect *before* the session reads any pre-existing on-disk
+    /// cached token.
+    pub fn disable_auth_cache(mut self, disable: bool) -> Self {
+        self.disable_auth_cache = disable;
+        self
+    }
+
+    /// Set the auth helper used for the initial authorization and for later
+    /// 401 re-authentication.
+    pub fn auth_helper<A>(mut self, auth_helper: A) -> Self
+    where
+        A: AuthHelper + Sync + Send + 'static,
+    {
+        self.auth_helper = Some(Arc::new(auth_helper));
+        self
+    }
+
+    /// Force renewal of authorization even if a cached token is available.
+    pub fn renew_auth(mut self, renew_auth: bool) -> Self {
+        self.renew_auth = renew_auth;
+        self
+    }
+
+    /// Set the maximum number of retries on 401 responses.
+    pub fn max_auth_retries(mut self, n: u32) -> Self {
+        self.max_auth_retries = n;
+        self
+    }
+
+    /// Override the request timeout (default: `CloudConfig.options.api_timeout`, or 30s).
+    pub fn http_timeout(mut self, timeout: Duration) -> Self {
+        self.http_options.timeout = Some(timeout);
+        self
+    }
+
+    /// Override the connect timeout (default: 5s).
+    pub fn http_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.http_options.connect_timeout = Some(timeout);
+        self
+    }
+
+    /// Override the TCP keepalive interval (default: 60s).
+    pub fn http_tcp_keepalive(mut self, interval: Duration) -> Self {
+        self.http_options.tcp_keepalive = Some(interval);
+        self
+    }
+
+    /// Enable/disable gzip response decompression (default: enabled).
+    pub fn http_gzip(mut self, enable: bool) -> Self {
+        self.http_options.gzip = Some(enable);
+        self
+    }
+
+    /// Enable/disable deflate response decompression (default: enabled).
+    pub fn http_deflate(mut self, enable: bool) -> Self {
+        self.http_options.deflate = Some(enable);
+        self
+    }
+
+    /// Override the maximum idle connections per host (default: 10).
+    pub fn http_pool_max_idle_per_host(mut self, max: usize) -> Self {
+        self.http_options.pool_max_idle_per_host = Some(max);
+        self
+    }
+
+    /// Override the idle connection pool timeout (default: 30s).
+    pub fn http_pool_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.http_options.pool_idle_timeout = Some(timeout);
+        self
+    }
+
+    /// Establish the session: resolves the Identity endpoint via version
+    /// discovery, then authorizes using the configured auth helper (or
+    /// [`Noop`] if none was set).
+    pub async fn connect(self) -> OpenStackResult<AsyncOpenStack> {
+        let cache_override = self.disable_auth_cache.then_some(false);
+        let mut session = AsyncOpenStack::new_impl_with_options(
+            &self.config,
+            Auth::None,
+            cache_override,
+            &self.http_options,
+        )?;
+        session.max_auth_retries = self.max_auth_retries;
+
+        session
+            .discover_service_endpoint(&ServiceType::Identity)
+            .await?;
+
+        if let Some(auth_helper) = &self.auth_helper {
+            session
+                .authorize_with_auth_helper(None, auth_helper, self.renew_auth)
+                .await?;
+            session.auth_helper = Some(Arc::clone(auth_helper));
+        } else {
+            session.authorize(None, false, self.renew_auth).await?;
+        }
+
+        if self.disable_auth_cache {
+            session.disable_auth_cache();
+        }
+
+        Ok(session)
+    }
+}
+
 impl AsyncOpenStack {
     /// Lock the session for reading. `location` is kept as a parameter for
     /// call-site self-documentation (parking_lot never poisons, so it no
@@ -360,6 +527,22 @@ impl AsyncOpenStack {
 
     /// Basic constructor — visible to the sync facade.
     pub fn new_impl(config: &CloudConfig, auth: Auth) -> OpenStackResult<Self> {
+        Self::new_impl_with_options(config, auth, None, &HttpClientOptions::default())
+    }
+
+    /// Basic constructor with an explicit auth-cache override and HTTP
+    /// client overrides. `auth_cache_override` bypasses
+    /// `CloudConfig.auth_cache`/global config resolution when `Some`. Used by
+    /// [`AsyncOpenStackBuilder::connect`] so `disable_auth_cache()` can take
+    /// effect *before* `SessionContext::new` reads any pre-existing on-disk
+    /// cached token, rather than only stopping future writes, and so the
+    /// `reqwest::ClientBuilder` overrides below take effect at construction.
+    fn new_impl_with_options(
+        config: &CloudConfig,
+        auth: Auth,
+        auth_cache_override: Option<bool>,
+        http_options: &HttpClientOptions,
+    ) -> OpenStackResult<Self> {
         // Ensure auth plugin registries are populated even if the linker
         // would otherwise strip crates with no other references.
         openstack_sdk_auth_core::anchor_plugins();
@@ -388,22 +571,39 @@ impl AsyncOpenStack {
             );
             client_builder = client_builder.danger_accept_invalid_certs(true);
         }
-        client_builder = client_builder.pool_max_idle_per_host(10);
-        client_builder = client_builder.pool_idle_timeout(Duration::from_secs(30));
-        client_builder = client_builder.timeout(Duration::from_secs(
-            config
-                .options
-                .get("api_timeout")
-                .and_then(|val| val.clone().into_uint().ok())
-                .unwrap_or(30),
-        ));
-        client_builder = client_builder.connect_timeout(Duration::from_secs(5));
-        client_builder = client_builder.tcp_keepalive(Duration::from_secs(60));
-        client_builder = client_builder.gzip(true);
-        client_builder = client_builder.deflate(true);
+        client_builder = client_builder
+            .pool_max_idle_per_host(http_options.pool_max_idle_per_host.unwrap_or(10));
+        client_builder = client_builder.pool_idle_timeout(
+            http_options
+                .pool_idle_timeout
+                .unwrap_or(Duration::from_secs(30)),
+        );
+        client_builder = client_builder.timeout(http_options.timeout.unwrap_or_else(|| {
+            Duration::from_secs(
+                config
+                    .options
+                    .get("api_timeout")
+                    .and_then(|val| val.clone().into_uint().ok())
+                    .unwrap_or(30),
+            )
+        }));
+        client_builder = client_builder.connect_timeout(
+            http_options
+                .connect_timeout
+                .unwrap_or(Duration::from_secs(5)),
+        );
+        client_builder = client_builder.tcp_keepalive(
+            http_options
+                .tcp_keepalive
+                .unwrap_or(Duration::from_secs(60)),
+        );
+        client_builder = client_builder.gzip(http_options.gzip.unwrap_or(true));
+        client_builder = client_builder.deflate(http_options.deflate.unwrap_or(true));
 
-        // Pass CloudConfig.auth_cache as override; SessionContext resolves priority chain.
-        let session_ctx = session::SessionContext::new(config, auth, config.auth_cache)?;
+        // Pass the explicit override (if any) or fall back to CloudConfig.auth_cache;
+        // SessionContext resolves the remaining priority chain.
+        let session_ctx =
+            session::SessionContext::new(config, auth, auth_cache_override.or(config.auth_cache))?;
         let auth_snapshot = Arc::new(ArcSwap::new(Arc::new(AuthSnapshot::from(&session_ctx))));
 
         Ok(AsyncOpenStack {
@@ -412,7 +612,7 @@ impl AsyncOpenStack {
             session: Arc::new(RwLock::new(session_ctx)),
             auth_snapshot,
             auth_helper: None,
-            max_auth_retries: 1,
+            max_auth_retries: DEFAULT_MAX_AUTH_RETRIES,
             reauth_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
@@ -420,16 +620,7 @@ impl AsyncOpenStack {
     /// Create a new OpenStack API session from CloudConfig
     #[instrument(name = "connect", level = "trace", skip(config))]
     pub async fn new(config: &CloudConfig) -> OpenStackResult<Self> {
-        let session = Self::new_impl(config, Auth::None)?;
-
-        // Ensure we resolve identity endpoint using version discovery
-        session
-            .discover_service_endpoint(&ServiceType::Identity)
-            .await?;
-
-        session.authorize(None, false, false).await?;
-
-        Ok(session)
+        Self::builder(config).connect().await
     }
 
     /// Create a new OpenStack API session from CloudConfig
@@ -442,20 +633,18 @@ impl AsyncOpenStack {
     where
         A: AuthHelper + Sync + Send + 'static,
     {
-        let mut session = Self::new_impl(config, Auth::None)?;
+        Self::builder(config)
+            .auth_helper(auth_helper)
+            .renew_auth(renew_auth)
+            .connect()
+            .await
+    }
 
-        // Ensure we resolve identity endpoint using version discovery
-        session
-            .discover_service_endpoint(&ServiceType::Identity)
-            .await?;
-
-        session
-            .authorize_with_auth_helper(None, &auth_helper, renew_auth)
-            .await?;
-
-        session.auth_helper = Some(Arc::new(auth_helper));
-
-        Ok(session)
+    /// Start building a session with connection options (auth cache, auth
+    /// helper, retries, ...) beyond what the plain constructors expose. See
+    /// [`AsyncOpenStackBuilder`].
+    pub fn builder(config: &CloudConfig) -> AsyncOpenStackBuilder {
+        AsyncOpenStackBuilder::new(config)
     }
 
     /// Create a new OpenStack API session from `CloudConfig`, loading any

--- a/openstack_sdk/src/test.rs
+++ b/openstack_sdk/src/test.rs
@@ -290,6 +290,89 @@ mod tests {
         );
     }
 
+    /// Wiring test: a too-short `http_timeout` must make the connect fail
+    /// with a client-side timeout, proving the builder's HTTP overrides
+    /// actually reach the `reqwest::ClientBuilder`.
+    #[cfg(all(feature = "sync", feature = "async"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_builder_http_timeout_applies() {
+        let server = MockServer::start_async().await;
+        let base_url = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/");
+            then.status(StatusCode::OK)
+                .delay(std::time::Duration::from_millis(200))
+                .json_body(serde_json::json!({
+                    "versions": [{
+                        "id": "v3", "status": "SUPPORTED",
+                        "links": [{ "rel": "self", "href": format!("{base_url}/v3/") }]
+                    }]
+                }));
+        });
+
+        let config = helpers::create_test_cloud_config(&server);
+
+        let result = AsyncOpenStack::builder(&config)
+            .http_timeout(std::time::Duration::from_millis(10))
+            .connect()
+            .await;
+
+        assert!(
+            result.is_err(),
+            "connect should fail once the request timeout is shorter than the mocked delay"
+        );
+    }
+
+    /// `AsyncOpenStackBuilder::disable_auth_cache` must take effect before
+    /// `SessionContext::new` resolves the on-disk cache, not just stop future
+    /// writes like the post-connect `disable_auth_cache()` setter does.
+    #[cfg(all(feature = "sync", feature = "async"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_builder_disable_auth_cache_async() {
+        let server = MockServer::start_async().await;
+
+        helpers::mock_identity_catalog(&server);
+
+        let config = helpers::create_test_cloud_config(&server);
+
+        let client = AsyncOpenStack::builder(&config)
+            .disable_auth_cache(true)
+            .connect()
+            .await
+            .expect("AsyncOpenStack client creation failed");
+
+        assert!(
+            client.get_auth_cache_file().is_none(),
+            "on-disk auth cache should be disabled when requested via the builder"
+        );
+        assert_eq!(
+            client.get_auth_token().unwrap().expose_secret(),
+            "test-token-from-catalog"
+        );
+    }
+
+    /// Sync facade counterpart of `test_builder_disable_auth_cache_async`.
+    #[cfg(all(feature = "sync", feature = "async"))]
+    #[test]
+    fn test_builder_disable_auth_cache_sync() {
+        let server = MockServer::start();
+
+        helpers::mock_identity_catalog(&server);
+
+        let config = helpers::create_test_cloud_config(&server);
+
+        let client = OpenStack::builder(&config)
+            .disable_auth_cache(true)
+            .build()
+            .expect("OpenStack client creation failed");
+
+        assert_eq!(
+            client.get_auth_token().unwrap().expose_secret(),
+            "test-token-from-catalog"
+        );
+    }
+
     /// Regression test for a bug where a scoped login (project requested by
     /// `project_id` only) triggered a *second*, redundant `POST
     /// /v3/auth/tokens` rescope call immediately after the first successful

--- a/sdk/core/src/config.rs
+++ b/sdk/core/src/config.rs
@@ -960,12 +960,6 @@ mod tests {
     }
 
     #[test]
-    fn test_default_auth_cache_enabled() {
-        let cfg = ConfigFile::new().unwrap();
-        assert!(cfg.is_auth_cache_enabled());
-    }
-
-    #[test]
     fn test_get_available_clouds() {
         let cfg = ConfigFile::new().unwrap();
         let _ = cfg.get_available_clouds();


### PR DESCRIPTION
Post-connect setters like disable_auth_cache() only stopped future
cache writes — SessionContext::new already read any pre-existing
on-disk token by the time they ran. Adding a constructor variant per
future option (HTTP timeouts, pool sizes, ...) doesn't scale either.

Introduce AsyncOpenStackBuilder/OpenStackBuilder (AsyncOpenStack::
builder()/OpenStack::builder()) exposing disable_auth_cache, auth_helper,
renew_auth, max_auth_retries, and reqwest ClientBuilder overrides
(http_timeout, http_connect_timeout, http_tcp_keepalive, http_gzip,
http_deflate, http_pool_max_idle_per_host, http_pool_idle_timeout),
all resolved before session/client construction. new()/new_with_
authentication_helper() now delegate to the builder; existing
constructors and call sites are unchanged.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
