### PR TITLE
feat: Add microversion negotiation strategy to RestClient

### DIFF
--- a/openstack_sdk/src/lib.rs
+++ b/openstack_sdk/src/lib.rs
@@ -34,6 +34,7 @@ pub use openstack_async::{AsyncOpenStack, AsyncOpenStackBuilder, RenewHandle};
 mod openstack;
 #[cfg(all(feature = "sync", feature = "async"))]
 pub use openstack::OpenStack;
+pub use openstack_sdk_core::api::MicroVersionStrategy;
 pub use openstack_sdk_core::auth::AuthError;
 pub use openstack_sdk_core::{BuilderError, OpenStackError, RestError};
 

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -30,7 +30,7 @@ use openstack_sdk_auth_core::{
     authtoken_scope::AuthTokenScope,
     types::{AuthResponse, Project},
 };
-use openstack_sdk_core::api::{self, Client, RestClient};
+use openstack_sdk_core::api::{self, Client, MicroVersionStrategy, RestClient};
 use openstack_sdk_core::auth::{AuthState, auth_helper::AuthHelper};
 use openstack_sdk_core::config::CloudConfig;
 use openstack_sdk_core::error::{OpenStackResult, RestError};
@@ -109,6 +109,10 @@ impl RestClient for OpenStack {
 
     fn get_current_project(&self) -> Option<Project> {
         self.inner.get_current_project()
+    }
+
+    fn microversion_strategy(&self) -> MicroVersionStrategy {
+        self.inner.microversion_strategy()
     }
 }
 
@@ -211,6 +215,12 @@ impl OpenStackBuilder {
     /// Override the idle connection pool timeout (default: 30s).
     pub fn http_pool_idle_timeout(mut self, timeout: std::time::Duration) -> Self {
         self.inner = self.inner.http_pool_idle_timeout(timeout);
+        self
+    }
+
+    /// Set the microversion negotiation strategy (default: `Floor`).
+    pub fn microversion_strategy(mut self, strategy: MicroVersionStrategy) -> Self {
+        self.inner = self.inner.microversion_strategy(strategy);
         self
     }
 

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -50,7 +50,7 @@ use openstack_sdk_auth_token as token_auth;
 use crate::auth::authtoken::{AuthType, build_token_info_endpoint};
 use crate::session;
 
-use openstack_sdk_core::api::{self, AsyncClient, QueryAsync, query, raw};
+use openstack_sdk_core::api::{self, AsyncClient, MicroVersionStrategy, QueryAsync, query, raw};
 use openstack_sdk_core::auth::{
     AuthState,
     auth_helper::{AuthHelper, Dialoguer, Noop},
@@ -140,6 +140,8 @@ pub struct AsyncOpenStack {
     /// on one re-auth instead of each running their own. Also intended to be
     /// shared with any future proactive token-renewal task.
     reauth_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Strategy for picking the microversion sent in the request header.
+    microversion_strategy: MicroVersionStrategy,
 }
 
 impl Clone for AsyncOpenStack {
@@ -152,6 +154,7 @@ impl Clone for AsyncOpenStack {
             auth_helper: self.auth_helper.clone(),
             max_auth_retries: self.max_auth_retries,
             reauth_lock: Arc::clone(&self.reauth_lock),
+            microversion_strategy: self.microversion_strategy,
         }
     }
 }
@@ -174,6 +177,10 @@ impl api::RestClient for AsyncOpenStack {
             return token.auth_info.clone().and_then(|x| x.token.project);
         }
         None
+    }
+
+    fn microversion_strategy(&self) -> MicroVersionStrategy {
+        self.microversion_strategy
     }
 }
 
@@ -382,6 +389,7 @@ pub struct AsyncOpenStackBuilder {
     renew_auth: bool,
     max_auth_retries: u32,
     http_options: HttpClientOptions,
+    microversion_strategy: MicroVersionStrategy,
 }
 
 impl AsyncOpenStackBuilder {
@@ -393,6 +401,7 @@ impl AsyncOpenStackBuilder {
             renew_auth: false,
             max_auth_retries: DEFAULT_MAX_AUTH_RETRIES,
             http_options: HttpClientOptions::default(),
+            microversion_strategy: MicroVersionStrategy::default(),
         }
     }
 
