### PR TITLE
fix: Use current MV when max is not set

### DIFF
--- a/openstack_tui/.config/config.yaml
+++ b/openstack_tui/.config/config.yaml
@@ -382,7 +382,7 @@ views:
     status_field: status
     fields:
       - name: flavor
-        json_pointer: "/original_name"
+        json_pointer: "/flavor/original_name"
   # dns
   dns.recordset:
     default_fields: [name, status, type, created, updated]

--- a/openstack_tui/src/components/compute/aggregates.rs
+++ b/openstack_tui/src/components/compute/aggregates.rs
@@ -12,12 +12,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cloud_worker::compute::v2::{
-    ComputeAggregateApiRequest, ComputeAggregateList, ComputeApiRequest,
-};
+use crate::action::Action;
+use crate::cloud_worker::compute::v2::ComputeAggregateList;
 use crate::cloud_worker::types::ApiRequest;
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
 
 /// Behaviour implementation for ComputeAggregates.
@@ -27,23 +26,22 @@ impl ResourceBehaviour for ComputeAggregatesBehaviour {
     type Filter = ComputeAggregateList;
 
     fn view_key() -> &'static str {
-        "compute.aggregate"
+        super::generated::aggregate::Generated::view_key()
     }
     fn title() -> &'static str {
-        "Compute Aggregates"
+        super::generated::aggregate::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::aggregate::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(ComputeAggregateApiRequest::List(Box::new(filter.clone())))
+        super::generated::aggregate::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Compute(ComputeApiRequest::Aggregate(boxreq))
-            if matches!(**boxreq, ComputeAggregateApiRequest::List(_))
-        )
+        super::generated::aggregate::Generated::matches_request(request)
+    }
+    fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
+        super::generated::aggregate::Generated::handle_set_filter_action(action)
     }
 }
 
@@ -53,12 +51,13 @@ pub type ComputeAggregates = GenericResourceView<'static, ComputeAggregatesBehav
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cloud_worker::compute::v2::{ComputeAggregateApiRequest, ComputeApiRequest};
     use crate::components::resource_behaviour::ResourceBehaviour;
 
     #[test]
     fn view_key_and_title() {
         assert_eq!(ComputeAggregatesBehaviour::view_key(), "compute.aggregate");
-        assert_eq!(ComputeAggregatesBehaviour::title(), "Compute Aggregates");
+        assert_eq!(ComputeAggregatesBehaviour::title(), "Aggregates");
         assert_eq!(
             ComputeAggregatesBehaviour::mode(),
             Mode::Resource(crate::mode::COMPUTE_AGGREGATE)
@@ -89,5 +88,19 @@ mod tests {
             crate::cloud_worker::types::ComputeHypervisorApiRequest::ListDetailed(Box::default()),
         )));
         assert!(!ComputeAggregatesBehaviour::matches_request(&req));
+    }
+
+    #[test]
+    fn handle_set_filter_action_returns_filter() {
+        let filter = ComputeAggregateList::default();
+        let action = Action::SetComputeAggregateListFilters(filter);
+        let result = ComputeAggregatesBehaviour::handle_set_filter_action(&action);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn handle_set_filter_action_returns_none_for_unrelated() {
+        let result = ComputeAggregatesBehaviour::handle_set_filter_action(&Action::Tick);
+        assert!(result.is_none());
     }
 }

--- a/openstack_tui/src/components/compute/flavors.rs
+++ b/openstack_tui/src/components/compute/flavors.rs
@@ -14,17 +14,12 @@
 
 use crate::{
     action::Action,
-    cloud_worker::compute::v2::{
-        ComputeApiRequest, ComputeFlavorApiRequest, ComputeFlavorList, ComputeServerListBuilder,
-    },
+    cloud_worker::compute::v2::{ComputeFlavorList, ComputeServerListBuilder},
     cloud_worker::types::ApiRequest,
     components::generic_resource_view::GenericResourceView,
-    components::resource_behaviour::{Mutation, ResourceBehaviour},
+    components::resource_behaviour::{GeneratedResourceBehaviour, Mutation, ResourceBehaviour},
     mode::Mode,
 };
