### PR TITLE
feat: Dispatch response schema per negotiated microversion

### DIFF
--- a/cli/block-storage/src/v3/group_type/group_spec/show_311.rs
+++ b/cli/block-storage/src/v3/group_type/group_spec/show_311.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::group_type::group_spec::get_311;
+use openstack_types::block_storage::v3::group_type::group_spec::response;
 
 /// Return a single extra spec item.
 #[derive(Args)]
@@ -91,7 +92,10 @@ impl GroupSpecCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::GroupSpecResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/block-storage/src/v3/host/show.rs
+++ b/cli/block-storage/src/v3/host/show.rs
@@ -81,6 +81,7 @@ impl HostCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::get::HostResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/block-storage/src/v3/manageable_snapshot/get.rs
+++ b/cli/block-storage/src/v3/manageable_snapshot/get.rs
@@ -136,6 +136,7 @@ impl ManageableSnapshotCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::get::ManageableSnapshotResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/block-storage/src/v3/manageable_volume/get.rs
+++ b/cli/block-storage/src/v3/manageable_volume/get.rs
@@ -136,6 +136,7 @@ impl ManageableVolumeCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::get::ManageableVolumeResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/block-storage/src/v3/type/volume_type_access/get.rs
+++ b/cli/block-storage/src/v3/type/volume_type_access/get.rs
@@ -86,6 +86,7 @@ impl VolumeTypeAccessCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::get::VolumeTypeAccessResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/block-storage/src/v3/version/get_30.rs
+++ b/cli/block-storage/src/v3/version/get_30.rs
@@ -30,6 +30,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::version::get_30;
+use openstack_types::block_storage::v3::version::response;
 
 /// Shows details for Block Storage API v3.
 #[derive(Args)]
@@ -70,7 +71,10 @@ impl VersionCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::VersionResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/block-storage/src/v3/volume/summary/get_312.rs
+++ b/cli/block-storage/src/v3/volume/summary/get_312.rs
@@ -30,6 +30,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::block_storage::v3::volume::summary::get_312;
+use openstack_types::block_storage::v3::volume::summary::response;
 
 /// Return summary of volumes.
 #[derive(Args)]
@@ -72,7 +73,10 @@ impl SummaryCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::SummaryResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/aggregate/add_host.rs
+++ b/cli/compute/src/v2/aggregate/add_host.rs
@@ -28,8 +28,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::add_host;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
 /// Command without description in OpenAPI