@@ -469,6 +478,16 @@ impl AsyncOpenStackBuilder {
         self
     }
 
+    /// Set the microversion negotiation strategy (default: `Floor`).
+    ///
+    /// [`MicroVersionStrategy::Floor`] sends the lowest compatible
+    /// microversion (backwards-compatible). [`MicroVersionStrategy::Ceiling`]
+    /// sends the highest compatible microversion.
+    pub fn microversion_strategy(mut self, strategy: MicroVersionStrategy) -> Self {
+        self.microversion_strategy = strategy;
+        self
+    }
+
     /// Establish the session: resolves the Identity endpoint via version
     /// discovery, then authorizes using the configured auth helper (or
     /// [`Noop`] if none was set).
@@ -481,6 +500,7 @@ impl AsyncOpenStackBuilder {
             &self.http_options,
         )?;
         session.max_auth_retries = self.max_auth_retries;
+        session.microversion_strategy = self.microversion_strategy;
 
         session
             .discover_service_endpoint(&ServiceType::Identity)
@@ -614,6 +634,7 @@ impl AsyncOpenStack {
             auth_helper: None,
             max_auth_retries: DEFAULT_MAX_AUTH_RETRIES,
             reauth_lock: Arc::new(tokio::sync::Mutex::new(())),
+            microversion_strategy: MicroVersionStrategy::default(),
         })
     }
 
@@ -839,6 +860,7 @@ impl AsyncOpenStack {
         let auth_helper = self.auth_helper.clone();
         let max_auth_retries = self.max_auth_retries;
         let reauth_lock = Arc::clone(&self.reauth_lock);
+        let microversion_strategy = self.microversion_strategy;
 
         let join = tokio::spawn(async move {
             // Rebuilds a client around the currently-live `session` Arc, or
@@ -852,6 +874,7 @@ impl AsyncOpenStack {
                     auth_helper: auth_helper.clone(),
                     max_auth_retries,
                     reauth_lock: Arc::clone(&reauth_lock),
+                    microversion_strategy,
                 })
             };
 
@@ -1718,6 +1741,7 @@ mod tests {
             auth_helper,
             max_auth_retries: max_retries,
             reauth_lock: Arc::new(tokio::sync::Mutex::new(())),
+            microversion_strategy: MicroVersionStrategy::default(),
         }
     }
 

--- a/openstack_tui/src/cloud_worker.rs
+++ b/openstack_tui/src/cloud_worker.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use chrono::TimeDelta;
 use eyre::{Result, eyre};
 use openstack_sdk::{
-    AsyncOpenStack, RenewHandle,
+    AsyncOpenStack, MicroVersionStrategy, RenewHandle,
     auth::auth_helper::{AuthHelper, AuthHelperError},
     config::ConfigFile,
 };
