### PR TITLE
fix: Dispatch response schema by resolved microversion

### DIFF
--- a/cli/compute/src/v2/aggregate/add_host.rs
+++ b/cli/compute/src/v2/aggregate/add_host.rs
@@ -32,7 +32,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::add_host;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
@@ -111,7 +111,7 @@ impl AggregateCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/aggregate/list_21.rs
+++ b/cli/compute/src/v2/aggregate/list_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::list_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
@@ -83,7 +83,7 @@ impl AggregatesCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/aggregate/remove_host.rs
+++ b/cli/compute/src/v2/aggregate/remove_host.rs
@@ -32,7 +32,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::remove_host;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
@@ -111,7 +111,7 @@ impl AggregateCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/aggregate/set_metadata.rs
+++ b/cli/compute/src/v2/aggregate/set_metadata.rs
@@ -33,7 +33,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::set_metadata;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
@@ -120,7 +120,7 @@ impl AggregateCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/aggregate/show_21.rs
+++ b/cli/compute/src/v2/aggregate/show_21.rs
@@ -33,7 +33,7 @@ use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::aggregate::find;
 use openstack_sdk::api::find;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::aggregate::response;
 
@@ -97,8 +97,11 @@ impl AggregateCommand {
                 find_ep_versioned.api_version().as_ref(),
             )
             .await?;