@@ -103,12 +107,19 @@ impl AggregateCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::add_host_21::AggregateResponse>(data.clone())
-            .or_else(|_| {
-                op.output_single::<response::add_host_241::AggregateResponse>(data.clone())
-            })?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 41)) {
+            op.output_single::<response::add_host_241::AggregateResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::add_host_21::AggregateResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/aggregate/list_21.rs
+++ b/cli/compute/src/v2/aggregate/list_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::list_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
 /// Lists all aggregates. Includes the ID, name, and availability zone for each
@@ -75,9 +79,19 @@ impl AggregatesCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 
-        op.output_list::<response::list_21::AggregateResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 41)) {
+            op.output_list::<response::list_241::AggregateResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_21::AggregateResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/aggregate/remove_host.rs
+++ b/cli/compute/src/v2/aggregate/remove_host.rs
@@ -28,8 +28,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::remove_host;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
 /// Command without description in OpenAPI
@@ -103,12 +107,19 @@ impl AggregateCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::remove_host_21::AggregateResponse>(data.clone())
-            .or_else(|_| {
-                op.output_single::<response::remove_host_241::AggregateResponse>(data.clone())
-            })?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 41)) {
+            op.output_single::<response::remove_host_241::AggregateResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::remove_host_21::AggregateResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/aggregate/set_metadata.rs
+++ b/cli/compute/src/v2/aggregate/set_metadata.rs
@@ -29,8 +29,12 @@ use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
 use openstack_cli_core::common::parse_key_val_opt;
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::set_metadata;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
 /// Command without description in OpenAPI
@@ -112,12 +116,19 @@ impl AggregateCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::set_metadata_21::AggregateResponse>(data.clone())
-            .or_else(|_| {
-                op.output_single::<response::set_metadata_241::AggregateResponse>(data.clone())
-            })?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 41)) {
+            op.output_single::<response::set_metadata_241::AggregateResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::set_metadata_21::AggregateResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/aggregate/show_21.rs
+++ b/cli/compute/src/v2/aggregate/show_21.rs
@@ -27,9 +27,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
+use openstack_sdk::api::Findable;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::find;
 use openstack_sdk::api::find;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
 /// Shows details for an aggregate. Details include hosts and metadata.
@@ -84,9 +89,23 @@ impl AggregateCommand {
         let find_ep = find_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+        let find_ep_versioned = find_ep.get_ep::<AsyncOpenStack>()?;
+
+        let service_endpoint = client
+            .get_service_endpoint(
+                &find_ep_versioned.service_type(),
+                find_ep_versioned.api_version().as_ref(),
+            )
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
-        op.output_single::<response::get_21::AggregateResponse>(find_data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 41)) {
+            op.output_single::<response::get_241::AggregateResponse>(find_data.clone())?;
+        } else {
+            op.output_single::<response::get_21::AggregateResponse>(find_data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/console_auth_token/show_21.rs
+++ b/cli/compute/src/v2/console_auth_token/show_21.rs
@@ -28,8 +28,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::console_auth_token::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::console_auth_token::response;
 
 /// Given the console authentication token for a server, shows the related
@@ -95,9 +99,19 @@ impl ConsoleAuthTokenCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21::ConsoleAuthTokenResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 99)) {
+            op.output_single::<response::get_299::ConsoleAuthTokenResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_21::ConsoleAuthTokenResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/flavor/add_tenant_access.rs
+++ b/cli/compute/src/v2/flavor/add_tenant_access.rs
@@ -117,6 +117,7 @@ impl FlavorCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::add_tenant_access::FlavorResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/compute/src/v2/flavor/extra_spec/show_21.rs
+++ b/cli/compute/src/v2/flavor/extra_spec/show_21.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::flavor::extra_spec::get_21;
+use openstack_types::compute::v2::flavor::extra_spec::response;
 
 /// Shows an extra spec, by key, for a flavor, by ID.
 ///
@@ -96,7 +97,10 @@ impl ExtraSpecCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::ExtraSpecResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/flavor/list_20.rs
+++ b/cli/compute/src/v2/flavor/list_20.rs
@@ -27,9 +27,13 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::flavor::list_detailed_20;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
 use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::flavor::response;
 
 /// Lists flavors with details.
@@ -140,11 +144,25 @@ impl FlavorsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_detailed_20::FlavorResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 102)) {
+            op.output_list::<response::list_detailed_2102::FlavorResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 61)) {
+            op.output_list::<response::list_detailed_261::FlavorResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 55)) {
+            op.output_list::<response::list_detailed_255::FlavorResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_detailed_20::FlavorResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/flavor/remove_tenant_access.rs
+++ b/cli/compute/src/v2/flavor/remove_tenant_access.rs
@@ -119,6 +119,7 @@ impl FlavorCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::remove_tenant_access::FlavorResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/compute/src/v2/flavor/show_20.rs
+++ b/cli/compute/src/v2/flavor/show_20.rs
@@ -27,9 +27,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
+use openstack_sdk::api::Findable;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::flavor::find;
 use openstack_sdk::api::find;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::flavor::response;
 
 /// Shows details for a flavor.
@@ -84,9 +89,29 @@ impl FlavorCommand {
         let find_ep = find_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+        let find_ep_versioned = find_ep.get_ep::<AsyncOpenStack>()?;
+
+        let service_endpoint = client
+            .get_service_endpoint(
+                &find_ep_versioned.service_type(),
+                find_ep_versioned.api_version().as_ref(),
+            )
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
-        op.output_single::<response::get_20::FlavorResponse>(find_data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 102)) {
+            op.output_single::<response::get_2102::FlavorResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 75)) {
+            op.output_single::<response::get_275::FlavorResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 61)) {
+            op.output_single::<response::get_261::FlavorResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 55)) {
+            op.output_single::<response::get_255::FlavorResponse>(find_data.clone())?;
+        } else {
+            op.output_single::<response::get_20::FlavorResponse>(find_data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/hypervisor/list_21.rs
+++ b/cli/compute/src/v2/hypervisor/list_21.rs
@@ -27,9 +27,13 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::hypervisor::list_detailed_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
 use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::hypervisor::response;
 
 /// Lists hypervisors details.
@@ -120,11 +124,27 @@ impl HypervisorsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_detailed_21::HypervisorResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 88)) {
+            op.output_list::<response::list_detailed_288::HypervisorResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 53)) {
+            op.output_list::<response::list_detailed_253::HypervisorResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 33)) {
+            op.output_list::<response::list_detailed_233::HypervisorResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 28)) {
+            op.output_list::<response::list_detailed_228::HypervisorResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_detailed_21::HypervisorResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/hypervisor/search/get_21.rs
+++ b/cli/compute/src/v2/hypervisor/search/get_21.rs
@@ -30,6 +30,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::hypervisor::search::get_21;
+use openstack_types::compute::v2::hypervisor::search::response;
 
 /// Search hypervisor by a given hypervisor host name or portion of it.
 ///
@@ -88,7 +89,10 @@ impl SearchCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
+        op.output_list::<response::get_21::SearchResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/hypervisor/server/get_21.rs
+++ b/cli/compute/src/v2/hypervisor/server/get_21.rs
@@ -30,6 +30,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::hypervisor::server::get_21;
+use openstack_types::compute::v2::hypervisor::server::response;
 
 /// List all servers belong to each hypervisor whose host name is matching a
 /// given hypervisor host name or portion of it.
@@ -89,7 +90,10 @@ impl ServerCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get_21::ServerResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/hypervisor/show_21.rs
+++ b/cli/compute/src/v2/hypervisor/show_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::hypervisor::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::hypervisor::response;
 
 /// Shows details for a given hypervisor.
@@ -96,9 +100,23 @@ impl HypervisorCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21::HypervisorResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 88)) {
+            op.output_single::<response::get_288::HypervisorResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 53)) {
+            op.output_single::<response::get_253::HypervisorResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 28)) {
+            op.output_single::<response::get_228::HypervisorResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_21::HypervisorResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/hypervisor/statistic/get_21.rs
+++ b/cli/compute/src/v2/hypervisor/statistic/get_21.rs
@@ -30,6 +30,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::hypervisor::statistic::get_21;
+use openstack_types::compute::v2::hypervisor::statistic::response;
 
 /// Shows summary statistics for all enabled hypervisors over all compute
 /// nodes.
@@ -82,7 +83,10 @@ impl StatisticCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get_21::StatisticResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/hypervisor/uptime/get_21.rs
+++ b/cli/compute/src/v2/hypervisor/uptime/get_21.rs
@@ -28,8 +28,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::hypervisor::uptime::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::hypervisor::uptime::response;
 
 /// Shows the uptime for a given hypervisor.
@@ -91,9 +95,19 @@ impl UptimeCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21::UptimeResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 53)) {
+            op.output_single::<response::get_253::UptimeResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_21::UptimeResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/keypair/list_20.rs
+++ b/cli/compute/src/v2/keypair/list_20.rs
@@ -28,11 +28,15 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::keypair::list_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
 use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::keypair::response;
 use tracing::warn;
 
@@ -170,11 +174,23 @@ impl KeypairsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_20::KeypairResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 35)) {
+            op.output_list::<response::list_235::KeypairResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 2)) {
+            op.output_list::<response::list_22::KeypairResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_20::KeypairResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/keypair/show_20.rs
+++ b/cli/compute/src/v2/keypair/show_20.rs
@@ -27,9 +27,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
+use openstack_sdk::api::Findable;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::keypair::find;
 use openstack_sdk::api::find;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::keypair::response;
 
 /// Shows details for a keypair that is associated with the account.
@@ -103,9 +108,23 @@ impl KeypairCommand {
         let find_ep = find_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+        let find_ep_versioned = find_ep.get_ep::<AsyncOpenStack>()?;
+
+        let service_endpoint = client
+            .get_service_endpoint(
+                &find_ep_versioned.service_type(),
+                find_ep_versioned.api_version().as_ref(),
+            )
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
-        op.output_single::<response::get_20::KeypairResponse>(find_data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 2)) {
+            op.output_single::<response::get_22::KeypairResponse>(find_data.clone())?;
+        } else {
+            op.output_single::<response::get_20::KeypairResponse>(find_data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/limit/list_21.rs
+++ b/cli/compute/src/v2/limit/list_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::limit::list_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::limit::response;
 
 /// Shows rate and absolute limits for the project.
@@ -82,9 +86,23 @@ impl LimitCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::list_21::LimitResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 57)) {
+            op.output_single::<response::list_257::LimitResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 39)) {
+            op.output_single::<response::list_239::LimitResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 36)) {
+            op.output_single::<response::list_236::LimitResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::list_21::LimitResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/migration/get_20.rs
+++ b/cli/compute/src/v2/migration/get_20.rs
@@ -28,11 +28,15 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::migration::get_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::migration::response;
 use tracing::warn;
 
@@ -283,8 +287,23 @@ impl MigrationCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
-        op.output_list::<response::get_20::MigrationResponse>(data.clone())?;
+
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 80)) {
+            op.output_list::<response::get_280::MigrationResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 59)) {
+            op.output_list::<response::get_259::MigrationResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 23)) {
+            op.output_list::<response::get_223::MigrationResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::get_20::MigrationResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/quota_class_set/show_21.rs
+++ b/cli/compute/src/v2/quota_class_set/show_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_class_set::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_class_set::response;
 
 /// Show the quota for the Quota Class.
@@ -85,9 +89,21 @@ impl QuotaClassSetCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21::QuotaClassSetResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 57)) {
+            op.output_single::<response::get_257::QuotaClassSetResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 50)) {
+            op.output_single::<response::get_250::QuotaClassSetResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_21::QuotaClassSetResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/quota_set/defaults_20.rs
+++ b/cli/compute/src/v2/quota_set/defaults_20.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_set::defaults_20;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_set::response;
 
 /// Lists the default quotas for a project.
@@ -85,9 +89,21 @@ impl QuotaSetCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::defaults_20::QuotaSetResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 57)) {
+            op.output_single::<response::defaults_257::QuotaSetResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 36)) {
+            op.output_single::<response::defaults_236::QuotaSetResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::defaults_20::QuotaSetResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/quota_set/details_20.rs
+++ b/cli/compute/src/v2/quota_set/details_20.rs
@@ -28,10 +28,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_set::details_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_set::response;
 use tracing::warn;
 
@@ -155,9 +159,21 @@ impl QuotaSetCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::details_20::QuotaSetResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 57)) {
+            op.output_single::<response::details_257::QuotaSetResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 36)) {
+            op.output_single::<response::details_236::QuotaSetResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::details_20::QuotaSetResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/quota_set/show_20.rs
+++ b/cli/compute/src/v2/quota_set/show_20.rs
@@ -28,10 +28,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_set::get_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_set::response;
 use tracing::warn;
 
@@ -151,9 +155,21 @@ impl QuotaSetCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_20::QuotaSetResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 57)) {
+            op.output_single::<response::get_257::QuotaSetResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 36)) {
+            op.output_single::<response::get_236::QuotaSetResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_20::QuotaSetResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/diagnostic/get_21.rs
+++ b/cli/compute/src/v2/server/diagnostic/get_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::diagnostic::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::diagnostic::response;
 
 /// Shows basic usage data for a server.
@@ -89,9 +93,19 @@ impl DiagnosticCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21::DiagnosticResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 48)) {
+            op.output_single::<response::get_248::DiagnosticResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_21::DiagnosticResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/instance_action/list_21.rs
+++ b/cli/compute/src/v2/server/instance_action/list_21.rs
@@ -27,9 +27,13 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::instance_action::list_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
 use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::instance_action::response;
 
 /// Lists actions for a server.
@@ -138,11 +142,21 @@ impl InstanceActionsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_21::InstanceActionResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 58)) {
+            op.output_list::<response::list_258::InstanceActionResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_21::InstanceActionResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/instance_action/show_21.rs
+++ b/cli/compute/src/v2/server/instance_action/show_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::instance_action::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::instance_action::response;
 
 /// Shows details for a server action.
@@ -105,9 +109,25 @@ impl InstanceActionCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21::InstanceActionResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 84)) {
+            op.output_single::<response::get_284::InstanceActionResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 62)) {
+            op.output_single::<response::get_262::InstanceActionResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 58)) {
+            op.output_single::<response::get_258::InstanceActionResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 51)) {
+            op.output_single::<response::get_251::InstanceActionResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_21::InstanceActionResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/interface/list_21.rs
+++ b/cli/compute/src/v2/server/interface/list_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::interface::list_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::interface::response;
 
 /// Lists port interfaces that are attached to a server.
@@ -86,9 +90,19 @@ impl InterfacesCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 
-        op.output_list::<response::list_21::InterfaceResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 70)) {
+            op.output_list::<response::list_270::InterfaceResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_21::InterfaceResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/interface/show_21.rs
+++ b/cli/compute/src/v2/server/interface/show_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::interface::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::interface::response;
 
 /// Shows details for a port interface that is attached to a server.
@@ -94,9 +98,19 @@ impl InterfaceCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21::InterfaceResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 70)) {
+            op.output_single::<response::get_270::InterfaceResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_21::InterfaceResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/ip/list_21.rs
+++ b/cli/compute/src/v2/server/ip/list_21.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::server::ip::list_21;
+use openstack_types::compute::v2::server::ip::response;
 
 /// Lists IP addresses that are assigned to an instance.
 ///
@@ -86,7 +87,10 @@ impl IpsCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
+        op.output_list::<response::list::IpResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/ip/show_21.rs
+++ b/cli/compute/src/v2/server/ip/show_21.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::server::ip::get_21;
+use openstack_types::compute::v2::server::ip::response;
 
 /// Shows IP addresses details for a network label of a server instance.
 ///
@@ -95,7 +96,10 @@ impl IpCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::IpResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/list_21.rs
+++ b/cli/compute/src/v2/server/list_21.rs
@@ -564,7 +564,60 @@ impl ServersCommand {
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_detailed_21::ServerResponse>(data.clone())?;
+        op.output_list::<response::list_detailed_21::ServerResponse>(data.clone())
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_2100_a::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_2100_b::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_216::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_219::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_226::ServerResponse>(data.clone())
+            })
+            .or_else(|_| op.output_list::<response::list_detailed_23::ServerResponse>(data.clone()))
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_247::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_263::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_269_a::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_269_b::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_273_a::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_273_b::ServerResponse>(data.clone())
+            })
+            .or_else(|_| op.output_list::<response::list_detailed_29::ServerResponse>(data.clone()))
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_290_a::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_290_b::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_296_a::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_296_b::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_298_a::ServerResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_list::<response::list_detailed_298_b::ServerResponse>(data.clone())
+            })?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/metadata/show_21.rs
+++ b/cli/compute/src/v2/server/metadata/show_21.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::server::metadata::get_21;
+use openstack_types::compute::v2::server::metadata::response;
 
 /// Shows details for a metadata item, by key, for a server.
 ///
