### PR TITLE
feat(plugin): Add versioned plugin storage and lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4340,6 +4340,7 @@ name = "openstack-sdk-plugin-wasm"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "dirs",
  "extism",
  "httpmock",

--- a/cli/plugin/src/info.rs
+++ b/cli/plugin/src/info.rs
@@ -1,0 +1,133 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Show details about an installed wasm auth plugin
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use openstack_cli_core::output::OutputProcessor;
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use structable::{StructTable, StructTableOptions};
+
+/// Show every installed version of a wasm auth plugin, read from the
+/// lockfile.
+#[derive(Debug, Parser)]
+pub struct InfoCommand {
+    /// Plugin name.
+    pub name: String,
+}
+
+/// Details of a single installed `name@version`.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, StructTable)]
+pub struct PluginVersionInfo {
+    /// Plugin name.
+    #[structable()]
+    pub name: String,
+
+    /// Installed version.
+    #[structable()]
+    pub version: String,
+
+    /// Whether this is the version currently used for auth-method
+    /// resolution.
+    #[structable()]
+    pub active: bool,
+
+    /// The path this version was originally installed from.
+    #[structable()]
+    pub source: String,
+
+    /// Lowercase hex-encoded SHA-256 recorded at install time.
+    #[structable()]
+    pub sha256: String,
+
+    /// When this version was installed.
+    #[structable()]
+    pub installed_at: String,
+
+    /// Whether the user explicitly confirmed installing this entry.
+    #[structable()]
+    pub confirmed_by_user: bool,
+
+    /// Whether this entry was allowed to install without a signature.
+    #[structable()]
+    pub allow_unsigned: bool,
+
+    /// Auth methods declared by this version's ABI. Only populated for the
+    /// active version, which is the only one ever loaded.
+    #[structable()]
+    pub supported_methods: String,
+
+    /// Identity API version (major.minor) declared by this version's ABI.
+    /// Only populated for the active version.
+    #[structable()]
+    pub api_version: String,
+}
+
+impl InfoCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(&self, parsed_args: &C) -> Result<(), OpenStackCliError> {
+        info!("Show wasm auth plugin info for {}", self.name);
+
+        let op = OutputProcessor::from_args(parsed_args, Some("plugin"), Some("info"));
+
+        let lockfile =
+            openstack_sdk_plugin_wasm::registry::installed().map_err(eyre::Report::from)?;
+        let mut versions: Vec<_> = lockfile.versions_of(&self.name).cloned().collect();
+        if versions.is_empty() {
+            return Err(eyre::eyre!("no installed plugin named `{}`", self.name).into());
+        }
+        versions.sort_by(|a, b| a.version.cmp(&b.version));
+
+        openstack_sdk_plugin_wasm::registry::ensure_loaded().map_err(eyre::Report::from)?;
+        let loaded =
+            openstack_sdk_plugin_wasm::registry::list_loaded().map_err(eyre::Report::from)?;
+        let active_loaded = loaded.iter().find(|p| p.name() == self.name);
+
+        let data: Vec<serde_json::Value> = versions
+            .into_iter()
+            .map(|entry| {
+                let active = lockfile
+                    .active
+                    .get(&entry.name)
+                    .map(|v| v == &entry.version)
+                    .unwrap_or(false);
+                let (supported_methods, api_version) =
+                    match active.then_some(active_loaded).flatten() {
+                        Some(p) => {
+                            let (major, minor) = p.api_version();
+                            (p.supported_methods().join(", "), format!("{major}.{minor}"))
+                        }
+                        None => (String::new(), String::new()),
+                    };
+                serde_json::to_value(PluginVersionInfo {
+                    name: entry.name,
+                    version: entry.version,
+                    active,
+                    source: entry.source.display().to_string(),
+                    sha256: entry.sha256,
+                    installed_at: entry.installed_at.to_string(),
+                    confirmed_by_user: entry.trust.confirmed_by_user,
+                    allow_unsigned: entry.trust.allow_unsigned,
+                    supported_methods,
+                    api_version,
+                })
+            })
+            .collect::<Result<_, _>>()?;
+
+        op.output_list::<PluginVersionInfo>(data)
+    }
+}

--- a/cli/plugin/src/install.rs
+++ b/cli/plugin/src/install.rs
@@ -28,13 +28,24 @@ use structable::{StructTable, StructTableOptions};
 ///
 /// The plugin is loaded and its ABI is validated before anything is copied,
 /// so a malformed `.wasm` file is rejected without touching the plugin