-        let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
+        let negotiated_version = resolve_microversion::<AsyncOpenStack, _>(
+            &service_endpoint,
+            &find_ep_versioned,
+            client,
+        )?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
         if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 41)) {

--- a/cli/compute/src/v2/console_auth_token/show_21.rs
+++ b/cli/compute/src/v2/console_auth_token/show_21.rs
@@ -32,7 +32,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::console_auth_token::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::console_auth_token::response;
 
@@ -103,7 +103,7 @@ impl ConsoleAuthTokenCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/flavor/list_20.rs
+++ b/cli/compute/src/v2/flavor/list_20.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::flavor::list_detailed_20;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::flavor::response;
@@ -148,7 +148,7 @@ impl FlavorsCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/flavor/show_20.rs
+++ b/cli/compute/src/v2/flavor/show_20.rs
@@ -33,7 +33,7 @@ use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::flavor::find;
 use openstack_sdk::api::find;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::flavor::response;
 
@@ -97,8 +97,11 @@ impl FlavorCommand {
                 find_ep_versioned.api_version().as_ref(),
             )
             .await?;
-        let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
+        let negotiated_version = resolve_microversion::<AsyncOpenStack, _>(
+            &service_endpoint,
+            &find_ep_versioned,
+            client,
+        )?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
         if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 102)) {

--- a/cli/compute/src/v2/hypervisor/list_21.rs
+++ b/cli/compute/src/v2/hypervisor/list_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::hypervisor::list_detailed_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::hypervisor::response;
@@ -128,7 +128,7 @@ impl HypervisorsCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/hypervisor/show_21.rs
+++ b/cli/compute/src/v2/hypervisor/show_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::hypervisor::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::hypervisor::response;
 
@@ -104,7 +104,7 @@ impl HypervisorCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/hypervisor/uptime/get_21.rs
+++ b/cli/compute/src/v2/hypervisor/uptime/get_21.rs
@@ -32,7 +32,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::hypervisor::uptime::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::hypervisor::uptime::response;
 
@@ -99,7 +99,7 @@ impl UptimeCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/keypair/list_20.rs
+++ b/cli/compute/src/v2/keypair/list_20.rs
@@ -34,7 +34,7 @@ use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::keypair::list_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::find as find_user;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::keypair::response;
@@ -178,7 +178,7 @@ impl KeypairsCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/keypair/show_20.rs
+++ b/cli/compute/src/v2/keypair/show_20.rs
@@ -33,7 +33,7 @@ use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::keypair::find;
 use openstack_sdk::api::find;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::keypair::response;
 
@@ -116,8 +116,11 @@ impl KeypairCommand {
                 find_ep_versioned.api_version().as_ref(),
             )
             .await?;
-        let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
+        let negotiated_version = resolve_microversion::<AsyncOpenStack, _>(
+            &service_endpoint,
+            &find_ep_versioned,
+            client,
+        )?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
         if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 2)) {

--- a/cli/compute/src/v2/limit/list_21.rs
+++ b/cli/compute/src/v2/limit/list_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::limit::list_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::limit::response;
 
@@ -90,7 +90,7 @@ impl LimitCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/migration/get_20.rs
+++ b/cli/compute/src/v2/migration/get_20.rs
@@ -35,7 +35,7 @@ use openstack_sdk::api::compute::v2::migration::get_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::identity::v3::user::find as find_user;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::migration::response;
 use tracing::warn;
@@ -291,7 +291,7 @@ impl MigrationCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/quota_class_set/show_21.rs
+++ b/cli/compute/src/v2/quota_class_set/show_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_class_set::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_class_set::response;
 
@@ -93,7 +93,7 @@ impl QuotaClassSetCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/quota_set/defaults_20.rs
+++ b/cli/compute/src/v2/quota_set/defaults_20.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_set::defaults_20;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_set::response;
 
@@ -93,7 +93,7 @@ impl QuotaSetCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/quota_set/details_20.rs
+++ b/cli/compute/src/v2/quota_set/details_20.rs
@@ -34,7 +34,7 @@ use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_set::details_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::find as find_user;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_set::response;
 use tracing::warn;
@@ -163,7 +163,7 @@ impl QuotaSetCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/quota_set/show_20.rs
+++ b/cli/compute/src/v2/quota_set/show_20.rs
@@ -34,7 +34,7 @@ use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::quota_set::get_20;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::user::find as find_user;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::quota_set::response;
 use tracing::warn;
@@ -159,7 +159,7 @@ impl QuotaSetCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server/diagnostic/get_21.rs
+++ b/cli/compute/src/v2/server/diagnostic/get_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::diagnostic::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::diagnostic::response;
 
@@ -97,7 +97,7 @@ impl DiagnosticCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server/instance_action/list_21.rs
+++ b/cli/compute/src/v2/server/instance_action/list_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::instance_action::list_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::instance_action::response;
@@ -146,7 +146,7 @@ impl InstanceActionsCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/server/instance_action/show_21.rs
+++ b/cli/compute/src/v2/server/instance_action/show_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::instance_action::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::instance_action::response;
 
@@ -113,7 +113,7 @@ impl InstanceActionCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server/interface/list_21.rs
+++ b/cli/compute/src/v2/server/interface/list_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::interface::list_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::interface::response;
 
@@ -94,7 +94,7 @@ impl InterfacesCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server/interface/show_21.rs
+++ b/cli/compute/src/v2/server/interface/show_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::interface::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::interface::response;
 
@@ -102,7 +102,7 @@ impl InterfaceCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server/list_21.rs
+++ b/cli/compute/src/v2/server/list_21.rs
@@ -35,7 +35,7 @@ use openstack_sdk::api::compute::v2::server::list_detailed_21;
 use openstack_sdk::api::find_by_name;
 use openstack_sdk::api::identity::v3::project::find as find_project;
 use openstack_sdk::api::identity::v3::user::find as find_user;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::response;
@@ -568,7 +568,7 @@ impl ServersCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/server/migration/list_223.rs
+++ b/cli/compute/src/v2/server/migration/list_223.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::migration::list_223;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::migration::response;
 
@@ -97,7 +97,7 @@ impl MigrationsCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server/migration/show_223.rs
+++ b/cli/compute/src/v2/server/migration/show_223.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::migration::get_223;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::migration::response;
 
@@ -106,7 +106,7 @@ impl MigrationCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server/show_20.rs
+++ b/cli/compute/src/v2/server/show_20.rs
@@ -33,7 +33,7 @@ use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::find;
 use openstack_sdk::api::find;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::response;
 
@@ -112,8 +112,11 @@ impl ServerCommand {
                 find_ep_versioned.api_version().as_ref(),
             )
             .await?;
-        let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
+        let negotiated_version = resolve_microversion::<AsyncOpenStack, _>(
+            &service_endpoint,
+            &find_ep_versioned,
+            client,
+        )?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
         if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 100)) {

--- a/cli/compute/src/v2/server/volume_attachment/list_20.rs
+++ b/cli/compute/src/v2/server/volume_attachment/list_20.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::volume_attachment::list_20;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::volume_attachment::response;
@@ -123,7 +123,7 @@ impl VolumeAttachmentsCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/server/volume_attachment/show_20.rs
+++ b/cli/compute/src/v2/server/volume_attachment/show_20.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server::volume_attachment::get_20;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server::volume_attachment::response;
 
@@ -107,7 +107,7 @@ impl VolumeAttachmentCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/server_group/list_20.rs
+++ b/cli/compute/src/v2/server_group/list_20.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server_group::list_20;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server_group::response;
@@ -119,7 +119,7 @@ impl ServerGroupsCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/server_group/show_21.rs
+++ b/cli/compute/src/v2/server_group/show_21.rs
@@ -33,7 +33,7 @@ use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::server_group::find;
 use openstack_sdk::api::find;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::server_group::response;
 
@@ -98,8 +98,11 @@ impl ServerGroupCommand {
                 find_ep_versioned.api_version().as_ref(),
             )
             .await?;
-        let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &find_ep_versioned)?;
+        let negotiated_version = resolve_microversion::<AsyncOpenStack, _>(
+            &service_endpoint,
+            &find_ep_versioned,
+            client,
+        )?;
         let find_data: serde_json::Value = find(find_ep).query_async(client).await?;
 
         if negotiated_version.is_some_and(|v| v >= ApiVersion::new(2, 64)) {

--- a/cli/compute/src/v2/service/list_20.rs
+++ b/cli/compute/src/v2/service/list_20.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::service::list_20;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::service::response;
 
@@ -98,7 +98,7 @@ impl ServicesCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = ep.query_async(client).await?;
 

--- a/cli/compute/src/v2/simple_tenant_usage/list_21.rs
+++ b/cli/compute/src/v2/simple_tenant_usage/list_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::simple_tenant_usage::list_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{Pagination, paged};
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::simple_tenant_usage::response;
@@ -134,7 +134,7 @@ impl SimpleTenantUsagesCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: Vec<serde_json::Value> = paged(ep, Pagination::Limit(self.max_items))
             .query_async(client)

--- a/cli/compute/src/v2/simple_tenant_usage/show_21.rs
+++ b/cli/compute/src/v2/simple_tenant_usage/show_21.rs
@@ -31,7 +31,7 @@ use openstack_sdk::api::AsyncClient;
 use openstack_sdk::api::QueryAsync;
 use openstack_sdk::api::RestEndpoint;
 use openstack_sdk::api::compute::v2::simple_tenant_usage::get_21;
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::types::ApiVersion;
 use openstack_types::compute::v2::simple_tenant_usage::response;
 
@@ -132,7 +132,7 @@ impl SimpleTenantUsageCommand {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep)?;
+            resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, client)?;
 
         let data: serde_json::Value = ep.query_async(client).await?;
 