@@ -96,7 +97,10 @@ impl MetadataCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::MetadataResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/migration/list_223.rs
+++ b/cli/compute/src/v2/server/migration/list_223.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::migration::list_223;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::migration::response;
 
 /// Lists in-progress live migrations for a given server.
@@ -89,9 +93,21 @@ impl MigrationsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 
-        op.output_list::<response::list_223::MigrationResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 80)) {
+            op.output_list::<response::list_280::MigrationResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 59)) {
+            op.output_list::<response::list_259::MigrationResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_223::MigrationResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/migration/show_223.rs
+++ b/cli/compute/src/v2/server/migration/show_223.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::migration::get_223;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::migration::response;
 
 /// Show details for an in-progress live migration for a given server.
@@ -98,9 +102,21 @@ impl MigrationCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_223::MigrationResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 80)) {
+            op.output_single::<response::get_280::MigrationResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 59)) {
+            op.output_single::<response::get_259::MigrationResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_223::MigrationResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/server_password/get_21.rs
+++ b/cli/compute/src/v2/server/server_password/get_21.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::compute::v2::server::server_password::get_21;
+use openstack_types::compute::v2::server::server_password::response;
 
 /// Shows the administrative password for a server.
 ///
@@ -98,7 +99,10 @@ impl ServerPasswordCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::ServerPasswordResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/show_20.rs
+++ b/cli/compute/src/v2/server/show_20.rs
@@ -101,7 +101,34 @@ impl ServerCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
-        op.output_single::<response::get_20::ServerResponse>(find_data.clone())?;
+        op.output_single::<response::get_20::ServerResponse>(find_data.clone())
+            .or_else(|_| {
+                op.output_single::<response::get_2100_a::ServerResponse>(find_data.clone())
+            })
+            .or_else(|_| {
+                op.output_single::<response::get_2100_b::ServerResponse>(find_data.clone())
+            })
+            .or_else(|_| op.output_single::<response::get_216::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_219::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_226::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_23::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_247::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_263::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_269_a::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_269_b::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_271_a::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_271_b::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_273_a::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_273_b::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_29::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_290_a::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_290_b::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_296_a::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_296_b::ServerResponse>(find_data.clone()))
+            .or_else(|_| op.output_single::<response::get_298_a::ServerResponse>(find_data.clone()))
+            .or_else(|_| {
+                op.output_single::<response::get_298_b::ServerResponse>(find_data.clone())
+            })?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/tag/replace_226.rs
+++ b/cli/compute/src/v2/server/tag/replace_226.rs
@@ -98,6 +98,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace_226::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/compute/src/v2/server/volume_attachment/list_20.rs
+++ b/cli/compute/src/v2/server/volume_attachment/list_20.rs
@@ -27,9 +27,13 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::volume_attachment::list_20;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
 use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::volume_attachment::response;
 
 /// List volume attachments for an instance.
@@ -115,11 +119,25 @@ impl VolumeAttachmentsCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_20::VolumeAttachmentResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 89)) {
+            op.output_list::<response::list_289::VolumeAttachmentResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 79)) {
+            op.output_list::<response::list_279::VolumeAttachmentResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 70)) {
+            op.output_list::<response::list_270::VolumeAttachmentResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_20::VolumeAttachmentResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/volume_attachment/show_20.rs
+++ b/cli/compute/src/v2/server/volume_attachment/show_20.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::volume_attachment::get_20;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::volume_attachment::response;
 
 /// Show a detail of a volume attachment.
@@ -99,9 +103,23 @@ impl VolumeAttachmentCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_20::VolumeAttachmentResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 89)) {
+            op.output_single::<response::get_289::VolumeAttachmentResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 79)) {
+            op.output_single::<response::get_279::VolumeAttachmentResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 70)) {
+            op.output_single::<response::get_270::VolumeAttachmentResponse>(data.clone())?;
+        } else {
+            op.output_single::<response::get_20::VolumeAttachmentResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server_group/list_20.rs
+++ b/cli/compute/src/v2/server_group/list_20.rs
@@ -27,8 +27,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server_group::list_20;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
+use openstack_types::compute::v2::server_group::response;
 
 /// Lists all server groups for the tenant.
 ///
@@ -108,7 +114,26 @@ impl ServerGroupsCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
+        let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
+            .query_async(client)
+            .await?;
+
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 64)) {
+            op.output_list::<response::list_264::ServerGroupResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 15)) {
+            op.output_list::<response::list_215::ServerGroupResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 13)) {
+            op.output_list::<response::list_213::ServerGroupResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_21::ServerGroupResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server_group/show_21.rs
+++ b/cli/compute/src/v2/server_group/show_21.rs
@@ -27,9 +27,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
+use openstack_sdk::api::Findable;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server_group::find;
 use openstack_sdk::api::find;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server_group::response;
 
 /// Shows details for a server group.
@@ -85,9 +90,27 @@ impl ServerGroupCommand {
         let find_ep = find_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+        let find_ep_versioned = find_ep.get_ep::<AsyncOpenStack>()?;
+
+        let service_endpoint = client
+            .get_service_endpoint(
+                &find_ep_versioned.service_type(),
+                find_ep_versioned.api_version().as_ref(),
+            )
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
-        op.output_single::<response::get_21::ServerGroupResponse>(find_data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 64)) {
+            op.output_single::<response::get_264::ServerGroupResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 15)) {
+            op.output_single::<response::get_215::ServerGroupResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 13)) {
+            op.output_single::<response::get_213::ServerGroupResponse>(find_data.clone())?;
+        } else {
+            op.output_single::<response::get_21::ServerGroupResponse>(find_data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/service/list_20.rs
+++ b/cli/compute/src/v2/service/list_20.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::service::list_20;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::service::response;
 
 /// Lists all running Compute services.
@@ -90,9 +94,23 @@ impl ServicesCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 
-        op.output_list::<response::list_20::ServiceResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 69)) {
+            op.output_list::<response::list_269::ServiceResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 53)) {
+            op.output_list::<response::list_253::ServiceResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 11)) {
+            op.output_list::<response::list_211::ServiceResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_20::ServiceResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/simple_tenant_usage/list_21.rs
+++ b/cli/compute/src/v2/simple_tenant_usage/list_21.rs
@@ -27,9 +27,13 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::simple_tenant_usage::list_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
 use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::simple_tenant_usage::response;
 
 /// Lists usage statistics for all tenants.
@@ -126,11 +130,21 @@ impl SimpleTenantUsagesCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_21::SimpleTenantUsageResponse>(data.clone())?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 40)) {
+            op.output_list::<response::list_240::SimpleTenantUsageResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_21::SimpleTenantUsageResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/simple_tenant_usage/show_21.rs
+++ b/cli/compute/src/v2/simple_tenant_usage/show_21.rs
@@ -129,6 +129,12 @@ impl SimpleTenantUsageCommand {
         op.output_single::<response::get_21_a::SimpleTenantUsageResponse>(data.clone())
             .or_else(|_| {
                 op.output_single::<response::get_21_b::SimpleTenantUsageResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_single::<response::get_240_a::SimpleTenantUsageResponse>(data.clone())
+            })
+            .or_else(|_| {
+                op.output_single::<response::get_240_b::SimpleTenantUsageResponse>(data.clone())
             })?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/identity/src/v3/os_federation/identity_provider/show.rs
+++ b/cli/identity/src/v3/os_federation/identity_provider/show.rs
@@ -86,6 +86,7 @@ impl IdentityProviderCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::get::IdentityProviderResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/identity/src/v3/project/tag/replace.rs
+++ b/cli/identity/src/v3/project/tag/replace.rs
@@ -161,6 +161,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/load-balancer/src/v2/amphorae/stats.rs
+++ b/cli/load-balancer/src/v2/amphorae/stats.rs
@@ -90,6 +90,7 @@ impl AmphoraeCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::stats::AmphoraeResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/floatingip/tag/replace.rs
+++ b/cli/network/src/v2/floatingip/tag/replace.rs
@@ -95,6 +95,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/network/tag/replace.rs
+++ b/cli/network/src/v2/network/tag/replace.rs
@@ -91,6 +91,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/network_segment_range/tag/replace.rs
+++ b/cli/network/src/v2/network_segment_range/tag/replace.rs
@@ -95,6 +95,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/policy/tag/replace.rs
+++ b/cli/network/src/v2/policy/tag/replace.rs
@@ -91,6 +91,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/port/tag/replace.rs
+++ b/cli/network/src/v2/port/tag/replace.rs
@@ -90,6 +90,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/router/tag/replace.rs
+++ b/cli/network/src/v2/router/tag/replace.rs
@@ -91,6 +91,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/security_group/tag/replace.rs
+++ b/cli/network/src/v2/security_group/tag/replace.rs
@@ -95,6 +95,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/subnet/tag/replace.rs
+++ b/cli/network/src/v2/subnet/tag/replace.rs
@@ -91,6 +91,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/subnetpool/tag/replace.rs
+++ b/cli/network/src/v2/subnetpool/tag/replace.rs
@@ -95,6 +95,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/network/src/v2/trunk/tag/replace.rs
+++ b/cli/network/src/v2/trunk/tag/replace.rs
@@ -91,6 +91,7 @@ impl TagCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::replace::TagResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/placement/src/v1/allocation_candidate/list_110.rs
+++ b/cli/placement/src/v1/allocation_candidate/list_110.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::placement::v1::allocation_candidate::list_110;
+use openstack_types::placement::v1::allocation_candidate::response;
 
 /// Returns a dictionary representing a collection of allocation requests and
 /// resource provider summaries. Each allocation request has information to
@@ -226,7 +227,10 @@ impl AllocationCandidateCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::list::AllocationCandidateResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/placement/src/v1/resource_class/create_12.rs
+++ b/cli/placement/src/v1/resource_class/create_12.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::placement::v1::resource_class::create_12;
+use openstack_types::placement::v1::resource_class::response;
 
 /// Create a new resource class. The new class must be a *custom* resource
 /// class, prefixed with CUSTOM\_ and distinct from the standard resource
@@ -92,7 +93,10 @@ impl ResourceClassCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::create::ResourceClassResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/placement/src/v1/resource_class/show_12.rs
+++ b/cli/placement/src/v1/resource_class/show_12.rs
@@ -29,6 +29,7 @@ use openstack_sdk::AsyncOpenStack;
 
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::placement::v1::resource_class::get_12;
+use openstack_types::placement::v1::resource_class::response;
 
 /// Return a representation of the resource class identified by {name}.
 ///
@@ -83,7 +84,10 @@ impl ResourceClassCommand {
         let ep = ep_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
-        openstack_sdk::api::ignore(ep).query_async(client).await?;
+
+        let data: serde_json::Value = ep.query_async(client).await?;
+
+        op.output_single::<response::get::ResourceClassResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/placement/src/v1/resource_provider/aggregate/list_11.rs
+++ b/cli/placement/src/v1/resource_provider/aggregate/list_11.rs
@@ -92,6 +92,7 @@ impl AggregateCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::list::AggregateResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/placement/src/v1/resource_provider/aggregate/set_11.rs
+++ b/cli/placement/src/v1/resource_provider/aggregate/set_11.rs
@@ -90,6 +90,7 @@ impl AggregateCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::set::AggregateResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/placement/src/v1/resource_provider/aggregate/set_119.rs
+++ b/cli/placement/src/v1/resource_provider/aggregate/set_119.rs
@@ -105,6 +105,7 @@ impl AggregateCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::set::AggregateResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/placement/src/v1/resource_provider/trait/list_16.rs
+++ b/cli/placement/src/v1/resource_provider/trait/list_16.rs
@@ -89,6 +89,7 @@ impl TraitCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::list::TraitResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/cli/placement/src/v1/resource_provider/trait/set_16.rs
+++ b/cli/placement/src/v1/resource_provider/trait/set_16.rs
@@ -102,6 +102,7 @@ impl TraitCommand {
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
+
         op.output_list::<response::set::TraitResponse>(data.clone())?;
         // Show command specific hints
         op.show_command_hint()?;

--- a/openstack_types/data/compute/v2.104.yaml
+++ b/openstack_types/data/compute/v2.104.yaml
@@ -88866,6 +88866,9 @@ components:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
@@ -93863,6 +93866,8 @@ components:
             additionalProperties: false
             properties:
               id:
+                description: |-
+                  The UUID of the server.
                 format: uuid
                 type: string
               links:

--- a/openstack_types/data/compute/v2.yaml
+++ b/openstack_types/data/compute/v2.yaml
@@ -88866,6 +88866,9 @@ components:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
@@ -93863,6 +93866,8 @@ components:
             additionalProperties: false
             properties:
               id:
+                description: |-
+                  The UUID of the server.
                 format: uuid
                 type: string
               links:

--- a/openstack_types/data/network/v2.29.yaml
+++ b/openstack_types/data/network/v2.29.yaml
@@ -10190,7 +10190,6 @@ components:
       in: query
       name: target_tenant
       schema:
-        maxLength: 255
         type: string
     rbac_policies_tenant_id:
       description: tenant_id query parameter for /v2.0/rbac-policies API
@@ -22196,7 +22195,6 @@ components:
                 actually the ID of the existing project. If, for example, the name of the project
                 is provided here, it will be accepted by the Neutron API, but the RBAC rule
                 created will not work as expected.
-              maxLength: 255
               type: string
             tenant_id:
               maxLength: 255
@@ -22238,7 +22236,6 @@ components:
             target_tenant:
               description: |-
                 The ID of the tenant to which the RBAC policy will be enforced.
-              maxLength: 255
               type: string
             tenant_id:
               description: |-
@@ -22283,7 +22280,6 @@ components:
               target_tenant:
                 description: |-
                   The ID of the tenant to which the RBAC policy will be enforced.
-                maxLength: 255
                 type: string
               tenant_id:
                 description: |-
@@ -22328,7 +22324,6 @@ components:
             target_tenant:
               description: |-
                 The ID of the tenant to which the RBAC policy will be enforced.
-              maxLength: 255
               type: string
             tenant_id:
               description: |-
@@ -22349,7 +22344,6 @@ components:
                 actually the ID of the existing project. If, for example, the name of the project
                 is provided here, it will be accepted by the Neutron API, but the RBAC rule
                 created will not work as expected.
-              maxLength: 255
               type: string
           type: object
       type: object
@@ -22388,7 +22382,6 @@ components:
             target_tenant:
               description: |-
                 The ID of the tenant to which the RBAC policy will be enforced.
-              maxLength: 255
               type: string
             tenant_id:
               description: |-

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -10190,7 +10190,6 @@ components:
       in: query
       name: target_tenant
       schema:
-        maxLength: 255
         type: string
     rbac_policies_tenant_id:
       description: tenant_id query parameter for /v2.0/rbac-policies API
@@ -22196,7 +22195,6 @@ components:
                 actually the ID of the existing project. If, for example, the name of the project
                 is provided here, it will be accepted by the Neutron API, but the RBAC rule
                 created will not work as expected.
-              maxLength: 255
               type: string
             tenant_id:
               maxLength: 255
@@ -22238,7 +22236,6 @@ components:
             target_tenant:
               description: |-
                 The ID of the tenant to which the RBAC policy will be enforced.
-              maxLength: 255
               type: string
             tenant_id:
               description: |-
@@ -22283,7 +22280,6 @@ components:
               target_tenant:
                 description: |-
                   The ID of the tenant to which the RBAC policy will be enforced.
-                maxLength: 255
                 type: string
               tenant_id:
                 description: |-
@@ -22328,7 +22324,6 @@ components:
             target_tenant:
               description: |-
                 The ID of the tenant to which the RBAC policy will be enforced.
-              maxLength: 255
               type: string
             tenant_id:
               description: |-
@@ -22349,7 +22344,6 @@ components:
                 actually the ID of the existing project. If, for example, the name of the project
                 is provided here, it will be accepted by the Neutron API, but the RBAC rule
                 created will not work as expected.
-              maxLength: 255
               type: string
           type: object
       type: object
@@ -22388,7 +22382,6 @@ components:
             target_tenant:
               description: |-
                 The ID of the tenant to which the RBAC policy will be enforced.
-              maxLength: 255
               type: string
             tenant_id:
               description: |-

--- a/types/compute/src/v2/server/response/list_21.rs
+++ b/types/compute/src/v2/server/response/list_21.rs
@@ -22,6 +22,7 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// The UUID of the server.
     #[structable()]
     pub id: String,
 

--- a/types/compute/src/v2/server/response/list_detailed_216.rs
+++ b/types/compute/src/v2/server/response/list_detailed_216.rs
@@ -23,6 +23,8 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// IPv4 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,


### PR DESCRIPTION
Response deserialization for openstack_cli has always tried each
candidate schema in spec-declaration order via a `.or_else` chain,
ignoring the microversion actually negotiated for the request even
though the min/max-ver bounds for each candidate were already parsed
into response_mod_candidates.

Add response_mod_candidates_sorted (descending by min_ver) and
has_response_version_variance to the rust_cli template context, and a
response_dispatch macro that, when real version variance is detected,
calls negotiate_microversion and generates a deterministic if/else-if
chain keyed on the negotiated version instead of trial-and-error
deserialization -- mirroring the ResourceBehaviour::deserialize_items
pattern already shipped on the TUI side. Operations without version
variance keep the existing .or_else chain unchanged.

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/999320

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