@@ -107,12 +107,12 @@ impl Cloud {
             .cloud_configs
             .get_cloud_config(cloud.clone())?
             .ok_or_else(|| eyre!("Cloud `{}` is not present in configuration files", cloud))?;
-        let session = AsyncOpenStack::new_with_authentication_helper(
-            &profile,
-            self.auth_helper.clone(),
-            false,
-        )
-        .await?;
+        let session = AsyncOpenStack::builder(&profile)
+            .auth_helper(self.auth_helper.clone())
+            .renew_auth(false)
+            .microversion_strategy(MicroVersionStrategy::Ceiling)
+            .connect()
+            .await?;
 
         Self::discover_services(&session, &TUI_SERVICES).await?;
 

--- a/sdk/core/src/api.rs
+++ b/sdk/core/src/api.rs
@@ -461,6 +461,7 @@ mod wait;
 pub use self::error::ApiError;
 pub use self::error::BodyError;
 
+pub use self::client::MicroVersionStrategy;
 pub use self::client::RestClient;
 
 pub use self::rest_endpoint::RestEndpoint;

--- a/sdk/core/src/api/client.rs
+++ b/sdk/core/src/api/client.rs
@@ -26,6 +26,25 @@ use crate::api::ApiError;
 use crate::catalog::ServiceEndpoint;
 use crate::types::{ApiVersion, BoxedAsyncRead, ServiceType};
 
+/// Strategy used to pick the microversion sent in the request header.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MicroVersionStrategy {
+    /// Send `max(endpoint.min_version, cloud.min_version)` — the lowest
+    /// compatible microversion (conservative, what the generated code was
+    /// written against).
+    #[default]
+    Floor,
+    /// Send `min(endpoint.max_version, cloud.max_version)`.
+    ///
+    /// When `endpoint.max_version()` is `None` falls back to
+    /// `cloud.max_version`, or to floor semantics when the latter is also
+    /// `None`.
+    ///
+    /// Useful when the response side already handles unknown extra fields
+    /// (e.g. `serde_json::Value` parsing).
+    Ceiling,
+}
+
 /// A trait representing a client which can communicate with a OpenStack service API via REST API.
 pub trait RestClient {
     /// The errors which may occur for this client.
@@ -33,6 +52,11 @@ pub trait RestClient {
 
     /// Get current token project information
     fn get_current_project(&self) -> Option<Project>;
+
+    /// Returns the default microversion negotiation strategy (floor).
+    fn microversion_strategy(&self) -> MicroVersionStrategy {
+        MicroVersionStrategy::Floor
+    }
 }
 
 /// A trait representing a client which can communicate with a OpenStack cloud APIs.

--- a/sdk/core/src/api/ignore.rs
+++ b/sdk/core/src/api/ignore.rs
@@ -56,6 +56,7 @@ where
             &ep,
             ep.build_request_url(&self.endpoint.endpoint())?,
             &self.endpoint,
+            client,
         )?;
 
         let query_uri = req.uri_ref().cloned();
@@ -93,6 +94,7 @@ where
             &ep,
             ep.build_request_url(&self.endpoint.endpoint())?,
             &self.endpoint,
+            client,
         )?;
 
         let query_uri = req.uri_ref().cloned();

--- a/sdk/core/src/api/paged.rs
+++ b/sdk/core/src/api/paged.rs
@@ -138,7 +138,7 @@ where
                 .method(self.endpoint.method())
                 .uri(query::url_to_http_uri(page_url.clone())?)
                 .header(header::ACCEPT, HeaderValue::from_static("application/json"));
-            set_request_microversion_header::<C, E>(&mut req, &ep, &self.endpoint)?;
+            set_request_microversion_header::<C, E>(&mut req, &ep, &self.endpoint, client)?;
             // Set endpoint headers
             if let Some(request_headers) = self.endpoint.request_headers()
                 && let Some(headers) = req.headers_mut()

--- a/sdk/core/src/api/paged/iter.rs
+++ b/sdk/core/src/api/paged/iter.rs
@@ -369,7 +369,7 @@ where
             return Ok(Vec::new());
         };
         let (mut req, data) = self.build_request::<C>(url.clone())?;
-        set_request_microversion_header::<C, E>(&mut req, &ep, &self.paged.endpoint)?;
+        set_request_microversion_header::<C, E>(&mut req, &ep, &self.paged.endpoint, client)?;
         let rsp = client.rest(req, data)?;
         self.process_response::<C, _>(rsp, url.clone())
     }
@@ -399,7 +399,7 @@ where
             return Ok(Vec::new());
         };
         let (mut req, data) = self.build_request::<C>(url.clone())?;
-        set_request_microversion_header::<C, E>(&mut req, &ep, &self.paged.endpoint)?;
+        set_request_microversion_header::<C, E>(&mut req, &ep, &self.paged.endpoint, client)?;
         let rsp = client.rest_async(req, data).await?;
         self.process_response::<C, _>(rsp, url.clone())
     }

