### PR TITLE
feat: Add fuzz more targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,10 @@ jobs:
           cargo install cargo-fuzz
 
       - name: Run tests
-        run: cargo +nightly fuzz run fuzz_openstack_sdk_config --features=fuzzing -- -max_total_time=60
+        run: |
+          for target in fuzz_openstack_sdk_config fuzz_openstack_sdk_config_yaml fuzz_link_header fuzz_next_page_from_body fuzz_expand_link fuzz_discovery_endpoints fuzz_api_version fuzz_api_error_from_openstack fuzz_auth_error_response fuzz_build_request_url fuzz_state_cache; do
+            cargo +nightly fuzz run "$target" --features=fuzzing -- -max_total_time=60
+          done
 
   mock:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -1149,6 +1152,17 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "derive_builder"
@@ -3773,8 +3787,16 @@ dependencies = [
 name = "openstack_sdk-fuzz"
 version = "0.0.0"
 dependencies = [
+ "arbitrary",
+ "bytes",
+ "http",
  "libfuzzer-sys",
+ "openstack-sdk-auth-core",
  "openstack_sdk",
+ "openstack_sdk_core",
+ "serde_json",
+ "tempfile",
+ "url",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,13 +13,30 @@ autobenches = false
 cargo-fuzz = true
 
 [features]
-fuzzing = ["dep:libfuzzer-sys"]
+fuzzing = [
+  "dep:libfuzzer-sys",
+  "dep:arbitrary",
+  "dep:tempfile",
+  "dep:openstack_sdk_core",
+  "dep:openstack-sdk-auth-core",
+  "openstack_sdk/fuzzing",
+  "openstack_sdk_core/fuzzing",
+  "openstack-sdk-auth-core/fuzzing",
+]
 
 [package.metadata.dist]
 dist = false
 
 [dependencies]
+arbitrary = { version = "1", features = ["derive"], optional = true }
+bytes.workspace = true
+http.workspace = true
 libfuzzer-sys = { version = "0.4", optional = true }
+openstack-sdk-auth-core = { workspace = true, optional = true }
+openstack_sdk_core = { workspace = true, optional = true }
+serde_json.workspace = true
+tempfile = { workspace = true, optional = true }
+url.workspace = true
 
 [dependencies.openstack_sdk]
 path = "../openstack_sdk"
@@ -27,6 +44,86 @@ path = "../openstack_sdk"
 [[bin]]
 name = "fuzz_openstack_sdk_config"
 path = "fuzz_targets/fuzz_openstack_sdk_config.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_openstack_sdk_config_yaml"
+path = "fuzz_targets/fuzz_openstack_sdk_config_yaml.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_link_header"
+path = "fuzz_targets/fuzz_link_header.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_next_page_from_body"
+path = "fuzz_targets/fuzz_next_page_from_body.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_expand_link"
+path = "fuzz_targets/fuzz_expand_link.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_discovery_endpoints"
+path = "fuzz_targets/fuzz_discovery_endpoints.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_api_version"
+path = "fuzz_targets/fuzz_api_version.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_api_error_from_openstack"
+path = "fuzz_targets/fuzz_api_error_from_openstack.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_auth_error_response"
+path = "fuzz_targets/fuzz_auth_error_response.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_build_request_url"
+path = "fuzz_targets/fuzz_build_request_url.rs"
+required-features = ["fuzzing"]
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_state_cache"
+path = "fuzz_targets/fuzz_state_cache.rs"
 required-features = ["fuzzing"]
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzz_api_error_from_openstack.rs
+++ b/fuzz/fuzz_targets/fuzz_api_error_from_openstack.rs
@@ -1,0 +1,75 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bytes::Bytes;
+use http::{HeaderValue, StatusCode};
+use libfuzzer_sys::fuzz_target;
+use openstack_sdk_core::api::ApiError;
+use serde_json::{Map, Value};
+
+extern crate openstack_sdk_core;
+
+// `ApiError::from_openstack` extracts a human message from an arbitrary/untrusted
+// OpenStack error JSON body, papering over how inconsistently services shape it:
+// `{"message": ...}`, `{"error": ...}` (Keystone/Nova-style), `{"faultstring": ...}`
+// (Octavia-style), a non-string value at any of those keys, or none of them present
+// at all. We model the presence/shape of each of those three keys directly rather
+// than fuzzing raw JSON text, since the function receives an already-parsed
+// `serde_json::Value` (parsing the raw body is a different fuzz target's job).
+
+#[derive(Debug, Arbitrary)]
+enum FuzzLeaf {
+    /// A string value -> recognized message.
+    Str(String),
+    /// A nested object value -> "we don't know how to parse this" path.
+    Nested(String),
+}
+
+impl FuzzLeaf {
+    fn to_value(&self) -> Value {
+        match self {
+            FuzzLeaf::Str(s) => Value::String(s.clone()),
+            FuzzLeaf::Nested(s) => {
+                let mut obj = Map::new();
+                obj.insert("nested".into(), Value::String(s.clone()));
+                Value::Object(obj)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    status: u16,
+    message: Option<FuzzLeaf>,
+    error: Option<FuzzLeaf>,
+    faultstring: Option<FuzzLeaf>,
+    req_id: Option<String>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let mut obj = Map::new();
+    if let Some(v) = &input.message {
+        obj.insert("message".into(), v.to_value());
+    }
+    if let Some(v) = &input.error {
+        obj.insert("error".into(), v.to_value());
+    }
+    if let Some(v) = &input.faultstring {
+        obj.insert("faultstring".into(), v.to_value());
+    }
+    let value = Value::Object(obj);
+
+    let status = StatusCode::from_u16(input.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let mut builder = http::Response::builder().status(status);
+    if let Some(id) = &input.req_id
+        && let Ok(hv) = HeaderValue::from_str(id)
+    {
+        builder = builder.header("x-openstack-request-id", hv);
+    }
+    let Ok(rsp) = builder.body(Bytes::new()) else {
+        return;
+    };
+
+    let _ = ApiError::<std::convert::Infallible>::fuzz_from_openstack(None, &rsp, value);
+});

--- a/fuzz/fuzz_targets/fuzz_api_version.rs
+++ b/fuzz/fuzz_targets/fuzz_api_version.rs
@@ -1,0 +1,60 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use openstack_sdk::types::ApiVersion;
+use url::Url;
+
+extern crate openstack_sdk;
+
+// `ApiVersion::from_apiver_str`/`from_url` are already fully public, so no
+// SDK-side changes were needed for this target. `from_apiver_str` is a
+// regex-based single-token parser (`v2.3`, `2.3`, `v1`); `from_url` walks a
+// URL's path segments, heuristically strips a trailing project-ID-looking
+// segment, and delegates to `from_apiver_str`.
+
+#[derive(Debug, Arbitrary)]
+enum FuzzHost {
+    FooBar,
+    ExampleOrg,
+}
+
+impl FuzzHost {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FuzzHost::FooBar => "foo.bar",
+            FuzzHost::ExampleOrg => "example.org",
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzInput {
+    /// Directly fuzz the single-token parser with both prefix modes.
+    ApiverStr { data: String, prefixed: bool },
+    /// Fuzz the URL/path-segment-stripping logic.
+    Url {
+        host: FuzzHost,
+        path_segments: Vec<String>,
+        project_id: Option<String>,
+    },
+}
+
+fuzz_target!(|input: FuzzInput| {
+    match input {
+        FuzzInput::ApiverStr { data, prefixed } => {
+            let _ = ApiVersion::from_apiver_str(&data, prefixed);
+        }
+        FuzzInput::Url {
+            host,
+            path_segments,
+            project_id,
+        } => {
+            let path = path_segments.join("/");
+            let Ok(url) = Url::parse(&format!("http://{}/{path}", host.as_str())) else {
+                return;
+            };
+            let _ = ApiVersion::from_url(&url, project_id.as_deref());
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_auth_error_response.rs
+++ b/fuzz/fuzz_targets/fuzz_auth_error_response.rs
@@ -1,0 +1,83 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use http::{HeaderMap, HeaderValue, StatusCode};
+use libfuzzer_sys::fuzz_target;
+use openstack_sdk_auth_core::authtoken::fuzz_parse_error_response;
+
+extern crate openstack_sdk_auth_core;
+
+// `parse_error_response` (extracted from `AuthToken::from_reqwest_response`) is a
+// 3-way fallback chain over an untrusted Keystone auth response: on 401 with an
+// `openstack-auth-receipt` header it tries an auth-receipt JSON shape, then falls
+// back to an identity-error JSON shape, then to a raw-text fallback; any other
+// non-success response only tries the identity-error shape before falling back.
+// It's the shared choke point every auth plugin (password, jwt, federation, ...)
+// funnels through, so this one target covers all of them.
+
+#[derive(Debug, Arbitrary)]
+enum FuzzStatus {
+    Unauthorized,
+    Other(u16),
+}
+
+impl FuzzStatus {
+    fn as_code(&self) -> StatusCode {
+        match self {
+            FuzzStatus::Unauthorized => StatusCode::UNAUTHORIZED,
+            FuzzStatus::Other(v) => {
+                StatusCode::from_u16(*v).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzReceiptHeader {
+    Absent,
+    /// A valid header value (any ASCII-ish text `to_str()` can handle).
+    Ascii(String),
+    /// Raw bytes that may fail `to_str()` (non-ASCII), exercising AuthReceiptNotString.
+    NonAscii(Vec<u8>),
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzBody {
+    /// Fully arbitrary text: covers "parses as neither shape" and the raw fallback.
+    Raw(String),
+    /// Matches `AuthErrorResponse` (`{"error": {"code": ..., "message": ...}}`).
+    ErrorShape { code: u32, message: String },
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    status: FuzzStatus,
+    receipt_header: FuzzReceiptHeader,
+    body: FuzzBody,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let mut headers = HeaderMap::new();
+    match &input.receipt_header {
+        FuzzReceiptHeader::Absent => {}
+        FuzzReceiptHeader::Ascii(s) => {
+            if let Ok(hv) = HeaderValue::from_str(s) {
+                headers.insert("openstack-auth-receipt", hv);
+            }
+        }
+        FuzzReceiptHeader::NonAscii(bytes) => {
+            if let Ok(hv) = HeaderValue::from_bytes(bytes) {
+                headers.insert("openstack-auth-receipt", hv);
+            }
+        }
+    }
+
+    let body_text = match &input.body {
+        FuzzBody::Raw(s) => s.clone(),
+        FuzzBody::ErrorShape { code, message } => {
+            serde_json::json!({"error": {"code": code, "message": message}}).to_string()
+        }
+    };
+
+    let _ = fuzz_parse_error_response(input.status.as_code(), &headers, &body_text);
+});

--- a/fuzz/fuzz_targets/fuzz_build_request_url.rs
+++ b/fuzz/fuzz_targets/fuzz_build_request_url.rs
@@ -1,0 +1,81 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use openstack_sdk_core::catalog::ServiceEndpoint;
+use openstack_sdk_core::types::ApiVersion;
+use url::Url;
+
+extern crate openstack_sdk_core;
+
+// `ServiceEndpoint::build_request_url` combines a server-supplied catalog URL with a
+// user-supplied endpoint path, stripping/re-appending a trailing project-ID path
+// segment to avoid doubling it. This target previously found a real panic: when
+// `endpoint` starts with `pid_suffix` but the byte right after the prefix begins a
+// multi-byte UTF-8 character, the old byte-offset slice landed mid-codepoint. Now
+// fixed via char-aware `strip_prefix`; this target guards against regressions and
+// any other edge case in the segment bookkeeping.
+
+#[derive(Debug, Arbitrary)]
+enum FuzzHost {
+    FooBar,
+    ExampleOrg,
+}
+
+impl FuzzHost {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FuzzHost::FooBar => "foo.bar",
+            FuzzHost::ExampleOrg => "example.org",
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzEndpoint {
+    /// Arbitrary text unrelated to the pid_suffix.
+    Raw(String),
+    /// Exactly the pid_suffix.
+    ExactSuffix,
+    /// pid_suffix + '/' + arbitrary text (the "normal" doubled-segment case).
+    SuffixSlashThen(String),
+    /// pid_suffix immediately followed by arbitrary text with no separator
+    /// (the shape that used to trigger the multi-byte-boundary panic).
+    SuffixThen(String),
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    base_host: FuzzHost,
+    base_path: String,
+    pid_suffix: Option<String>,
+    endpoint: FuzzEndpoint,
+    major: u8,
+    minor: u8,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let base_url_str = format!("http://{}/{}", input.base_host.as_str(), input.base_path);
+    let Ok(base_url) = Url::parse(&base_url_str) else {
+        return;
+    };
+    if base_url.cannot_be_a_base() {
+        return;
+    }
+
+    let mut endpoint = ServiceEndpoint::new(base_url, ApiVersion::new(input.major, input.minor));
+    endpoint.set_last_segment_with_project_id(input.pid_suffix.clone());
+
+    let endpoint_path = match &input.endpoint {
+        FuzzEndpoint::Raw(s) => s.clone(),
+        FuzzEndpoint::ExactSuffix => input.pid_suffix.clone().unwrap_or_default(),
+        FuzzEndpoint::SuffixSlashThen(rest) => {
+            format!("{}/{rest}", input.pid_suffix.clone().unwrap_or_default())
+        }
+        FuzzEndpoint::SuffixThen(rest) => {
+            format!("{}{rest}", input.pid_suffix.clone().unwrap_or_default())
+        }
+    };
+
+    let _ = endpoint.build_request_url(&endpoint_path);
+});

--- a/fuzz/fuzz_targets/fuzz_discovery_endpoints.rs
+++ b/fuzz/fuzz_targets/fuzz_discovery_endpoints.rs
@@ -1,0 +1,155 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bytes::Bytes;
+use libfuzzer_sys::fuzz_target;
+use serde_json::{Map, Value};
+use url::Url;
+
+extern crate openstack_sdk;
+
+// `extract_discovery_endpoints` tries three different JSON shapes in sequence
+// for a version-discovery document (`{"versions": [...]}`, `{"version": {}}`,
+// Keystone's `{"versions": {"values": [...]}}`), then walks each version's
+// `links` looking for a `rel: "self"` entry and resolves it via `expand_link`.
+// We combine two Arbitrary-derived generation modes in one target: fully raw
+// bytes (to check robustness against garbage input) and a structured model of
+// the three document shapes (to actually reach the per-version/link handling
+// that raw bytes essentially never survive JSON parsing long enough to hit).
+
+#[derive(Debug, Arbitrary)]
+struct FuzzLink {
+    href: String,
+    rel: FuzzRel,
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzRel {
+    SelfRel,
+    Other(String),
+}
+
+impl FuzzLink {
+    fn to_value(&self) -> Value {
+        let rel = match &self.rel {
+            FuzzRel::SelfRel => "self".to_string(),
+            FuzzRel::Other(s) => s.clone(),
+        };
+        let mut obj = Map::new();
+        obj.insert("href".into(), Value::String(self.href.clone()));
+        obj.insert("rel".into(), Value::String(rel));
+        Value::Object(obj)
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzEndpointVersion {
+    id: String,
+    status: String,
+    version: Option<String>,
+    min_version: Option<String>,
+    max_version: Option<String>,
+    links: Vec<FuzzLink>,
+}
+
+impl FuzzEndpointVersion {
+    fn to_value(&self) -> Value {
+        let mut obj = Map::new();
+        obj.insert("id".into(), Value::String(self.id.clone()));
+        obj.insert("status".into(), Value::String(self.status.clone()));
+        if let Some(v) = &self.version {
+            obj.insert("version".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.min_version {
+            obj.insert("min_version".into(), Value::String(v.clone()));
+        }
+        if let Some(v) = &self.max_version {
+            obj.insert("max_version".into(), Value::String(v.clone()));
+        }
+        let links: Vec<Value> = self.links.iter().map(FuzzLink::to_value).collect();
+        obj.insert("links".into(), Value::Array(links));
+        Value::Object(obj)
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzBody {
+    /// `{"versions": [...]}` (Nova/Glance-style unversioned discovery doc).
+    Versions(Vec<FuzzEndpointVersion>),
+    /// `{"version": {...}}` (versioned endpoint discovery doc).
+    Version(FuzzEndpointVersion),
+    /// `{"versions": {"values": [...]}}` (Keystone-style).
+    VersionsValues(Vec<FuzzEndpointVersion>),
+}
+
+impl FuzzBody {
+    fn to_value(&self) -> Value {
+        let mut obj = Map::new();
+        match self {
+            FuzzBody::Versions(versions) => {
+                let versions: Vec<Value> =
+                    versions.iter().map(FuzzEndpointVersion::to_value).collect();
+                obj.insert("versions".into(), Value::Array(versions));
+            }
+            FuzzBody::Version(version) => {
+                obj.insert("version".into(), version.to_value());
+            }
+            FuzzBody::VersionsValues(versions) => {
+                let values: Vec<Value> =
+                    versions.iter().map(FuzzEndpointVersion::to_value).collect();
+                let mut inner = Map::new();
+                inner.insert("values".into(), Value::Array(values));
+                obj.insert("versions".into(), Value::Object(inner));
+            }
+        }
+        Value::Object(obj)
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzInput {
+    Structured(FuzzBody),
+    RawBytes(Vec<u8>),
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzHost {
+    FooBar,
+    ExampleOrg,
+    Localhost,
+}
+
+impl FuzzHost {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FuzzHost::FooBar => "foo.bar",
+            FuzzHost::ExampleOrg => "example.org",
+            FuzzHost::Localhost => "localhost",
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct Input {
+    body: FuzzInput,
+    discovery_host: FuzzHost,
+    service_type: String,
+}
+
+fuzz_target!(|input: Input| {
+    let Ok(discovery_url) = Url::parse(&format!("http://{}/", input.discovery_host.as_str()))
+    else {
+        return;
+    };
+
+    let data: Vec<u8> = match &input.body {
+        FuzzInput::Structured(body) => body.to_value().to_string().into_bytes(),
+        FuzzInput::RawBytes(bytes) => bytes.clone(),
+    };
+
+    let _ = openstack_sdk::catalog::extract_discovery_endpoints(
+        &discovery_url,
+        &Bytes::from(data),
+        &input.service_type,
+    );
+});

--- a/fuzz/fuzz_targets/fuzz_expand_link.rs
+++ b/fuzz/fuzz_targets/fuzz_expand_link.rs
@@ -1,0 +1,113 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use url::Url;
+
+extern crate openstack_sdk;
+
+// `expand_link` resolves a `href` from a version-discovery document into an
+// absolute URL relative to a base URL, with recovery paths for a malformed
+// port (regex-based) and for relative URLs without a scheme/host. Random
+// bytes rarely produce a string that even looks like `scheme://host:port/path`,
+// so we model the shapes the function actually branches on and let the
+// fuzzer mutate within them.
+
+#[derive(Debug, Arbitrary)]
+enum FuzzScheme {
+    Http,
+    Https,
+}
+
+impl FuzzScheme {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FuzzScheme::Http => "http",
+            FuzzScheme::Https => "https",
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzHost {
+    FooBar,
+    ExampleOrg,
+    Localhost,
+}
+
+impl FuzzHost {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FuzzHost::FooBar => "foo.bar",
+            FuzzHost::ExampleOrg => "example.org",
+            FuzzHost::Localhost => "localhost",
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzLink {
+    /// A path with no scheme/host, e.g. "/v2/foo" -> RelativeUrlWithoutBase.
+    Relative(String),
+    /// A well-formed absolute URL pointing at the same host as the base.
+    AbsoluteSameHost(String),
+    /// A well-formed absolute URL pointing at a different host.
+    AbsoluteOtherHost(FuzzScheme, FuzzHost, String),
+    /// `scheme://host:<non-numeric-port>/path` -> triggers the InvalidPort
+    /// regex-recovery branch.
+    BadPort(FuzzScheme, FuzzHost, u16, String),
+    /// Fully arbitrary text, to explore other/unexpected parse errors.
+    Raw(String),
+}
+
+impl FuzzLink {
+    fn render(&self, own_scheme: &FuzzScheme, own_host: &FuzzHost) -> String {
+        match self {
+            FuzzLink::Relative(path) => format!("/{path}"),
+            FuzzLink::AbsoluteSameHost(path) => {
+                format!("{}://{}/{path}", own_scheme.as_str(), own_host.as_str())
+            }
+            FuzzLink::AbsoluteOtherHost(scheme, host, path) => {
+                format!("{}://{}/{path}", scheme.as_str(), host.as_str())
+            }
+            FuzzLink::BadPort(scheme, host, port, path) => {
+                // Append a non-digit so the port segment fails to parse as u16.
+                format!("{}://{}:{port}x/{path}", scheme.as_str(), host.as_str())
+            }
+            FuzzLink::Raw(s) => s.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    link: FuzzLink,
+    base_scheme: FuzzScheme,
+    base_host: FuzzHost,
+    base_port: Option<u16>,
+    base_path: String,
+    service_type: String,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let base_url_str = match input.base_port {
+        Some(port) => format!(
+            "{}://{}:{port}/{}",
+            input.base_scheme.as_str(),
+            input.base_host.as_str(),
+            input.base_path
+        ),
+        None => format!(
+            "{}://{}/{}",
+            input.base_scheme.as_str(),
+            input.base_host.as_str(),
+            input.base_path
+        ),
+    };
+    let Ok(base_url) = Url::parse(&base_url_str) else {
+        return;
+    };
+
+    let link = input.link.render(&input.base_scheme, &input.base_host);
+    let _ = openstack_sdk::catalog::expand_link(&link, &base_url, &input.service_type);
+});

--- a/fuzz/fuzz_targets/fuzz_link_header.rs
+++ b/fuzz/fuzz_targets/fuzz_link_header.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+extern crate openstack_sdk;
+
+// `&str` targets are driven by `arbitrary`'s built-in impl: libfuzzer-sys
+// interprets the raw fuzz bytes as (possibly truncated) UTF-8 before handing
+// them to the closure, so malformed byte sequences are filtered out for us.
+fuzz_target!(|s: &str| {
+    let _ = openstack_sdk::api::fuzz_parse_link_header(s);
+});

--- a/fuzz/fuzz_targets/fuzz_next_page_from_body.rs
+++ b/fuzz/fuzz_targets/fuzz_next_page_from_body.rs
@@ -1,0 +1,150 @@
+#![no_main]
+
+use std::borrow::Cow;
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use serde_json::{Map, Value};
+use url::Url;
+
+extern crate openstack_sdk;
+
+// `next_page_from_body` walks an already-parsed `serde_json::Value` looking
+// for OpenStack pagination hints ("links", "<resource>_links", "next").
+// Random bytes almost never parse as JSON at all, so instead of fuzzing raw
+// bytes we derive `Arbitrary` on a small model of the shapes the function
+// actually branches on, and build the `serde_json::Value` from that. This
+// lets libFuzzer's mutations explore the interesting branches (missing
+// "rel", relative vs. absolute "href"/"next", matching vs. differing host)
+// far more effectively than byte-level fuzzing would.
+
+#[derive(Debug, Arbitrary)]
+enum FuzzHost {
+    FooBar,
+    ExampleOrg,
+    Localhost,
+}
+
+impl FuzzHost {
+    fn as_str(&self) -> &'static str {
+        match self {
+            FuzzHost::FooBar => "foo.bar",
+            FuzzHost::ExampleOrg => "example.org",
+            FuzzHost::Localhost => "localhost",
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzTargetUrl {
+    Relative(String),
+    AbsoluteSameHost(String),
+    AbsoluteOtherHost(FuzzHost, String),
+    Raw(String),
+}
+
+impl FuzzTargetUrl {
+    fn render(&self, own_host: &FuzzHost) -> String {
+        match self {
+            FuzzTargetUrl::Relative(path) => format!("/{path}"),
+            FuzzTargetUrl::AbsoluteSameHost(path) => format!("http://{}/{path}", own_host.as_str()),
+            FuzzTargetUrl::AbsoluteOtherHost(host, path) => {
+                format!("http://{}/{path}", host.as_str())
+            }
+            FuzzTargetUrl::Raw(s) => s.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzLinkEntry {
+    rel: Option<String>,
+    href: Option<FuzzTargetUrl>,
+}
+
+impl FuzzLinkEntry {
+    fn to_value(&self, own_host: &FuzzHost) -> Value {
+        let mut obj = Map::new();
+        if let Some(rel) = &self.rel {
+            obj.insert("rel".into(), Value::String(rel.clone()));
+        }
+        if let Some(href) = &self.href {
+            obj.insert("href".into(), Value::String(href.render(own_host)));
+        }
+        Value::Object(obj)
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+enum FuzzBody {
+    Empty,
+    LinksArray(Vec<FuzzLinkEntry>),
+    ResourceLinksArray(Vec<FuzzLinkEntry>),
+    LinksDict { next: Option<String> },
+    NextField(Option<FuzzTargetUrl>),
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    body: FuzzBody,
+    response_key: Option<String>,
+    base_host: FuzzHost,
+    base_port: Option<u16>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let base_url_str = match input.base_port {
+        Some(port) => format!("http://{}:{port}/v1", input.base_host.as_str()),
+        None => format!("http://{}/v1", input.base_host.as_str()),
+    };
+    let Ok(base_endpoint) = Url::parse(&base_url_str) else {
+        return;
+    };
+
+    let response_key: Option<Cow<'_, str>> = input.response_key.clone().map(Cow::Owned);
+
+    let content = match &input.body {
+        FuzzBody::Empty => Value::Object(Map::new()),
+        FuzzBody::LinksArray(entries) => {
+            let links: Vec<Value> = entries
+                .iter()
+                .map(|e| e.to_value(&input.base_host))
+                .collect();
+            let mut obj = Map::new();
+            obj.insert("links".into(), Value::Array(links));
+            Value::Object(obj)
+        }
+        FuzzBody::ResourceLinksArray(entries) => {
+            let key = response_key.clone().unwrap_or(Cow::Borrowed("resource"));
+            let links: Vec<Value> = entries
+                .iter()
+                .map(|e| e.to_value(&input.base_host))
+                .collect();
+            let mut obj = Map::new();
+            obj.insert(format!("{key}_links"), Value::Array(links));
+            Value::Object(obj)
+        }
+        FuzzBody::LinksDict { next } => {
+            let mut links = Map::new();
+            links.insert(
+                "next".into(),
+                next.clone().map(Value::String).unwrap_or(Value::Null),
+            );
+            let mut obj = Map::new();
+            obj.insert("links".into(), Value::Object(links));
+            Value::Object(obj)
+        }
+        FuzzBody::NextField(next) => {
+            let mut obj = Map::new();
+            obj.insert(
+                "next".into(),
+                next.as_ref()
+                    .map(|n| Value::String(n.render(&input.base_host)))
+                    .unwrap_or(Value::Null),
+            );
+            Value::Object(obj)
+        }
+    };
+
+    let _ = openstack_sdk::api::fuzz_next_page_from_body(&content, &response_key, base_endpoint);
+});

--- a/fuzz/fuzz_targets/fuzz_openstack_sdk_config_yaml.rs
+++ b/fuzz/fuzz_targets/fuzz_openstack_sdk_config_yaml.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use std::io::Write;
+
+use libfuzzer_sys::fuzz_target;
+extern crate openstack_sdk;
+
+// Unlike `fuzz_openstack_sdk_config` (which only fuzzes the cloud-name
+// argument), this target feeds the fuzzed bytes as the *content* of a
+// `clouds.yaml`-style file, exercising the actual YAML parsing and
+// `ConfigFile` deserialization path.
+fuzz_target!(|data: &[u8]| {
+    let Ok(mut file) = tempfile::Builder::new().suffix(".yaml").tempfile() else {
+        return;
+    };
+    if file.write_all(data).is_err() {
+        return;
+    }
+    let _ = openstack_sdk::config::ConfigFile::builder().add_source(file.path());
+});

--- a/fuzz/fuzz_targets/fuzz_state_cache.rs
+++ b/fuzz/fuzz_targets/fuzz_state_cache.rs
@@ -1,0 +1,38 @@
+#![no_main]
+
+use std::fs::File;
+use std::io::Write;
+
+use libfuzzer_sys::fuzz_target;
+use openstack_sdk_core::state::State;
+
+extern crate openstack_sdk_core;
+
+// The on-disk auth/discovery cache files (`~/.osc/<auth_hash>[.discovery]`) are
+// local, not network-controlled, but a corrupted file (disk corruption, partial
+// write, cross-version cache reuse) is a plausible real-world scenario. The
+// reader logic (split off a format-version byte, then `postcard::from_bytes`) is
+// meant to degrade gracefully -- log and delete the file -- rather than panic on
+// malformed content. This target checks that guarantee holds for arbitrary bytes.
+
+fuzz_target!(|data: &[u8]| {
+    let state = State::new();
+
+    if let Ok(mut file) = tempfile::NamedTempFile::new()
+        && file.write_all(data).is_ok()
+    {
+        let path = file.path().to_path_buf();
+        if let Ok(mut read_file) = File::open(&path) {
+            state.fuzz_read_auth_state_from_file(&mut read_file, &path);
+        }
+    }
+
+    if let Ok(mut file) = tempfile::NamedTempFile::new()
+        && file.write_all(data).is_ok()
+    {
+        let path = file.path().to_path_buf();
+        if let Ok(mut read_file) = File::open(&path) {
+            state.fuzz_read_discovery_state_from_file(&mut read_file, &path);
+        }
+    }
+});

--- a/openstack_sdk/Cargo.toml
+++ b/openstack_sdk/Cargo.toml
@@ -64,6 +64,10 @@ async = ["openstack_sdk_core/async",
 ]
 client_der = []
 client_pem = []
+# Exposes otherwise crate-private parsers as public functions so they can be
+# exercised by fuzz targets in the top-level `fuzz` crate. Not part of the
+# stable public API.
+fuzzing = ["openstack_sdk_core/fuzzing"]
 keystone_ng = ["dep:openstack-sdk-auth-jwt", "dep:openstack-sdk-auth-federation"]
 passkey = ["keystone_ng", "dep:openstack-sdk-auth-passkey"]
 

--- a/openstack_sdk/src/lib.rs
+++ b/openstack_sdk/src/lib.rs
@@ -19,6 +19,8 @@ pub mod auth;
 pub mod config;
 pub mod catalog {
     pub use openstack_sdk_core::catalog::CatalogError;
+    #[cfg(feature = "fuzzing")]
+    pub use openstack_sdk_core::catalog::{expand_link, extract_discovery_endpoints};
 }
 pub mod types;
 

--- a/sdk/auth-core/Cargo.toml
+++ b/sdk/auth-core/Cargo.toml
@@ -13,6 +13,10 @@ repository.workspace = true
 
 [features]
 interactive = ["dep:dialoguer"]
+# Exposes otherwise crate-private parsers as public functions so they can be
+# exercised by fuzz targets in the top-level `fuzz` crate. Not part of the
+# stable public API.
+fuzzing = []
 
 [dependencies]
 async-trait.workspace = true

--- a/sdk/auth-core/src/authtoken.rs
+++ b/sdk/auth-core/src/authtoken.rs
@@ -226,40 +226,9 @@ impl AuthToken {
     pub async fn from_reqwest_response(response: Response) -> Result<Self, AuthError> {
         if !response.status().is_success() {
             let status = response.status();
-            if let StatusCode::UNAUTHORIZED = status
-                && let Some(receipt_header) = response.headers().get("openstack-auth-receipt")
-            {
-                let receipt_token = receipt_header
-                    .to_str()
-                    .map_err(|_| AuthError::AuthReceiptNotString)?
-                    .into();
-
-                let body_text = response.text().await?;
-                if let Ok(mut receipt) = serde_json::from_str::<AuthReceiptResponse>(&body_text) {
-                    receipt.token = Some(receipt_token);
-                    return Err(AuthError::AuthReceipt(Box::new(receipt)));
-                }
-
-                if let Ok(data) = serde_json::from_str::<AuthErrorResponse>(&body_text) {
-                    return Err(AuthError::Identity(data.error));
-                } else {
-                    return Err(AuthError::UnknownAuth {
-                        code: status.into(),
-                        message: Some(body_text),
-                    });
-                }
-            }
-
-            let body = response.text().await?;
-
-            if let Ok(data) = serde_json::from_str::<AuthErrorResponse>(&body) {
-                return Err(AuthError::Identity(data.error));
-            } else {
-                return Err(AuthError::UnknownAuth {
-                    code: status.into(),
-                    message: Some(body),
-                });
-            }
+            let headers = response.headers().clone();
+            let body_text = response.text().await?;
+            return Err(parse_error_response(status, &headers, &body_text));
         }
 
         let token = response
@@ -281,6 +250,58 @@ impl AuthToken {
             auth_info: Some(token_info),
         })
     }
+}
+
+/// Build the [`AuthError`] for a non-success Keystone auth response, given its status,
+/// headers, and already-read body text.
+///
+/// Handles Keystone's several error-response shapes: a multi-factor auth receipt (401 with
+/// an `openstack-auth-receipt` header), a structured identity error body, or an opaque
+/// fallback carrying the raw body text.
+fn parse_error_response(status: StatusCode, headers: &HeaderMap, body_text: &str) -> AuthError {
+    if let StatusCode::UNAUTHORIZED = status
+        && let Some(receipt_header) = headers.get("openstack-auth-receipt")
+    {
+        let receipt_token = match receipt_header.to_str() {
+            Ok(v) => v.into(),
+            Err(_) => return AuthError::AuthReceiptNotString,
+        };
+
+        if let Ok(mut receipt) = serde_json::from_str::<AuthReceiptResponse>(body_text) {
+            receipt.token = Some(receipt_token);
+            return AuthError::AuthReceipt(Box::new(receipt));
+        }
+
+        return if let Ok(data) = serde_json::from_str::<AuthErrorResponse>(body_text) {
+            AuthError::Identity(data.error)
+        } else {
+            AuthError::UnknownAuth {
+                code: status.into(),
+                message: Some(body_text.to_string()),
+            }
+        };
+    }
+
+    if let Ok(data) = serde_json::from_str::<AuthErrorResponse>(body_text) {
+        AuthError::Identity(data.error)
+    } else {
+        AuthError::UnknownAuth {
+            code: status.into(),
+            message: Some(body_text.to_string()),
+        }
+    }
+}
+
+/// Fuzz target entry point for the otherwise private [`parse_error_response`].
+///
+/// Only compiled with the `fuzzing` feature; not part of the stable public API.
+#[cfg(feature = "fuzzing")]
+pub fn fuzz_parse_error_response(
+    status: StatusCode,
+    headers: &HeaderMap,
+    body_text: &str,
+) -> AuthError {
+    parse_error_response(status, headers, body_text)
 }
 
 impl TryFrom<http::Response<bytes::Bytes>> for AuthToken {

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -21,6 +21,10 @@ sync = ["reqwest/blocking"]
 async = []
 json-schema = ["schemars"]
 interactive = ["openstack-sdk-auth-core/interactive"]
+# Exposes otherwise crate-private parsers as public functions so they can be
+# exercised by fuzz targets in the top-level `fuzz` crate. Not part of the
+# stable public API.
+fuzzing = []
 
 [dependencies]
 arc-swap.workspace = true

--- a/sdk/core/src/api.rs
+++ b/sdk/core/src/api.rs
@@ -487,6 +487,9 @@ pub use self::paged::Pagination;
 pub use self::paged::PaginationError;
 pub use self::paged::paged;
 
+#[cfg(feature = "fuzzing")]
+pub use self::paged::{fuzz_next_page_from_body, fuzz_parse_link_header};
+
 pub use self::find::{Findable, find, find_by_name};
 
 pub use self::params::JsonBodyParams;

--- a/sdk/core/src/api/error.rs
+++ b/sdk/core/src/api/error.rs
@@ -332,6 +332,18 @@ where
         }
     }
 
+    /// Fuzz target entry point for the otherwise crate-private [`from_openstack`](Self::from_openstack).
+    ///
+    /// Only compiled with the `fuzzing` feature; not part of the stable public API.
+    #[cfg(feature = "fuzzing")]
+    pub fn fuzz_from_openstack(
+        uri: Option<Uri>,
+        rsp: &Response<Bytes>,
+        value: serde_json::Value,
+    ) -> Self {
+        Self::from_openstack(uri, rsp, value)
+    }
+
     pub(crate) fn data_type<T>(source: serde_json::Error) -> Self {
         ApiError::DataType {
             source,

--- a/sdk/core/src/api/paged.rs
+++ b/sdk/core/src/api/paged.rs
@@ -27,6 +27,9 @@ use serde::de::DeserializeOwned;
 
 pub use self::pagination::{Pagination, PaginationError};
 
+#[cfg(feature = "fuzzing")]
+pub use self::next_page::{fuzz_next_page_from_body, fuzz_parse_link_header};
+
 use crate::api::rest_endpoint::set_request_microversion_header;
 use crate::api::{ApiError, RestEndpoint, query};
 

--- a/sdk/core/src/api/paged/next_page.rs
+++ b/sdk/core/src/api/paged/next_page.rs
@@ -53,7 +53,7 @@ impl<'a> LinkHeader<'a> {
                     .next()
                     .ok_or_else(|| LinkHeaderParseError::MalformedLink(part.to_string()))?;
                 let value = if let Some(value) = halves.next() {
-                    if value.starts_with('"') && value.ends_with('"') {
+                    if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
                         &value[1..value.len() - 1]
                     } else {
                         value
@@ -236,6 +236,26 @@ pub(crate) fn next_page_from_body(
     Ok(None)
 }
 
+/// Fuzz target entry point for the otherwise private [`LinkHeader::parse`].
+///
+/// Only compiled with the `fuzzing` feature; not part of the stable public API.
+#[cfg(feature = "fuzzing")]
+pub fn fuzz_parse_link_header(s: &str) -> Result<(), LinkHeaderParseError> {
+    LinkHeader::parse(s).map(|_| ())
+}
+
+/// Fuzz target entry point for [`next_page_from_body`].
+///
+/// Only compiled with the `fuzzing` feature; not part of the stable public API.
+#[cfg(feature = "fuzzing")]
+pub fn fuzz_next_page_from_body(
+    content: &Value,
+    response_key: &Option<Cow<'_, str>>,
+    base_endpoint: Url,
+) -> Result<Option<Url>, PaginationError> {
+    next_page_from_body(content, response_key, base_endpoint)
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;
@@ -327,6 +347,17 @@ mod tests {
         let link = LinkHeader::parse("<url>").unwrap();
         assert_eq!(link.url, "url");
         assert_eq!(link.params.len(), 0);
+    }
+
+    #[test]
+    fn test_link_header_single_quote_char_param_value() {
+        // Regression test: a value consisting of a single '"' character used
+        // to panic on slice index `value[1..value.len() - 1]` since it
+        // trivially satisfies both `starts_with('"')` and `ends_with('"')`
+        // while being too short to strip a leading and trailing quote from.
+        // Found by the `fuzz_link_header` fuzz target.
+        let link = LinkHeader::parse("<url>; param=\"").unwrap();
+        assert_eq!(link.params[0].1, "\"");
     }
 
     #[test]

--- a/sdk/core/src/catalog.rs
+++ b/sdk/core/src/catalog.rs
@@ -35,6 +35,12 @@ use openstack_sdk_auth_core::types::ServiceEndpoints as ApiServiceEndpoints;
 
 pub use crate::catalog::error::CatalogError;
 pub use crate::catalog::service_endpoint::ServiceEndpoint;
+
+/// Exposed only under the `fuzzing` feature as fuzz target entry points into the otherwise
+/// crate-private version-discovery parsers. Not part of the stable public API.
+#[cfg(feature = "fuzzing")]
+pub use crate::catalog::discovery::{expand_link, extract_discovery_endpoints};
+
 use crate::catalog::{service_authority::ServiceAuthority, service_endpoint::ServiceEndpoints};
 use crate::config::CloudConfig;
 use crate::types::{ServiceType, api_version::ApiVersion};

--- a/sdk/core/src/catalog/service_endpoint.rs
+++ b/sdk/core/src/catalog/service_endpoint.rs
@@ -205,14 +205,14 @@ impl ServiceEndpoint {
                 if work_endpoint == pid_suffix {
                     work_endpoint = ""
                 } else {
-                    work_endpoint =
-                        work_endpoint
-                            .get(pid_suffix.len() + 1..)
-                            .unwrap_or_else(|| {
-                                panic!(
-                                    "project_id suffix '{pid_suffix}' can be stripped from the endpoint '{work_endpoint}'"
-                                )
-                            });
+                    // Strip the pid_suffix prefix and the separating '/' char-wise (rather than
+                    // by byte offset) so this can never panic on a multi-byte UTF-8 boundary. If
+                    // the byte after the prefix is not '/' (unexpected shape), leave the endpoint
+                    // untouched instead of guessing.
+                    work_endpoint = work_endpoint
+                        .strip_prefix(pid_suffix)
+                        .and_then(|rest| rest.strip_prefix('/'))
+                        .unwrap_or(work_endpoint);
                 }
             }
 
@@ -811,5 +811,21 @@ mod tests {
                 "ServiceEndpoint: {service_url} with URL: {endpoint} results in {expected}"
             );
         }
+    }
+
+    #[test]
+    fn test_construct_request_pid_suffix_multibyte_boundary() {
+        // Regression test: when `endpoint` starts with `pid_suffix` but isn't followed by
+        // a '/' (e.g. it's immediately followed by a multi-byte UTF-8 character), the old
+        // byte-offset slice `work_endpoint[pid_suffix.len() + 1..]` could land mid-codepoint
+        // and panic. It must not strip anything in that case.
+        let result = ServiceEndpoint::new(
+            Url::parse("http://foo.bar/v1/a").unwrap(),
+            ApiVersion::new(1, 0),
+        )
+        .set_last_segment_with_project_id(Some("a".to_string()))
+        .build_request_url("aé")
+        .unwrap();
+        assert_eq!("http://foo.bar/v1/a/a%C3%A9", result.as_str());
     }
 }

--- a/sdk/core/src/state.rs
+++ b/sdk/core/src/state.rs
@@ -427,6 +427,14 @@ impl State {
         }
     }
 
+    /// Fuzz target entry point for the otherwise private [`read_discovery_state_from_file`](Self::read_discovery_state_from_file).
+    ///
+    /// Only compiled with the `fuzzing` feature; not part of the stable public API.
+    #[cfg(feature = "fuzzing")]
+    pub fn fuzz_read_discovery_state_from_file(&self, file: &mut File, path: &PathBuf) {
+        let _ = self.read_discovery_state_from_file(file, path);
+    }
+
     /// Loads the discovery cache with a shared lock (mirrors [`State::load_auth_state`]).
     fn load_discovery_state(&self) -> Option<DiscoveryEntries> {
         let fname = self.get_discovery_state_filename();
@@ -656,6 +664,14 @@ impl State {
                 None
             }
         }
+    }
+
+    /// Fuzz target entry point for the otherwise private [`read_auth_state_from_file`](Self::read_auth_state_from_file).
+    ///
+    /// Only compiled with the `fuzzing` feature; not part of the stable public API.
+    #[cfg(feature = "fuzzing")]
+    pub fn fuzz_read_auth_state_from_file(&self, file: &mut File, path: &PathBuf) {
+        let _ = self.read_auth_state_from_file(file, path);
     }
 
     /// Loads auth state from the cache file with a shared lock.


### PR DESCRIPTION
Extend fuzz testing with arbitrary-driven structured targets

Add three new fuzz targets alongside the existing config lookup one:

- fuzz_link_header: fuzzes the Link HTTP header parser with typed &str
  input (uses arbitrary's built-in UTF-8 handling via libfuzzer-sys).
  This immediately found and fixed a real panic: a param value
  consisting of a single '"' character satisfied both starts_with('"')
  and ends_with('"') while being too short to strip, causing a slice
  index panic in LinkHeader::parse.
- fuzz_next_page_from_body: fuzzes the pagination-link detection logic
  using a hand-derived Arbitrary model of the JSON shapes the function
  branches on (links array/dict, Nova-style <resource>_links, relative
  vs. absolute vs. cross-host next URLs), converted to serde_json::Value.
  Structure-aware generation explores these branches far more
  effectively than raw byte fuzzing of JSON would.
- fuzz_openstack_sdk_config_yaml: writes fuzzed bytes as the content of
  a clouds.yaml-style file and runs it through the real YAML parsing +
  ConfigFile deserialization path, unlike the existing target which
  only fuzzes the cloud-name lookup argument.
- fuzz_expand_link: fuzzes catalog::discovery::expand_link, which
  resolves a version-discovery document's href into an absolute URL
  relative to a base, including a regex-based recovery path for
  malformed ports and relative-URL-without-base handling. Models the
  link shapes (relative, same/other host absolute, bad port, raw) via
  Arbitrary so mutations land in the interesting branches.
- fuzz_discovery_endpoints: fuzzes
  catalog::discovery::extract_discovery_endpoints, which tries three
  different JSON shapes in sequence for a discovery document (plain
  "versions" array, single "version", and Keystone's nested
  "versions.values"). Combines a structured Arbitrary model of all
  three shapes with a raw-bytes mode in the same target.
- fuzz_api_version: fuzzes ApiVersion::from_apiver_str (regex-based
  microversion token parser) and ApiVersion::from_url (path-segment
  walk with project-ID-suffix stripping). Both were already fully
  public, so no SDK-side visibility changes were needed for this one.
- fuzz_build_request_url: fuzzes ServiceEndpoint::build_request_url,
  which combines a server-supplied catalog URL with a user-supplied
  endpoint path. This target's design immediately pointed at a real
  panic: when `endpoint` starts with `pid_suffix` but the byte right
  after the prefix begins a multi-byte UTF-8 character, the old
  byte-offset slice `work_endpoint[pid_suffix.len() + 1..]` landed
  mid-codepoint (e.g. pid_suffix="a", endpoint="aé"). Fixed by
  stripping the prefix and separator char-wise via strip_prefix
  instead of raw byte-offset slicing, with a regression test.
- fuzz_auth_error_response: fuzzes a newly extracted
  authtoken::parse_error_response, pulled out of
  AuthToken::from_reqwest_response's non-success branch so the 3-way
  Keystone error-shape fallback (auth-receipt / identity-error /
  opaque raw body) is fuzzable without needing a live reqwest
  response. Pure extraction, no behavior change (auth-core test suite
  still green). This is the shared choke point every auth plugin
  funnels through.
- fuzz_api_error_from_openstack: fuzzes ApiError::from_openstack's
  /message, /error, /faultstring JSON-pointer fallback used to paper
  over inconsistent OpenStack error body shapes across services.
- fuzz_state_cache: fuzzes the local auth/discovery cache file reader
  (version-byte + postcard) for panic-safety against a corrupted
  cache file, using the real file-backed private methods via
  fuzzing-gated wrappers rather than reimplementing the logic.