--- a/openstack_tui/src/cloud_worker/block_storage/v3/backup/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/backup/list_detailed.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -106,7 +106,7 @@ impl ExecuteApiRequest for BlockStorageBackupList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/snapshot/list_detailed.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -111,7 +111,7 @@ impl ExecuteApiRequest for BlockStorageSnapshotList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/block_storage/v3/volume/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/block_storage/v3/volume/list_detailed.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -121,7 +121,7 @@ impl ExecuteApiRequest for BlockStorageVolumeList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/compute/v2/aggregate/list.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/aggregate/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -64,7 +64,7 @@ impl ExecuteApiRequest for ComputeAggregateList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/compute/v2/flavor/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/flavor/list_detailed.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -106,7 +106,7 @@ impl ExecuteApiRequest for ComputeFlavorList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/compute/v2/hypervisor/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/hypervisor/list_detailed.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -86,7 +86,7 @@ impl ExecuteApiRequest for ComputeHypervisorList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/instance_action/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -94,7 +94,7 @@ impl ExecuteApiRequest for ComputeServerInstanceActionList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/compute/v2/server/list_detailed.rs
+++ b/openstack_tui/src/cloud_worker/compute/v2/server/list_detailed.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -423,7 +423,7 @@ impl ExecuteApiRequest for ComputeServerList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/dns/v2/recordset/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/recordset/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -133,7 +133,7 @@ impl ExecuteApiRequest for DnsRecordsetList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -116,7 +116,7 @@ impl ExecuteApiRequest for DnsZoneList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/list.rs
+++ b/openstack_tui/src/cloud_worker/dns/v2/zone/recordset/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -124,7 +124,7 @@ impl ExecuteApiRequest for DnsZoneRecordsetList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/identity/v3/auth/project/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/auth/project/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -64,7 +64,7 @@ impl ExecuteApiRequest for IdentityAuthProjectList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/identity/v3/group/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -108,7 +108,7 @@ impl ExecuteApiRequest for IdentityGroupList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/identity/v3/group/user/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/group/user/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -78,7 +78,7 @@ impl ExecuteApiRequest for IdentityGroupUserList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/identity/v3/project/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/project/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -145,7 +145,7 @@ impl ExecuteApiRequest for IdentityProjectList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/application_credential/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -78,7 +78,7 @@ impl ExecuteApiRequest for IdentityUserApplicationCredentialList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/identity/v3/user/list.rs
+++ b/openstack_tui/src/cloud_worker/identity/v3/user/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -169,7 +169,7 @@ impl ExecuteApiRequest for IdentityUserList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/image/v2/image/list.rs
+++ b/openstack_tui/src/cloud_worker/image/v2/image/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -166,7 +166,7 @@ impl ExecuteApiRequest for ImageImageList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/healthmonitor/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -225,7 +225,7 @@ impl ExecuteApiRequest for LoadBalancerHealthmonitorList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/listener/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/listener/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -267,7 +267,7 @@ impl ExecuteApiRequest for LoadBalancerListenerList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/loadbalancer/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -263,7 +263,7 @@ impl ExecuteApiRequest for LoadBalancerLoadbalancerList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -205,7 +205,7 @@ impl ExecuteApiRequest for LoadBalancerPoolList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/pool/member/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -223,7 +223,7 @@ impl ExecuteApiRequest for LoadBalancerPoolMemberList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/load_balancer/v2/quota/list.rs
+++ b/openstack_tui/src/cloud_worker/load_balancer/v2/quota/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -64,7 +64,7 @@ impl ExecuteApiRequest for LoadBalancerQuotaList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/network/v2/network/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/network/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -225,7 +225,7 @@ impl ExecuteApiRequest for NetworkNetworkList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/network/v2/router/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/router/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -168,7 +168,7 @@ impl ExecuteApiRequest for NetworkRouterList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/network/v2/security_group/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -168,7 +168,7 @@ impl ExecuteApiRequest for NetworkSecurityGroupList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/network/v2/security_group_rule/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/security_group_rule/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -226,7 +226,7 @@ impl ExecuteApiRequest for NetworkSecurityGroupRuleList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);