--- a/sdk/core/src/api/raw.rs
+++ b/sdk/core/src/api/raw.rs
@@ -137,6 +137,7 @@ where
             &ep,
             ep.build_request_url(&self.endpoint.endpoint())?,
             &self.endpoint,
+            client,
         )?;
 
         let query_uri = req.uri_ref().cloned();
@@ -169,6 +170,7 @@ where
             &ep,
             ep.build_request_url(&self.endpoint.endpoint())?,
             &self.endpoint,
+            client,
         )?;
 
         let query_uri = req.uri_ref().cloned();
@@ -215,6 +217,7 @@ where
             &ep,
             ep.build_request_url(&self.endpoint.endpoint())?,
             &self.endpoint,
+            client,
         )?;
 
         client.download_async(req, data).await

--- a/sdk/core/src/api/rest_endpoint.rs
+++ b/sdk/core/src/api/rest_endpoint.rs
@@ -31,7 +31,7 @@ use serde::de::DeserializeOwned;
 
 use serde_json::json;
 
-use crate::api::{ApiError, BodyError, QueryParams, RestClient, query};
+use crate::api::{ApiError, BodyError, MicroVersionStrategy, QueryParams, RestClient, query};
 #[cfg(feature = "async")]
 use crate::api::{AsyncClient, QueryAsync, RawQueryAsync};
 #[cfg(feature = "sync")]
@@ -198,7 +198,14 @@ where
 /// Validate the endpoint's microversion against the cloud's discovered
 /// range and set the `OpenStack-API-Version` header.
 ///
-/// See [`negotiate_microversion`] for how the sent version is picked.
+/// The requested version is picked according to
+/// [`RestClient::microversion_strategy`]. When the strategy is
+/// [`MicroVersionStrategy::Floor`] the lowest compatible microversion is
+/// sent (floor semantics — backwards compatible with pre-existing behaviour).
+/// When the strategy is [`MicroVersionStrategy::Ceiling`] the highest
+/// compatible microversion is sent.
+///
+/// See [`negotiate_microversion`] for how bounds checking works.
 /// Returns `Ok(())` when the header was set (or skipped for unversioned
 /// endpoints, or an unrecognized service type). Returns `Err` when no
 /// version can satisfy both the endpoint's and the cloud's constraints.