-
-const TITLE: &str = "Compute Flavors";
-const VIEW_CONFIG_KEY: &str = "compute.flavor";
 
 pub struct ComputeFlavorsBehaviour;
 
@@ -32,15 +27,15 @@ impl ResourceBehaviour for ComputeFlavorsBehaviour {
     type Filter = ComputeFlavorList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::flavor::Generated::view_key()
     }
 
     fn title() -> &'static str {
-        TITLE
+        super::generated::flavor::Generated::title()
     }
 
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::flavor::Generated::mode()
     }
 
     fn normalise_filter(filter: Self::Filter) -> Self::Filter {
@@ -53,17 +48,15 @@ impl ResourceBehaviour for ComputeFlavorsBehaviour {
     }
 
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(ComputeFlavorApiRequest::ListDetailed(Box::new(
-            filter.clone(),
-        )))
+        super::generated::flavor::Generated::request_from_filter(filter)
     }
 
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Compute(ComputeApiRequest::Flavor(inner))
-                if matches!(&**inner, ComputeFlavorApiRequest::ListDetailed(_))
-        )
+        super::generated::flavor::Generated::matches_request(request)
+    }
+
+    fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
+        super::generated::flavor::Generated::handle_set_filter_action(action)
     }
 
     fn filter_carry_action(
@@ -104,7 +97,9 @@ pub type ComputeFlavors = GenericResourceView<'static, ComputeFlavorsBehaviour>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cloud_worker::compute::v2::ComputeServerApiRequest;
+    use crate::cloud_worker::compute::v2::{
+        ComputeApiRequest, ComputeFlavorApiRequest, ComputeServerApiRequest,
+    };
     use crate::components::resource_behaviour::ResourceBehaviour;
 
     fn make_flavor(id: &str) -> serde_json::Value {
@@ -142,7 +137,7 @@ mod tests {
     #[test]
     fn view_key_and_title() {
         assert_eq!(ComputeFlavorsBehaviour::view_key(), "compute.flavor");
-        assert_eq!(ComputeFlavorsBehaviour::title(), "Compute Flavors");
+        assert_eq!(ComputeFlavorsBehaviour::title(), "Flavors");
         assert_eq!(
             ComputeFlavorsBehaviour::mode(),
             Mode::Resource(crate::mode::COMPUTE_FLAVOR)
@@ -176,6 +171,20 @@ mod tests {
                 ComputeServerApiRequest::ListDetailed(Box::default())
             )))
         ));
+    }
+
+    #[test]
+    fn handle_set_filter_action_returns_filter() {
+        let filter = ComputeFlavorList::default();
+        let action = Action::SetComputeFlavorListFilters(filter);
+        let result = ComputeFlavorsBehaviour::handle_set_filter_action(&action);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn handle_set_filter_action_returns_none_for_unrelated() {
+        let result = ComputeFlavorsBehaviour::handle_set_filter_action(&Action::Tick);
+        assert!(result.is_none());
     }
 
     #[test]

--- a/openstack_tui/src/components/compute/hypervisors.rs
+++ b/openstack_tui/src/components/compute/hypervisors.rs
@@ -12,15 +12,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cloud_worker::compute::v2::{
-    ComputeApiRequest, ComputeHypervisorApiRequest, ComputeHypervisorList,
-};
+use crate::action::Action;
+use crate::cloud_worker::compute::v2::ComputeHypervisorList;
 use crate::cloud_worker::types::ApiRequest;
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
-
-const VIEW_CONFIG_KEY: &str = "compute.hypervisor";
 
 /// Behaviour implementation for ComputeHypervisors.
 pub struct ComputeHypervisorsBehaviour;
@@ -29,25 +26,22 @@ impl ResourceBehaviour for ComputeHypervisorsBehaviour {
     type Filter = ComputeHypervisorList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::hypervisor::Generated::view_key()
     }
     fn title() -> &'static str {
-        "Compute Hypervisors"
+        super::generated::hypervisor::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::hypervisor::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(ComputeHypervisorApiRequest::ListDetailed(Box::new(
-            filter.clone(),
-        )))
+        super::generated::hypervisor::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Compute(ComputeApiRequest::Hypervisor(boxreq))
-            if matches!(**boxreq, ComputeHypervisorApiRequest::ListDetailed(_))
-        )
+        super::generated::hypervisor::Generated::matches_request(request)
+    }
+    fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
+        super::generated::hypervisor::Generated::handle_set_filter_action(action)
     }
 }
 