--- a/openstack_tui/src/cloud_worker/network/v2/subnet/list.rs
+++ b/openstack_tui/src/cloud_worker/network/v2/subnet/list.rs
@@ -17,7 +17,7 @@
 
 use derive_builder::Builder;
 use eyre::{Report, Result, WrapErr};
-use openstack_sdk::api::rest_endpoint::negotiate_microversion;
+use openstack_sdk::api::rest_endpoint::resolve_microversion;
 use openstack_sdk::api::{AsyncClient, RestEndpoint};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -249,7 +249,7 @@ impl ExecuteApiRequest for NetworkSubnetList {
             .get_service_endpoint(&ep.service_type(), ep.api_version().as_ref())
             .await?;
         let negotiated_version =
-            match negotiate_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep) {
+            match resolve_microversion::<AsyncOpenStack, _>(&service_endpoint, &ep, session) {
                 Ok(v) => v,
                 Err(e) => {
                     warn!("Microversion negotiation failed: {}", e);


### PR DESCRIPTION
negotiate_microversion() always returned the floor-compatible version,
even when the client's microversion_strategy is Ceiling, so generated
response-schema dispatch could disagree with the version actually sent
in the OpenStack-API-Version header. Route both through the new
resolve_microversion() (openstack_sdk), which applies the client's
strategy consistently for header and dispatch.

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/1000881

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
