### PR TITLE
feat: Source ColumnSpec from config.yaml, not struct scraping

### DIFF
--- a/cli/network/src/v2/subnet/create.rs
+++ b/cli/network/src/v2/subnet/create.rs
@@ -174,13 +174,13 @@ struct Subnet {
     ip_version: i32,
 
     /// The IPv6 address modes specifies mechanisms for assigning IP addresses.
-    /// Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless`.
+    /// Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
     #[arg(help_heading = "Body parameters", long)]
     ipv6_address_mode: Option<Ipv6AddressMode>,
 
     /// The IPv6 router advertisement specifies whether the networking service
     /// should transmit ICMPv6 packets, for a subnet. Value is `slaac`,
-    /// `dhcpv6-stateful`, `dhcpv6-stateless`.
+    /// `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
     #[arg(help_heading = "Body parameters", long)]
     ipv6_ra_mode: Option<Ipv6RaMode>,
 

--- a/openstack_tui/src/components/network/generated/security_group.rs
+++ b/openstack_tui/src/components/network/generated/security_group.rs
@@ -17,14 +17,53 @@
 use crate::action::Action;
 use crate::cloud_worker::types as cloud_types;
 use crate::cloud_worker::types::ApiRequest;
+use crate::components::dynamic_item::{ColumnSpec, impl_dynamic_item};
 use crate::components::resource_behaviour::GeneratedResourceBehaviour;
 use crate::mode::Mode;
-use openstack_types::network::v2::security_group::response::list::SecurityGroupResponse;
+
+static COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec {
+        title: "id",
+        pointer: "/id",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "name",
+        pointer: "/name",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "description",
+        pointer: "/description",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "created_at",
+        pointer: "/created_at",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "updated_at",
+        pointer: "/updated_at",
+        wide: false,
+        status: false,
+    },
+];
+
+impl_dynamic_item!(
+    SecurityGroupItem,
+    crate::mode::NETWORK_SECURITY_GROUP,
+    COLUMNS
+);
 
 pub(crate) struct Generated;
 
 impl GeneratedResourceBehaviour for Generated {
-    type Item = SecurityGroupResponse;
+    type Item = SecurityGroupItem;
     type Filter = cloud_types::NetworkSecurityGroupList;
 
     fn view_key() -> &'static str {

--- a/openstack_tui/src/components/network/generated/security_group_rule.rs
+++ b/openstack_tui/src/components/network/generated/security_group_rule.rs
@@ -17,14 +17,65 @@
 use crate::action::Action;
 use crate::cloud_worker::types as cloud_types;
 use crate::cloud_worker::types::ApiRequest;
+use crate::components::dynamic_item::{ColumnSpec, impl_dynamic_item};
 use crate::components::resource_behaviour::GeneratedResourceBehaviour;
 use crate::mode::Mode;
-use openstack_types::network::v2::security_group_rule::response::list::SecurityGroupRuleResponse;
+
+static COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec {
+        title: "id",
+        pointer: "/id",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "ethertype",
+        pointer: "/ethertype",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "direction",
+        pointer: "/direction",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "protocol",
+        pointer: "/protocol",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "port_range_min",
+        pointer: "/port_range_min",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "port_range_max",
+        pointer: "/port_range_max",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "description",
+        pointer: "/description",
+        wide: false,
+        status: false,
+    },
+];
+
+impl_dynamic_item!(
+    SecurityGroupRuleItem,
+    crate::mode::NETWORK_SECURITY_GROUP_RULE,
+    COLUMNS
+);
 
 pub(crate) struct Generated;
 
 impl GeneratedResourceBehaviour for Generated {
-    type Item = SecurityGroupRuleResponse;
+    type Item = SecurityGroupRuleItem;
     type Filter = cloud_types::NetworkSecurityGroupRuleList;
 
     fn view_key() -> &'static str {

--- a/openstack_tui/src/components/network/generated/subnet.rs
+++ b/openstack_tui/src/components/network/generated/subnet.rs
@@ -17,14 +17,49 @@
 use crate::action::Action;
 use crate::cloud_worker::types as cloud_types;
 use crate::cloud_worker::types::ApiRequest;
+use crate::components::dynamic_item::{ColumnSpec, impl_dynamic_item};
 use crate::components::resource_behaviour::GeneratedResourceBehaviour;
 use crate::mode::Mode;
-use openstack_types::network::v2::subnet::response::list::SubnetResponse;
+
+static COLUMNS: &[ColumnSpec] = &[
+    ColumnSpec {
+        title: "id",
+        pointer: "/id",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "name",
+        pointer: "/name",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "cidr",
+        pointer: "/cidr",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "description",
+        pointer: "/description",
+        wide: false,
+        status: false,
+    },
+    ColumnSpec {
+        title: "created_at",
+        pointer: "/created_at",
+        wide: false,
+        status: false,
+    },
+];
+
+impl_dynamic_item!(SubnetItem, crate::mode::NETWORK_SUBNET, COLUMNS);
 
 pub(crate) struct Generated;
 
 impl GeneratedResourceBehaviour for Generated {
-    type Item = SubnetResponse;
+    type Item = SubnetItem;
     type Filter = cloud_types::NetworkSubnetList;
 
     fn view_key() -> &'static str {

--- a/openstack_types/data/compute/v2.104.yaml
+++ b/openstack_types/data/compute/v2.104.yaml
@@ -88866,9 +88866,6 @@ components:
                   - 'null'
                   - string
               accessIPv4:
-                description: |-
-                  IPv4 address that should be used to access this server. May be
-                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
@@ -93866,8 +93863,6 @@ components:
             additionalProperties: false
             properties:
               id:
-                description: |-
-                  The UUID of the server.
                 format: uuid
                 type: string
               links:

--- a/openstack_types/data/compute/v2.yaml
+++ b/openstack_types/data/compute/v2.yaml
@@ -88866,9 +88866,6 @@ components:
                   - 'null'
                   - string
               accessIPv4:
-                description: |-
-                  IPv4 address that should be used to access this server. May be
-                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
@@ -93866,8 +93863,6 @@ components:
             additionalProperties: false
             properties:
               id:
-                description: |-
-                  The UUID of the server.
                 format: uuid
                 type: string
               links:

--- a/openstack_types/data/identity/keystone_rust.yaml
+++ b/openstack_types/data/identity/keystone_rust.yaml
@@ -851,6 +851,155 @@ paths:
                 $ref: '#/components/schemas/GroupResponse'
         '404':
           description: Group not found
+  /v3/policies:
+    get:
+      tags:
+      - policies
+      summary: List policies.
+      description: List policies
+      operationId: list
+      parameters:
+      - name: type
+        in: query
+        description: |-
+          Filters the response by a MIME media type for the serialized policy
+          blob. For example, `application/json`. Exact match.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: limit
+        in: query
+        description: Limit number of entries on the single response page.
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          minimum: 0
+      - name: marker
+        in: query
+        description: Page marker (id of the last entry of the previous page).
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: page_reverse
+        in: query
+        description: |-
+          Fetch the page preceding `marker` instead of the page following it.
+
+          v3 endpoints accept this field (unknown-to-python-keystone query
+          params are harmless) but never read or forward it; only v4 endpoints
+          wire it through.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: List of policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyList'
+        '500':
+          description: Internal error
+    post:
+      tags:
+      - policies
+      summary: Create a new policy.
+      description: |-
+        Any caller-supplied `id` in the body is discarded and a fresh UUID
+        assigned, matching python keystone's `_assign_unique_id`.
+      operationId: create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyCreateRequest'
+        required: true
+      responses:
+        '201':
+          description: Policy created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyResponse'
+        '400':
+          description: Invalid input
+        '500':
+          description: Internal error
+  /v3/policies/{policy_id}:
+    get:
+      tags:
+      - policies
+      summary: Get a single policy.
+      description: Get policy by ID
+      operationId: show
+      parameters:
+      - name: policy_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Policy object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyResponse'
+        '404':
+          description: Policy not found
+    delete:
+      tags:
+      - policies
+      summary: Delete a policy.
+      description: Delete policy by ID
+      operationId: delete
+      parameters:
+      - name: policy_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Policy deleted
+        '404':
+          description: Policy not found
+    patch:
+      tags:
+      - policies
+      summary: Update an existing policy.
+      description: Update policy by ID
+      operationId: update
+      parameters:
+      - name: policy_id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicyUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Updated policy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PolicyResponse'
+        '400':
+          description: Invalid input
+        '404':
+          description: Policy not found
   /v3/projects:
     get:
       tags:
@@ -2144,6 +2293,107 @@ paths:
                 $ref: '#/components/schemas/UserResponse'
         '404':
           description: User not found
+  /v3/users/{user_id}/application_credentials:
+    get:
+      tags:
+      - application_credentials
+      operationId: list
+      parameters:
+      - name: name
+        in: query
+        description: |-
+          Optional name filter. When set, only application credentials whose
+          name matches this value are returned.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      responses:
+        '200':
+          description: List of application credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationCredentialList'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: User not found
+    post:
+      tags:
+      - application_credentials
+      summary: Create application credential.
+      description: POST /v3/users/{user_id}/application_credentials
+      operationId: create
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationCredentialCreateRequest'
+        required: true
+      responses:
+        '201':
+          description: Application credential created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationCredentialCreateResponse'
+        '400':
+          description: Bad request — validation error or role not found
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: User not found
+        '409':
+          description: Conflict — application credential already exists
+  /v3/users/{user_id}/application_credentials/{application_credential_id}:
+    get:
+      tags:
+      - application_credentials
+      operationId: show
+      parameters:
+      - name: application_credential_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Single application credential
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationCredentialResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Application credential or user not found
+    delete:
+      tags:
+      - application_credentials
+      operationId: delete
+      parameters:
+      - name: application_credential_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Application credential deleted
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Application credential or user not found
   /v3/users/{user_id}/credentials/OS-EC2:
     get:
       tags:
@@ -5242,6 +5492,14 @@ paths:
           type:
           - string
           - 'null'
+      - name: type
+        in: query
+        description: Filter users by type (`local`, `federated`, `nonlocal`, `all`).
+        required: false
+        schema:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/UserType'
       - name: limit
         in: query
         description: Limit number of entries on the single response page.
@@ -5530,6 +5788,90 @@ paths:
       - x-auth: []
 components:
   schemas:
+    AccessRule:
+      type: object
+      description: |-
+        Short access rule representation.
+
+        Access rules are fine-grained permissions attached to application
+        credentials. Each rule constrains the credential to a specific service
+        type, HTTP method, and API path. Once created, an access rule can be
+        viewed and deleted independently of the application credential.
+      required:
+      - id
+      properties:
+        id:
+          type: string
+          description: |-
+            Unique identifier of the access rule. This ID can be used to reuse an
+            existing access rule when creating a new application credential.
+        method:
+          type:
+          - string
+          - 'null'
+          description: |-
+            HTTP method that this access rule permits (e.g., `GET`, `POST`, `PUT`,
+            `DELETE`, `PATCH`).
+        path:
+          type:
+          - string
+          - 'null'
+          description: |-
+            API path pattern that this access rule permits. Supports wildcard
+            syntax: `*` matches a single path segment, `**` matches any number
+            of segments recursively, and `{variable}` matches a named path
+            parameter. For example, `/v2.1/servers/*/ips` or `/v2.1/**`.
+        service:
+          type:
+          - string
+          - 'null'
+          description: |-
+            OpenStack service type that this access rule applies to
+            (e.g., `compute`, `monitoring`, `identity`). Matched against the
+            service catalog.
+    AccessRuleCreate:
+      type: object
+      description: |-
+        Access rule for creation (id is optional).
+
+        When creating an application credential, access rules can either be
+        defined inline (with `method`, `path`, and `service`) or reference an
+        existing rule by its `id`. All fields are optional so that both creation
+        patterns are supported.
+      properties:
+        id:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Optional identifier of an existing access rule to reuse. When
+            provided, the other fields (`method`, `path`, `service`) are ignored
+            and the referenced rule is attached to the new application credential.
+        method:
+          type:
+          - string
+          - 'null'
+          description: |-
+            HTTP method that this access rule permits (e.g., `GET`, `POST`, `PUT`,
+            `DELETE`, `PATCH`). Required when creating a new rule inline (i.e.,
+            without specifying `id`).
+        path:
+          type:
+          - string
+          - 'null'
+          description: |-
+            API path pattern that this access rule permits. Supports wildcard
+            syntax: `*` matches a single path segment, `**` matches any number
+            of segments recursively, and `{variable}` matches a named path
+            parameter. Required when creating a new rule inline.
+        service:
+          type:
+          - string
+          - 'null'
+          description: |-
+            OpenStack service type that this access rule applies to
+            (e.g., `compute`, `monitoring`, `identity`). Matched against the
+            service catalog. Required when creating a new rule inline.
     AllowCredentials:
       type: object
       description: A descriptor of a credential that can be used.
@@ -5804,6 +6146,219 @@ components:
         api_key:
           $ref: '#/components/schemas/ApiKeyUpdate'
           description: API Key update payload.
+    ApplicationCredential:
+      type: object
+      description: Full application credential representation.
+      required:
+      - id
+      - name
+      - project_id
+      - roles
+      - unrestricted
+      properties:
+        access_rules:
+          type:
+          - array
+          - 'null'
+          items:
+            $ref: '#/components/schemas/AccessRule'
+          description: |-
+            Optional list of access rules that restrict which API requests this
+            credential is permitted to make. Each rule specifies a service, HTTP
+            method, and URL path.
+        description:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Optional human-readable description of the application credential's
+            purpose.
+        expires_at:
+          type:
+          - string
+          - 'null'
+          format: date-time
+          description: |-
+            Optional expiration date and time for the application credential. After
+            this timestamp the credential is no longer valid. When `None`, the
+            credential does not expire.
+        id:
+          type: string
+          description: Unique identifier of the application credential.
+        name:
+          type: string
+          description: |-
+            User-provided name of the application credential. Must be unique within
+            the owning user's set of application credentials.
+        project_id:
+          type: string
+          description: Identifier of the project that the application credential is scoped to.
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleRef'
+          description: |-
+            List of roles delegated to this application credential. These must be a
+            subset of the roles the owning user holds on the target project.
+        unrestricted:
+          type: boolean
+          description: |-
+            Whether this application credential has unrestricted access. When
+            `false` (the default), the credential cannot be used to create
+            additional application credentials or trusts.
+    ApplicationCredentialCreate:
+      type: object
+      description: Data for creating an application credential.
+      required:
+      - name
+      - roles
+      properties:
+        access_rules:
+          type:
+          - array
+          - 'null'
+          items:
+            $ref: '#/components/schemas/AccessRuleCreate'
+          description: |-
+            Optional list of access rules to restrict which API requests the new
+            credential is allowed to make.
+        description:
+          type:
+          - string
+          - 'null'
+          description: Optional human-readable description of the application credential.
+        expires_at:
+          type:
+          - string
+          - 'null'
+          format: date-time
+          description: |-
+            Optional expiration date and time. When `None`, the credential does not
+            expire.
+        name:
+          type: string
+          description: |-
+            Name of the application credential. Must be unique among the owning
+            user's application credentials.
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleRef'
+          description: |-
+            Roles to delegate to the new credential. Must be a subset of the
+            user's roles on the project. Defaults to all of the user's roles on the
+            project when empty.
+        secret:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Optional secret to use for the new credential. If not provided, a
+            random secret will be generated.
+        unrestricted:
+          type:
+          - boolean
+          - 'null'
+          description: |-
+            Whether to allow unrestricted access. When `true`, the credential can
+            create additional application credentials or trusts, which is
+            potentially dangerous. Defaults to `false`.
+    ApplicationCredentialCreateRequest:
+      type: object
+      description: Wrapper for a create request body.
+      required:
+      - application_credential
+      properties:
+        application_credential:
+          $ref: '#/components/schemas/ApplicationCredentialCreate'
+          description: The application credential creation payload.
+    ApplicationCredentialCreateResponse:
+      type: object
+      description: Wrapper for create response body.
+      required:
+      - application_credential
+      properties:
+        application_credential:
+          $ref: '#/components/schemas/ApplicationCredentialCreated'
+          description: |-
+            The newly created application credential, including the one-time
+            secret.
+    ApplicationCredentialCreated:
+      type: object
+      description: |-
+        Application credential as returned by create — includes secret (shown once
+        only).
+      required:
+      - id
+      - name
+      - project_id
+      - roles
+      - secret
+      - unrestricted
+      properties:
+        access_rules:
+          type:
+          - array
+          - 'null'
+          items:
+            $ref: '#/components/schemas/AccessRule'
+          description: Optional list of access rules associated with the credential.
+        description:
+          type:
+          - string
+          - 'null'
+          description: Optional human-readable description of the application credential.
+        expires_at:
+          type:
+          - string
+          - 'null'
+          format: date-time
+          description: |-
+            Optional expiration date and time. `None` means the credential does not
+            expire.
+        id:
+          type: string
+          description: Unique identifier of the newly created application credential.
+        name:
+          type: string
+          description: Name of the application credential.
+        project_id:
+          type: string
+          description: Identifier of the project the credential is scoped to.
+        roles:
+          type: array
+          items:
+            $ref: '#/components/schemas/RoleRef'
+          description: List of roles delegated to this application credential.
+        secret:
+          type: string
+          description: |-
+            The secret used for authentication. The secret is hashed before storage,
+            so this is the only time it is returned in plaintext. If lost, a new
+            application credential must be created.
+        unrestricted:
+          type: boolean
+          description: Whether this credential has unrestricted access.
+    ApplicationCredentialList:
+      type: object
+      description: List of application credentials.
+      required:
+      - application_credentials
+      properties:
+        application_credentials:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApplicationCredential'
+          description: Collection of application credentials belonging to the user.
+    ApplicationCredentialResponse:
+      type: object
+      description: Wrapper for a single application credential response.
+      required:
+      - application_credential
+      properties:
+        application_credential:
+          $ref: '#/components/schemas/ApplicationCredential'
+          description: The application credential object.
     Assignment:
       type: object
       description: Assignment.
@@ -8331,6 +8886,140 @@ components:
         user_id:
           type: string
           description: The ID of the user that is authenticating.
+    Policy:
+      type: object
+      description: The policy data.
+      required:
+      - id
+      - type
+      - blob
+      properties:
+        blob:
+          description: |-
+            The policy rule set itself, as a serialized blob.
+
+            Any JSON value: normally the string the caller supplied on create, but
+            an object for rows written by older python keystone releases. No
+            `value_type` override here on purpose — `serde_json::Value`'s native
+            utoipa mapping is an unconstrained `AnyValue`, whereas `Object` would
+            document `type: object` and make a generated client reject the ordinary
+            string case.
+        id:
+          type: string
+          description: Policy ID.
+        type:
+          type: string
+          description: The MIME media type of the serialized policy blob.
+      additionalProperties: {}
+    PolicyCreate:
+      type: object
+      description: Policy create request body.
+      required:
+      - type
+      - blob
+      properties:
+        blob:
+          type: string
+          description: |-
+            The policy rule set itself, as a serialized blob. Required, and a
+            string only — see the module docs.
+        id:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Ignored: a caller-supplied `id` on create is discarded and a fresh
+            UUID assigned, matching python keystone's `_assign_unique_id`.
+
+            Declared explicitly (rather than left to `extra`'s `#[serde(flatten)]`)
+            so it is *consumed* here instead of being silently persisted as an
+            extra property.
+
+            Typed as an arbitrary `Value`, not `String`: upstream never validates
+            it — `id` is not in `_policy_properties`, so it arrives as an
+            unconstrained `additionalProperties` entry and is then overwritten. A
+            `{"id": 123}` body is therefore a 201 upstream, and must not be a 400
+            here.
+        type:
+          type: string
+          description: |-
+            The MIME media type of the serialized policy blob.
+
+            Required, but only length-capped: python keystone's schema is
+            `{'type': 'string', 'maxLength': 255}`, so the empty string is valid.
+      additionalProperties:
+        description: Extra attributes for the policy.
+    PolicyCreateRequest:
+      type: object
+      description: New policy creation request.
+      required:
+      - policy
+      properties:
+        policy:
+          $ref: '#/components/schemas/PolicyCreate'
+          description: Policy object.
+    PolicyList:
+      type: object
+      description: Policies.
+      required:
+      - policies
+      properties:
+        links:
+          type:
+          - array
+          - 'null'
+          items:
+            $ref: '#/components/schemas/Link'
+          description: Pagination links.
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Policy'
+          description: Collection of policy objects.
+    PolicyResponse:
+      type: object
+      required:
+      - policy
+      properties:
+        policy:
+          $ref: '#/components/schemas/Policy'
+          description: Policy object.
+    PolicyUpdate:
+      type: object
+      description: Update policy data.
+      properties:
+        blob:
+          type:
+          - string
+          - 'null'
+          description: New policy blob. String only — see the module docs.
+        id:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Only accepted when equal to the `{policy_id}` path segment; a
+            different value is a 400 ("Cannot change policy ID"), matching python
+            keystone's `Manager.update_policy`. Never persisted.
+
+            Declared explicitly so it is consumed here rather than landing in
+            `extra`.
+        type:
+          type:
+          - string
+          - 'null'
+          description: New MIME media type of the serialized policy blob.
+      additionalProperties:
+        description: Extra attributes for the policy, merged into the stored properties.
+    PolicyUpdateRequest:
+      type: object
+      description: Policy update request.
+      required:
+      - policy
+      properties:
+        policy:
+          $ref: '#/components/schemas/PolicyUpdate'
+          description: Policy object.
     Project:
       type: object
       description: Project information.
@@ -10413,6 +11102,14 @@ components:
         user:
           $ref: '#/components/schemas/User'
           description: User object.
+    UserType:
+      type: string
+      description: User type filter for listing users.
+      enum:
+      - all
+      - federated
+      - local
+      - nonlocal
     UserUpdate:
       type: object
       description: Update user data.

--- a/openstack_types/data/identity/v3.14.yaml
+++ b/openstack_types/data/identity/v3.14.yaml
@@ -7112,6 +7112,32 @@ paths:
         - users
     parameters:
       - $ref: '#/components/parameters/users_projects_user_id'
+  /v3/users/{user_id}/tokens:
+    delete:
+      description: |-
+        Revoke all tokens for a user.
+
+        DELETE /v3/users/{user_id}/tokens
+
+        Revokes every token issued for the given user by creating a
+        revocation event scoped to user_id. This is the self-service
+        remedy for users who cannot change their password (LDAP,
+        federated, OIDC) and need to invalidate all active sessions.
+
+        Users may revoke their own tokens. Admins may revoke tokens for
+        any user.
+      operationId: users/user_id/tokens:delete
+      responses:
+        '204':
+          description: Ok
+        '403':
+          description: Error
+        '404':
+          description: Error
+      tags:
+        - users
+    parameters:
+      - $ref: '#/components/parameters/users_tokens_user_id'
 components:
   headers:
     Openstack-Auth-Receipt:
@@ -8766,6 +8792,16 @@ components:
       schema:
         description: Sorts resources by attribute.
         type: string
+    users_tokens_user_id:
+      description: |-
+        user_id parameter for /v3/users/{user_id}/tokens API
+      in: path
+      name: user_id
+      required: true
+      schema:
+        type: string
+      x-openstack:
+        resource_link: identity/v3/user.id
     users_unique_id:
       description: Filters the response by a unique ID.
       in: query

--- a/openstack_types/data/identity/v3.yaml
+++ b/openstack_types/data/identity/v3.yaml
@@ -7112,6 +7112,32 @@ paths:
         - users
     parameters:
       - $ref: '#/components/parameters/users_projects_user_id'
+  /v3/users/{user_id}/tokens:
+    delete:
+      description: |-
+        Revoke all tokens for a user.
+
+        DELETE /v3/users/{user_id}/tokens
+
+        Revokes every token issued for the given user by creating a
+        revocation event scoped to user_id. This is the self-service
+        remedy for users who cannot change their password (LDAP,
+        federated, OIDC) and need to invalidate all active sessions.
+
+        Users may revoke their own tokens. Admins may revoke tokens for
+        any user.
+      operationId: users/user_id/tokens:delete
+      responses:
+        '204':
+          description: Ok
+        '403':
+          description: Error
+        '404':
+          description: Error
+      tags:
+        - users
+    parameters:
+      - $ref: '#/components/parameters/users_tokens_user_id'
 components:
   headers:
     Openstack-Auth-Receipt:
@@ -8766,6 +8792,16 @@ components:
       schema:
         description: Sorts resources by attribute.
         type: string
+    users_tokens_user_id:
+      description: |-
+        user_id parameter for /v3/users/{user_id}/tokens API
+      in: path
+      name: user_id
+      required: true
+      schema:
+        type: string
+      x-openstack:
+        resource_link: identity/v3/user.id
     users_unique_id:
       description: Filters the response by a unique ID.
       in: query

--- a/openstack_types/data/network/v2.29.yaml
+++ b/openstack_types/data/network/v2.29.yaml
@@ -15937,10 +15937,14 @@ components:
             ipv4_address_scope:
               description: |-
                 The ID of the IPv4 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv4
+                address scope.
               type: string
             ipv6_address_scope:
               description: |-
                 The ID of the IPv6 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv6
+                address scope.
               type: string
             is_default:
               description: |-
@@ -16241,10 +16245,14 @@ components:
             ipv4_address_scope:
               description: |-
                 The ID of the IPv4 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv4
+                address scope.
               type: string
             ipv6_address_scope:
               description: |-
                 The ID of the IPv6 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv6
+                address scope.
               type: string
             is_default:
               description: |-
@@ -17076,10 +17084,14 @@ components:
             ipv4_address_scope:
               description: |-
                 The ID of the IPv4 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv4
+                address scope.
               type: string
             ipv6_address_scope:
               description: |-
                 The ID of the IPv6 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv6
+                address scope.
               type: string
             is_default:
               description: |-
@@ -17290,10 +17302,14 @@ components:
               ipv4_address_scope:
                 description: |-
                   The ID of the IPv4 address scope that the network is associated with.
+                  This value is `null` if the network is not associated with any IPv4
+                  address scope.
                 type: string
               ipv6_address_scope:
                 description: |-
                   The ID of the IPv6 address scope that the network is associated with.
+                  This value is `null` if the network is not associated with any IPv6
+                  address scope.
                 type: string
               is_default:
                 description: |-
@@ -17937,7 +17953,8 @@ components:
                 by the port, and a `resources` key contains a mapping of requested
                 resource class name and requested amount from the QoS policy.
                 `same_subtree` key contains a list of `id` values from every resource
-                group.
+                group. This value is `null` if the port does not request any Placement
+                resources.
               type: string
             revision_number:
               description: |-
@@ -18467,7 +18484,8 @@ components:
                 by the port, and a `resources` key contains a mapping of requested
                 resource class name and requested amount from the QoS policy.
                 `same_subtree` key contains a list of `id` values from every resource
-                group.
+                group. This value is `null` if the port does not request any Placement
+                resources.
               type: string
             revision_number:
               description: |-
@@ -19307,7 +19325,8 @@ components:
                 by the port, and a `resources` key contains a mapping of requested
                 resource class name and requested amount from the QoS policy.
                 `same_subtree` key contains a list of `id` values from every resource
-                group.
+                group. This value is `null` if the port does not request any Placement
+                resources.
               type: string
             revision_number:
               description: |-
@@ -19618,7 +19637,8 @@ components:
                   by the port, and a `resources` key contains a mapping of requested
                   resource class name and requested amount from the QoS policy.
                   `same_subtree` key contains a list of `id` values from every resource
-                  group.
+                  group. This value is `null` if the port does not request any Placement
+                  resources.
                 type: string
               revision_number:
                 description: |-
@@ -27185,7 +27205,7 @@ components:
             ipv6_address_mode:
               description: |-
                 The IPv6 address modes specifies mechanisms for assigning IP addresses.
-                Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless`.
+                Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
               enum:
                 - dhcpv6-stateful
                 - dhcpv6-stateless
@@ -27195,7 +27215,7 @@ components:
               description: |-
                 The IPv6 router advertisement specifies whether the networking service
                 should transmit ICMPv6 packets, for a subnet. Value is `slaac`,
-                `dhcpv6-stateful`, `dhcpv6-stateless`.
+                `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
               enum:
                 - dhcpv6-stateful
                 - dhcpv6-stateless

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -15937,10 +15937,14 @@ components:
             ipv4_address_scope:
               description: |-
                 The ID of the IPv4 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv4
+                address scope.
               type: string
             ipv6_address_scope:
               description: |-
                 The ID of the IPv6 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv6
+                address scope.
               type: string
             is_default:
               description: |-
@@ -16241,10 +16245,14 @@ components:
             ipv4_address_scope:
               description: |-
                 The ID of the IPv4 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv4
+                address scope.
               type: string
             ipv6_address_scope:
               description: |-
                 The ID of the IPv6 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv6
+                address scope.
               type: string
             is_default:
               description: |-
@@ -17076,10 +17084,14 @@ components:
             ipv4_address_scope:
               description: |-
                 The ID of the IPv4 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv4
+                address scope.
               type: string
             ipv6_address_scope:
               description: |-
                 The ID of the IPv6 address scope that the network is associated with.
+                This value is `null` if the network is not associated with any IPv6
+                address scope.
               type: string
             is_default:
               description: |-
@@ -17290,10 +17302,14 @@ components:
               ipv4_address_scope:
                 description: |-
                   The ID of the IPv4 address scope that the network is associated with.
+                  This value is `null` if the network is not associated with any IPv4
+                  address scope.
                 type: string
               ipv6_address_scope:
                 description: |-
                   The ID of the IPv6 address scope that the network is associated with.
+                  This value is `null` if the network is not associated with any IPv6
+                  address scope.
                 type: string
               is_default:
                 description: |-
@@ -17937,7 +17953,8 @@ components:
                 by the port, and a `resources` key contains a mapping of requested
                 resource class name and requested amount from the QoS policy.
                 `same_subtree` key contains a list of `id` values from every resource
-                group.
+                group. This value is `null` if the port does not request any Placement
+                resources.
               type: string
             revision_number:
               description: |-
@@ -18467,7 +18484,8 @@ components:
                 by the port, and a `resources` key contains a mapping of requested
                 resource class name and requested amount from the QoS policy.
                 `same_subtree` key contains a list of `id` values from every resource
-                group.
+                group. This value is `null` if the port does not request any Placement
+                resources.
               type: string
             revision_number:
               description: |-
@@ -19307,7 +19325,8 @@ components:
                 by the port, and a `resources` key contains a mapping of requested
                 resource class name and requested amount from the QoS policy.
                 `same_subtree` key contains a list of `id` values from every resource
-                group.
+                group. This value is `null` if the port does not request any Placement
+                resources.
               type: string
             revision_number:
               description: |-
@@ -19618,7 +19637,8 @@ components:
                   by the port, and a `resources` key contains a mapping of requested
                   resource class name and requested amount from the QoS policy.
                   `same_subtree` key contains a list of `id` values from every resource
-                  group.
+                  group. This value is `null` if the port does not request any Placement
+                  resources.
                 type: string
               revision_number:
                 description: |-
@@ -27185,7 +27205,7 @@ components:
             ipv6_address_mode:
               description: |-
                 The IPv6 address modes specifies mechanisms for assigning IP addresses.
-                Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless`.
+                Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
               enum:
                 - dhcpv6-stateful
                 - dhcpv6-stateless
@@ -27195,7 +27215,7 @@ components:
               description: |-
                 The IPv6 router advertisement specifies whether the networking service
                 should transmit ICMPv6 packets, for a subnet. Value is `slaac`,
-                `dhcpv6-stateful`, `dhcpv6-stateless`.
+                `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
               enum:
                 - dhcpv6-stateful
                 - dhcpv6-stateless

--- a/sdk/network/src/v2/subnet/create.rs
+++ b/sdk/network/src/v2/subnet/create.rs
@@ -167,14 +167,14 @@ pub struct Subnet<'a> {
     pub(crate) ip_version: i32,
 
     /// The IPv6 address modes specifies mechanisms for assigning IP addresses.
-    /// Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless`.
+    /// Value is `slaac`, `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub(crate) ipv6_address_mode: Option<Ipv6AddressMode>,
 
     /// The IPv6 router advertisement specifies whether the networking service
     /// should transmit ICMPv6 packets, for a subnet. Value is `slaac`,
-    /// `dhcpv6-stateful`, `dhcpv6-stateless`.
+    /// `dhcpv6-stateful`, `dhcpv6-stateless` or `null`.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default)]
     pub(crate) ipv6_ra_mode: Option<Ipv6RaMode>,

--- a/types/compute/src/v2/server/response/list_21.rs
+++ b/types/compute/src/v2/server/response/list_21.rs
@@ -22,7 +22,6 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
-    /// The UUID of the server.
     #[structable()]
     pub id: String,
 

--- a/types/compute/src/v2/server/response/list_detailed_216.rs
+++ b/types/compute/src/v2/server/response/list_detailed_216.rs
@@ -23,8 +23,6 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
-    /// IPv4 address that should be used to access this server. May be
-    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,

--- a/types/network/src/v2/network/response/create.rs
+++ b/types/network/src/v2/network/response/create.rs
@@ -62,11 +62,15 @@ pub struct NetworkResponse {
     pub id: Option<String>,
 
     /// The ID of the IPv4 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv4
+    /// address scope.
     #[serde(default)]
     #[structable(optional)]
     pub ipv4_address_scope: Option<String>,
 
     /// The ID of the IPv6 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv6
+    /// address scope.
     #[serde(default)]
     #[structable(optional)]
     pub ipv6_address_scope: Option<String>,

--- a/types/network/src/v2/network/response/get.rs
+++ b/types/network/src/v2/network/response/get.rs
@@ -62,11 +62,15 @@ pub struct NetworkResponse {
     pub id: Option<String>,
 
     /// The ID of the IPv4 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv4
+    /// address scope.
     #[serde(default)]
     #[structable(optional)]
     pub ipv4_address_scope: Option<String>,
 
     /// The ID of the IPv6 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv6
+    /// address scope.
     #[serde(default)]
     #[structable(optional)]
     pub ipv6_address_scope: Option<String>,

--- a/types/network/src/v2/network/response/list.rs
+++ b/types/network/src/v2/network/response/list.rs
@@ -62,11 +62,15 @@ pub struct NetworkResponse {
     pub id: Option<String>,
 
     /// The ID of the IPv4 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv4
+    /// address scope.
     #[serde(default)]
     #[structable(optional, wide)]
     pub ipv4_address_scope: Option<String>,
 
     /// The ID of the IPv6 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv6
+    /// address scope.
     #[serde(default)]
     #[structable(optional, wide)]
     pub ipv6_address_scope: Option<String>,

--- a/types/network/src/v2/network/response/set.rs
+++ b/types/network/src/v2/network/response/set.rs
@@ -62,11 +62,15 @@ pub struct NetworkResponse {
     pub id: Option<String>,
 
     /// The ID of the IPv4 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv4
+    /// address scope.
     #[serde(default)]
     #[structable(optional)]
     pub ipv4_address_scope: Option<String>,
 
     /// The ID of the IPv6 address scope that the network is associated with.
+    /// This value is `null` if the network is not associated with any IPv6
+    /// address scope.
     #[serde(default)]
     #[structable(optional)]
     pub ipv6_address_scope: Option<String>,

--- a/types/network/src/v2/port/response/create.rs
+++ b/types/network/src/v2/port/response/create.rs
@@ -238,7 +238,8 @@ pub struct PortResponse {
     /// (generated from the `vnic_type` and the `physnet`) required by the
     /// port, and a `resources` key contains a mapping of requested resource
     /// class name and requested amount from the QoS policy. `same_subtree` key
-    /// contains a list of `id` values from every resource group.
+    /// contains a list of `id` values from every resource group. This value is
+    /// `null` if the port does not request any Placement resources.
     #[serde(default)]
     #[structable(optional)]
     pub resource_request: Option<String>,

--- a/types/network/src/v2/port/response/get.rs
+++ b/types/network/src/v2/port/response/get.rs
@@ -238,7 +238,8 @@ pub struct PortResponse {
     /// (generated from the `vnic_type` and the `physnet`) required by the
     /// port, and a `resources` key contains a mapping of requested resource
     /// class name and requested amount from the QoS policy. `same_subtree` key
-    /// contains a list of `id` values from every resource group.
+    /// contains a list of `id` values from every resource group. This value is
+    /// `null` if the port does not request any Placement resources.
     #[serde(default)]
     #[structable(optional)]
     pub resource_request: Option<String>,

--- a/types/network/src/v2/port/response/list.rs
+++ b/types/network/src/v2/port/response/list.rs
@@ -238,7 +238,8 @@ pub struct PortResponse {
     /// (generated from the `vnic_type` and the `physnet`) required by the
     /// port, and a `resources` key contains a mapping of requested resource
     /// class name and requested amount from the QoS policy. `same_subtree` key
-    /// contains a list of `id` values from every resource group.
+    /// contains a list of `id` values from every resource group. This value is
+    /// `null` if the port does not request any Placement resources.
     #[serde(default)]
     #[structable(optional, wide)]
     pub resource_request: Option<String>,

--- a/types/network/src/v2/port/response/set.rs
+++ b/types/network/src/v2/port/response/set.rs
@@ -238,7 +238,8 @@ pub struct PortResponse {
     /// (generated from the `vnic_type` and the `physnet`) required by the
     /// port, and a `resources` key contains a mapping of requested resource
     /// class name and requested amount from the QoS policy. `same_subtree` key
-    /// contains a list of `id` values from every resource group.
+    /// contains a list of `id` values from every resource group. This value is
+    /// `null` if the port does not request any Placement resources.
     #[serde(default)]
     #[structable(optional)]
     pub resource_request: Option<String>,


### PR DESCRIPTION
RustResourceBehaviourGenerator previously imported the resource's
openstack_types response struct directly as ResourceBehaviour::Item.
That doesn't work for microversioned resources where the response
schema genuinely changes shape across variants (e.g. compute.flavor's
swap i64->i32) -- no single generated struct is correct for every
version.

generate_behaviour now builds a ColumnSpec array from the resource's
.config/config.yaml views.<res> entry (default_fields, wide_fields,
fields[].json_pointer overrides, status_field) and emits
impl_dynamic_item!(...) instead, reading columns out of the raw
response by JSON pointer at render time. The config already carries
this data by hand for every resource; there's no need for the
generator to also scrape #[structable(...)] attrs out of generated
struct source to arrive at the same information.

A resource with no `views` entry in config.yaml is skipped (same
skip-not-crash pattern as the existing filter_type check) rather than
generated with empty columns. api_version is no longer required
either, since nothing derives an openstack_types import path from it
anymore.

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/999311

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