@@ -206,14 +213,34 @@ pub fn set_request_microversion_header<C, E>(
     request: &mut Builder,
     service_endpoint: &ServiceEndpoint,
     endpoint: &E,
+    client: &C,
 ) -> Result<(), ApiError<C::Error>>
 where
     C: RestClient,
     E: RestEndpoint,
 {
-    let Some(req_ver) = negotiate_microversion::<C, E>(service_endpoint, endpoint)? else {
+    let Some(mut req_ver) = negotiate_microversion::<C, E>(service_endpoint, endpoint)? else {
         return Ok(());
     };
+
+    // Ceiling strategy: pick the highest compatible microversion instead
+    // of the lowest.  Negotiate above already validated that a compatible
+    // range exists, so we only need to compute the upper bound.
+    if client.microversion_strategy() == MicroVersionStrategy::Ceiling {
+        let ep_max = endpoint.max_version();
+        let cloud_max: Option<ApiVersion> = service_endpoint
+            .max_version()
+            .as_deref()
+            .and_then(|s| ApiVersion::from_apiver_str(s, false).ok());
+        if let Some(ceil) = match (ep_max, cloud_max) {
+            (Some(em), Some(cm)) => Some(em.min(cm)),
+            (Some(em), None) => Some(em), // no cloud max → use endpoint max
+            (None, Some(cm)) => Some(cm), // no endpoint max → use cloud max
+            (None, None) => None,         // no ceiling info → fall back to floor
+        } {
+            req_ver = ceil;
+        }
+    }
 
     let Some(st) = (match endpoint.service_type() {
         ServiceType::BlockStorage => Some("volume"),
@@ -237,6 +264,7 @@ pub fn prepare_request<C, E>(
     service_endpoint: &ServiceEndpoint,
     mut url: Url,
     endpoint: &E,
+    client: &C,
 ) -> Result<(Builder, Vec<u8>), ApiError<C::Error>>
 where
     E: RestEndpoint,
@@ -247,7 +275,7 @@ where
         .method(endpoint.method())
         .uri(query::url_to_http_uri(url)?)
         .header(header::ACCEPT, HeaderValue::from_static("application/json"));
-    set_request_microversion_header::<C, E>(&mut req, service_endpoint, endpoint)?;
+    set_request_microversion_header::<C, E>(&mut req, service_endpoint, endpoint, client)?;
     if let Some(request_headers) = endpoint.request_headers()
         && let Some(headers) = req.headers_mut()
     {
@@ -312,7 +340,7 @@ where
     fn query(&self, client: &C) -> Result<T, ApiError<C::Error>> {
         let ep = client.get_service_endpoint(&self.service_type(), self.api_version().as_ref())?;
         let url = ep.build_request_url(&self.endpoint())?;
-        let (req, data) = prepare_request::<C, E>(&ep, url, self)?;
+        let (req, data) = prepare_request::<C, E>(&ep, url, self, client)?;
 
         let query_uri = req.uri_ref().cloned();
         let rsp = client.rest(req, data)?;
@@ -365,7 +393,7 @@ where
             .get_service_endpoint(&self.service_type(), self.api_version().as_ref())
             .await?;
         let (req, data) =
-            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self)?;
+            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self, client)?;
 
         let query_uri = req.uri_ref().cloned();
         let rsp = client.rest_async(req, data).await?;
@@ -415,7 +443,7 @@ where
     fn raw_query(&self, client: &C) -> Result<Response<Bytes>, ApiError<C::Error>> {
         let ep = client.get_service_endpoint(&self.service_type(), self.api_version().as_ref())?;
         let (req, data) =
-            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self)?;
+            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self, client)?;
 
         let rsp = client.rest(req, data)?;
 
@@ -441,7 +469,7 @@ where
             .get_service_endpoint(&self.service_type(), self.api_version().as_ref())
             .await?;
         let (req, data) =
-            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self)?;
+            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self, client)?;
 
         let query_uri = req.uri_ref().cloned();
         let rsp = client.rest_async(req, data).await?;
@@ -470,7 +498,7 @@ where
         let mut req = Request::builder()
             .method(self.method())
             .uri(query::url_to_http_uri(url)?);
-        set_request_microversion_header::<C, E>(&mut req, &ep, self)?;
+        set_request_microversion_header::<C, E>(&mut req, &ep, self, client)?;
         if let Some(request_headers) = self.request_headers()
             && let Some(headers) = req.headers_mut()
         {
@@ -495,7 +523,7 @@ where
             .get_service_endpoint(&self.service_type(), self.api_version().as_ref())
             .await?;
         let (req, data) =
-            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self)?;
+            prepare_request::<C, E>(&ep, ep.build_request_url(&self.endpoint())?, self, client)?;
 
         let rsp = client.download_async(req, data).await?;
 
@@ -776,10 +804,39 @@ mod tests {
 
     mod microversion {
         use super::*;
+        use crate::RestError;
         use crate::api::rest_endpoint::{negotiate_microversion, set_request_microversion_header};
+        use crate::api::{MicroVersionStrategy, RestClient};
         use crate::catalog::ServiceEndpoint;
         use crate::test::client::FakeOpenStackClient;
+        use openstack_sdk_auth_core::types::Project;
         use url::Url;
+
+        /// Default test client — uses the `Floor` strategy.
+        fn floor_client() -> FakeOpenStackClient {
+            FakeOpenStackClient::new("http://test/")
+        }
+
+        /// Test client that uses the `Ceiling` strategy.
+        fn ceiling_client() -> StrategyClient {
+            StrategyClient {
+                strategy: MicroVersionStrategy::Ceiling,
+            }
+        }
+
+        /// Test client with a configurable microversion strategy.
+        struct StrategyClient {
+            strategy: MicroVersionStrategy,
+        }
+        impl RestClient for StrategyClient {
+            type Error = RestError;
+            fn get_current_project(&self) -> Option<Project> {
+                None
+            }
+            fn microversion_strategy(&self) -> MicroVersionStrategy {
+                self.strategy
+            }
+        }
 
         struct VersionedEndpoint {
             version: Option<ApiVersion>,
@@ -852,7 +909,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.50".into()));
         }
 
@@ -863,7 +926,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(3, 50)), ServiceType::BlockStorage);
             let sep = make_service_endpoint(Some("3.0"), Some("3.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("volume 3.50".into()));
         }
 
@@ -875,7 +944,13 @@ mod tests {
             );
             let sep = make_service_endpoint(Some("1.0"), Some("1.20"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("container-infra 1.15".into()));
         }
 
@@ -884,7 +959,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(1, 10)), ServiceType::Placement);
             let sep = make_service_endpoint(Some("1.0"), Some("1.20"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("placement 1.10".into()));
         }
 