@@ -57,6 +51,7 @@ pub type ComputeHypervisors = GenericResourceView<'static, ComputeHypervisorsBeh
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cloud_worker::compute::v2::{ComputeApiRequest, ComputeHypervisorApiRequest};
     use crate::components::resource_behaviour::ResourceBehaviour;
 
     #[test]
@@ -65,7 +60,7 @@ mod tests {
             ComputeHypervisorsBehaviour::view_key(),
             "compute.hypervisor"
         );
-        assert_eq!(ComputeHypervisorsBehaviour::title(), "Compute Hypervisors");
+        assert_eq!(ComputeHypervisorsBehaviour::title(), "Hypervisors");
         assert_eq!(
             ComputeHypervisorsBehaviour::mode(),
             Mode::Resource(crate::mode::COMPUTE_HYPERVISOR)
@@ -96,5 +91,19 @@ mod tests {
             crate::cloud_worker::compute::v2::ComputeFlavorApiRequest::ListDetailed(Box::default()),
         )));
         assert!(!ComputeHypervisorsBehaviour::matches_request(&req));
+    }
+
+    #[test]
+    fn handle_set_filter_action_returns_filter() {
+        let filter = ComputeHypervisorList::default();
+        let action = Action::SetComputeHypervisorListFilters(filter);
+        let result = ComputeHypervisorsBehaviour::handle_set_filter_action(&action);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn handle_set_filter_action_returns_none_for_unrelated() {
+        let result = ComputeHypervisorsBehaviour::handle_set_filter_action(&Action::Tick);
+        assert!(result.is_none());
     }
 }