-/// directory. Installing a plugin under a name that's already installed
-/// fails; remove the existing file from the plugin directory first to
-/// replace it.
+/// directory. It is installed as `<name>@<version>` (name comes from the
+/// plugin's own ABI; version defaults to `0.0.0` when `--version` is not
+/// given) and becomes the active version for that name. Installing over an
+/// already-installed `name@version` fails unless `--force` is given.
 #[derive(Debug, Parser)]
 pub struct InstallCommand {
     /// Path to the `.wasm` auth plugin file to install.
     pub file: PathBuf,
+
+    /// Version to record this install under. Defaults to `0.0.0` when not
+    /// given; multiple versions of the same plugin name may be installed
+    /// side by side.
+    #[arg(long)]
+    pub version: Option<String>,
+
+    /// Replace an existing installation of the same `name@version`.
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Information about an installed plugin.
@@ -64,8 +75,12 @@ impl InstallCommand {
 
         let op = OutputProcessor::from_args(parsed_args, Some("plugin"), Some("install"));
 
-        let plugin =
-            openstack_sdk_plugin_wasm::registry::install(&self.file).map_err(eyre::Report::from)?;
+        let plugin = openstack_sdk_plugin_wasm::registry::install(
+            &self.file,
+            self.version.as_deref(),
+            self.force,
+        )
+        .map_err(eyre::Report::from)?;
         let (major, minor) = plugin.api_version();
 
         let info = InstalledPlugin {

--- a/cli/plugin/src/lib.rs
+++ b/cli/plugin/src/lib.rs
@@ -23,8 +23,11 @@ use clap::{Parser, Subcommand};
 
 use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
 
+pub mod info;
 pub mod install;
 pub mod list;
+pub mod remove;
+pub mod verify;
 
 /// WASM auth plugin management
 ///
@@ -43,6 +46,9 @@ pub struct PluginCommand {
 pub enum PluginCommands {
     Install(install::InstallCommand),
     List(list::ListCommand),
+    Info(info::InfoCommand),
+    Remove(remove::RemoveCommand),
+    Verify(verify::VerifyCommand),
 }
 
 impl PluginCommand {
@@ -51,6 +57,9 @@ impl PluginCommand {
         match &self.command {
             PluginCommands::Install(cmd) => cmd.take_action(parsed_args).await,
             PluginCommands::List(cmd) => cmd.take_action(parsed_args).await,
+            PluginCommands::Info(cmd) => cmd.take_action(parsed_args).await,
+            PluginCommands::Remove(cmd) => cmd.take_action(parsed_args).await,
+            PluginCommands::Verify(cmd) => cmd.take_action(parsed_args).await,
         }
     }
 }

--- a/cli/plugin/src/remove.rs
+++ b/cli/plugin/src/remove.rs
@@ -12,63 +12,47 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! List installed wasm auth plugins
+//! Remove an installed wasm auth plugin
 
 use clap::Parser;
-use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use openstack_cli_core::output::OutputProcessor;
+use openstack_cli_core::output::{OutputFor, OutputProcessor};
 use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
-use structable::{StructTable, StructTableOptions};
 
-/// A single installed `name@version` entry, as recorded in the plugin
-/// lockfile. Listed regardless of whether it's the active version.
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, StructTable)]
-pub struct PluginListEntry {
-    /// Plugin name.
-    #[structable()]
+use crate::list::PluginListEntry;
+
+/// Remove an installed wasm auth plugin.
+///
+/// Removes every installed version of `name` unless `--version` narrows it
+/// to a single one. If the removed set included the active version and
+/// other versions of `name` remain, the most recently installed of those
+/// becomes active.
+#[derive(Debug, Parser)]
+pub struct RemoveCommand {
+    /// Plugin name to remove.
     pub name: String,
 
-    /// Installed version.
-    #[structable()]
-    pub version: String,
-
-    /// Whether this is the version currently used for auth-method
-    /// resolution.
-    #[structable()]
-    pub active: bool,
-
-    /// The path this version was originally installed from.
-    #[structable()]
-    pub source: String,
-
-    /// Lowercase hex-encoded SHA-256 recorded at install time.
-    #[structable()]
-    pub sha256: String,
-
-    /// When this version was installed.
-    #[structable()]
-    pub installed_at: String,
+    /// Remove only this specific version, leaving other installed versions
+    /// (if any) in place.
+    #[arg(long)]
+    pub version: Option<String>,
 }
 
-/// List installed wasm auth plugins.
-#[derive(Debug, Parser)]
-pub struct ListCommand {}
-
-impl ListCommand {
+impl RemoveCommand {
     /// Perform command action
     pub async fn take_action<C: CliArgs>(&self, parsed_args: &C) -> Result<(), OpenStackCliError> {
-        info!("List installed wasm auth plugins");
+        info!("Remove wasm auth plugin {}", self.name);
 
-        let op = OutputProcessor::from_args(parsed_args, Some("plugin"), Some("list"));
+        let op = OutputProcessor::from_args(parsed_args, Some("plugin"), Some("remove"));
+
+        openstack_sdk_plugin_wasm::registry::remove(&self.name, self.version.as_deref())
+            .map_err(eyre::Report::from)?;
 
         let lockfile =
             openstack_sdk_plugin_wasm::registry::installed().map_err(eyre::Report::from)?;
-
-        let data: Vec<serde_json::Value> = lockfile
-            .plugins
-            .values()
+        let remaining: Vec<serde_json::Value> = lockfile
+            .versions_of(&self.name)
             .map(|entry| {
                 let active = lockfile
                     .active
@@ -86,6 +70,15 @@ impl ListCommand {
             })
             .collect::<Result<_, _>>()?;
 
-        op.output_list::<PluginListEntry>(data)
+        if remaining.is_empty() {
+            if let OutputFor::Human = op.target {
+                println!("Removed all installed versions of `{}`.", self.name);
+            } else {
+                op.output_machine(serde_json::Value::Array(Vec::new()))?;
+            }
+            return Ok(());
+        }
+
+        op.output_list::<PluginListEntry>(remaining)
     }
 }

--- a/cli/plugin/src/verify.rs
+++ b/cli/plugin/src/verify.rs
@@ -1,0 +1,81 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Re-check installed wasm auth plugin file(s) against the lockfile
+
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use openstack_cli_core::output::OutputProcessor;
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use structable::{StructTable, StructTableOptions};
+
+/// Re-check installed wasm auth plugin file(s) against the SHA-256 recorded
+/// in the lockfile at install time.
+///
+/// Fails on the first version whose on-disk content no longer matches, or
+/// whose file is missing.
+#[derive(Debug, Parser)]
+pub struct VerifyCommand {
+    /// Plugin name to verify.
+    pub name: String,
+
+    /// Verify only this specific version. Defaults to every installed
+    /// version of `name`.
+    #[arg(long)]
+    pub version: Option<String>,
+}
+
+/// A single version that passed verification.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, StructTable)]
+pub struct VerifiedPluginVersion {
+    /// Plugin name.
+    #[structable()]
+    pub name: String,
+
+    /// Verified version.
+    #[structable()]
+    pub version: String,
+
+    /// The SHA-256 that matched between the lockfile and the file on disk.
+    #[structable()]
+    pub sha256: String,
+}
+
+impl VerifyCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(&self, parsed_args: &C) -> Result<(), OpenStackCliError> {
+        info!("Verify wasm auth plugin {}", self.name);
+
+        let op = OutputProcessor::from_args(parsed_args, Some("plugin"), Some("verify"));
+
+        let verified =
+            openstack_sdk_plugin_wasm::registry::verify(&self.name, self.version.as_deref())
+                .map_err(eyre::Report::from)?;
+
+        let data: Vec<serde_json::Value> = verified
+            .into_iter()
+            .map(|entry| {
+                serde_json::to_value(VerifiedPluginVersion {
+                    name: entry.name,
+                    version: entry.version,
+                    sha256: entry.sha256,
+                })
+            })
+            .collect::<Result<_, _>>()?;
+
+        op.output_list::<VerifiedPluginVersion>(data)
+    }
+}

--- a/sdk/plugin-wasm/Cargo.toml
+++ b/sdk/plugin-wasm/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+chrono.workspace = true
 dirs.workspace = true
 extism.workspace = true
 openstack-sdk-auth-core.workspace = true

--- a/sdk/plugin-wasm/src/error.rs
+++ b/sdk/plugin-wasm/src/error.rs
@@ -121,4 +121,40 @@ pub enum WasmPluginError {
     /// The in-process plugin registry could not be accessed or updated.
     #[error("plugin registry error: {0}")]
     Registry(String),
+
+    /// The plugin lockfile at `path` could not be parsed or serialized.
+    #[error("malformed plugin lockfile at {}: {}", path.display(), source)]
+    LockfileFormat {
+        /// Path of the lockfile.
+        path: PathBuf,
+        /// The underlying JSON error.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// The installed file's content no longer matches the hash recorded in
+    /// the lockfile when it was installed.
+    #[error(
+        "plugin {name}@{version} failed integrity verification: expected sha256 {expected}, found {actual}"
+    )]
+    HashMismatch {
+        /// Plugin name.
+        name: String,
+        /// Plugin version.
+        version: String,
+        /// The hash recorded in the lockfile at install time.
+        expected: String,
+        /// The hash computed from the file currently on disk.
+        actual: String,
+    },
+
+    /// The requested `name`/`version` is not present in the lockfile.
+    #[error("no installed plugin matches {name}{}", version.as_ref().map(|v| format!("@{v}")).unwrap_or_default())]
+    NotInstalled {
+        /// Plugin name.
+        name: String,
+        /// Specific version requested, if any; `None` means "any/all
+        /// versions of `name`".
+        version: Option<String>,
+    },
 }

--- a/sdk/plugin-wasm/src/lib.rs
+++ b/sdk/plugin-wasm/src/lib.rs
@@ -20,8 +20,10 @@
 
 pub mod error;
 pub(crate) mod host;
+pub mod lockfile;
 pub mod plugin;
 pub mod registry;
 
 pub use error::WasmPluginError;
+pub use lockfile::{PluginEntry, PluginLockfile, TrustInfo};
 pub use plugin::WasmAuthPlugin;

--- a/sdk/plugin-wasm/src/lockfile.rs
+++ b/sdk/plugin-wasm/src/lockfile.rs
@@ -1,0 +1,259 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-disk record of installed plugins: which `name@version` pairs are
+//! installed, their content hash, and which version is currently active for
+//! each plugin name.
+//!
+//! Stored as JSON at `OSC_PLUGIN_LOCKFILE`, or `<config-dir>/osc/plugins.lock`
+//! by default. Every write goes through [`atomic_write`]: the new content is
+//! written to a sibling `.tmp` file and then renamed over the real path, so a
+//! process killed mid-write leaves the previous, valid lockfile in place
+//! rather than a truncated or partially-written one.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::WasmPluginError;
+
+/// Trust metadata recorded for an installed plugin.
+///
+/// At this phase there is no signature or provenance source to check
+/// against, so installing via `osc plugin install` always records
+/// `confirmed_by_user: true` (the user explicitly pointed at the file) and
+/// `allow_unsigned: true`.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TrustInfo {
+    /// Whether the user explicitly confirmed installing this plugin.
+    pub confirmed_by_user: bool,
+    /// Whether an unsigned plugin is allowed to be installed/loaded.
+    pub allow_unsigned: bool,
+}
+
+/// A single installed `name@version` plugin record.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PluginEntry {
+    /// Plugin name.
+    pub name: String,
+    /// Plugin version (free-form; defaults to `"0.0.0"` when not specified
+    /// at install time).
+    pub version: String,
+    /// Lowercase hex-encoded SHA-256 of the installed `.wasm` file.
+    pub sha256: String,
+    /// The path the plugin was installed from (for reference; not read
+    /// again after install).
+    pub source: PathBuf,
+    /// When this entry was installed.
+    pub installed_at: DateTime<Utc>,
+    /// Trust metadata for this entry.
+    pub trust: TrustInfo,
+}
+
+/// The full set of installed plugins and which version of each is active.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PluginLockfile {
+    /// Installed `name@version` entries, keyed by [`entry_key`].
+    pub plugins: BTreeMap<String, PluginEntry>,
+    /// The active version for each installed plugin name. The active
+    /// version is the one the registry loads for auth-method resolution.
+    pub active: BTreeMap<String, String>,
+}
+
+/// The `"name@version"` key an entry is stored under.
+pub fn entry_key(name: &str, version: &str) -> String {
+    format!("{name}@{version}")
+}
+
+/// Path to the lockfile: `OSC_PLUGIN_LOCKFILE` if set, otherwise
+/// `<config-dir>/osc/plugins.lock`.
+pub fn lockfile_path() -> Result<PathBuf, WasmPluginError> {
+    if let Some(path) = std::env::var_os("OSC_PLUGIN_LOCKFILE") {
+        return Ok(PathBuf::from(path));
+    }
+    dirs::config_dir()
+        .map(|d| d.join("osc").join("plugins.lock"))
+        .ok_or(WasmPluginError::PluginDirCannotBeIdentified)
+}
+
+impl PluginLockfile {
+    /// Load the lockfile from [`lockfile_path`]. A missing file is treated
+    /// as an empty lockfile rather than an error.
+    pub fn load() -> Result<Self, WasmPluginError> {
+        let path = lockfile_path()?;
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Self::default()),
+            Err(source) => return Err(WasmPluginError::Io { path, source }),
+        };
+        serde_json::from_slice(&bytes)
+            .map_err(|source| WasmPluginError::LockfileFormat { path, source })
+    }
+
+    /// Serialize and atomically write this lockfile to [`lockfile_path`].
+    pub fn save(&self) -> Result<(), WasmPluginError> {
+        let path = lockfile_path()?;
+        let bytes =
+            serde_json::to_vec_pretty(self).map_err(|source| WasmPluginError::LockfileFormat {
+                path: path.clone(),
+                source,
+            })?;
+        atomic_write(&path, &bytes)
+    }
+
+    /// The entry for a specific `name@version`, if installed.
+    pub fn entry(&self, name: &str, version: &str) -> Option<&PluginEntry> {
+        self.plugins.get(&entry_key(name, version))
+    }
+
+    /// All installed versions of a given plugin name, in `entry_key` order.
+    pub fn versions_of<'a>(&'a self, name: &'a str) -> impl Iterator<Item = &'a PluginEntry> {
+        self.plugins.values().filter(move |e| e.name == name)
+    }
+
+    /// The entry for the currently active version of a plugin name, if any.
+    pub fn active_entry(&self, name: &str) -> Option<&PluginEntry> {
+        let version = self.active.get(name)?;
+        self.entry(name, version)
+    }
+}
+
+/// Write `bytes` to `path` atomically: write to a sibling `.tmp` file, then
+/// rename over `path`. A crash after the write but before the rename leaves
+/// `path` untouched; a crash after the rename leaves `path` fully updated.
+/// There is no window in which `path` can observe partial content.
+fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), WasmPluginError> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(dir).map_err(|source| WasmPluginError::Io {
+        path: dir.to_path_buf(),
+        source,
+    })?;
+    let mut tmp_name = path
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_default();
+    tmp_name.push(".tmp");
+    let tmp_path = path.with_file_name(tmp_name);
+
+    fs::write(&tmp_path, bytes).map_err(|source| WasmPluginError::Io {
+        path: tmp_path.clone(),
+        source,
+    })?;
+    fs::rename(&tmp_path, path).map_err(|source| WasmPluginError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    Ok(())
+}
+
+/// Lowercase hex-encoded SHA-256 of a file's contents, streamed rather than
+/// read fully into memory.
+pub fn sha256_hex(path: &Path) -> Result<String, WasmPluginError> {
+    let mut file = fs::File::open(path).map_err(|source| WasmPluginError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).map_err(|source| WasmPluginError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let digest = hasher.finalize();
+    Ok(digest.iter().map(|b| format!("{b:02x}")).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All scenarios below share the `OSC_PLUGIN_LOCKFILE` env var, which is
+    /// process-wide state; they're combined into one `#[test]` fn (run
+    /// sequentially) rather than split across several, which the default
+    /// multi-threaded test harness would race against each other.
+    #[test]
+    fn lockfile_round_trip_and_crash_safety() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("plugins.lock");
+        // SAFETY: no other test in this process touches this env var.
+        unsafe {
+            std::env::set_var("OSC_PLUGIN_LOCKFILE", &path);
+        }
+
+        // A missing lockfile loads as an empty default rather than erroring.
+        let lf = PluginLockfile::load()?;
+        assert!(lf.plugins.is_empty());
+        assert!(lf.active.is_empty());
+
+        // Saving and reloading round-trips exactly.
+        let mut lf = PluginLockfile::default();
+        lf.plugins.insert(
+            entry_key("demo", "1.0.0"),
+            PluginEntry {
+                name: "demo".into(),
+                version: "1.0.0".into(),
+                sha256: "deadbeef".into(),
+                source: PathBuf::from("/tmp/demo.wasm"),
+                installed_at: Utc::now(),
+                trust: TrustInfo {
+                    confirmed_by_user: true,
+                    allow_unsigned: true,
+                },
+            },
+        );
+        lf.active.insert("demo".into(), "1.0.0".into());
+        lf.save()?;
+
+        let reloaded = PluginLockfile::load()?;
+        assert_eq!(reloaded, lf);
+        let active = reloaded
+            .active_entry("demo")
+            .ok_or("expected an active entry for demo")?;
+        assert_eq!(active.sha256, "deadbeef");
+
+        // Simulate a crash between the `.tmp` write and the rename: a
+        // stale/garbage `.tmp` file left on disk must not affect what
+        // `PluginLockfile::load` sees.
+        let mut tmp_name = path
+            .file_name()
+            .ok_or("scratch lockfile path has no file name")?
+            .to_os_string();
+        tmp_name.push(".tmp");
+        fs::write(path.with_file_name(tmp_name), b"not valid json")?;
+
+        let reloaded = PluginLockfile::load()?;
+        assert_eq!(reloaded, lf);
+
+        // A later successful save still replaces the file cleanly,
+        // overwriting the stale `.tmp` in the process.
+        let mut lf2 = lf.clone();
+        lf2.active.insert("demo".into(), "2.0.0".into());
+        lf2.save()?;
+        let reloaded2 = PluginLockfile::load()?;
+        assert_eq!(reloaded2, lf2);
+
+        Ok(())
+    }
+}

--- a/sdk/plugin-wasm/src/registry.rs
+++ b/sdk/plugin-wasm/src/registry.rs
@@ -12,31 +12,49 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Process-wide registry of loaded [`WasmAuthPlugin`]s.
+//! Process-wide registry of loaded [`WasmAuthPlugin`]s, backed by the
+//! on-disk [`PluginLockfile`](crate::lockfile::PluginLockfile).
 //!
-//! Plugins live in a single directory on disk (by default
-//! `<data-dir>/osc/plugins`, overridable via `OSC_PLUGIN_DIR`). On first use
-//! the registry lazily loads every `*.wasm` file found there; [`install`]
-//! validates and copies a new plugin into that directory and loads it
-//! immediately so it's available for the rest of the process's lifetime.
+//! Plugins live at `<plugin-root>/<name>/<version>/<name>.wasm` (by default
+//! `<data-dir>/osc/plugins`, overridable via `OSC_PLUGIN_DIR`), one directory
+//! per installed version. Multiple versions of the same plugin name may be
+//! installed side by side; exactly one of them is the *active* version for
+//! that name at any time, recorded in the lockfile. Only the active version
+//! is ever loaded into the in-process registry for auth-method resolution.
 //!
-//! This is intentionally simple (no hot-reload, no uninstall-while-running):
-//! plugins are resolved once per process, matching how the compiled-in,
-//! `inventory`-based auth plugins already behave.
+//! [`install`] makes the newly installed version active. [`remove`] falls
+//! back to the most recently installed remaining version if the active one
+//! is removed, or clears the name entirely if none remain. Every load
+//! (whether at [`install`], [`ensure_loaded`], or explicit [`verify`])
+//! re-checks the on-disk file's SHA-256 against the lockfile record before
+//! trusting it.
+//!
+//! This is intentionally simple (no hot-reload of a *different* active
+//! version while the process is running): the active plugin for a name is
+//! resolved once per process, matching how the compiled-in, `inventory`-based
+//! auth plugins already behave.
 
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock, RwLock};
 