@@ -893,7 +974,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 30)), ServiceType::Network);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert!(header(&req).is_none());
         }
 
@@ -905,7 +992,13 @@ mod tests {
             );
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert!(header(&req).is_none());
         }
 
@@ -921,7 +1014,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 5)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.10"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.10".into()));
         }
 
@@ -930,9 +1029,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            let err =
-                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
-                    .unwrap_err();
+            let err = set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap_err();
             assert!(matches!(err, ApiError::MicroversionIncompatible { .. }));
         }
 
@@ -941,7 +1044,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 10)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.10"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.10".into()));
         }
 
@@ -950,7 +1059,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 60)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.60".into()));
         }
 
@@ -961,7 +1076,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 5)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.10"), None);
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.10".into()));
         }
 
@@ -970,7 +1091,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.10"), None);
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.99".into()));
         }
 
@@ -979,9 +1106,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
             let sep = make_service_endpoint(None, Some("2.60"));
             let mut req = http::Request::builder();
-            let err =
-                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
-                    .unwrap_err();
+            let err = set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap_err();
             assert!(matches!(err, ApiError::MicroversionIncompatible { .. }));
         }
 
@@ -990,7 +1121,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 5)), ServiceType::Compute);
             let sep = make_service_endpoint(None, Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.5".into()));
         }
 
@@ -999,7 +1136,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
             let sep = make_service_endpoint(None, None);
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.99".into()));
         }
 
@@ -1010,7 +1153,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(1, 99)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.1".into()));
         }
 
@@ -1019,9 +1168,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(3, 0)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            let err =
-                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
-                    .unwrap_err();
+            let err = set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap_err();
             assert!(matches!(err, ApiError::MicroversionIncompatible { .. }));
         }
 
@@ -1032,7 +1185,13 @@ mod tests {
             let ep = make_ep(None, ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert!(header(&req).is_none());
         }
 
@@ -1041,7 +1200,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(0, 0)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert!(header(&req).is_none());
         }
 
@@ -1050,7 +1215,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 0)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("1.0"), Some("2.60"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.0".into()));
         }
 
@@ -1061,7 +1232,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2"), Some("3"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.50".into()));
         }
 
@@ -1070,7 +1247,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("abc"), Some("def"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.50".into()));
         }
 
@@ -1079,7 +1262,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("bad"), Some("2.99"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.50".into()));
         }
 
