### PR TITLE
fix(cli): Group kind-suffix response candidates by microversion

### DIFF
--- a/cli/compute/src/v2/server/list_21.rs
+++ b/cli/compute/src/v2/server/list_21.rs
@@ -28,12 +28,16 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::list_detailed_21;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::identity::v3::user::find as find_user;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
 use openstack_sdk::api::{Pagination, paged};
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::response;
 use tracing::warn;
 
@@ -560,64 +564,63 @@ impl ServersCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)
             .await?;
 
-        op.output_list::<response::list_detailed_21::ServerResponse>(data.clone())
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_2100_a::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_2100_b::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_216::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_219::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_226::ServerResponse>(data.clone())
-            })
-            .or_else(|_| op.output_list::<response::list_detailed_23::ServerResponse>(data.clone()))
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_247::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_263::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_269_a::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_269_b::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_273_a::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_273_b::ServerResponse>(data.clone())
-            })
-            .or_else(|_| op.output_list::<response::list_detailed_29::ServerResponse>(data.clone()))
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_290_a::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_290_b::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_296_a::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_296_b::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_298_a::ServerResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_list::<response::list_detailed_298_b::ServerResponse>(data.clone())
-            })?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 100)) {
+            op.output_list::<response::list_detailed_2100_a::ServerResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_list::<response::list_detailed_2100_b::ServerResponse>(data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 98)) {
+            op.output_list::<response::list_detailed_298_a::ServerResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_list::<response::list_detailed_298_b::ServerResponse>(data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 96)) {
+            op.output_list::<response::list_detailed_296_a::ServerResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_list::<response::list_detailed_296_b::ServerResponse>(data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 90)) {
+            op.output_list::<response::list_detailed_290_a::ServerResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_list::<response::list_detailed_290_b::ServerResponse>(data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 73)) {
+            op.output_list::<response::list_detailed_273_a::ServerResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_list::<response::list_detailed_273_b::ServerResponse>(data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 69)) {
+            op.output_list::<response::list_detailed_269_a::ServerResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_list::<response::list_detailed_269_b::ServerResponse>(data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 63)) {
+            op.output_list::<response::list_detailed_263::ServerResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 47)) {
+            op.output_list::<response::list_detailed_247::ServerResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 26)) {
+            op.output_list::<response::list_detailed_226::ServerResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 19)) {
+            op.output_list::<response::list_detailed_219::ServerResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 16)) {
+            op.output_list::<response::list_detailed_216::ServerResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 9)) {
+            op.output_list::<response::list_detailed_29::ServerResponse>(data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 3)) {
+            op.output_list::<response::list_detailed_23::ServerResponse>(data.clone())?;
+        } else {
+            op.output_list::<response::list_detailed_21::ServerResponse>(data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/server/show_20.rs
+++ b/cli/compute/src/v2/server/show_20.rs
@@ -27,9 +27,14 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
+use openstack_sdk::api::Findable;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::find;
 use openstack_sdk::api::find;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::response;
 
 /// Shows details for a server.
@@ -99,36 +104,70 @@ impl ServerCommand {
         let find_ep = find_builder
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
+        let find_ep_versioned = find_ep.get_ep::<AsyncOpenStack>()?;
+
+        let service_endpoint = client
+            .get_service_endpoint(
+                &find_ep_versioned.service_type(),
+                find_ep_versioned.api_version().as_ref(),
+            )
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
-        op.output_single::<response::get_20::ServerResponse>(find_data.clone())
-            .or_else(|_| {
-                op.output_single::<response::get_2100_a::ServerResponse>(find_data.clone())
-            })
-            .or_else(|_| {
-                op.output_single::<response::get_2100_b::ServerResponse>(find_data.clone())
-            })
-            .or_else(|_| op.output_single::<response::get_216::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_219::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_226::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_23::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_247::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_263::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_269_a::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_269_b::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_271_a::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_271_b::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_273_a::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_273_b::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_29::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_290_a::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_290_b::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_296_a::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_296_b::ServerResponse>(find_data.clone()))
-            .or_else(|_| op.output_single::<response::get_298_a::ServerResponse>(find_data.clone()))
-            .or_else(|_| {
-                op.output_single::<response::get_298_b::ServerResponse>(find_data.clone())
-            })?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 100)) {
+            op.output_single::<response::get_2100_a::ServerResponse>(find_data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_2100_b::ServerResponse>(find_data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 98)) {
+            op.output_single::<response::get_298_a::ServerResponse>(find_data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_298_b::ServerResponse>(find_data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 96)) {
+            op.output_single::<response::get_296_a::ServerResponse>(find_data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_296_b::ServerResponse>(find_data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 90)) {
+            op.output_single::<response::get_290_a::ServerResponse>(find_data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_290_b::ServerResponse>(find_data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 73)) {
+            op.output_single::<response::get_273_a::ServerResponse>(find_data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_273_b::ServerResponse>(find_data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 71)) {
+            op.output_single::<response::get_271_a::ServerResponse>(find_data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_271_b::ServerResponse>(find_data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 69)) {
+            op.output_single::<response::get_269_a::ServerResponse>(find_data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_269_b::ServerResponse>(find_data.clone())
+                })?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 63)) {
+            op.output_single::<response::get_263::ServerResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 47)) {
+            op.output_single::<response::get_247::ServerResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 26)) {
+            op.output_single::<response::get_226::ServerResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 19)) {
+            op.output_single::<response::get_219::ServerResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 16)) {
+            op.output_single::<response::get_216::ServerResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 9)) {
+            op.output_single::<response::get_29::ServerResponse>(find_data.clone())?;
+        } else if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 3)) {
+            op.output_single::<response::get_23::ServerResponse>(find_data.clone())?;
+        } else {
+            op.output_single::<response::get_20::ServerResponse>(find_data.clone())?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())