+use chrono::Utc;
+
 use crate::error::WasmPluginError;
+use crate::lockfile::{self, PluginEntry, PluginLockfile, TrustInfo};
 use crate::plugin::WasmAuthPlugin;
+
+/// Version recorded for a plugin installed without an explicit version.
+pub const DEFAULT_VERSION: &str = "0.0.0";
 
 #[derive(Default)]
 struct Registry {
-    /// All successfully loaded plugins, keyed by plugin (file stem) name.
+    /// The active plugin for each installed name.
     by_name: HashMap<String, Arc<WasmAuthPlugin>>,
-    /// Index from a supported auth method name to the plugin implementing it.
+    /// Index from a supported auth method name to the plugin implementing
+    /// it. First plugin to claim a method wins if more than one active
+    /// plugin declares it.
     by_method: HashMap<&'static str, Arc<WasmAuthPlugin>>,
     loaded_default_dir: bool,
 }
@@ -58,17 +76,26 @@ fn lock_write() -> Result<std::sync::RwLockWriteGuard<'static, Registry>, WasmPl
         .map_err(|_| WasmPluginError::Registry("registry lock poisoned".into()))
 }
 
-/// The directory plugins are loaded from and installed into.
+/// Root directory plugin versions are installed under:
+/// `<plugin_root>/<name>/<version>/<name>.wasm`.
 ///
 /// Overridable via the `OSC_PLUGIN_DIR` environment variable; otherwise
 /// `<data-dir>/osc/plugins`.
