### PR TITLE
feat(tui): Dispatch item deser per negotiated version

### DIFF
--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -152,9 +152,15 @@ where
         }
 
         // --- ApiResponsesData: only accept if request matches ---
-        if let Action::ApiResponsesData { request, data, .. } = &action {
+        if let Action::ApiResponsesData {
+            request,
+            data,
+            negotiated_version,
+        } = &action
+        {
             if B::matches_request(request) {
-                self.base.set_data(data.clone())?;
+                let items = B::deserialize_items(data, *negotiated_version)?;
+                self.base.set_data_items(items, data.clone())?;
                 return Ok(None);
             }
             // --- Singular API response: delegate to behaviour ---

--- a/openstack_tui/src/components/resource_behaviour.rs
+++ b/openstack_tui/src/components/resource_behaviour.rs
@@ -16,6 +16,7 @@ use crate::action::Action;
 use crate::cloud_worker::types::ApiRequest;
 use crate::mode::Mode;
 use crate::utils::ResourceKey;
+use openstack_sdk::types::ApiVersion;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::fmt::Display;
@@ -158,6 +159,20 @@ pub trait ResourceBehaviour {
     fn clear_data_on_filter_change() -> bool {
         false
     }
+
+    /// Deserialize a list response batch into `Self::Item`, given the microversion actually
+    /// negotiated for the request that produced it (`None` for unversioned resources, or when the
+    /// worker didn't resolve it). The default ignores `negotiated_version` and deserializes as-is,
+    /// which is correct for every resource whose response schema does not vary by microversion.
+    /// Resources with real microversion-variant response schemas override this to pick the
+    /// variant matching `negotiated_version` before upcasting into the canonical `Self::Item`.
+    fn deserialize_items(
+        data: &[Value],
+        negotiated_version: Option<ApiVersion>,
+    ) -> serde_json::Result<Vec<Self::Item>> {
+        let _ = negotiated_version;
+        serde_json::from_value(Value::Array(data.to_vec()))
+    }
 }
 
 /// Result of handling a mutation API response.
@@ -170,4 +185,134 @@ pub enum Mutation {
     AppendRow(Value),
     /// Refresh the entire list.
     Refresh,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, Default, Clone, PartialEq)]
+    struct Item {
+        id: String,
+        #[serde(default)]
+        extra: Option<String>,
+    }
+    impl ResourceKey for Item {
+        fn get_key() -> &'static str {
+            "test.item"
+        }
+    }
+
+    #[derive(Debug, Default, Clone)]
+    struct Filter;
+    impl Display for Filter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "")
+        }
+    }
+
+    struct DefaultBehaviour;
+    impl ResourceBehaviour for DefaultBehaviour {
+        type Item = Item;
+        type Filter = Filter;
+        fn view_key() -> &'static str {
+            "test.item"
+        }
+        fn title() -> &'static str {
+            "Items"
+        }
+        fn mode() -> Mode {
+            Mode::Resource(Self::view_key())
+        }
+        fn request_from_filter(_filter: &Self::Filter) -> ApiRequest {
+            unimplemented!()
+        }
+        fn matches_request(_request: &ApiRequest) -> bool {
+            false
+        }
+    }
+
+    struct VersionedBehaviour;
+    impl ResourceBehaviour for VersionedBehaviour {
+        type Item = Item;
+        type Filter = Filter;
+        fn view_key() -> &'static str {
+            "test.item"
+        }
+        fn title() -> &'static str {
+            "Items"
+        }
+        fn mode() -> Mode {
+            Mode::Resource(Self::view_key())
+        }
+        fn request_from_filter(_filter: &Self::Filter) -> ApiRequest {
+            unimplemented!()
+        }
+        fn matches_request(_request: &ApiRequest) -> bool {
+            false
+        }
+        fn deserialize_items(
+            data: &[Value],
+            negotiated_version: Option<ApiVersion>,
+        ) -> serde_json::Result<Vec<Self::Item>> {
+            let mut items: Vec<Item> = serde_json::from_value(Value::Array(data.to_vec()))?;
+            if negotiated_version
+                .is_some_and(|v| v >= ApiVersion::from_apiver_str("2.5", false).unwrap())
+            {
+                for item in &mut items {
+                    item.extra = Some("present-since-2.5".into());
+                }
+            }
+            Ok(items)
+        }
+    }
+
+    #[test]
+    fn default_deserialize_items_ignores_negotiated_version() {
+        let data = vec![serde_json::json!({"id": "a"})];
+        let items = DefaultBehaviour::deserialize_items(&data, None).unwrap();
+        assert_eq!(
+            items,
+            vec![Item {
+                id: "a".into(),
+                extra: None
+            }]
+        );
+
+        let items = DefaultBehaviour::deserialize_items(
+            &data,
+            Some(ApiVersion::from_apiver_str("2.99", false).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(
+            items,
+            vec![Item {
+                id: "a".into(),
+                extra: None
+            }]
+        );
+    }
+
+    #[test]
+    fn overridden_deserialize_items_dispatches_on_negotiated_version() {
+        let data = vec![serde_json::json!({"id": "a"})];
+
+        let items = VersionedBehaviour::deserialize_items(&data, None).unwrap();
+        assert_eq!(items[0].extra, None);
+
+        let items = VersionedBehaviour::deserialize_items(
+            &data,
+            Some(ApiVersion::from_apiver_str("2.1", false).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(items[0].extra, None);
+
+        let items = VersionedBehaviour::deserialize_items(
+            &data,
+            Some(ApiVersion::from_apiver_str("2.5", false).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(items[0].extra, Some("present-since-2.5".into()));
+    }
 }

--- a/openstack_tui/src/components/table_view.rs
+++ b/openstack_tui/src/components/table_view.rs
@@ -322,8 +322,19 @@ where
     pub fn set_data(&mut self, data: Vec<Value>) -> Result<(), TuiError> {
         if data != self.raw_items {
             let items = serde_json::from_value::<Vec<T>>(serde_json::Value::Array(data.clone()))?;
+            return self.set_data_items(items, data);
+        }
+        self.set_loading(false);
+        Ok(())
+    }
+
+    /// Like `set_data`, but accepts already-deserialized items alongside the raw payload, for
+    /// callers that need to pick the deserialization function themselves (e.g. based on a
+    /// negotiated microversion) rather than deserializing into a single fixed type here.
+    pub fn set_data_items(&mut self, items: Vec<T>, raw_data: Vec<Value>) -> Result<(), TuiError> {
+        if raw_data != self.raw_items {
             self.items = items;
-            self.raw_items = data;
+            self.raw_items = raw_data;
             self.state.select_first();
             self.scroll_state =
                 ScrollbarState::new(self.items.len().saturating_sub(1) * ITEM_HEIGHT);


### PR DESCRIPTION
Response schemas can vary by microversion, but TableView pinned
one deserialization path per resource at compile time and ignored
the version actually negotiated for the request. Add
`ResourceBehaviour::deserialize_items`, a default method resources
can override to pick the right schema for `negotiated_version`;
default behavior is unchanged plain deserialization. Wire it
through `TableViewComponentBase::set_data_items` and the
`ApiResponsesData` handler in `generic_resource_view.rs`.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