--- a/cli/compute/src/v2/simple_tenant_usage/show_21.rs
+++ b/cli/compute/src/v2/simple_tenant_usage/show_21.rs
@@ -27,8 +27,12 @@ use openstack_cli_core::error::OpenStackCliError;
 use openstack_cli_core::output::OutputProcessor;
 use openstack_sdk::AsyncOpenStack;
 
+use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
+use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::simple_tenant_usage::get_21;
+use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::simple_tenant_usage::response;
 
 /// Shows usage statistics for a tenant.
@@ -124,18 +128,25 @@ impl SimpleTenantUsageCommand {
             .build()
             .map_err(|x| OpenStackCliError::EndpointBuild(x.to_string()))?;
 
+        let service_endpoint = client
+            .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
+            .await?;
+        let negotiated_version =
+            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+
         let data: serde_json::Value = ep.query_async(client).await?;
 
-        op.output_single::<response::get_21_a::SimpleTenantUsageResponse>(data.clone())
-            .or_else(|_| {
-                op.output_single::<response::get_21_b::SimpleTenantUsageResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_single::<response::get_240_a::SimpleTenantUsageResponse>(data.clone())
-            })
-            .or_else(|_| {
-                op.output_single::<response::get_240_b::SimpleTenantUsageResponse>(data.clone())
-            })?;
+        if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 40)) {
+            op.output_single::<response::get_240_a::SimpleTenantUsageResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_240_b::SimpleTenantUsageResponse>(data.clone())
+                })?;
+        } else {
+            op.output_single::<response::get_21_a::SimpleTenantUsageResponse>(data.clone())
+                .or_else(|_| {
+                    op.output_single::<response::get_21_b::SimpleTenantUsageResponse>(data.clone())
+                })?;
+        }
         // Show command specific hints
         op.show_command_hint()?;
         Ok(())


### PR DESCRIPTION
Real specs (server list/show) mix version-varying response schemas
with same-version kind-suffix pairs (e.g. list_detailed_2100_a/_b).
The prior "all min_ver unique" check disabled deterministic dispatch
entirely whenever any such pair existed, silently falling back to the
pre-existing trial-and-error .or_else chain across all 14+ candidates
-- which can pick a structurally-similar-but-wrong microversion schema
and silently drop fields (e.g. server list returning flavor: null).

Candidates are now grouped by identical min_ver; the negotiated
version selects a group deterministically, and only within a tied
group does dispatch fall back to trial-and-error.

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/1000872

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