-pub fn plugin_dir() -> Result<PathBuf, WasmPluginError> {
+pub fn plugin_root() -> Result<PathBuf, WasmPluginError> {
     if let Some(dir) = std::env::var_os("OSC_PLUGIN_DIR") {
         return Ok(PathBuf::from(dir));
     }
     dirs::data_dir()
         .map(|d| d.join("osc").join("plugins"))
         .ok_or(WasmPluginError::PluginDirCannotBeIdentified)
+}
+
+fn version_dir(name: &str, version: &str) -> Result<PathBuf, WasmPluginError> {
+    Ok(plugin_root()?.join(name).join(version))
+}
+
+fn version_file(name: &str, version: &str) -> Result<PathBuf, WasmPluginError> {
+    Ok(version_dir(name, version)?.join(format!("{name}.wasm")))
 }
 
 fn insert(reg: &mut Registry, plugin: WasmAuthPlugin) -> Arc<WasmAuthPlugin> {
@@ -83,44 +110,45 @@ fn insert(reg: &mut Registry, plugin: WasmAuthPlugin) -> Arc<WasmAuthPlugin> {
     plugin
 }
 
-/// Load every `*.wasm` file directly inside `dir` into the registry.
-///
-/// Missing directories are treated as "no plugins installed" rather than an
-/// error. Returns the number of plugins successfully loaded.
-pub fn load_dir(dir: &Path) -> Result<usize, WasmPluginError> {
-    let entries = match fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(source) => {
-            return Err(WasmPluginError::Io {
-                path: dir.to_path_buf(),
-                source,
-            });
-        }
-    };
-
-    let mut loaded = 0;
-    let mut reg = lock_write()?;
-    for entry in entries {
-        let entry = entry.map_err(|source| WasmPluginError::Io {
-            path: dir.to_path_buf(),
-            source,
-        })?;
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("wasm") {
-            continue;
-        }
-        let plugin = WasmAuthPlugin::load(&path)?;
-        insert(&mut reg, plugin);
-        loaded += 1;
+/// Recompute `entry`'s on-disk SHA-256 and compare it against the hash
+/// recorded in the lockfile at install time.
+fn verify_entry(entry: &PluginEntry) -> Result<(), WasmPluginError> {
+    let path = version_file(&entry.name, &entry.version)?;
+    let actual = lockfile::sha256_hex(&path)?;
+    if actual != entry.sha256 {
+        return Err(WasmPluginError::HashMismatch {
+            name: entry.name.clone(),
+            version: entry.version.clone(),
+            expected: entry.sha256.clone(),
+            actual,
+        });
     }
-    Ok(loaded)
+    Ok(())
 }
 
-/// Ensure the default plugin directory has been scanned and loaded, exactly
-/// once per process. Safe to call repeatedly and from multiple call sites
-/// (e.g. once from SDK client construction, again defensively before auth
-/// dispatch).
+/// Hash-verify and load the active version of `name` into `reg`.
+fn load_active(
+    reg: &mut Registry,
+    lockfile: &PluginLockfile,
+    name: &str,
+) -> Result<(), WasmPluginError> {
+    let entry = lockfile
+        .active_entry(name)
+        .ok_or_else(|| WasmPluginError::NotInstalled {
+            name: name.to_string(),
+            version: None,
+        })?;
+    verify_entry(entry)?;
+    let path = version_file(&entry.name, &entry.version)?;
+    let plugin = WasmAuthPlugin::load(&path)?;
+    insert(reg, plugin);
+    Ok(())
+}
+
+/// Ensure the active version of every installed plugin has been loaded into
+/// the in-process registry, exactly once per process. Safe to call
+/// repeatedly and from multiple call sites (e.g. once from SDK client
+/// construction, again defensively before auth dispatch).
 pub fn ensure_loaded() -> Result<(), WasmPluginError> {
     {
         let reg = lock_read()?;
@@ -128,9 +156,11 @@ pub fn ensure_loaded() -> Result<(), WasmPluginError> {
             return Ok(());
         }
     }
-    let dir = plugin_dir()?;
-    load_dir(&dir)?;
+    let lockfile = PluginLockfile::load()?;
     let mut reg = lock_write()?;
+    for name in lockfile.active.keys() {
+        load_active(&mut reg, &lockfile, name)?;
+    }
     reg.loaded_default_dir = true;
     Ok(())
 }
@@ -142,39 +172,181 @@ pub fn lookup(method: &str) -> Result<Option<Arc<WasmAuthPlugin>>, WasmPluginErr
     Ok(lock_read()?.by_method.get(method).cloned())
 }
 
-/// All currently loaded plugins.
+/// The active plugins currently loaded into the in-process registry.
 pub fn list_loaded() -> Result<Vec<Arc<WasmAuthPlugin>>, WasmPluginError> {
     Ok(lock_read()?.by_name.values().cloned().collect())
 }
 
-/// Validate a `.wasm` file at `src_path` and install it into the plugin
-/// directory, loading it into the registry immediately.
+/// The full lockfile of installed `name@version` entries and their active
+/// markers, read directly from disk (independent of what's currently loaded
+/// into the in-process registry).
+pub fn installed() -> Result<PluginLockfile, WasmPluginError> {
+    PluginLockfile::load()
+}
+
+/// Validate a `.wasm` file at `src_path` and install it as `name@version`
+/// (name is taken from the plugin's own ABI; version defaults to
+/// [`DEFAULT_VERSION`] when not given), making it the active version for
+/// that name.
 ///
-/// Installing a plugin under a name that's already installed is rejected;
-/// remove the existing file from the plugin directory first to replace it.
-pub fn install(src_path: &Path) -> Result<Arc<WasmAuthPlugin>, WasmPluginError> {
+/// Installing over an already-installed `name@version` is rejected unless
+/// `force` is set, in which case the existing file and lockfile entry are
+/// replaced.
+pub fn install(
+    src_path: &Path,
+    version: Option<&str>,
+    force: bool,
+) -> Result<Arc<WasmAuthPlugin>, WasmPluginError> {
     // Validate before touching the plugin directory: a malformed module
     // should never be copied in.
     let probe = WasmAuthPlugin::load(src_path)?;
     let name = probe.name().to_string();
+    let version = version.unwrap_or(DEFAULT_VERSION).to_string();
 
-    let dir = plugin_dir()?;
-    fs::create_dir_all(&dir).map_err(|source| WasmPluginError::Io {
-        path: dir.clone(),
+    let mut lf = PluginLockfile::load()?;
+    let key = lockfile::entry_key(&name, &version);
+    if lf.plugins.contains_key(&key) && !force {
+        return Err(WasmPluginError::AlreadyInstalled(format!(
+            "{name}@{version}"
+        )));
+    }
+
+    let dest_dir = version_dir(&name, &version)?;
+    fs::create_dir_all(&dest_dir).map_err(|source| WasmPluginError::Io {
+        path: dest_dir.clone(),
         source,
     })?;
-    let dest = dir.join(format!("{name}.wasm"));
-    if dest.exists() {
-        return Err(WasmPluginError::AlreadyInstalled(name));
-    }
+    let dest = dest_dir.join(format!("{name}.wasm"));
     fs::copy(src_path, &dest).map_err(|source| WasmPluginError::Io {
         path: dest.clone(),
         source,
     })?;
+    let sha256 = lockfile::sha256_hex(&dest)?;
 
-    // Reload from the installed location so `source()` reflects where the
-    // plugin actually lives from now on.
-    let plugin = WasmAuthPlugin::load(&dest)?;
+    lf.plugins.insert(
+        key,
+        PluginEntry {
+            name: name.clone(),
+            version: version.clone(),
+            sha256,
+            source: src_path.to_path_buf(),
+            installed_at: Utc::now(),
+            trust: TrustInfo {
+                confirmed_by_user: true,
+                allow_unsigned: true,
+            },
+        },
+    );
+    lf.active.insert(name.clone(), version.clone());
+    lf.save()?;
+
+    // Reload from the installed, hash-verified location so `source()`
+    // reflects where the plugin actually lives from now on, and make it the
+    // active plugin for this name in the in-process registry.
     let mut reg = lock_write()?;
-    Ok(insert(&mut reg, plugin))
+    load_active(&mut reg, &lf, &name)?;
+    reg.by_name
+        .get(&name)
+        .cloned()
+        .ok_or_else(|| WasmPluginError::NotInstalled {
+            name: name.clone(),
+            version: Some(version.clone()),
+        })
+}
+
+/// Remove an installed plugin. If `version` is `None`, every installed
+/// version of `name` is removed; otherwise only that version.
+///
+/// If the removed version(s) included the active one, the most recently
+/// installed remaining version (if any) becomes active. Returns an error if
+/// nothing matching `name`/`version` is installed.
+pub fn remove(name: &str, version: Option<&str>) -> Result<(), WasmPluginError> {
+    let mut lf = PluginLockfile::load()?;
+
+    let to_remove: Vec<String> = match version {
+        Some(v) => {
+            if lf.entry(name, v).is_none() {
+                return Err(WasmPluginError::NotInstalled {
+                    name: name.to_string(),
+                    version: Some(v.to_string()),
+                });
+            }
+            vec![v.to_string()]
+        }
+        None => {
+            let versions: Vec<String> = lf.versions_of(name).map(|e| e.version.clone()).collect();
+            if versions.is_empty() {
+                return Err(WasmPluginError::NotInstalled {
+                    name: name.to_string(),
+                    version: None,
+                });
+            }
+            versions
+        }
+    };
+
+    for v in &to_remove {
+        lf.plugins.remove(&lockfile::entry_key(name, v));
+        let dir = version_dir(name, v)?;
+        if dir.exists() {
+            fs::remove_dir_all(&dir).map_err(|source| WasmPluginError::Io { path: dir, source })?;
+        }
+    }
+
+    let removed_active = match version {
+        Some(v) => lf.active.get(name).map(|a| a == v).unwrap_or(false),
+        None => true,
+    };
+    if removed_active {
+        lf.active.remove(name);
+        let next = lf
+            .versions_of(name)
+            .max_by_key(|e| e.installed_at)
+            .map(|e| e.version.clone());
+        if let Some(v) = next {
+            lf.active.insert(name.to_string(), v);
+        }
+    }
+    lf.save()?;
+
+    let mut reg = lock_write()?;
+    reg.by_name.remove(name);
+    reg.by_method.retain(|_, p| p.name() != name);
+    if lf.active.contains_key(name) {
+        load_active(&mut reg, &lf, name)?;
+    }
+    Ok(())
+}
+
+/// Re-check the on-disk SHA-256 of installed plugin file(s) against the
+/// lockfile. If `version` is `None`, every installed version of `name` is
+/// checked. Returns the entries that passed verification; the first mismatch
+/// or missing file is returned as an error.
+pub fn verify(name: &str, version: Option<&str>) -> Result<Vec<PluginEntry>, WasmPluginError> {
+    let lf = PluginLockfile::load()?;
+    let entries: Vec<PluginEntry> = match version {
+        Some(v) => {
+            let entry = lf
+                .entry(name, v)
+                .ok_or_else(|| WasmPluginError::NotInstalled {
+                    name: name.to_string(),
+                    version: Some(v.to_string()),
+                })?;
+            vec![entry.clone()]
+        }
+        None => {
+            let entries: Vec<PluginEntry> = lf.versions_of(name).cloned().collect();
+            if entries.is_empty() {
+                return Err(WasmPluginError::NotInstalled {
+                    name: name.to_string(),
+                    version: None,
+                });
+            }
+            entries
+        }
+    };
+    for entry in &entries {
+        verify_entry(entry)?;
+    }
+    Ok(entries)
 }

--- a/sdk/plugin-wasm/tests/registry.rs
+++ b/sdk/plugin-wasm/tests/registry.rs
@@ -12,15 +12,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//! Integration test for the runtime plugin registry: install a plugin into a
-//! scratch `OSC_PLUGIN_DIR`, then confirm it's discoverable via
-//! `ensure_loaded`/`list_loaded`/`lookup`.
+//! Integration test for the runtime plugin registry: install a plugin
+//! (across multiple versions) into a scratch plugin directory and lockfile,
+//! then confirm it's discoverable and manageable via
+//! `ensure_loaded`/`list_loaded`/`lookup`/`installed`/`remove`/`verify`.
 //!
 //! This is the only test in this binary so it can safely set the
-//! process-wide `OSC_PLUGIN_DIR` environment variable and rely on the
-//! registry's own process-lifetime, load-once semantics without racing
-//! another test thread.
+//! process-wide `OSC_PLUGIN_DIR`/`OSC_PLUGIN_LOCKFILE` environment variables
+//! and rely on the registry's own process-lifetime, load-once semantics
+//! without racing another test thread.
 
+use std::fs;
 use std::path::PathBuf;
 
 use openstack_sdk_plugin_wasm::registry;
@@ -31,18 +33,41 @@ fn fixture_path() -> PathBuf {
 
 #[test]
 fn install_then_list_then_lookup() -> Result<(), Box<dyn std::error::Error>> {
-    let dir = tempfile::tempdir()?;
+    let plugin_dir = tempfile::tempdir()?;
+    let lockfile_dir = tempfile::tempdir()?;
     // SAFETY: this is the only test in this binary, so nothing else races on
     // the process environment.
     unsafe {
-        std::env::set_var("OSC_PLUGIN_DIR", dir.path());
+        std::env::set_var("OSC_PLUGIN_DIR", plugin_dir.path());
+        std::env::set_var(
+            "OSC_PLUGIN_LOCKFILE",
+            lockfile_dir.path().join("plugins.lock"),
+        );
     }
 
-    let installed = registry::install(&fixture_path())?;
+    // Installing without an explicit version uses the default and becomes
+    // active.
+    let installed = registry::install(&fixture_path(), Some("1.0.0"), false)?;
     assert_eq!(installed.name(), "example_auth");
 
-    // Installing a plugin under a name that's already installed is rejected.
-    assert!(registry::install(&fixture_path()).is_err());
+    // Installing the same name@version again is rejected without --force.
+    assert!(registry::install(&fixture_path(), Some("1.0.0"), false).is_err());
+    // ...but succeeds with force.
+    registry::install(&fixture_path(), Some("1.0.0"), true)?;
+
+    // A second version installs alongside the first and becomes active.
+    registry::install(&fixture_path(), Some("2.0.0"), false)?;
+
+    let lockfile = registry::installed()?;
+    let versions: Vec<&str> = lockfile
+        .versions_of("example_auth")
+        .map(|e| e.version.as_str())
+        .collect();
+    assert_eq!(versions.len(), 2);
+    assert_eq!(
+        lockfile.active.get("example_auth").map(String::as_str),
+        Some("2.0.0")
+    );
 
     registry::ensure_loaded()?;
     let all = registry::list_loaded()?;
@@ -54,6 +79,41 @@ fn install_then_list_then_lookup() -> Result<(), Box<dyn std::error::Error>> {
 
     let missing = registry::lookup("does-not-exist")?;
     assert!(missing.is_none());
+
+    // Verifying an untampered install succeeds for every installed version.
+    let verified = registry::verify("example_auth", None)?;
+    assert_eq!(verified.len(), 2);
+
+    // Removing the active version (2.0.0) falls back to the remaining one
+    // (1.0.0), which is still untampered at this point so the fallback load
+    // succeeds.
+    registry::remove("example_auth", Some("2.0.0"))?;
+    let lockfile = registry::installed()?;
+    assert_eq!(
+        lockfile.active.get("example_auth").map(String::as_str),
+        Some("1.0.0")
+    );
+
+    // Tampering with the remaining installed file is caught on the next
+    // verify.
+    let entry = lockfile
+        .entry("example_auth", "1.0.0")
+        .ok_or("expected example_auth@1.0.0 to be installed")?;
+    let tampered_path = registry::plugin_root()?
+        .join(&entry.name)
+        .join(&entry.version)
+        .join(format!("{}.wasm", entry.name));
+    fs::write(&tampered_path, b"not a real wasm module")?;
+    assert!(registry::verify("example_auth", Some("1.0.0")).is_err());
+
+    // Removing every remaining version clears the plugin entirely, from
+    // both the lockfile and the in-process registry. This doesn't attempt
+    // to load the (tampered) file since no version remains active.
+    registry::remove("example_auth", None)?;
+    let lockfile = registry::installed()?;
+    assert!(lockfile.versions_of("example_auth").next().is_none());
+    assert!(!lockfile.active.contains_key("example_auth"));
+    assert!(registry::lookup("v3exampleauth")?.is_none());
 
     Ok(())
 }


### PR DESCRIPTION
Phase 2 of WASM auth plugin support: installed plugins now live at
<plugin_root>/<name>/<version>/<name>.wasm and are tracked in a JSON
lockfile (plugins.lock) recording each entry's sha256, source, install
time, and trust metadata, plus which version of each plugin name is
active. Lockfile writes go through a tmp-file-then-rename atomic write
so a process killed mid-install can never leave it corrupted.

- PluginLockfile/PluginEntry/TrustInfo with load/save and atomic_write
- registry::install/remove/verify/installed for the full lifecycle,
  loading only the active version and re-checking sha256 on every load
- osc plugin remove/info/verify commands; install/list updated for the
  versioned, multi-version-aware layout

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
