### PR TITLE
feat(tui): Dynamic Value+ColumnSpec items

### DIFF
--- a/openstack_tui/.config/config.yaml
+++ b/openstack_tui/.config/config.yaml
@@ -371,14 +371,19 @@ views:
     default_fields: [name, uuid, az, updated_at]
   compute.flavor:
     default_fields: [id, name, vcpus, ram, disk, swap]
+    wide_fields: [swap]
   compute.hypervisor:
     default_fields: [ip, hostname, status, state]
+    wide_fields: [vcpus, "memory mb"]
+    status_field: status
   compute.server/instance_action/event:
     default_fields: [event, result, start_time, finish_time, host]
   compute.server/instance_action:
     default_fields: [id, action, message, start_time, user_id]
   compute.server:
     default_fields: [id, name, flavor, status, created, updated]
+    wide_fields: ["task state", "power state", "availability zone"]
+    status_field: status
     fields:
       - name: flavor
         json_pointer: "/original_name"
@@ -399,6 +404,8 @@ views:
   # image
   image.image:
     default_fields: [id, name, distro, version, visibility, min_disk, min_ram]
+    wide_fields: ["disk format", "container format"]
+    status_field: status
   # load balancer
   load-balancer.healthmonitor:
     default_fields: [id, name, status, type]

--- a/openstack_tui/src/components.rs
+++ b/openstack_tui/src/components.rs
@@ -30,6 +30,7 @@ pub mod compute;
 pub mod confirm_popup;
 pub mod describe;
 pub mod dns;
+pub mod dynamic_item;
 pub mod error_popup;
 pub mod generic_resource_view;
 pub mod header;

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -12,33 +12,69 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use openstack_types::compute::v2::flavor::response::list_detailed_255::FlavorResponse;
-
 use crate::{
     action::Action,
     cloud_worker::compute::v2::{
         ComputeApiRequest, ComputeFlavorApiRequest, ComputeFlavorList, ComputeServerListBuilder,
     },
     cloud_worker::types::ApiRequest,
+    components::dynamic_item::{ColumnSpec, impl_dynamic_item},
     components::generic_resource_view::GenericResourceView,
     components::resource_behaviour::{Mutation, ResourceBehaviour},
     mode::Mode,
-    utils::ResourceKey,
 };
 
 const TITLE: &str = "Compute Flavors";
 const VIEW_CONFIG_KEY: &str = "compute.flavor";
 