--- a/openstack_tui/src/components/compute/servers.rs
+++ b/openstack_tui/src/components/compute/servers.rs
@@ -19,10 +19,8 @@ use crate::cloud_worker::compute::v2::{
 };
 use crate::cloud_worker::types::{ApiRequest, ComputeApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
-
-const VIEW_CONFIG_KEY: &str = "compute.server";
 
 /// Behaviour implementation for ComputeServers.
 pub struct ComputeServersBehaviour;
@@ -31,13 +29,13 @@ impl ResourceBehaviour for ComputeServersBehaviour {
     type Filter = ComputeServerList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::server::Generated::view_key()
     }
     fn title() -> &'static str {
-        "Compute Servers"
+        super::generated::server::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::server::Generated::mode()
     }
     fn normalise_filter(mut filter: Self::Filter) -> Self::Filter {
         if filter.sort_key.is_none() {
@@ -47,23 +45,15 @@ impl ResourceBehaviour for ComputeServersBehaviour {
         filter
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::Compute(ComputeApiRequest::Server(Box::new(
-            ComputeServerApiRequest::ListDetailed(Box::new(filter.clone())),
-        )))
+        // `Generated::Filter` is boxed (matches `Action::SetComputeServerListFilters`'s boxed
+        // payload); this behaviour's `Filter` stays unboxed, so adapt at the boundary.
+        super::generated::server::Generated::request_from_filter(&Box::new(filter.clone()))
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Compute(ComputeApiRequest::Server(boxreq))
-            if matches!(**boxreq, ComputeServerApiRequest::ListDetailed(_))
-        )
+        super::generated::server::Generated::matches_request(request)
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetComputeServerListFilters(f) = action {
-            Some((**f).clone())
-        } else {
-            None
-        }
+        super::generated::server::Generated::handle_set_filter_action(action).map(|f| *f)
     }
     fn confirm_request(
         action: &Action,
@@ -223,7 +213,7 @@ mod tests {
     #[test]
     fn view_key_and_title() {
         assert_eq!(ComputeServersBehaviour::view_key(), "compute.server");
-        assert_eq!(ComputeServersBehaviour::title(), "Compute Servers");
+        assert_eq!(ComputeServersBehaviour::title(), "Servers");
         assert_eq!(
             ComputeServersBehaviour::mode(),
             Mode::Resource(crate::mode::COMPUTE_SERVER)

--- a/openstack_tui/src/components/dns/recordsets.rs
+++ b/openstack_tui/src/components/dns/recordsets.rs
@@ -19,10 +19,8 @@ use crate::cloud_worker::dns::v2::{
 };
 use crate::cloud_worker::types::ApiRequest;
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
-
-const VIEW_CONFIG_KEY: &str = "dns.recordset";
 
 impl From<DnsRecordsetList> for DnsZoneRecordsetList {
     fn from(value: DnsRecordsetList) -> Self {
@@ -49,13 +47,13 @@ impl ResourceBehaviour for DnsRecordsetsBehaviour {
     type Filter = DnsRecordsetList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::recordset::Generated::view_key()
     }
     fn title() -> &'static str {
-        "DNS Recordsets"
+        super::generated::recordset::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::recordset::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
         if filter.zone_id.is_some() {
@@ -76,11 +74,7 @@ impl ResourceBehaviour for DnsRecordsetsBehaviour {
         }
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetDnsRecordsetListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
+        super::generated::recordset::Generated::handle_set_filter_action(action)
     }
 }
 
@@ -105,7 +99,7 @@ mod tests {
     #[test]
     fn view_key_and_title() {
         assert_eq!(DnsRecordsetsBehaviour::view_key(), "dns.recordset");
-        assert_eq!(DnsRecordsetsBehaviour::title(), "DNS Recordsets");
+        assert_eq!(DnsRecordsetsBehaviour::title(), "Recordsets");
         assert_eq!(
             DnsRecordsetsBehaviour::mode(),
             Mode::Resource(crate::mode::DNS_RECORDSET)

--- a/openstack_tui/src/components/dns/zones.rs
+++ b/openstack_tui/src/components/dns/zones.rs
@@ -14,15 +14,13 @@
 
 use crate::action::Action;
 use crate::cloud_worker::dns::v2::{
-    DnsApiRequest, DnsRecordsetList, DnsRecordsetListBuilder, DnsZoneApiRequest, DnsZoneDelete,
+    DnsRecordsetList, DnsRecordsetListBuilder, DnsZoneApiRequest, DnsZoneDelete,
     DnsZoneDeleteBuilder, DnsZoneList,
 };
 use crate::cloud_worker::types::ApiRequest;
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
-
-const VIEW_CONFIG_KEY: &str = "dns.zone";
 
 impl TryFrom<&serde_json::Value> for DnsZoneDelete {
     type Error = crate::cloud_worker::dns::v2::DnsZoneDeleteBuilderError;
@@ -58,30 +56,22 @@ impl ResourceBehaviour for DnsZonesBehaviour {
     type Filter = DnsZoneList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::zone::Generated::view_key()
     }
     fn title() -> &'static str {
-        "DNS Zones"
+        super::generated::zone::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::zone::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(DnsZoneApiRequest::List(Box::new(filter.clone())))
+        super::generated::zone::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Dns(DnsApiRequest::Zone(boxreq))
-            if matches!(**boxreq, DnsZoneApiRequest::List(_))
-        )
+        super::generated::zone::Generated::matches_request(request)
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetDnsZoneListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
+        super::generated::zone::Generated::handle_set_filter_action(action)
     }
     fn confirm_request(
         action: &Action,
@@ -126,6 +116,7 @@ pub type DnsZones = GenericResourceView<'static, DnsZonesBehaviour>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cloud_worker::dns::v2::DnsApiRequest;
     use crate::components::resource_behaviour::ResourceBehaviour;
 
     fn make_zone(id: &str, name: &str) -> serde_json::Value {
@@ -151,7 +142,7 @@ mod tests {
     #[test]
     fn view_key_and_title() {
         assert_eq!(DnsZonesBehaviour::view_key(), "dns.zone");
-        assert_eq!(DnsZonesBehaviour::title(), "DNS Zones");
+        assert_eq!(DnsZonesBehaviour::title(), "Zones");
         assert_eq!(
             DnsZonesBehaviour::mode(),
             Mode::Resource(crate::mode::DNS_ZONE)

--- a/openstack_tui/src/components/image/images.rs
+++ b/openstack_tui/src/components/image/images.rs
@@ -19,11 +19,11 @@ use crate::cloud_worker::image::v2::{
 };
 use crate::cloud_worker::types::ApiRequest;
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::{Mutation, ResourceBehaviour};
+use crate::components::resource_behaviour::{
+    GeneratedResourceBehaviour, Mutation, ResourceBehaviour,
+};
 use crate::mode::Mode;
 use serde_json::Value;
-
-const VIEW_CONFIG_KEY: &str = "image.image";
 
 impl TryFrom<&Value> for ImageImageDelete {
     type Error = crate::cloud_worker::image::v2::ImageImageDeleteBuilderError;
@@ -45,30 +45,25 @@ impl ResourceBehaviour for ImageImagesBehaviour {
     type Filter = ImageImageList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::image::Generated::view_key()
     }
     fn title() -> &'static str {
+        // NOTE: `super::generated::image::Generated::title()` currently returns the wrong
+        // value ("s") due to a codegenerator title-stripping bug for the "image.image"
+        // resource - kept hand-written here until that's fixed upstream.
         "Images"
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::image::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(ImageImageApiRequest::List(Box::new(filter.clone())))
+        super::generated::image::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::Image(ImageApiRequest::Image(boxreq))
-            if matches!(**boxreq, ImageImageApiRequest::List(_))
-        )
+        super::generated::image::Generated::matches_request(request)
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetImageListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
+        super::generated::image::Generated::handle_set_filter_action(action)
     }
     fn confirm_request(action: &Action, selected: Option<&Value>) -> Option<ApiRequest> {
         if let Action::ResourceOp {

--- a/sdk/core/src/api/rest_endpoint.rs
+++ b/sdk/core/src/api/rest_endpoint.rs
@@ -227,16 +227,21 @@ where
     // of the lowest.  Negotiate above already validated that a compatible
     // range exists, so we only need to compute the upper bound.
     if client.microversion_strategy() == MicroVersionStrategy::Ceiling {
+        tracing::info!("strategy is ceiling");
         let ep_max = endpoint.max_version();
         let cloud_max: Option<ApiVersion> = service_endpoint
             .max_version()
             .as_deref()
             .and_then(|s| ApiVersion::from_apiver_str(s, false).ok());
+        tracing::info!("strategy is cloud_max={:?}", cloud_max);
         if let Some(ceil) = match (ep_max, cloud_max) {
             (Some(em), Some(cm)) => Some(em.min(cm)),
             (Some(em), None) => Some(em), // no cloud max → use endpoint max
             (None, Some(cm)) => Some(cm), // no endpoint max → use cloud max
-            (None, None) => None,         // no ceiling info → fall back to floor
+            (None, None) => {
+                let current = *service_endpoint.version();
+                Some(if current > req_ver { current } else { req_ver })
+            }
         } {
             req_ver = ceil;
         }
@@ -1531,9 +1536,9 @@ mod tests {
         }
 
         #[test]
-        fn ceiling_no_bounded_falls_back_to_floor() {
-            // Neither endpoint nor cloud has a max version — ceiling falls
-            // back to floor semantics (the only known bound).
+        fn ceiling_no_bounded_falls_back_to_current() {
+            // Neither endpoint nor cloud has a max version — ceiling uses
+            // current cloud version, but not below the negotiated floor.
             let ep = make_ep(Some(ApiVersion::new(2, 50)), ServiceType::Compute);
             let sep = make_service_endpoint(Some("2.1"), None);
             let mut req = http::Request::builder();


### PR DESCRIPTION
Modify Ceiling MV negotiation to use current endpoint version when
neither resource not the service endpoint specify the upper boundary.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
