### PR TITLE
feat: Surface negotiated microversion end to end

### DIFF
--- a/openstack_tui/src/action.rs
+++ b/openstack_tui/src/action.rs
@@ -86,6 +86,10 @@ pub enum Action {
     ApiResponsesData {
         request: cloud_types::ApiRequest,
         data: Vec<serde_json::Value>,
+        /// The microversion actually negotiated for the request that produced `data`, when the
+        /// resource's response schema varies by microversion. `None` for unversioned resources,
+        /// or when the worker didn't need to resolve it.
+        negotiated_version: Option<openstack_sdk::types::ApiVersion>,
     },
     /// Open resource(mode) select popup
     ApiRequestSelect,

--- a/openstack_tui/src/cloud_worker/block_storage/v3/backup/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/backup/list_detailed.rs
@@ -108,12 +108,14 @@ impl ExecuteApiRequest for BlockStorageBackupList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/list_detailed.rs
@@ -113,12 +113,14 @@ impl ExecuteApiRequest for BlockStorageSnapshotList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/block_storage/v3/volume/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/volume/list_detailed.rs
@@ -123,12 +123,14 @@ impl ExecuteApiRequest for BlockStorageVolumeList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/common.rs
+++ b/openstack_tui/src/cloud_worker/common.rs
@@ -13,12 +13,36 @@
 // SPDX-License-Identifier: Apache-2.0
 use thiserror::Error;
 
+use openstack_sdk::AsyncOpenStack;
+use openstack_sdk::api::{AsyncClient, RestEndpoint, rest_endpoint::negotiate_microversion};
+use openstack_sdk::types::ApiVersion;
+
 use crate::action;
 
 pub trait ConfirmableRequest {
     fn get_confirm_message(&self) -> Option<String> {
         None
     }
+}
+
+/// Learn the microversion that will actually be negotiated for `endpoint` against the cloud
+/// behind `session`, without sending any request.
+///
+/// Reuses `openstack_sdk`'s own `negotiate_microversion` (the same bounds-check logic that picks
+/// the version sent in the `OpenStack-API-Version` header) so callers that need to choose a
+/// version-appropriate response schema can learn the answer up front, rather than guessing which
+/// microversion-specific struct will match the JSON that comes back.
+pub(crate) async fn negotiated_version<E: RestEndpoint>(
+    session: &AsyncOpenStack,
+    endpoint: &E,
+) -> Result<Option<ApiVersion>, CloudWorkerError> {
+    let service_endpoint = session
+        .get_service_endpoint(&endpoint.service_type(), endpoint.api_version().as_ref())
+        .await?;
+    Ok(negotiate_microversion::<AsyncOpenStack, E>(
+        &service_endpoint,
+        endpoint,
+    )?)
 }
 
 #[derive(Error, Debug)]

--- a/openstack_tui/src/cloud_worker/compute/v2/aggregate/list.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/aggregate/list.rs
@@ -60,6 +60,7 @@ impl ExecuteApiRequest for ComputeAggregateList {
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: ep.query_async(session).await?,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/compute/v2/flavor/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/flavor/list_detailed.rs
@@ -108,12 +108,14 @@ impl ExecuteApiRequest for ComputeFlavorList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/compute/v2/hypervisor/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/hypervisor/list_detailed.rs
@@ -88,12 +88,14 @@ impl ExecuteApiRequest for ComputeHypervisorList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
@@ -96,12 +96,14 @@ impl ExecuteApiRequest for ComputeServerInstanceActionList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/compute/v2/server/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/list_detailed.rs
@@ -425,12 +425,14 @@ impl ExecuteApiRequest for ComputeServerList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/dns/v2/recordset/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/recordset/list.rs
@@ -135,12 +135,14 @@ impl ExecuteApiRequest for DnsRecordsetList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/list.rs
@@ -118,12 +118,14 @@ impl ExecuteApiRequest for DnsZoneList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/list.rs
@@ -126,12 +126,14 @@ impl ExecuteApiRequest for DnsZoneRecordsetList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/identity/v3/auth/project/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/auth/project/list.rs
@@ -60,6 +60,7 @@ impl ExecuteApiRequest for IdentityAuthProjectList {
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: ep.query_async(session).await?,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/identity/v3/group/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/list.rs
@@ -110,12 +110,14 @@ impl ExecuteApiRequest for IdentityGroupList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/identity/v3/group/user/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/user/list.rs
@@ -74,6 +74,7 @@ impl ExecuteApiRequest for IdentityGroupUserList {
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: ep.query_async(session).await?,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/identity/v3/project/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/project/list.rs
@@ -147,12 +147,14 @@ impl ExecuteApiRequest for IdentityProjectList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/list.rs
@@ -74,6 +74,7 @@ impl ExecuteApiRequest for IdentityUserApplicationCredentialList {
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: ep.query_async(session).await?,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/identity/v3/user/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/list.rs
@@ -171,12 +171,14 @@ impl ExecuteApiRequest for IdentityUserList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/image/v2/image/list.rs
+++ b/openstack_tui/src/cloud_worker/image/v2/image/list.rs
@@ -168,12 +168,14 @@ impl ExecuteApiRequest for ImageImageList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/list.rs
@@ -227,12 +227,14 @@ impl ExecuteApiRequest for LoadBalancerHealthmonitorList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/listener/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/listener/list.rs
@@ -269,12 +269,14 @@ impl ExecuteApiRequest for LoadBalancerListenerList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/list.rs
@@ -265,12 +265,14 @@ impl ExecuteApiRequest for LoadBalancerLoadbalancerList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/list.rs
@@ -207,12 +207,14 @@ impl ExecuteApiRequest for LoadBalancerPoolList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/list.rs
@@ -225,12 +225,14 @@ impl ExecuteApiRequest for LoadBalancerPoolMemberList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/quota/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/quota/list.rs
@@ -60,6 +60,7 @@ impl ExecuteApiRequest for LoadBalancerQuotaList {
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: ep.query_async(session).await?,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/network/v2/network/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/network/list.rs
@@ -227,12 +227,14 @@ impl ExecuteApiRequest for NetworkNetworkList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/network/v2/router/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/router/list.rs
@@ -170,12 +170,14 @@ impl ExecuteApiRequest for NetworkRouterList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/network/v2/security_group/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group/list.rs
@@ -170,12 +170,14 @@ impl ExecuteApiRequest for NetworkSecurityGroupList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/network/v2/security_group_rule/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group_rule/list.rs
@@ -228,12 +228,14 @@ impl ExecuteApiRequest for NetworkSecurityGroupRuleList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/cloud_worker/network/v2/subnet/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/subnet/list.rs
@@ -251,12 +251,14 @@ impl ExecuteApiRequest for NetworkSubnetList {
                 app_tx.send(Action::ApiResponsesData {
                     request: request.clone(),
                     data: items.clone(),
+                    negotiated_version: None,
                 })?;
             }
         }
         app_tx.send(Action::ApiResponsesData {
             request: request.clone(),
             data: items,
+            negotiated_version: None,
         })?;
         Ok(())
     }

--- a/openstack_tui/src/components/compute/server_instance_action_events.rs
+++ b/openstack_tui/src/components/compute/server_instance_action_events.rs
@@ -115,6 +115,7 @@ impl ResourceBehaviour for ComputeServerInstanceActionEventsBehaviour {
                 return Some(Action::ApiResponsesData {
                     request: request.clone(),
                     data: ar.to_vec(),
+                    negotiated_version: None,
                 });
             }
         }

--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -152,7 +152,7 @@ where
         }
 
         // --- ApiResponsesData: only accept if request matches ---
-        if let Action::ApiResponsesData { request, data } = &action {
+        if let Action::ApiResponsesData { request, data, .. } = &action {
             if B::matches_request(request) {
                 self.base.set_data(data.clone())?;
                 return Ok(None);
@@ -354,7 +354,11 @@ mod tests {
         )));
         let data: Vec<Value> = Vec::new();
         let result = comp.update(
-            Action::ApiResponsesData { request, data },
+            Action::ApiResponsesData {
+                request,
+                data,
+                negotiated_version: None,
+            },
             Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
@@ -374,7 +378,11 @@ mod tests {
         )));
         let data: Vec<Value> = Vec::new();
         let result = comp.update(
-            Action::ApiResponsesData { request, data },
+            Action::ApiResponsesData {
+                request,
+                data,
+                negotiated_version: None,
+            },
             Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
@@ -453,7 +461,11 @@ mod tests {
             ComputeServerApiRequest::ListDetailed(Box::default()),
         )));
         comp.update(
-            Action::ApiResponsesData { request, data },
+            Action::ApiResponsesData {
+                request,
+                data,
+                negotiated_version: None,
+            },
             Mode::Resource(crate::mode::COMPUTE_SERVER),
         )
         .unwrap();
@@ -480,7 +492,11 @@ mod tests {
         let (console_data, request) = setup_comp_with_matching_singular_request_and_data();
         let data = vec![console_data];
         let result = comp.update(
-            Action::ApiResponsesData { request, data },
+            Action::ApiResponsesData {
+                request,
+                data,
+                negotiated_version: None,
+            },
             Mode::Resource(crate::mode::COMPUTE_SERVER),
         );
         assert!(result.is_ok());
@@ -543,6 +559,7 @@ mod tests {
             Action::ApiResponsesData {
                 request,
                 data: vec![volume_json],
+                negotiated_version: None,
             },
             Mode::Resource(crate::mode::BLOCK_STORAGE_VOLUME),
         )
@@ -600,6 +617,7 @@ mod tests {
             Action::ApiResponsesData {
                 request,
                 data: vec![flavor_json],
+                negotiated_version: None,
             },
             Mode::Resource(crate::mode::COMPUTE_FLAVOR),
         )

--- a/openstack_tui/src/components/project_select_popup.rs
+++ b/openstack_tui/src/components/project_select_popup.rs
@@ -129,6 +129,7 @@ impl Component for ProjectSelect {
             Action::ApiResponsesData {
                 data,
                 request: ApiRequest::Identity(IdentityApiRequest::Auth(_req)),
+                ..
             } => self.on_data(data.clone())?,
             _ => {}
         }

--- a/sdk/core/src/types/api_version.rs
+++ b/sdk/core/src/types/api_version.rs
@@ -17,6 +17,7 @@
 //! Endpoint api version handling.
 
 use regex::{Error as RegexError, Regex};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::OnceLock;
 use thiserror::Error;
@@ -70,7 +71,7 @@ impl From<&'static RegexError> for ApiVersionError {
 ///
 /// ApiVersion of the Endpoint as described in
 /// <https://specs.openstack.org/openstack/api-sig/guidelines/consuming-catalog/version-discovery.html>. It is a subset of a SemVer and only includes `major` and `minor` parts.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct ApiVersion {
     /// Major version.
     pub major: u8,


### PR DESCRIPTION
openstack_sdk_core::api::negotiate_microversion already existed,
documented as pub specifically so a caller could learn the negotiated
version to pick a version-appropriate response schema -- but nothing
used it. Response deserialization has always hardcoded one schema struct
at codegen time (the operation's minimum microversion) and never varied
it at runtime, regardless of what version actually gets negotiated
against a given cloud.

Add ApiVersion: Serialize/Deserialize (needed since Action derives them)
and a negotiated_version helper in cloud_worker/common.rs that calls the
existing negotiate_microversion against the session's discovered
ServiceEndpoint. Thread negotiated_version: Option<ApiVersion> through
Action::ApiResponsesData so a future dispatch step (picking the response
struct that matches what was actually negotiated) has something to key
off. All call sites pass None for now -- no cloud_worker file resolves
it yet, this is foundational plumbing only.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
