### PR TITLE
feat(tui): Broadcast actions to all components

### DIFF
--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -508,10 +508,6 @@ impl App {
                         // Hide popup
                         self.active_popup = None;
                     }
-                    // Broadcast to all popups so they can clear stale data
-                    for popup in self.popups.values_mut() {
-                        let _ = popup.update(action.clone(), self.mode);
-                    }
                     self.render(tui)?;
                     self.cloud_worker_tx
                         .send(Action::CloudChangeScope(scope.clone()))?;
@@ -522,10 +518,6 @@ impl App {
                     {
                         // Hide popup
                         self.active_popup = None;
-                    }
-                    // Broadcast to all popups so they can clear stale data
-                    for popup in self.popups.values_mut() {
-                        let _ = popup.update(action.clone(), self.mode);
                     }
                     self.render(tui)?;
                     self.cloud_worker_tx
@@ -599,12 +591,12 @@ impl App {
                         .send(Action::ConnectToCloud(cloud.clone()))?;
                     self.active_popup = None;
                     self.cloud_connected = false;
-                    // Broadcast to all popups so they can clear stale data
-                    for popup in self.popups.values_mut() {
-                        let _ = popup.update(action.clone(), self.mode);
-                    }
-                    // Let the active mode component know to refresh
-                    self.action_tx.send(Action::Refresh)?;
+                    // Do NOT send Action::Refresh here: the reconnect is async and hasn't
+                    // completed yet, so the active view's filter may still be mid-reset
+                    // (see GenericResourceView::reset_filter_on_cloud_switch) -- refreshing
+                    // now can fire a request with a stale/cleared filter. ConnectedToCloud,
+                    // sent once the reconnect actually completes and filters are reseeded,
+                    // already triggers the equivalent fetch for the active view.
                     self.render(tui)?;
                 }
                 Action::Confirm(ref request) => {
@@ -649,18 +641,33 @@ impl App {
                 self.action_tx.send(action)?
             };
 
-            // Only the active popup receives actions
-            if let Some(popup_type) = self.active_popup.as_ref()
-                && let Some(popup) = self.popups.get_mut(popup_type)
-                && let Some(action) = popup.update(action.clone(), self.mode)?
-            {
-                self.action_tx.send(action)?;
+            // Broadcast to every popup, not just the active one, so a popup that isn't
+            // currently shown still sees state-changing actions (e.g. ConnectedToCloud).
+            // Invariant: a popup's update() must never unconditionally return an action it
+            // (or a peer) will react to the same way again -- this loop's Ok(Some(action))
+            // re-enters the action_rx drain below and gets rebroadcast, so a stable echo
+            // spins forever. (Hit and fixed once already, in a test stub -- see the
+            // RecordingComponent comment in this file's test module.)
+            for popup in self.popups.values_mut() {
+                match popup.update(action.clone(), self.mode) {
+                    Ok(Some(returned_action)) => self.action_tx.send(returned_action)?,
+                    Err(err @ TuiError::JsonError { .. }) => {
+                        self.action_tx.send(Action::Error {
+                            msg: err.to_string(),
+                            action: Some(Box::new(action.clone())),
+                        })?
+                    }
+                    _ => {}
+                }
             }
 
-            // Only the active mode component receives the action
-            if let Some(component) = self.components.get_mut(&self.mode) {
+            // Broadcast to every mode component, not just the active one, so an inactive
+            // view's stored filter/state can stay correct (e.g. ConnectedToCloud seeding
+            // a resource's filter before the user ever navigates there).
+            // Same re-echo/livelock invariant as the popup loop above applies here too.
+            for component in self.components.values_mut() {
                 match component.update(action.clone(), self.mode) {
-                    Ok(Some(action)) => self.action_tx.send(action)?,
+                    Ok(Some(returned_action)) => self.action_tx.send(returned_action)?,
                     Err(err @ TuiError::JsonError { .. }) => {
                         self.action_tx.send(Action::Error {
                             msg: err.to_string(),
@@ -727,5 +734,289 @@ impl App {
             }
         })?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Frame;
+    use std::sync::{Arc, Mutex};
+
+    /// Records every action it was updated with, and optionally echoes one action back.
+    struct RecordingComponent {
+        received: Arc<Mutex<Vec<Action>>>,
+        echo: Option<Action>,
+    }
+
+    impl RecordingComponent {
+        fn new(received: Arc<Mutex<Vec<Action>>>) -> Self {
+            Self {
+                received,
+                echo: None,
+            }
+        }
+
+        fn with_echo(received: Arc<Mutex<Vec<Action>>>, echo: Action) -> Self {
+            Self {
+                received,
+                echo: Some(echo),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Component for RecordingComponent {
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
+        }
+
+        fn update(
+            &mut self,
+            action: Action,
+            _current_mode: Mode,
+        ) -> Result<Option<Action>, TuiError> {
+            self.received.lock().unwrap().push(action);
+            // `.take()`, not `.clone()`: `handle_actions` drains `action_rx` in a `while
+            // let Ok(action) = self.action_rx.try_recv()` loop, so a broadcast component
+            // that echoed the same action on every call would have its own echo re-enter
+            // the queue and be reprocessed forever. Firing the echo exactly once still
+            // proves forwarding works, without hanging the test.
+            Ok(self.echo.take())
+        }
+
+        fn draw(&mut self, _f: &mut Frame<'_>, _area: Rect) -> Result<(), TuiError> {
+            Ok(())
+        }
+    }
+
+    fn make_test_app() -> App {
+        let (action_tx, action_rx) = mpsc::unbounded_channel();
+        let (cloud_worker_tx, _cloud_worker_rx) = mpsc::unbounded_channel();
+        App {
+            config: Config::default(),
+            tick_rate: 4.0,
+            frame_rate: 30.0,
+            components: HashMap::new(),
+            header: Box::new(crate::components::header::Header::new()),
+            should_quit: false,
+            should_suspend: false,
+            mode: Mode::Home,
+            mode_switch_stack: Vec::new(),
+            action_tx,
+            action_rx,
+            cloud_worker_tx,
+            last_tick_key_events: Vec::new(),
+            cloud_name: None,
+            cloud_connected: false,
+            active_popup: None,
+            popups: HashMap::new(),
+        }
+    }
+
+    /// Like `make_test_app`, but also returns the cloud-worker receiver so a test can
+    /// inspect exactly which `Action`s (e.g. `PerformApiRequest`) were sent to the cloud
+    /// worker during `handle_actions`.
+    fn make_test_app_with_cloud_worker_rx() -> (App, mpsc::UnboundedReceiver<Action>) {
+        let (action_tx, action_rx) = mpsc::unbounded_channel();
+        let (cloud_worker_tx, cloud_worker_rx) = mpsc::unbounded_channel();
+        let app = App {
+            config: Config::default(),
+            tick_rate: 4.0,
+            frame_rate: 30.0,
+            components: HashMap::new(),
+            header: Box::new(crate::components::header::Header::new()),
+            should_quit: false,
+            should_suspend: false,
+            mode: Mode::Home,
+            mode_switch_stack: Vec::new(),
+            action_tx,
+            action_rx,
+            cloud_worker_tx,
+            last_tick_key_events: Vec::new(),
+            cloud_name: None,
+            cloud_connected: false,
+            active_popup: None,
+            popups: HashMap::new(),
+        };
+        (app, cloud_worker_rx)
+    }
+
+    // `Tui::new()` calls `tokio::spawn(async {})` internally, so any test that
+    // constructs one needs an active Tokio runtime — use `#[tokio::test]`, not `#[test]`.
+    // `openstack_tui`'s dev-dependencies already enable tokio's `rt` + `macros` features
+    // (see `openstack_tui/Cargo.toml`), so `#[tokio::test]` is available without changes.
+
+    #[tokio::test]
+    async fn broadcast_reaches_inactive_mode_component() {
+        let mut app = make_test_app();
+        let received = Arc::new(Mutex::new(Vec::new()));
+        app.components.insert(
+            Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
+            Box::new(RecordingComponent::new(received.clone())),
+        );
+        // Active mode is Home, not the resource the stub is registered under.
+        app.mode = Mode::Home;
+
+        let token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        app.action_tx
+            .send(Action::ConnectedToCloud(Box::new(token_info)))
+            .unwrap();
+
+        let mut tui = crate::tui::Tui::new().unwrap();
+        app.handle_actions(&mut tui).unwrap();
+
+        let received = received.lock().unwrap();
+        assert!(
+            received
+                .iter()
+                .any(|a| matches!(a, Action::ConnectedToCloud(_))),
+            "inactive mode component should still see ConnectedToCloud"
+        );
+    }
+
+    #[tokio::test]
+    async fn broadcast_reaches_inactive_popup() {
+        let mut app = make_test_app();
+        let received = Arc::new(Mutex::new(Vec::new()));
+        app.popups.insert(
+            Popup::SwitchRegion,
+            Box::new(RecordingComponent::new(received.clone())),
+        );
+        // No popup is active.
+        app.active_popup = None;
+
+        let token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        app.action_tx
+            .send(Action::ConnectedToCloud(Box::new(token_info)))
+            .unwrap();
+
+        let mut tui = crate::tui::Tui::new().unwrap();
+        app.handle_actions(&mut tui).unwrap();
+
+        let received = received.lock().unwrap();
+        assert!(
+            received
+                .iter()
+                .any(|a| matches!(a, Action::ConnectedToCloud(_))),
+            "inactive popup should still see ConnectedToCloud"
+        );
+    }
+
+    #[tokio::test]
+    async fn returned_action_from_broadcast_component_is_forwarded() {
+        let mut app = make_test_app();
+        let received = Arc::new(Mutex::new(Vec::new()));
+        app.components.insert(
+            Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
+            Box::new(RecordingComponent::with_echo(
+                received.clone(),
+                Action::Refresh,
+            )),
+        );
+        app.mode = Mode::Home;
+
+        app.action_tx.send(Action::Tick).unwrap();
+
+        let mut tui = crate::tui::Tui::new().unwrap();
+        app.handle_actions(&mut tui).unwrap();
+
+        // The echoed Action::Refresh should have been forwarded back onto the channel
+        // and processed in the same handle_actions call (drains until empty), reaching
+        // the same stub component a second time.
+        let received = received.lock().unwrap();
+        assert!(
+            received.iter().any(|a| matches!(a, Action::Refresh)),
+            "action returned from update() should be forwarded via action_tx"
+        );
+    }
+
+    #[tokio::test]
+    async fn connected_to_cloud_seeds_application_credentials_filter_when_inactive() {
+        use crate::components::identity::application_credentials::IdentityApplicationCredentials;
+
+        let mut app = make_test_app();
+        app.components.insert(
+            Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
+            Box::new(IdentityApplicationCredentials::new()),
+        );
+        // Active mode is Home -- the application-credentials view is not on screen.
+        app.mode = Mode::Home;
+
+        let mut token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        token_info.user.id = "user-42".to_string();
+        app.action_tx
+            .send(Action::ConnectedToCloud(Box::new(token_info)))
+            .unwrap();
+
+        let mut tui = crate::tui::Tui::new().unwrap();
+        app.handle_actions(&mut tui).unwrap();
+
+        let component = app
+            .components
+            .get_mut(&Mode::Resource(
+                crate::mode::IDENTITY_APPLICATION_CREDENTIAL,
+            ))
+            .unwrap();
+        let concrete = component
+            .as_any_mut()
+            .downcast_mut::<IdentityApplicationCredentials>()
+            .unwrap();
+        assert_eq!(concrete.filters_for_test().user_id, "user-42");
+    }
+
+    #[tokio::test]
+    async fn connect_to_cloud_does_not_prematurely_refresh_active_view() {
+        // Regression test: ConnectToCloud used to unconditionally send Action::Refresh
+        // immediately, before the (async) reconnect completes and before the active
+        // view's filter is reseeded by ConnectedToCloud. For a view whose filter gets
+        // reset on cloud switch (e.g. application-credentials' user_id), that premature
+        // Refresh fired a request with an already-cleared/invalid filter -- e.g. a list
+        // request with an empty user_id, which the API rejects with 403.
+        use crate::cloud_worker::identity::v3::{
+            IdentityApiRequest, IdentityUserApiRequest, IdentityUserApplicationCredentialApiRequest,
+        };
+        use crate::cloud_worker::types::ApiRequest;
+        use crate::components::identity::application_credentials::IdentityApplicationCredentials;
+
+        let (mut app, mut cloud_worker_rx) = make_test_app_with_cloud_worker_rx();
+        let mut component = IdentityApplicationCredentials::new();
+        // Simulate an already-scoped, properly-populated view (user_id set, data shown).
+        let concrete_filter =
+            crate::cloud_worker::identity::v3::IdentityUserApplicationCredentialList {
+                user_id: "user-42".to_string(),
+                ..Default::default()
+            };
+        let _ = component.update(
+            Action::SetIdentityApplicationCredentialListFilters(concrete_filter),
+            Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
+        );
+        app.components.insert(
+            Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL),
+            Box::new(component),
+        );
+        app.mode = Mode::Resource(crate::mode::IDENTITY_APPLICATION_CREDENTIAL);
+
+        app.action_tx
+            .send(Action::ConnectToCloud("some-cloud".to_string()))
+            .unwrap();
+
+        let mut tui = crate::tui::Tui::new().unwrap();
+        app.handle_actions(&mut tui).unwrap();
+
+        // Nothing should have reached the cloud worker with an empty user_id.
+        while let Ok(sent) = cloud_worker_rx.try_recv() {
+            if let Action::PerformApiRequest(ApiRequest::Identity(IdentityApiRequest::User(boxreq))) =
+                &sent
+                && let IdentityUserApiRequest::ApplicationCredential(inner) = &**boxreq
+                && let IdentityUserApplicationCredentialApiRequest::List(list) = &**inner
+            {
+                assert!(
+                    !list.user_id.is_empty(),
+                    "ConnectToCloud must not trigger a premature list request with an \
+                     empty/cleared user_id"
+                );
+            }
+        }
     }
 }

--- a/openstack_tui/src/app.rs
+++ b/openstack_tui/src/app.rs
@@ -863,7 +863,7 @@ mod tests {
             .send(Action::ConnectedToCloud(Box::new(token_info)))
             .unwrap();
 
-        let mut tui = crate::tui::Tui::new().unwrap();
+        let mut tui = crate::tui::Tui::new_for_test().unwrap();
         app.handle_actions(&mut tui).unwrap();
 
         let received = received.lock().unwrap();
@@ -891,7 +891,7 @@ mod tests {
             .send(Action::ConnectedToCloud(Box::new(token_info)))
             .unwrap();
 
-        let mut tui = crate::tui::Tui::new().unwrap();
+        let mut tui = crate::tui::Tui::new_for_test().unwrap();
         app.handle_actions(&mut tui).unwrap();
 
         let received = received.lock().unwrap();
@@ -918,7 +918,7 @@ mod tests {
 
         app.action_tx.send(Action::Tick).unwrap();
 
-        let mut tui = crate::tui::Tui::new().unwrap();
+        let mut tui = crate::tui::Tui::new_for_test().unwrap();
         app.handle_actions(&mut tui).unwrap();
 
         // The echoed Action::Refresh should have been forwarded back onto the channel
@@ -949,7 +949,7 @@ mod tests {
             .send(Action::ConnectedToCloud(Box::new(token_info)))
             .unwrap();
 
-        let mut tui = crate::tui::Tui::new().unwrap();
+        let mut tui = crate::tui::Tui::new_for_test().unwrap();
         app.handle_actions(&mut tui).unwrap();
 
         let component = app
@@ -1001,7 +1001,7 @@ mod tests {
             .send(Action::ConnectToCloud("some-cloud".to_string()))
             .unwrap();
 
-        let mut tui = crate::tui::Tui::new().unwrap();
+        let mut tui = crate::tui::Tui::new_for_test().unwrap();
         app.handle_actions(&mut tui).unwrap();
 
         // Nothing should have reached the cloud worker with an empty user_id.

--- a/openstack_tui/src/components/generic_resource_view.rs
+++ b/openstack_tui/src/components/generic_resource_view.rs
@@ -45,6 +45,11 @@ where
             behaviour: std::marker::PhantomData,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn filters_for_test(&self) -> &B::Filter {
+        self.base.get_filters()
+    }
 }
 
 impl<'a, B> Default for GenericResourceView<'a, B>
@@ -89,28 +94,50 @@ where
                 return Ok(None);
             }
             Action::DescribeApiResponse => {
-                self.base.describe_selected_entry()?;
+                // Only the view the user is currently looking at should populate the
+                // describe pane -- under broadcast dispatch every populated resource
+                // component would otherwise race to fill it, and HashMap iteration
+                // order over `components` is non-deterministic.
+                if current_mode == B::mode() {
+                    self.base.describe_selected_entry()?;
+                }
                 return Ok(None);
             }
             _ => {}
         }
 
-        // --- Connect / re-scope / region switch: clear stale data ---
-        if let Action::ConnectToCloud(_) | Action::CloudChangeScope(_) | Action::SwitchToRegion(_) =
-            &action
-        {
+        // --- Connect to a (possibly different) cloud: clear stale data and any filter value
+        // that's only valid for the previous cloud's identity (e.g. a seeded/selected user_id) ---
+        if let Action::ConnectToCloud(_) = &action {
+            self.base.set_loading(true);
+            self.base.set_data(Vec::new())?;
+            let filter = B::reset_filter_on_cloud_switch(self.base.get_filters().clone());
+            self.base.set_filters(filter);
+            return Ok(None);
+        }
+
+        // --- Re-scope or region switch: same authenticated user, just clear stale data ---
+        if let Action::CloudChangeScope(_) | Action::SwitchToRegion(_) = &action {
             self.base.set_loading(true);
             self.base.set_data(Vec::new())?;
             return Ok(None);
         }
 
-        // --- Connected to cloud: only request data if we are the current mode ---
-        if let Action::ConnectedToCloud(_) = &action {
+        // --- Connected to cloud: seed the filter from the current user regardless of
+        // whether we're the active view, but only request data if we are the current mode ---
+        if let Action::ConnectedToCloud(token_info) = &action {
             self.base.set_loading(true);
             self.base.set_data(Vec::new())?;
+            let filter =
+                B::seed_filter_from_current_user(self.base.get_filters().clone(), token_info);
+            self.base.set_filters(filter);
             if B::mode() == current_mode {
                 let filter = B::normalise_filter(self.base.get_filters().clone());
                 self.base.set_filters(filter);
+                if !B::is_filter_ready(self.base.get_filters()) {
+                    self.base.set_loading(false);
+                    return Ok(None);
+                }
                 return Ok(Some(Action::PerformApiRequest(B::request_from_filter(
                     self.base.get_filters(),
                 ))));
@@ -118,8 +145,17 @@ where
             return Ok(None);
         }
 
-        // --- Refresh or mode switch to us: request data ---
+        // --- Refresh: only the active view should re-fetch. Refresh is sent on every
+        // mode switch and every login; under broadcast every registered resource
+        // component sees it, so without this gate all ~26 of them would fire a list
+        // request simultaneously. ---
         if let Action::Refresh = &action {
+            if B::mode() != current_mode {
+                return Ok(None);
+            }
+            if !B::is_filter_ready(self.base.get_filters()) {
+                return Ok(None);
+            }
             self.base.set_loading(true);
             return Ok(Some(Action::PerformApiRequest(B::request_from_filter(
                 self.base.get_filters(),
@@ -134,9 +170,12 @@ where
 
         // --- Filter change actions ---
         if let Some(new_filter) = B::handle_set_filter_action(&action) {
-            self.base.set_loading(true);
             let filter = B::normalise_filter(new_filter);
             self.base.set_filters(filter);
+            if !B::is_filter_ready(self.base.get_filters()) {
+                return Ok(None);
+            }
+            self.base.set_loading(true);
             return Ok(Some(Action::PerformApiRequest(B::request_from_filter(
                 self.base.get_filters(),
             ))));
@@ -175,6 +214,9 @@ where
                             self.base.append_new_row(row_data)?;
                         }
                         super::resource_behaviour::Mutation::Refresh => {
+                            if !B::is_filter_ready(self.base.get_filters()) {
+                                return Ok(None);
+                            }
                             return Ok(Some(Action::PerformApiRequest(B::request_from_filter(
                                 self.base.get_filters(),
                             ))));
@@ -190,6 +232,13 @@ where
             {
                 return Ok(Some(ret_action));
             }
+            return Ok(None);
+        }
+
+        // --- Everything below here is selection/interaction-derived and only makes sense
+        // for the view the user is currently looking at (it reads self.base.get_selected(),
+        // which for an inactive view may be stale or unrelated to what's on screen). ---
+        if B::mode() != current_mode {
             return Ok(None);
         }
 
@@ -422,6 +471,123 @@ mod tests {
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn connected_to_cloud_seeds_filter_even_when_mode_does_not_match() {
+        use crate::components::identity::application_credentials::{
+            IdentityApplicationCredentials, IdentityApplicationCredentialsBehaviour,
+        };
+        use crate::components::resource_behaviour::ResourceBehaviour;
+
+        let mut comp: IdentityApplicationCredentials = GenericResourceView::new();
+        let mut token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        token_info.user.id = "user-42".to_string();
+
+        let result = comp.update(
+            Action::ConnectedToCloud(Box::new(token_info)),
+            Mode::Resource(crate::mode::COMPUTE_SERVER),
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(comp.base.get_filters().user_id, "user-42");
+        let _ = IdentityApplicationCredentialsBehaviour::view_key();
+    }
+
+    #[test]
+    fn connect_to_cloud_then_connected_replaces_stale_user_id_from_previous_cloud() {
+        use crate::components::identity::application_credentials::IdentityApplicationCredentials;
+
+        let mut comp: IdentityApplicationCredentials = GenericResourceView::new();
+
+        // Simulate having been seeded/scoped to cloud A's user already.
+        let mut filter = comp.base.get_filters().clone();
+        filter.user_id = "cloud-a-user".to_string();
+        comp.base.set_filters(filter);
+
+        // User switches clouds: ConnectToCloud fires first...
+        comp.update(Action::ConnectToCloud("cloud-b".to_string()), Mode::Home)
+            .unwrap();
+        assert_eq!(
+            comp.base.get_filters().user_id,
+            "",
+            "ConnectToCloud must clear the previous cloud's user_id"
+        );
+
+        // ...then ConnectedToCloud arrives with the new cloud's token.
+        let mut token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        token_info.user.id = "cloud-b-user".to_string();
+        comp.update(Action::ConnectedToCloud(Box::new(token_info)), Mode::Home)
+            .unwrap();
+
+        assert_eq!(
+            comp.base.get_filters().user_id,
+            "cloud-b-user",
+            "filter must pick up the new cloud's user, not stay stuck on cloud A's"
+        );
+    }
+
+    #[test]
+    fn connected_to_cloud_does_not_fetch_when_user_id_still_empty() {
+        use crate::components::identity::application_credentials::{
+            IdentityApplicationCredentials, IdentityApplicationCredentialsBehaviour,
+        };
+        use crate::components::resource_behaviour::ResourceBehaviour;
+
+        let mut comp: IdentityApplicationCredentials = GenericResourceView::new();
+        // A token with no user id (e.g. not actually authenticated) leaves user_id empty
+        // even after seeding -- must not fire a request with it unset.
+        let token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        let mode = IdentityApplicationCredentialsBehaviour::mode();
+
+        let result = comp.update(Action::ConnectedToCloud(Box::new(token_info)), mode);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), None);
+        assert_eq!(comp.base.get_filters().user_id, "");
+    }
+
+    #[test]
+    fn refresh_does_not_fetch_when_user_id_empty() {
+        use crate::components::identity::application_credentials::{
+            IdentityApplicationCredentials, IdentityApplicationCredentialsBehaviour,
+        };
+        use crate::components::resource_behaviour::ResourceBehaviour;
+
+        let mut comp: IdentityApplicationCredentials = GenericResourceView::new();
+        let mode = IdentityApplicationCredentialsBehaviour::mode();
+
+        let result = comp.update(Action::Refresh, mode);
+
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            None,
+            "Refresh must not fire a list request while user_id is unset"
+        );
+    }
+
+    #[test]
+    fn refresh_fetches_once_user_id_is_set() {
+        use crate::components::identity::application_credentials::{
+            IdentityApplicationCredentials, IdentityApplicationCredentialsBehaviour,
+        };
+        use crate::components::resource_behaviour::ResourceBehaviour;
+
+        let mut comp: IdentityApplicationCredentials = GenericResourceView::new();
+        let mode = IdentityApplicationCredentialsBehaviour::mode();
+        let mut token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        token_info.user.id = "user-42".to_string();
+        comp.update(Action::ConnectedToCloud(Box::new(token_info)), mode)
+            .unwrap();
+
+        let result = comp.update(Action::Refresh, mode);
+
+        assert!(matches!(
+            result.unwrap(),
+            Some(Action::PerformApiRequest(_))
+        ));
     }
 
     fn make_server_json() -> Value {

--- a/openstack_tui/src/components/identity/application_credentials.rs
+++ b/openstack_tui/src/components/identity/application_credentials.rs
@@ -59,6 +59,25 @@ impl ResourceBehaviour for IdentityApplicationCredentialsBehaviour {
             None
         }
     }
+
+    fn seed_filter_from_current_user(
+        mut filter: Self::Filter,
+        token: &openstack_sdk::types::identity::v3::TokenInfo,
+    ) -> Self::Filter {
+        if filter.user_id.is_empty() {
+            filter.user_id = token.user.id.clone();
+        }
+        filter
+    }
+
+    fn reset_filter_on_cloud_switch(mut filter: Self::Filter) -> Self::Filter {
+        filter.user_id = String::new();
+        filter
+    }
+
+    fn is_filter_ready(filter: &Self::Filter) -> bool {
+        !filter.user_id.is_empty()
+    }
 }
 
 pub type IdentityApplicationCredentials =
@@ -130,5 +149,91 @@ mod tests {
         let result =
             IdentityApplicationCredentialsBehaviour::handle_set_filter_action(&Action::Tick);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn seed_filter_from_current_user_sets_empty_user_id() {
+        let filter = IdentityUserApplicationCredentialList::default();
+        assert_eq!(filter.user_id, "");
+        let mut token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        token_info.user.id = "current-user-id".to_string();
+
+        let result = IdentityApplicationCredentialsBehaviour::seed_filter_from_current_user(
+            filter,
+            &token_info,
+        );
+
+        assert_eq!(result.user_id, "current-user-id");
+    }
+
+    #[test]
+    fn seed_filter_from_current_user_does_not_override_existing_user_id() {
+        let filter = IdentityUserApplicationCredentialList {
+            user_id: "explicitly-selected-user".to_string(),
+            ..Default::default()
+        };
+        let mut token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        token_info.user.id = "current-user-id".to_string();
+
+        let result = IdentityApplicationCredentialsBehaviour::seed_filter_from_current_user(
+            filter,
+            &token_info,
+        );
+
+        assert_eq!(result.user_id, "explicitly-selected-user");
+    }
+
+    #[test]
+    fn reset_filter_on_cloud_switch_clears_user_id() {
+        let filter = IdentityUserApplicationCredentialList {
+            user_id: "stale-user-from-previous-cloud".to_string(),
+            ..Default::default()
+        };
+
+        let result = IdentityApplicationCredentialsBehaviour::reset_filter_on_cloud_switch(filter);
+
+        assert_eq!(result.user_id, "");
+    }
+
+    #[test]
+    fn reset_then_reseed_picks_up_new_cloud_user() {
+        // Regression test: switching clouds must not leave the previous cloud's user_id
+        // stuck in the filter forever (seed_filter_from_current_user's "don't clobber an
+        // explicit selection" guard would otherwise treat it as already-scoped).
+        let filter = IdentityUserApplicationCredentialList {
+            user_id: "cloud-a-user".to_string(),
+            ..Default::default()
+        };
+
+        let filter = IdentityApplicationCredentialsBehaviour::reset_filter_on_cloud_switch(filter);
+
+        let mut token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        token_info.user.id = "cloud-b-user".to_string();
+        let result = IdentityApplicationCredentialsBehaviour::seed_filter_from_current_user(
+            filter,
+            &token_info,
+        );
+
+        assert_eq!(result.user_id, "cloud-b-user");
+    }
+
+    #[test]
+    fn is_filter_ready_false_when_user_id_empty() {
+        let filter = IdentityUserApplicationCredentialList::default();
+        assert_eq!(filter.user_id, "");
+        assert!(!IdentityApplicationCredentialsBehaviour::is_filter_ready(
+            &filter
+        ));
+    }
+
+    #[test]
+    fn is_filter_ready_true_when_user_id_set() {
+        let filter = IdentityUserApplicationCredentialList {
+            user_id: "user-42".to_string(),
+            ..Default::default()
+        };
+        assert!(IdentityApplicationCredentialsBehaviour::is_filter_ready(
+            &filter
+        ));
     }
 }

--- a/openstack_tui/src/components/resource_behaviour.rs
+++ b/openstack_tui/src/components/resource_behaviour.rs
@@ -61,9 +61,48 @@ pub trait ResourceBehaviour {
     /// The Mode that corresponds to this component (when shown, data should be loaded).
     fn mode() -> Mode;
 
+    /// Seed a freshly-authenticated user's identity into the filter, if this resource cares.
+    /// Called on every `ConnectedToCloud`, regardless of whether this resource's view is
+    /// currently active, so the filter is already correct by the time the user navigates here.
+    /// Default is a no-op; override where a resource needs to default-scope to the current user.
+    ///
+    /// This only *seeds*, it never clobbers: it's also called after `CloudChangeScope`/
+    /// `SwitchToRegion` reconnects (same user, different project/region), where a value
+    /// already in the filter (e.g. a user explicitly drilled down to) must survive. Values
+    /// that must NOT survive a genuine cloud switch belong in `reset_filter_on_cloud_switch`
+    /// instead, which runs only for `ConnectToCloud`.
+    fn seed_filter_from_current_user(
+        filter: Self::Filter,
+        _token: &openstack_sdk::types::identity::v3::TokenInfo,
+    ) -> Self::Filter {
+        filter
+    }
+
+    /// Clear any cloud-scoped value from the filter before a genuine cloud switch
+    /// (`Action::ConnectToCloud`, as opposed to `CloudChangeScope`/`SwitchToRegion`, which
+    /// keep the same authenticated user). Called before the new cloud's `ConnectedToCloud`
+    /// arrives, so `seed_filter_from_current_user`'s "don't clobber an existing value" guard
+    /// doesn't mistake a stale value from the *previous* cloud for a deliberate selection made
+    /// on this one. Default is a no-op; override where a resource seeds from the current user's
+    /// identity (which is only ever valid within one cloud).
+    fn reset_filter_on_cloud_switch(filter: Self::Filter) -> Self::Filter {
+        filter
+    }
+
     /// Normalise the filter before sending to the API. The default returns the filter unchanged.
     fn normalise_filter(filter: Self::Filter) -> Self::Filter {
         filter
+    }
+
+    /// Whether the (normalised) filter has everything it needs to issue a list request.
+    /// Checked before every fetch this view would otherwise trigger (login, refresh, mode
+    /// switch, filter change, post-mutation reload). Default is always ready. Override for a
+    /// resource whose filter can be transiently incomplete -- e.g. a required id that's only
+    /// empty before `ConnectedToCloud` seeds it or right after `ConnectToCloud` clears it on a
+    /// cloud switch -- so a request is never sent with a value the API would reject.
+    fn is_filter_ready(filter: &Self::Filter) -> bool {
+        let _ = filter;
+        true
     }
 
     /// Build the ApiRequest to list resources, given the current (normalised) filters.
@@ -219,5 +258,23 @@ mod tests {
         assert!(
             DefaultBehaviour::filter_carry_action(&Action::Tick, Some(&value), &Filter).is_empty()
         );
+    }
+
+    #[test]
+    fn seed_filter_from_current_user_default_is_noop() {
+        let token_info = openstack_sdk::types::identity::v3::TokenInfo::default();
+        let result = DefaultBehaviour::seed_filter_from_current_user(Filter, &token_info);
+        assert_eq!(format!("{result}"), "");
+    }
+
+    #[test]
+    fn reset_filter_on_cloud_switch_default_is_noop() {
+        let result = DefaultBehaviour::reset_filter_on_cloud_switch(Filter);
+        assert_eq!(format!("{result}"), "");
+    }
+
+    #[test]
+    fn is_filter_ready_default_is_always_ready() {
+        assert!(DefaultBehaviour::is_filter_ready(&Filter));
     }
 }

--- a/openstack_tui/src/mode.rs
+++ b/openstack_tui/src/mode.rs
@@ -105,6 +105,7 @@ pub const LB_HEALTHMONITOR: ViewKey = "load-balancer.healthmonitor";
 /// of truth used both by the `resolve_view_key` round-trip test and by coverage tests that
 /// check `app.rs` and `.config/config.yaml` stay in sync with this list — add a new
 /// resource's `(name, const)` pair here too.
+#[cfg(test)]
 pub(crate) const ALL_VIEW_KEYS: &[(&str, ViewKey)] = &[
     // BEGIN GENERATED rust-tui-view mode-all_view_keys network.security_group
     ("NETWORK_SECURITY_GROUP", NETWORK_SECURITY_GROUP),

--- a/openstack_tui/src/tui.rs
+++ b/openstack_tui/src/tui.rs
@@ -84,6 +84,33 @@ impl Tui {
         })
     }
 
+    /// Test-only constructor. `Terminal::new` (used by the real `new()` above) always builds
+    /// a `Viewport::Fullscreen` terminal, which queries the real terminal size via
+    /// `backend.size()` -- an ioctl on stdout that fails in headless/CI environments where
+    /// stdout isn't a real tty. `Viewport::Fixed` skips that query entirely (confirmed against
+    /// `ratatui-core`'s `Terminal::with_options`: the `Fixed` branch never calls
+    /// `backend.size()`), so this is safe to construct anywhere, including CI.
+    #[cfg(test)]
+    pub(crate) fn new_for_test() -> Result<Self> {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        Ok(Self {
+            terminal: ratatui::Terminal::with_options(
+                Backend::new(stdout()),
+                ratatui::TerminalOptions {
+                    viewport: ratatui::Viewport::Fixed(ratatui::layout::Rect::new(0, 0, 80, 24)),
+                },
+            )?,
+            task: tokio::spawn(async {}),
+            cancellation_token: CancellationToken::new(),
+            event_rx,
+            event_tx,
+            frame_rate: 60.0,
+            tick_rate: 1.0,
+            mouse: false,
+            paste: false,
+        })
+    }
+
     pub fn tick_rate(mut self, tick_rate: f64) -> Self {
         self.tick_rate = tick_rate;
         self


### PR DESCRIPTION
Broadcast dispatch sends every action to all ~26 resource components,
not just the active one. Refresh and DescribeApiResponse were never
mode-gated because single-target dispatch used to make that implicit --
now they fan out, firing simultaneous API calls / racing the describe
pane on every navigation and login. Add explicit current_mode ==
B::mode() gates; add one for the selection-derived hooks block too since
it reads get_selected() and has the same shape of bug.

Investigated ConnectedToCloud reaching project/region-select popups
unconditionally: confirmed harmless, each fires exactly one fetch per
login event either way -- left as-is (pre-warm).

Add an end-to-end regression test through the real App::handle_actions
path for the actual reported bug (application-credentials filter seeding
on an inactive view), plus a #[cfg(test)] accessor to read a
GenericResourceView's filter back out for assertions.

seed_filter_from_current_user's "don't clobber an existing value" guard
protects a drilled-down user selection across
CloudChangeScope/SwitchToRegion reconnects (same authenticated user) --
but ConnectToCloud (a genuine cloud switch, different user) hits the
same guard and gets skipped too, since user_id is never empty again
after the first login. Filter stays stuck on the previous cloud's user
forever.

Add reset_filter_on_cloud_switch, run only for ConnectToCloud (split out
from the CloudChangeScope/SwitchToRegion branch, which must keep the old
behavior), overridden to clear user_id so the following
ConnectedToCloud's seed sees an empty filter and re-scopes to the new
cloud's user.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