@@ -1090,9 +1279,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            let err =
-                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
-                    .unwrap_err();
+            let err = set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap_err();
             match err {
                 ApiError::MicroversionIncompatible {
                     required_major,
@@ -1114,9 +1307,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 99)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let mut req = http::Request::builder();
-            let err =
-                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
-                    .unwrap_err();
+            let err = set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap_err();
             let msg = err.to_string();
             assert!(
                 msg.contains("2.99"),
@@ -1140,7 +1337,13 @@ mod tests {
             );
             let sep = make_service_endpoint(Some("2.30"), Some("2.90"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.30".into()));
         }
 
@@ -1155,9 +1358,13 @@ mod tests {
             );
             let sep = make_service_endpoint(Some("2.80"), Some("2.90"));
             let mut req = http::Request::builder();
-            let err =
-                set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep)
-                    .unwrap_err();
+            let err = set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap_err();
             assert!(matches!(err, ApiError::MicroversionIncompatible { .. }));
         }
 
@@ -1171,7 +1378,13 @@ mod tests {
             );
             let sep = make_service_endpoint(Some("2.75"), Some("2.90"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.75".into()));
         }
 
@@ -1186,7 +1399,13 @@ mod tests {
             );
             let sep = make_service_endpoint(None, Some("2.90"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.0".into()));
         }
 
@@ -1197,7 +1416,13 @@ mod tests {
             let ep = make_ep(Some(ApiVersion::new(2, 0)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.95"), Some("2.99"));
             let mut req = http::Request::builder();
-            set_request_microversion_header::<FakeOpenStackClient, _>(&mut req, &sep, &ep).unwrap();
+            set_request_microversion_header::<FakeOpenStackClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &floor_client(),
+            )
+            .unwrap();
             assert_eq!(header(&req), Some("compute 2.95".into()));
         }
 
@@ -1229,6 +1454,113 @@ mod tests {
             let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
             let negotiated = negotiate_microversion::<FakeOpenStackClient, _>(&sep, &ep).unwrap();
             assert_eq!(negotiated, None);
+        }
+
+        // ── ceiling strategy ─────────────────────────────────────────
+
+        #[test]
+        fn ceiling_sends_highest_available() {
+            let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<StrategyClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &ceiling_client(),
+            )
+            .unwrap();
+            assert_eq!(header(&req), Some("compute 2.60".into()));
+        }
+
+        #[test]
+        fn ceiling_respects_endpoint_max_version() {
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 45)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(Some("2.1"), Some("2.90"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<StrategyClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &ceiling_client(),
+            )
+            .unwrap();
+            assert_eq!(header(&req), Some("compute 2.45".into()));
+        }
+
+        #[test]
+        fn ceiling_clamps_to_cloud_max() {
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 90)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(Some("2.1"), Some("2.60"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<StrategyClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &ceiling_client(),
+            )
+            .unwrap();
+            assert_eq!(header(&req), Some("compute 2.60".into()));
+        }
+
+        #[test]
+        fn ceiling_no_cloud_max_uses_endpoint_max() {
+            let ep = make_ep_bounded(
+                Some(ApiVersion::new(2, 0)),
+                Some(ApiVersion::new(2, 75)),
+                ServiceType::Compute,
+            );
+            let sep = make_service_endpoint(Some("2.1"), None);
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<StrategyClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &ceiling_client(),
+            )
+            .unwrap();
+            assert_eq!(header(&req), Some("compute 2.75".into()));
+        }
+
+        #[test]
+        fn ceiling_no_bounded_falls_back_to_floor() {
+            // Neither endpoint nor cloud has a max version — ceiling falls
+            // back to floor semantics (the only known bound).
+            let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.1"), None);
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<StrategyClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &ceiling_client(),
+            )
+            .unwrap();
+            assert_eq!(header(&req), Some("compute 2.50".into()));
+        }
+
+        #[test]
+        fn ceiling_clamped_by_cloud_min() {
+            // Floor is clamped to 2.80 (cloud_min), ceiling is 2.90.
+            let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
+            let sep = make_service_endpoint(Some("2.80"), Some("2.90"));
+            let mut req = http::Request::builder();
+            set_request_microversion_header::<StrategyClient, _>(
+                &mut req,
+                &sep,
+                &ep,
+                &ceiling_client(),
+            )
+            .unwrap();
+            assert_eq!(header(&req), Some("compute 2.90".into()));
         }
     }
 }


### PR DESCRIPTION
MicroVersionStrategy enum (Floor/Ceiling) on RestClient allows clients
to opt into requesting the highest compatible microversion instead of
the lowest.  TUI builds sessions with Ceiling so serde_json::Value
parsing sees richer response fields from newer API versions.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
