### PR TITLE
chore(deps): Upgrade comfy-table to version 8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
 dependencies = [
  "crossterm 0.29.0",
  "unicode-segmentation",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 base64 = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-comfy-table = { version = "^7.2" }
+comfy-table = { version = "8" }
 config.workspace = true
 dialoguer = { workspace = true }
 dirs = { workspace = true }

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -33,7 +33,7 @@ use crate::tracing_stats::HttpRequestStats;
 pub fn build_http_requests_timing_table(data: &HttpRequestStats) -> Table {
     let mut table = Table::new();
     table
-        .load_preset(UTF8_FULL_CONDENSED)
+        .load_style(UTF8_FULL_CONDENSED)
         .set_content_arrangement(ContentArrangement::Dynamic)
         .set_header(Vec::from(["Url", "Method", "Duration (ms)"]));
 

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -301,7 +301,7 @@ impl OutputProcessor {
                     });
                 let mut table = Table::new();
                 table
-                    .load_preset(UTF8_FULL_CONDENSED)
+                    .load_style(UTF8_FULL_CONDENSED)
                     .set_content_arrangement(ContentArrangement::from(self.table_arrangement))
                     .set_header(headers)
                     .add_rows(rows);
@@ -348,7 +348,7 @@ impl OutputProcessor {
 
         let mut table = Table::new();
         table
-            .load_preset(UTF8_FULL_CONDENSED)
+            .load_style(UTF8_FULL_CONDENSED)
             .set_content_arrangement(ContentArrangement::from(self.table_arrangement))
             .set_header(headers)
             .add_rows(table_rows);


### PR DESCRIPTION
The v8 release renamed load_preset() to load_style(). Updated all
call sites in cli/core.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