-impl ResourceKey for FlavorResponse {
-    fn get_key() -> &'static str {
-        VIEW_CONFIG_KEY
-    }
-}
+// Flavor's `swap` field changed type (i64 -> i32) at microversion 2.102 -- no single
+// `openstack_types` struct correctly represents every microversion, so `Item` reads columns out
+// of the raw response by JSON pointer instead of deserializing into a versioned struct.
+static FLAVOR_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec {
+        title: "ID",
+        pointer: "/id",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Name",
+        pointer: "/name",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "RAM",
+        pointer: "/ram",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "VCPUs",
+        pointer: "/vcpus",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Disk",
+        pointer: "/disk",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Swap",
+        pointer: "/swap",
+        wide: true,
+        status: false,
+    },
+];
+
+impl_dynamic_item!(FlavorItem, VIEW_CONFIG_KEY, FLAVOR_COLUMNS);
 
 pub struct ComputeFlavorsBehaviour;
 
 impl ResourceBehaviour for ComputeFlavorsBehaviour {
-    type Item = FlavorResponse;
+    type Item = FlavorItem;
     type Filter = ComputeFlavorList;
 
     fn view_key() -> &'static str {
@@ -84,8 +120,9 @@ impl ResourceBehaviour for ComputeFlavorsBehaviour {
         if let Action::ShowResource(key) = action
             && *key == crate::mode::COMPUTE_SERVER
             && let Some(sel) = selected
+            && let Some(flavor_id) = sel.get_str("/id")
             && let Ok(server_list) = ComputeServerListBuilder::default()
-                .flavor(sel.id.clone())
+                .flavor(flavor_id)
                 .build()
         {
             return vec![
@@ -115,9 +152,8 @@ mod tests {
     use super::*;
     use crate::cloud_worker::compute::v2::ComputeServerApiRequest;
     use crate::components::resource_behaviour::ResourceBehaviour;
-    use openstack_types::compute::v2::flavor::response::list_detailed_255::FlavorResponse;
 
-    fn make_flavor(id: &str) -> FlavorResponse {
+    fn make_flavor(id: &str) -> FlavorItem {
         let json = serde_json::json!({
             "id": id,
             "name": "test",
@@ -131,7 +167,7 @@ mod tests {
             "metadata": {},
             "os-flavor-access:is_public": true,
         });
-        serde_json::from_value(json).unwrap()
+        FlavorItem(json)
     }
 
     #[test]

--- a/openstack_tui/src/components/compute/hypervisors.rs
+++ b/openstack_tui/src/components/compute/hypervisors.rs
@@ -16,20 +16,72 @@ use crate::cloud_worker::compute::v2::{
     ComputeApiRequest, ComputeHypervisorApiRequest, ComputeHypervisorList,
 };
 use crate::cloud_worker::types::ApiRequest;
+use crate::components::dynamic_item::{ColumnSpec, impl_dynamic_item};
 use crate::components::generic_resource_view::GenericResourceView;
 use crate::components::resource_behaviour::ResourceBehaviour;
 use crate::mode::Mode;
-use openstack_types::compute::v2::hypervisor::response::list_detailed_253::HypervisorResponse;
+
+const VIEW_CONFIG_KEY: &str = "compute.hypervisor";
+
+// Hypervisor's `id` field changed type (i32 -> String) at microversion 2.53 -- no single
+// `openstack_types` struct correctly represents every microversion, so `Item` reads columns out
+// of the raw response by JSON pointer instead of deserializing into a versioned struct.
+static HYPERVISOR_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec {
+        title: "ID",
+        pointer: "/id",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Hostname",
+        pointer: "/hypervisor_hostname",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Type",
+        pointer: "/hypervisor_type",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "State",
+        pointer: "/state",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Status",
+        pointer: "/status",
+        wide: false,
+        status: true,
+    },
+    ColumnSpec {
+        title: "VCPUs",
+        pointer: "/vcpus",
+        wide: true,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Memory MB",
+        pointer: "/memory_mb",
+        wide: true,
+        status: false,
+    },
+];
+
+impl_dynamic_item!(HypervisorItem, VIEW_CONFIG_KEY, HYPERVISOR_COLUMNS);
 
 /// Behaviour implementation for ComputeHypervisors.
 pub struct ComputeHypervisorsBehaviour;
 
 impl ResourceBehaviour for ComputeHypervisorsBehaviour {
-    type Item = HypervisorResponse;
+    type Item = HypervisorItem;
     type Filter = ComputeHypervisorList;
 
     fn view_key() -> &'static str {
-        "compute.hypervisor"
+        VIEW_CONFIG_KEY
     }
     fn title() -> &'static str {
         "Compute Hypervisors"

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -18,20 +18,67 @@ use crate::cloud_worker::compute::v2::{
     ComputeServerInstanceActionListBuilder, ComputeServerList,
 };
 use crate::cloud_worker::types::{ApiRequest, ComputeApiRequest};
+use crate::components::dynamic_item::{ColumnSpec, impl_dynamic_item};
 use crate::components::generic_resource_view::GenericResourceView;
 use crate::components::resource_behaviour::ResourceBehaviour;
 use crate::mode::Mode;
-use openstack_types::compute::v2::server::response::list_detailed_21::ServerResponse;
+
+const VIEW_CONFIG_KEY: &str = "compute.server";
+
+// Server's `OS-EXT-SRV-ATTR:hostname` field changed from absent/`Option<String>` to a required
+// `String` at microversion 2.90 (bucket `_a`) -- no single `openstack_types` struct correctly
+// represents every microversion, so `Item` reads columns out of the raw response by JSON pointer
+// instead of deserializing into a versioned struct.
+static SERVER_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec {
+        title: "ID",
+        pointer: "/id",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Name",
+        pointer: "/name",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Status",
+        pointer: "/status",
+        wide: false,
+        status: true,
+    },
+    ColumnSpec {
+        title: "Task State",
+        pointer: "/OS-EXT-STS:task_state",
+        wide: true,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Power State",
+        pointer: "/OS-EXT-STS:power_state",
+        wide: true,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Availability Zone",
+        pointer: "/OS-EXT-AZ:availability_zone",
+        wide: true,
+        status: false,
+    },
+];
+
+impl_dynamic_item!(ServerItem, VIEW_CONFIG_KEY, SERVER_COLUMNS);
 
 /// Behaviour implementation for ComputeServers.
 pub struct ComputeServersBehaviour;
 
 impl ResourceBehaviour for ComputeServersBehaviour {
-    type Item = ServerResponse;
+    type Item = ServerItem;
     type Filter = ComputeServerList;
 
     fn view_key() -> &'static str {
-        "compute.server"
+        VIEW_CONFIG_KEY
     }
     fn title() -> &'static str {
         "Compute Servers"
@@ -74,9 +121,9 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         {
             let sel = selected?;
             let mut del_builder = ComputeServerDeleteBuilder::default();
-            del_builder.id(sel.id.clone());
-            if let Some(name) = &sel.name {
-                del_builder.name(name.clone());
+            del_builder.id(sel.get_str("/id")?);
+            if let Some(name) = sel.get_str("/name") {
+                del_builder.name(name);
             }
             let del = del_builder.build().ok()?;
             Some(ApiRequest::from(ComputeServerApiRequest::Delete(Box::new(
@@ -91,7 +138,7 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         selected: Option<&Self::Item>,
     ) -> Option<(Vec<Action>, ApiRequest)> {
         if let Action::ShowServerConsoleOutput = action {
-            let server_id = selected?.id.clone();
+            let server_id = selected?.get_str("/id")?;
             let req = ComputeServerApiRequest::GetConsoleOutput(Box::new(
                 ComputeServerGetConsoleOutputBuilder::default()
                     .id(server_id)
@@ -141,11 +188,12 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         if let Action::ShowResource(key) = action
             && *key == crate::mode::COMPUTE_SERVER_INSTANCE_ACTION
             && let Some(sel) = selected
+            && let Some(server_id) = sel.get_str("/id")
         {
             let mut list_builder = ComputeServerInstanceActionListBuilder::default();
-            list_builder.server_id(sel.id.clone());
-            if let Some(name) = &sel.name {
-                list_builder.server_name(name.clone());
+            list_builder.server_id(server_id);
+            if let Some(name) = sel.get_str("/name") {
+                list_builder.server_name(name);
             }
             if let Ok(list) = list_builder.build() {
                 return vec![
@@ -169,10 +217,9 @@ mod tests {
     use super::*;
     use crate::cloud_worker::compute::v2::ComputeServerDelete;
     use crate::components::resource_behaviour::ResourceBehaviour;
-    use openstack_types::compute::v2::server::response::list_detailed_21::ServerResponse;
 
-    fn make_server(id: &str, name: &str) -> ServerResponse {
-        serde_json::from_value(serde_json::json!({
+    fn make_server(id: &str, name: &str) -> ServerItem {
+        ServerItem(serde_json::json!({
             "id": id,
             "name": name,
             "status": "ACTIVE",
@@ -195,7 +242,6 @@ mod tests {
             "key_name": null,
             "security_groups": []
         }))
-        .unwrap()
     }
 
     #[test]

--- a/openstack_tui/src/components/dynamic_item.rs
+++ b/openstack_tui/src/components/dynamic_item.rs
@@ -1,0 +1,255 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Support for resources whose response schema genuinely changes shape (not just adds fields)
+//! across microversions (e.g. compute.flavor's `swap` i64->i32, compute.hypervisor's `id`
+//! i32->String). For those, no single Rust struct can correctly represent every microversion, so
+//! `ResourceBehaviour::Item` is a thin newtype around the raw `serde_json::Value` instead of a
+//! generated `openstack_types` struct -- table columns are read out of the JSON by pointer at
+//! render time, tolerating whatever shape actually came back, with no per-version deserialization
+//! logic at all. See `impl_dynamic_item!` for the per-resource wiring.
+
+use serde_json::Value;
+use structable::StructTableOptions;
+
+/// One table column: display title, JSON pointer (RFC 6901) into the raw response entry, whether
+/// it's a `wide`-only column, and whether it backs `StructTable::status()` (row-coloring hook).
+pub struct ColumnSpec {
+    pub title: &'static str,
+    pub pointer: &'static str,
+    pub wide: bool,
+    pub status: bool,
+}
+
+/// Stringify whatever's at `pointer` in `value`, the same way `StructTable`'s derive macro would
+/// for a typed field: `None` for missing/null, plain text for a JSON string, `Display`-style (via
+/// `Value`'s own formatting) for a scalar, and pretty-vs-compact JSON (per
+/// `options.pretty_mode()`) for an object/array -- matching how `structable_derive` renders
+/// `serialize`/`pretty`-tagged (i.e. non-primitive) fields.
+fn stringify(value: &Value, pointer: &str, pretty: bool) -> Option<String> {
+    match value.pointer(pointer) {
+        None | Some(Value::Null) => None,
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(complex @ (Value::Object(_) | Value::Array(_))) => Some(if pretty {
+            serde_json::to_string_pretty(complex).unwrap_or_else(|_| complex.to_string())
+        } else {
+            complex.to_string()
+        }),
+        Some(other) => Some(other.to_string()),
+    }
+}
+
+/// `StructTable::class_headers` body for a dynamic item: header list is just the configured
+/// column titles, filtered by `should_return_field` like any generated struct's headers are.
+pub fn dynamic_headers<O: StructTableOptions>(
+    columns: &[ColumnSpec],
+    options: &O,
+) -> Option<Vec<String>> {
+    Some(
+        columns
+            .iter()
+            .filter(|c| options.should_return_field(c.title, c.wide))
+            .map(|c| c.title.to_string())
+            .collect(),
+    )
+}
+
+/// `StructTable::data` body for a dynamic item. Honors `StructTableOptions::field_data_json_pointer`
+/// so user config can remap a column to a different pointer into the raw response entry, same as
+/// the `structable_derive` macro does for `serialize`/`pretty` fields.
+pub fn dynamic_data<O: StructTableOptions>(
+    value: &Value,
+    columns: &[ColumnSpec],
+    options: &O,
+) -> Vec<Option<String>> {
+    let pretty = options.pretty_mode();
+    columns
+        .iter()
+        .filter(|c| options.should_return_field(c.title, c.wide))
+        .map(|c| {
+            let pointer = options.field_data_json_pointer(c.title);
+            stringify(value, pointer.as_deref().unwrap_or(c.pointer), pretty)
+        })
+        .collect()
+}
+
+/// `StructTable::status` body for a dynamic item: the value at the column marked `status: true`
+/// (if any). Unlike `dynamic_data`, `StructTable::status` has no `options` parameter to consult
+/// for a pointer override or pretty-mode, so this always reads the column's baked pointer as
+/// plain text.
+pub fn dynamic_status(value: &Value, columns: &[ColumnSpec]) -> Option<String> {
+    let column = columns.iter().find(|c| c.status)?;
+    stringify(value, column.pointer, false)
+}
+
+/// Declare a newtype wrapper around `serde_json::Value` usable as `ResourceBehaviour::Item` for a
+/// resource with a genuinely breaking microversion schema change. `$columns` is a
+/// `&'static [ColumnSpec]`.
+///
+/// A per-resource newtype (rather than one shared `Item = Value`) is required because
+/// `ResourceKey::get_key` is a static method with no way to know which resource a bare `Value` is
+/// for.
+macro_rules! impl_dynamic_item {
+    ($name:ident, $key:expr, $columns:expr) => {
+        #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+        #[serde(transparent)]
+        pub struct $name(pub serde_json::Value);
+
+        impl $name {
+            pub fn get(&self, pointer: &str) -> Option<&serde_json::Value> {
+                self.0.pointer(pointer)
+            }
+
+            pub fn get_str(&self, pointer: &str) -> Option<String> {
+                self.get(pointer)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            }
+        }
+
+        impl crate::utils::ResourceKey for $name {
+            fn get_key() -> &'static str {
+                $key
+            }
+        }
+
+        impl structable::StructTable for $name {
+            fn class_headers<O: structable::StructTableOptions>(
+                options: &O,
+            ) -> Option<Vec<String>> {
+                crate::components::dynamic_item::dynamic_headers($columns, options)
+            }
+            fn data<O: structable::StructTableOptions>(&self, options: &O) -> Vec<Option<String>> {
+                crate::components::dynamic_item::dynamic_data(&self.0, $columns, options)
+            }
+            fn status(&self) -> Option<String> {
+                crate::components::dynamic_item::dynamic_status(&self.0, $columns)
+            }
+        }
+
+        impl structable::StructTable for &$name {
+            fn class_headers<O: structable::StructTableOptions>(
+                options: &O,
+            ) -> Option<Vec<String>> {
+                <$name as structable::StructTable>::class_headers(options)
+            }
+            fn data<O: structable::StructTableOptions>(&self, options: &O) -> Vec<Option<String>> {
+                structable::StructTable::data(*self, options)
+            }
+            fn status(&self) -> Option<String> {
+                structable::StructTable::status(*self)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_dynamic_item;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const COLUMNS: &[ColumnSpec] = &[
+        ColumnSpec {
+            title: "ID",
+            pointer: "/id",
+            wide: false,
+            status: false,
+        },
+        ColumnSpec {
+            title: "Status",
+            pointer: "/status",
+            wide: false,
+            status: true,
+        },
+        ColumnSpec {
+            title: "Metadata",
+            pointer: "/metadata",
+            wide: false,
+            status: false,
+        },
+    ];
+
+    struct Opts {
+        pretty: bool,
+    }
+
+    impl StructTableOptions for Opts {
+        fn wide_mode(&self) -> bool {
+            false
+        }
+        fn pretty_mode(&self) -> bool {
+            self.pretty
+        }
+        fn should_return_field<S: AsRef<str>>(&self, _field: S, _is_wide_field: bool) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn stringify_scalar_ignores_pretty() {
+        let value = serde_json::json!({"id": "abc"});
+        assert_eq!(stringify(&value, "/id", true), Some("abc".to_string()));
+    }
+
+    #[test]
+    fn stringify_object_respects_pretty_mode() {
+        let value = serde_json::json!({"metadata": {"a": 1}});
+        assert_eq!(
+            stringify(&value, "/metadata", false),
+            Some(serde_json::json!({"a": 1}).to_string())
+        );
+        assert_eq!(
+            stringify(&value, "/metadata", true),
+            Some(serde_json::to_string_pretty(&serde_json::json!({"a": 1})).unwrap())
+        );
+    }
+
+    #[test]
+    fn stringify_missing_or_null_is_none() {
+        let value = serde_json::json!({"id": null});
+        assert_eq!(stringify(&value, "/id", false), None);
+        assert_eq!(stringify(&value, "/missing", false), None);
+    }
+
+    #[test]
+    fn dynamic_data_honors_pretty_mode_for_complex_fields() {
+        let value = serde_json::json!({"id": "abc", "status": "ACTIVE", "metadata": {"a": 1}});
+        let compact = dynamic_data(&value, COLUMNS, &Opts { pretty: false });
+        assert_eq!(compact[2], Some(serde_json::json!({"a": 1}).to_string()));
+        let pretty = dynamic_data(&value, COLUMNS, &Opts { pretty: true });
+        assert_eq!(
+            pretty[2],
+            Some(serde_json::to_string_pretty(&serde_json::json!({"a": 1})).unwrap())
+        );
+    }
+
+    #[test]
+    fn dynamic_status_returns_marked_column_value() {
+        let value = serde_json::json!({"id": "abc", "status": "ACTIVE"});
+        assert_eq!(dynamic_status(&value, COLUMNS), Some("ACTIVE".to_string()));
+    }
+
+    #[test]
+    fn dynamic_status_none_when_no_column_marked() {
+        let value = serde_json::json!({"id": "abc"});
+        let columns: &[ColumnSpec] = &[ColumnSpec {
+            title: "ID",
+            pointer: "/id",
+            wide: false,
+            status: false,
+        }];
+        assert_eq!(dynamic_status(&value, columns), None);
+    }
+}

--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -481,8 +481,7 @@ mod tests {
     }
 
     fn setup_comp_with_matching_singular_request_and_data() -> (Value, ApiRequest) {
-        let server: openstack_types::compute::v2::server::response::list_detailed_21::ServerResponse =
-            serde_json::from_value(make_server_json()).unwrap();
+        let server = crate::components::compute::servers::ServerItem(make_server_json());
         let (_display_actions, request) =
             crate::components::compute::servers::ComputeServersBehaviour::action_to_singular_request(
                 &Action::ShowServerConsoleOutput,

--- a/openstack_tui/src/components/image/images.rs
+++ b/openstack_tui/src/components/image/images.rs
@@ -18,29 +18,67 @@ use crate::cloud_worker::image::v2::{
     ImageImageList,
 };
 use crate::cloud_worker::types::ApiRequest;
+use crate::components::dynamic_item::{ColumnSpec, impl_dynamic_item};
 use crate::components::generic_resource_view::GenericResourceView;
 use crate::components::resource_behaviour::{Mutation, ResourceBehaviour};
 use crate::mode::Mode;
-use openstack_types::image::v2::image::response::list::ImageResponse;
 use serde_json::Value;
 
 const VIEW_CONFIG_KEY: &str = "image.image";
 
-impl crate::utils::ResourceKey for ImageResponse {
-    fn get_key() -> &'static str {
-        VIEW_CONFIG_KEY
-    }
-}
+// image.image has no microversion schema drift today (single unversioned `response::list`) --
+// converted to the dynamic-item pattern here purely to verify the design generalizes to a
+// resource that isn't a genuine breaking-change case.
+static IMAGE_COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec {
+        title: "ID",
+        pointer: "/id",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Name",
+        pointer: "/name",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Status",
+        pointer: "/status",
+        wide: false,
+        status: true,
+    },
+    ColumnSpec {
+        title: "Visibility",
+        pointer: "/visibility",
+        wide: true,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Disk Format",
+        pointer: "/disk_format",
+        wide: true,
+        status: false,
+    },
+    ColumnSpec {
+        title: "Container Format",
+        pointer: "/container_format",
+        wide: true,
+        status: false,
+    },
+];
 
-impl TryFrom<&ImageResponse> for ImageImageDelete {
+impl_dynamic_item!(ImageItem, VIEW_CONFIG_KEY, IMAGE_COLUMNS);
+
+impl TryFrom<&ImageItem> for ImageImageDelete {
     type Error = crate::cloud_worker::image::v2::ImageImageDeleteBuilderError;
-    fn try_from(value: &ImageResponse) -> Result<Self, Self::Error> {
+    fn try_from(value: &ImageItem) -> Result<Self, Self::Error> {
         let mut builder = ImageImageDeleteBuilder::default();
-        if let Some(val) = &value.id {
-            builder.id(val.clone());
+        if let Some(val) = value.get_str("/id") {
+            builder.id(val);
         }
-        if let Some(val) = &value.name {
-            builder.name(val.clone());
+        if let Some(val) = value.get_str("/name") {
+            builder.name(val);
         }
         builder.build()
     }
@@ -49,7 +87,7 @@ impl TryFrom<&ImageResponse> for ImageImageDelete {
 pub struct ImageImagesBehaviour;
 
 impl ResourceBehaviour for ImageImagesBehaviour {
-    type Item = ImageResponse;
+    type Item = ImageItem;
     type Filter = ImageImageList;
 
     fn view_key() -> &'static str {
@@ -109,10 +147,9 @@ pub type Images = GenericResourceView<'static, ImageImagesBehaviour>;
 mod tests {
     use super::*;
     use crate::components::resource_behaviour::ResourceBehaviour;
-    use openstack_types::image::v2::image::response::list::ImageResponse;
 
-    fn make_image(id: &str, name: &str) -> ImageResponse {
-        let json = serde_json::json!({
+    fn make_image(id: &str, name: &str) -> ImageItem {
+        ImageItem(serde_json::json!({
             "id": id,
             "name": name,
             "status": "active",
@@ -125,8 +162,7 @@ mod tests {
             "visibility": "public",
             "created_at": "2024-01-01T00:00:00Z",
             "updated_at": "2024-01-01T00:00:00Z"
-        });
-        serde_json::from_value(json).unwrap()
+        }))
     }
 
     #[test]

--- a/openstack_tui/src/config.rs
+++ b/openstack_tui/src/config.rs
@@ -194,6 +194,12 @@ pub struct ViewConfig {
     /// Limit fields (their titles) to be returned
     #[serde(default)]
     pub default_fields: Vec<String>,
+    /// Extra fields (their titles) only shown in wide mode, on top of `default_fields`
+    #[serde(default)]
+    pub wide_fields: Vec<String>,
+    /// Field (its title) backing row-status coloring, if any
+    #[serde(default)]
+    pub status_field: Option<String>,
     /// Fields configurations
     #[serde(default)]
     pub fields: Vec<FieldConfig>,
@@ -281,10 +287,18 @@ impl StructTableOptions for ViewConfig {
         true
     }
 
-    fn should_return_field<S: AsRef<str>>(&self, field: S, _is_wide_field: bool) -> bool {
-        self.default_fields
+    fn should_return_field<S: AsRef<str>>(&self, field: S, is_wide_field: bool) -> bool {
+        let field = field.as_ref().to_lowercase();
+        if self
+            .default_fields
             .iter()
-            .any(|x| x.to_lowercase() == field.as_ref().to_lowercase())
+            .any(|x| x.to_lowercase() == field)
+        {
+            return true;
+        }
+        is_wide_field
+            && self.wide_mode()
+            && self.wide_fields.iter().any(|x| x.to_lowercase() == field)
     }
 
     fn field_data_json_pointer<S: AsRef<str>>(&self, field: S) -> Option<String> {
@@ -1037,5 +1051,60 @@ mod tests {
                 .contains_key(&Mode::Resource(crate::mode::LB_HEALTHMONITOR)),
             "Resource(load-balancer.healthmonitor) keybindings must be present"
         );
+    }
+
+    #[test]
+    fn should_return_field_default_field_always_shown() {
+        let view = ViewConfig {
+            default_fields: vec!["id".into()],
+            ..Default::default()
+        };
+        assert!(view.should_return_field("id", false));
+        assert!(view.should_return_field("ID", false));
+    }
+
+    #[test]
+    fn should_return_field_wide_field_hidden_without_wide_mode() {
+        let view = ViewConfig {
+            default_fields: vec!["id".into()],
+            wide_fields: vec!["swap".into()],
+            wide: Some(false),
+            ..Default::default()
+        };
+        assert!(!view.should_return_field("swap", true));
+    }
+
+    #[test]
+    fn should_return_field_wide_field_shown_in_wide_mode() {
+        let view = ViewConfig {
+            default_fields: vec!["id".into()],
+            wide_fields: vec!["swap".into()],
+            wide: Some(true),
+            ..Default::default()
+        };
+        assert!(view.should_return_field("swap", true));
+    }
+
+    #[test]
+    fn should_return_field_unlisted_field_never_shown() {
+        let view = ViewConfig {
+            default_fields: vec!["id".into()],
+            wide: Some(true),
+            ..Default::default()
+        };
+        assert!(!view.should_return_field("unknown", false));
+        assert!(!view.should_return_field("unknown", true));
+    }
+
+    #[test]
+    fn should_return_field_no_wide_fields_configured_no_regression() {
+        // Resources with no `wide_fields` entry keep today's behavior: a compile-time
+        // `#[structable(wide)]` field is never shown via this options impl, wide mode or not.
+        let view = ViewConfig {
+            default_fields: vec!["id".into()],
+            wide: Some(true),
+            ..Default::default()
+        };
+        assert!(!view.should_return_field("some_wide_struct_field", true));
     }
 }


### PR DESCRIPTION
compute.flavor's `swap`, compute.hypervisor's `id`, and compute.server's
`OS-EXT-SRV-ATTR:hostname` change type across microversions, so no
single generated struct can represent every version.
ResourceBehaviour::Item becomes a thin newtype around raw
serde_json::Value for these plus image.image (converted to validate the
pattern generalizes), reading table columns out of the response by JSON
pointer instead.

Column visibility, wide-only columns, and status-field row coloring are
driven by ViewConfig (.config/config.yaml's `views.<resource>` entries),
extended with `wide_fields` and `status_field` keys so this is
configurable without recompiling, matching how `default_fields` already
works.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
