### PR TITLE
fix(openapi): Safely handle schemas missing 'type' field

### DIFF
--- a/openstack_types/data/compute/v2.104.yaml
+++ b/openstack_types/data/compute/v2.104.yaml
@@ -87974,20 +87974,51 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -88000,35 +88031,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -88061,6 +88132,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -88070,19 +88145,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -88091,10 +88198,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -88113,11 +88234,20 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               id:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -88125,6 +88255,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -88145,10 +88279,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -88167,15 +88307,22 @@ components:
                 type: array
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -88186,10 +88333,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -88200,6 +88353,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -88223,14 +88378,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -88264,6 +88434,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -88764,6 +88939,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -88794,48 +88974,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -88848,35 +89104,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -88909,6 +89205,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -88918,19 +89218,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -88939,10 +89271,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -88961,8 +89307,27 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -88974,6 +89339,9 @@ components:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -88981,6 +89349,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -89001,10 +89373,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -89022,18 +89400,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -89048,10 +89437,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -89062,6 +89457,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -89085,14 +89482,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -89127,6 +89539,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -89158,48 +89575,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -89212,35 +89705,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -89273,6 +89806,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -89282,23 +89819,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -89307,10 +89881,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -89329,8 +89917,27 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -89342,6 +89949,9 @@ components:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -89349,6 +89959,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -89369,10 +89983,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -89390,18 +90010,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -89416,10 +90047,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -89430,6 +90067,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -89453,14 +90092,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -89496,6 +90150,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -89527,48 +90186,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -89581,19 +90316,48 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
@@ -89607,12 +90371,20 @@ components:
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -89645,6 +90417,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -89654,23 +90430,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -89679,10 +90492,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -89701,8 +90528,27 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -89714,6 +90560,9 @@ components:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -89721,6 +90570,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -89741,10 +90594,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -89762,18 +90621,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -89788,10 +90658,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -89802,6 +90678,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -89825,19 +90703,38 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tags:
+                description: |-
+                  A list of tags. The maximum count of tags in this list is 50.
+
+                  **New in version 2.26**
                 items:
                   type: string
                 maxItems: 50
                 type: array
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -89874,6 +90771,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -89905,48 +90807,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -89959,35 +90937,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -90020,6 +91038,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -90029,19 +91051,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -90050,10 +91104,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -90072,11 +91140,20 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               id:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -90084,6 +91161,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -90104,10 +91185,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -90126,15 +91213,22 @@ components:
                 type: array
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -90149,10 +91243,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -90163,6 +91263,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -90186,14 +91288,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -90227,6 +91344,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -90258,48 +91380,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -90312,35 +91510,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -90373,6 +91611,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -90382,23 +91624,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -90407,24 +91686,62 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   disk:
+                    description: |-
+                      The size of the root disk that was created in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   ephemeral:
+                    description: |-
+                      The size of the ephemeral disk that was created, in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   extra_specs:
                     additionalProperties: false
+                    description: |-
+                      A dictionary of the flavor’s extra-specs key-and-value pairs. This will
+                      only be included if the user is allowed by policy to index flavor
+                      extra_specs.
+
+                      **New in version 2.47**
                     patternProperties:
                       ^.+$:
                         type: string
                     type: object
                   original_name:
+                    description: |-
+                      The display name of a flavor.
+
+                      **New in version 2.47**
                     type: string
                   ram:
+                    description: |-
+                      The amount of RAM a flavor has, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   swap:
+                    description: |-
+                      The size of a dedicated swap disk that was allocated, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   vcpus:
+                    description: |-
+                      The number of virtual CPUs that were allocated to the server.
+
+                      **New in version 2.47**
                     type: integer
                 required:
                   - disk
@@ -90435,8 +91752,27 @@ components:
                   - vcpus
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -90445,9 +91781,14 @@ components:
                   - UP
                 type: string
               id:
+                description: |-
+                  The UUID of the server.
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -90455,6 +91796,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -90475,10 +91820,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -90496,18 +91847,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -90522,10 +91884,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -90536,6 +91904,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -90559,19 +91929,38 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tags:
+                description: |-
+                  A list of tags. The maximum count of tags in this list is 50.
+
+                  **New in version 2.26**
                 items:
                   type: string
                 maxItems: 50
                 type: array
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -90608,6 +91997,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -90639,48 +92033,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -90693,35 +92163,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -90754,6 +92264,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -90763,23 +92277,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -90788,24 +92339,62 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   disk:
+                    description: |-
+                      The size of the root disk that was created in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   ephemeral:
+                    description: |-
+                      The size of the ephemeral disk that was created, in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   extra_specs:
                     additionalProperties: false
+                    description: |-
+                      A dictionary of the flavor’s extra-specs key-and-value pairs. This will
+                      only be included if the user is allowed by policy to index flavor
+                      extra_specs.
+
+                      **New in version 2.47**
                     patternProperties:
                       ^.+$:
                         type: string
                     type: object
                   original_name:
+                    description: |-
+                      The display name of a flavor.
+
+                      **New in version 2.47**
                     type: string
                   ram:
+                    description: |-
+                      The amount of RAM a flavor has, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   swap:
+                    description: |-
+                      The size of a dedicated swap disk that was allocated, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   vcpus:
+                    description: |-
+                      The number of virtual CPUs that were allocated to the server.
+
+                      **New in version 2.47**
                     type: integer
                 required:
                   - disk
@@ -90816,8 +92405,27 @@ components:
                   - vcpus
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -90826,9 +92434,14 @@ components:
                   - UP
                 type: string
               id:
+                description: |-
+                  The UUID of the server.
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -90836,6 +92449,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -90856,10 +92473,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -90877,18 +92500,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -90903,10 +92537,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -90917,6 +92557,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -90940,25 +92582,51 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tags:
+                description: |-
+                  A list of tags. The maximum count of tags in this list is 50.
+
+                  **New in version 2.26**
                 items:
                   type: string
                 maxItems: 50
                 type: array
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               trusted_image_certificates:
+                description: |-
+                  A list of trusted certificate IDs, that were used during image signature
+                  verification to verify the signing certificate. The list is restricted
+                  to a maximum of 50 IDs. The value is `null` if trusted certificate IDs
+                  are not set.
+
+                  **New in version 2.63**
                 items:
                   type: string
                 type:
                   - array
                   - 'null'
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -90996,6 +92664,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -91425,6 +93098,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -91859,6 +93537,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -91890,48 +93573,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -91944,19 +93703,48 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
@@ -91970,12 +93758,20 @@ components:
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -92008,6 +93804,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -92017,19 +93817,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -92038,10 +93870,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -92060,11 +93906,20 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               id:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -92072,6 +93927,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -92092,10 +93951,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -92113,18 +93978,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -92139,10 +94015,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -92153,6 +94035,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -92176,14 +94060,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -92218,6 +94117,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -92653,6 +94557,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93093,6 +95002,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93542,6 +95456,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93874,6 +95793,10 @@ components:
                 format: uuid
                 type: string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -93891,6 +95814,8 @@ components:
                   type: object
                 type: array
               name:
+                description: |-
+                  The server name.
                 type: string
             required:
               - id
@@ -93899,6 +95824,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93989,6 +95919,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:

--- a/openstack_types/data/compute/v2.yaml
+++ b/openstack_types/data/compute/v2.yaml
@@ -87974,20 +87974,51 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -88000,35 +88031,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -88061,6 +88132,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -88070,19 +88145,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -88091,10 +88198,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -88113,11 +88234,20 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               id:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -88125,6 +88255,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -88145,10 +88279,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -88167,15 +88307,22 @@ components:
                 type: array
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -88186,10 +88333,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -88200,6 +88353,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -88223,14 +88378,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -88264,6 +88434,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -88764,6 +88939,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -88794,48 +88974,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -88848,35 +89104,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -88909,6 +89205,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -88918,19 +89218,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -88939,10 +89271,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -88961,8 +89307,27 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -88974,6 +89339,9 @@ components:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -88981,6 +89349,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -89001,10 +89373,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -89022,18 +89400,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -89048,10 +89437,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -89062,6 +89457,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -89085,14 +89482,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -89127,6 +89539,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -89158,48 +89575,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -89212,35 +89705,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -89273,6 +89806,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -89282,23 +89819,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -89307,10 +89881,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -89329,8 +89917,27 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -89342,6 +89949,9 @@ components:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -89349,6 +89959,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -89369,10 +89983,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -89390,18 +90010,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -89416,10 +90047,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -89430,6 +90067,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -89453,14 +90092,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -89496,6 +90150,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -89527,48 +90186,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -89581,19 +90316,48 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
@@ -89607,12 +90371,20 @@ components:
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -89645,6 +90417,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -89654,23 +90430,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -89679,10 +90492,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -89701,8 +90528,27 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -89714,6 +90560,9 @@ components:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -89721,6 +90570,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -89741,10 +90594,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -89762,18 +90621,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -89788,10 +90658,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -89802,6 +90678,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -89825,19 +90703,38 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tags:
+                description: |-
+                  A list of tags. The maximum count of tags in this list is 50.
+
+                  **New in version 2.26**
                 items:
                   type: string
                 maxItems: 50
                 type: array
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -89874,6 +90771,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -89905,48 +90807,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -89959,35 +90937,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -90020,6 +91038,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -90029,19 +91051,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -90050,10 +91104,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -90072,11 +91140,20 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               id:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -90084,6 +91161,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -90104,10 +91185,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -90126,15 +91213,22 @@ components:
                 type: array
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -90149,10 +91243,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -90163,6 +91263,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -90186,14 +91288,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -90227,6 +91344,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -90258,48 +91380,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -90312,35 +91510,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -90373,6 +91611,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -90382,23 +91624,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -90407,24 +91686,62 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   disk:
+                    description: |-
+                      The size of the root disk that was created in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   ephemeral:
+                    description: |-
+                      The size of the ephemeral disk that was created, in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   extra_specs:
                     additionalProperties: false
+                    description: |-
+                      A dictionary of the flavor’s extra-specs key-and-value pairs. This will
+                      only be included if the user is allowed by policy to index flavor
+                      extra_specs.
+
+                      **New in version 2.47**
                     patternProperties:
                       ^.+$:
                         type: string
                     type: object
                   original_name:
+                    description: |-
+                      The display name of a flavor.
+
+                      **New in version 2.47**
                     type: string
                   ram:
+                    description: |-
+                      The amount of RAM a flavor has, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   swap:
+                    description: |-
+                      The size of a dedicated swap disk that was allocated, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   vcpus:
+                    description: |-
+                      The number of virtual CPUs that were allocated to the server.
+
+                      **New in version 2.47**
                     type: integer
                 required:
                   - disk
@@ -90435,8 +91752,27 @@ components:
                   - vcpus
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -90445,9 +91781,14 @@ components:
                   - UP
                 type: string
               id:
+                description: |-
+                  The UUID of the server.
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -90455,6 +91796,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -90475,10 +91820,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -90496,18 +91847,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -90522,10 +91884,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -90536,6 +91904,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -90559,19 +91929,38 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tags:
+                description: |-
+                  A list of tags. The maximum count of tags in this list is 50.
+
+                  **New in version 2.26**
                 items:
                   type: string
                 maxItems: 50
                 type: array
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -90608,6 +91997,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -90639,48 +92033,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -90693,35 +92163,75 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               accessIPv4:
+                description: |-
+                  IPv4 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -90754,6 +92264,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -90763,23 +92277,60 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               description:
+                description: |-
+                  The description of the server.
+                  Before microversion 2.19 this was set to the server name.
+
+                  **New in version 2.19**
                 type:
                   - 'null'
                   - string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -90788,24 +92339,62 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   disk:
+                    description: |-
+                      The size of the root disk that was created in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   ephemeral:
+                    description: |-
+                      The size of the ephemeral disk that was created, in GiB.
+
+                      **New in version 2.47**
                     type: integer
                   extra_specs:
                     additionalProperties: false
+                    description: |-
+                      A dictionary of the flavor’s extra-specs key-and-value pairs. This will
+                      only be included if the user is allowed by policy to index flavor
+                      extra_specs.
+
+                      **New in version 2.47**
                     patternProperties:
                       ^.+$:
                         type: string
                     type: object
                   original_name:
+                    description: |-
+                      The display name of a flavor.
+
+                      **New in version 2.47**
                     type: string
                   ram:
+                    description: |-
+                      The amount of RAM a flavor has, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   swap:
+                    description: |-
+                      The size of a dedicated swap disk that was allocated, in MiB.
+
+                      **New in version 2.47**
                     type: integer
                   vcpus:
+                    description: |-
+                      The number of virtual CPUs that were allocated to the server.
+
+                      **New in version 2.47**
                     type: integer
                 required:
                   - disk
@@ -90816,8 +92405,27 @@ components:
                   - vcpus
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               host_status:
+                description: |-
+                  The host status. Values where next value in list can override the previous:
+
+                  * `UP` if nova-compute up.
+                  * `UNKNOWN` if nova-compute not reported by servicegroup driver.
+                  * `DOWN` if nova-compute forced down.
+                  * `MAINTENANCE` if nova-compute is disabled.
+                  * Empty string indicates there is no host for server.
+
+                  This attribute appears in the response only if the policy permits.
+                  By default, only administrators can get this parameter.
+
+                  **New in version 2.16**
                 enum:
                   - ''
                   - DOWN
@@ -90826,9 +92434,14 @@ components:
                   - UP
                 type: string
               id:
+                description: |-
+                  The UUID of the server.
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -90836,6 +92449,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -90856,10 +92473,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -90877,18 +92500,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -90903,10 +92537,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -90917,6 +92557,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -90940,25 +92582,51 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tags:
+                description: |-
+                  A list of tags. The maximum count of tags in this list is 50.
+
+                  **New in version 2.26**
                 items:
                   type: string
                 maxItems: 50
                 type: array
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               trusted_image_certificates:
+                description: |-
+                  A list of trusted certificate IDs, that were used during image signature
+                  verification to verify the signing certificate. The list is restricted
+                  to a maximum of 50 IDs. The value is `null` if trusted certificate IDs
+                  are not set.
+
+                  **New in version 2.63**
                 items:
                   type: string
                 type:
                   - array
                   - 'null'
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -90996,6 +92664,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -91425,6 +93098,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -91859,6 +93537,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -91890,48 +93573,124 @@ components:
             additionalProperties: false
             properties:
               OS-DCF:diskConfig:
+                description: |-
+                  Disk configuration. The value is either:
+
+                  * `AUTO`. The API builds the server with a single partition the size of
+                    the target flavor disk. The API automatically adjusts the file system to
+                    fit the entire partition.
+                  * `MANUAL`. The API builds the server by using the partition scheme and
+                    file system that is in the source image. If the target flavor disk is
+                    larger, The API does not partition the remaining disk space.
                 type: string
               OS-EXT-AZ:availability_zone:
+                description: |-
+                  The availability zone name.
                 type: string
               OS-EXT-SRV-ATTR:host:
+                description: |-
+                  The name of the compute host on which this instance is running.
+                  Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:hostname:
+                description: |-
+                  The hostname of the instance reported in the metadata service.
+                  This parameter only appears in responses for administrators until
+                  microversion 2.90, after which it is shown for all users.
+
+                  Note
+
+                  This information is published via the metadata service and requires
+                  application such as `cloud-init` to propagate it through to the
+                  instance.
+
+                  **New in version 2.3**
                 type: string
               OS-EXT-SRV-ATTR:hypervisor_hostname:
+                description: |-
+                  The hypervisor host name provided by the Nova virt driver. For the Ironic driver,
+                  it is the Ironic node uuid. Appears in the response for administrative users only.
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:instance_name:
+                description: |-
+                  The instance name. The Compute API generates the instance name from the instance
+                  name template. Appears in the response for administrative users only.
                 type: string
               OS-EXT-SRV-ATTR:kernel_id:
+                description: |-
+                  The UUID of the kernel image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:launch_index:
+                description: |-
+                  When servers are launched via multiple create, this is the
+                  sequence in which the servers were launched.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - integer
                   - 'null'
               OS-EXT-SRV-ATTR:ramdisk_id:
+                description: |-
+                  The UUID of the ramdisk image when using an AMI. Will be null if not.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:reservation_id:
+                description: |-
+                  The reservation id for the server. This is an id that can
+                  be useful in tracking groups of servers created with multiple
+                  create, that will all have the same reservation_id.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:root_device_name:
+                description: |-
+                  The root device name for the instance
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 type:
                   - 'null'
                   - string
               OS-EXT-SRV-ATTR:user_data:
+                description: |-
+                  The user_data the instance was created with.
+                  By default, it appears in the response for administrative users only.
+
+                  **New in version 2.3**
                 format: base64
                 maxLength: 65535
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:power_state:
+                description: |-
+                  The power state of the instance. This is an enum value that is mapped as:
+
+                  ```
+                  0: NOSTATE
+                  1: RUNNING
+                  3: PAUSED
+                  4: SHUTDOWN
+                  6: CRASHED
+                  7: SUSPENDED
+                  ```
                 enum:
                   - 
                   - 0
@@ -91944,19 +93703,48 @@ components:
                   - integer
                   - 'null'
               OS-EXT-STS:task_state:
+                description: |-
+                  The task state of the instance.
                 type:
                   - 'null'
                   - string
               OS-EXT-STS:vm_state:
+                description: |-
+                  The VM state.
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:launched_at:
+                description: |-
+                  The date and time when the server was launched.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+
+                  The `hh±:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
                   - string
               OS-SRV-USG:terminated_at:
+                description: |-
+                  The date and time when the server was deleted.
+
+                  The date and time stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`.
+                  The `±hh:mm` value, if included, is the time zone as an offset from UTC.
+                  If the `deleted_at` date and time stamp is not set, its value is `null`.
                 format: date-time
                 type:
                   - 'null'
@@ -91970,12 +93758,20 @@ components:
                   - format: ipv4
                 type: string
               accessIPv6:
+                description: |-
+                  IPv6 address that should be used to access this server. May be
+                  automatically set by the provider.
                 oneOf:
                   - const: ''
                   - format: ipv6
                 type: string
               addresses:
                 additionalProperties: false
+                description: |-
+                  The addresses for the server. Servers with status `BUILD` hide their
+                  addresses information.
+                  This view is not updated immediately.
+                  Please consult with OpenStack Networking API for up-to-date information.
                 patternProperties:
                   ^.*$:
                     items:
@@ -92008,6 +93804,10 @@ components:
                     type: array
                 type: object
               config_drive:
+                description: |-
+                  Indicates whether or not a config drive was used for this server.
+                  The value is `True` or an empty string. An empty string stands for
+                  `False`.
                 enum:
                   - ''
                   - 
@@ -92017,19 +93817,51 @@ components:
                   - 'null'
                   - string
               created:
+                description: |-
+                  The date and time when the resource was created. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               fault:
                 additionalProperties: false
+                description: |-
+                  A fault object. Only displayed when the server status is `ERROR` or
+                  `DELETED` and a fault occurred.
                 properties:
                   code:
+                    description: |-
+                      The error response code.
                     type: integer
                   created:
+                    description: |-
+                      The date and time when the exception was raised. The date and time
+                      stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                      ```
+                      CCYY-MM-DDThh:mm:ss±hh:mm
+                      ```
+
+                      For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                      value, if included, is the time zone as an offset from UTC. In
+                      the previous example, the offset value is `-05:00`.
                     format: date-time
                     type: string
                   details:
+                    description: |-
+                      The stack trace. It is available if the response code is not 500 or
+                      you have the administrator privilege
                     type: string
                   message:
+                    description: |-
+                      The error message.
                     type: string
                 required:
                   - code
@@ -92038,10 +93870,24 @@ components:
                 type: object
               flavor:
                 additionalProperties: false
+                description: |-
+                  Before microversion 2.47 this contains the ID and links for the flavor
+                  used to boot the server instance. This can be an empty object in case
+                  flavor information is no longer present in the system.
+
+                  As of microversion 2.47 this contains a subset of the actual flavor
+                  information used to create the server instance, represented as a nested
+                  dictionary.
                 properties:
                   id:
+                    description: |-
+                      The UUID of the server.
                     type: string
                   links:
+                    description: |-
+                      Links to the resources in question. See [API Guide / Links and
+                      References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                      for more info.
                     items:
                       additionalProperties: false
                       properties:
@@ -92060,11 +93906,20 @@ components:
                     type: array
                 type: object
               hostId:
+                description: |-
+                  An ID string representing the host. This is a hashed value so will not actually look like
+                  a hostname, and is hashed with data from the project_id, so the same physical host as seen
+                  by two different project_ids, will be different. It is useful when within the same project you
+                  need to determine if two instances are on the same or different physical hosts for the
+                  purposes of availability or performance.
                 type: string
               id:
                 format: uuid
                 type: string
               image:
+                description: |-
+                  The UUID and links for the image for your server instance. The `image` object
+                  will be an empty string when you boot the server from a volume.
                 oneOf:
                   - additionalProperties: false
                     properties:
@@ -92072,6 +93927,10 @@ components:
                         format: uuid
                         type: string
                       links:
+                        description: |-
+                          Links to the resources in question. See [API Guide / Links and
+                          References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                          for more info.
                         items:
                           additionalProperties: false
                           properties:
@@ -92092,10 +93951,16 @@ components:
                   - const: ''
                     type: string
               key_name:
+                description: |-
+                  The name of associated key pair, if any.
                 type:
                   - 'null'
                   - string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -92113,18 +93978,29 @@ components:
                   type: object
                 type: array
               locked:
+                description: |-
+                  True if the instance is locked otherwise False.
+
+                  **New in version 2.9**
                 type: boolean
               metadata:
                 additionalProperties: false
+                description: |-
+                  A dictionary of metadata key-and-value pairs, which is maintained for backward
+                  compatibility.
                 patternProperties:
                   ^.+$:
                     type: string
                 type: object
               name:
+                description: |-
+                  The server name.
                 type:
                   - 'null'
                   - string
               os-extended-volumes:volumes_attached:
+                description: |-
+                  The attached volumes, if any.
                 items:
                   additionalProperties: false
                   properties:
@@ -92139,10 +94015,16 @@ components:
                   type: object
                 type: array
               progress:
+                description: |-
+                  A percentage value of the operation progress.
+                  This parameter only appears when the server status is `ACTIVE`,
+                  `BUILD`, `REBUILD`, `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
                 type:
                   - 'null'
                   - number
               security_groups:
+                description: |-
+                  One or more security groups objects.
                 items:
                   additionalProperties: false
                   properties:
@@ -92153,6 +94035,8 @@ components:
                   type: object
                 type: array
               status:
+                description: |-
+                  The server status.
                 enum:
                   - ACTIVE
                   - BUILD
@@ -92176,14 +94060,29 @@ components:
                   - VERIFY_RESIZE
                 type: string
               tenant_id:
+                description: |-
+                  The UUID of the tenant in a multi-tenancy cloud.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
                 type: string
               updated:
+                description: |-
+                  The date and time when the resource was updated. The date and time
+                  stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+
+                  ```
+                  CCYY-MM-DDThh:mm:ss±hh:mm
+                  ```
+
+                  For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm`
+                  value, if included, is the time zone as an offset from UTC. In
+                  the previous example, the offset value is `-05:00`.
                 format: date-time
                 type: string
               user_id:
+                description: |-
+                  The user ID of the user who owns the server.
                 maxLength: 255
                 minLength: 1
                 pattern: ^[a-zA-Z0-9-]*$
@@ -92218,6 +94117,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -92653,6 +94557,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93093,6 +95002,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93542,6 +95456,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93874,6 +95793,10 @@ components:
                 format: uuid
                 type: string
               links:
+                description: |-
+                  Links to the resources in question. See [API Guide / Links and
+                  References](https://docs.openstack.org/api-guide/compute/links_and_references.html)
+                  for more info.
                 items:
                   additionalProperties: false
                   properties:
@@ -93891,6 +95814,8 @@ components:
                   type: object
                 type: array
               name:
+                description: |-
+                  The server name.
                 type: string
             required:
               - id
@@ -93899,6 +95824,11 @@ components:
             type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:
@@ -93989,6 +95919,11 @@ components:
                 type: object
           type: array
         servers_links:
+          description: |-
+            Links to the next server. It is available when the number of servers exceeds
+            `limit` parameter or `[api]/max_limit` in the configuration file.
+            See [Paginated collections](https://docs.openstack.org/api-guide/compute/paginated_collections.html)
+            for more info.
           items:
             additionalProperties: false
             properties:

--- a/openstack_types/data/image/v2.16.yaml
+++ b/openstack_types/data/image/v2.16.yaml
@@ -3516,6 +3516,8 @@ components:
     ImagesListResponse:
       properties:
         first:
+          description: |-
+            The URI for the first page of response.
           type: string
         images:
           description: |-
@@ -3730,8 +3732,13 @@ components:
                 type: string
           type: array
         next:
+          description: |-
+            The URI for the next page of response. Will not be present on the last
+            page of the response.
           type: string
         schema:
+          description: |-
+            The URL for the schema describing a list of images.
           type: string
       type: object
     ImagesLocationsAdd_LocationRequest:
@@ -4071,6 +4078,8 @@ components:
         next:
           type: string
         schema:
+          description: |-
+            The URL for the schema describing an image member list.
           type: string
       type: object
     ImagesStageStageRequest:

--- a/openstack_types/data/image/v2.yaml
+++ b/openstack_types/data/image/v2.yaml
@@ -3516,6 +3516,8 @@ components:
     ImagesListResponse:
       properties:
         first:
+          description: |-
+            The URI for the first page of response.
           type: string
         images:
           description: |-
@@ -3730,8 +3732,13 @@ components:
                 type: string
           type: array
         next:
+          description: |-
+            The URI for the next page of response. Will not be present on the last
+            page of the response.
           type: string
         schema:
+          description: |-
+            The URL for the schema describing a list of images.
           type: string
       type: object
     ImagesLocationsAdd_LocationRequest:
@@ -4071,6 +4078,8 @@ components:
         next:
           type: string
         schema:
+          description: |-
+            The URL for the schema describing an image member list.
           type: string
       type: object
     ImagesStageStageRequest:

--- a/types/compute/src/v2/server/response/list_21.rs
+++ b/types/compute/src/v2/server/response/list_21.rs
@@ -26,6 +26,7 @@ pub struct ServerResponse {
     #[structable()]
     pub id: String,
 
+    /// The server name.
     #[structable()]
     pub name: String,
 }

--- a/types/compute/src/v2/server/response/list_detailed_21.rs
+++ b/types/compute/src/v2/server/response/list_detailed_21.rs
@@ -23,30 +23,65 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// IPv4 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
@@ -54,79 +89,159 @@ pub struct ServerResponse {
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -191,6 +306,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -230,6 +347,13 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -239,6 +363,8 @@ pub struct Flavor {
     pub links: Option<Vec<Links>>,
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {

--- a/types/compute/src/v2/server/response/list_detailed_216.rs
+++ b/types/compute/src/v2/server/response/list_detailed_216.rs
@@ -23,34 +23,82 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// IPv4 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// The host status. Values where next value in list can override the
+    /// previous:
+    ///
+    /// - `UP` if nova-compute up.
+    /// - `UNKNOWN` if nova-compute not reported by servicegroup driver.
+    /// - `DOWN` if nova-compute forced down.
+    /// - `MAINTENANCE` if nova-compute is disabled.
+    /// - Empty string indicates there is no host for server.
+    ///
+    /// This attribute appears in the response only if the policy permits. By
+    /// default, only administrators can get this parameter.
+    ///
+    /// **New in version 2.16**
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub host_status: Option<HostStatus>,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
@@ -58,110 +106,231 @@ pub struct ServerResponse {
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// True if the instance is locked otherwise False.
+    ///
+    /// **New in version 2.9**
     #[structable(wide)]
     pub locked: bool,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hostname of the instance reported in the metadata service. This
+    /// parameter only appears in responses for administrators until
+    /// microversion 2.90, after which it is shown for all users.
+    ///
+    /// Note
+    ///
+    /// This information is published via the metadata service and requires
+    /// application such as `cloud-init` to propagate it through to the
+    /// instance.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hostname", wide)]
     pub os_ext_srv_attr_hostname: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The UUID of the kernel image when using an AMI. Will be null if not. By
+    /// default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:kernel_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:kernel_id", wide)]
     pub os_ext_srv_attr_kernel_id: Option<String>,
 
+    /// When servers are launched via multiple create, this is the sequence in
+    /// which the servers were launched. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:launch_index")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:launch_index", wide)]
     pub os_ext_srv_attr_launch_index: Option<i32>,
 
+    /// The UUID of the ramdisk image when using an AMI. Will be null if not.
+    /// By default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:ramdisk_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:ramdisk_id", wide)]
     pub os_ext_srv_attr_ramdisk_id: Option<String>,
 
+    /// The reservation id for the server. This is an id that can be useful in
+    /// tracking groups of servers created with multiple create, that will all
+    /// have the same reservation_id. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:reservation_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:reservation_id", wide)]
     pub os_ext_srv_attr_reservation_id: Option<String>,
 
+    /// The root device name for the instance By default, it appears in the
+    /// response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:root_device_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:root_device_name", wide)]
     pub os_ext_srv_attr_root_device_name: Option<String>,
 
+    /// The user_data the instance was created with. By default, it appears in
+    /// the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:user_data")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:user_data", wide)]
     pub os_ext_srv_attr_user_data: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -226,6 +395,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -265,6 +436,13 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -311,6 +489,8 @@ impl std::str::FromStr for HostStatus {
     }
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {

--- a/types/compute/src/v2/server/response/list_detailed_219.rs
+++ b/types/compute/src/v2/server/response/list_detailed_219.rs
@@ -23,37 +23,89 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// IPv4 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// The description of the server. Before microversion 2.19 this was set to
+    /// the server name.
+    ///
+    /// **New in version 2.19**
     #[structable(optional, wide)]
     pub description: Option<String>,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// The host status. Values where next value in list can override the
+    /// previous:
+    ///
+    /// - `UP` if nova-compute up.
+    /// - `UNKNOWN` if nova-compute not reported by servicegroup driver.
+    /// - `DOWN` if nova-compute forced down.
+    /// - `MAINTENANCE` if nova-compute is disabled.
+    /// - Empty string indicates there is no host for server.
+    ///
+    /// This attribute appears in the response only if the policy permits. By
+    /// default, only administrators can get this parameter.
+    ///
+    /// **New in version 2.16**
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub host_status: Option<HostStatus>,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
@@ -61,110 +113,231 @@ pub struct ServerResponse {
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// True if the instance is locked otherwise False.
+    ///
+    /// **New in version 2.9**
     #[structable(wide)]
     pub locked: bool,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hostname of the instance reported in the metadata service. This
+    /// parameter only appears in responses for administrators until
+    /// microversion 2.90, after which it is shown for all users.
+    ///
+    /// Note
+    ///
+    /// This information is published via the metadata service and requires
+    /// application such as `cloud-init` to propagate it through to the
+    /// instance.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hostname", wide)]
     pub os_ext_srv_attr_hostname: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The UUID of the kernel image when using an AMI. Will be null if not. By
+    /// default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:kernel_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:kernel_id", wide)]
     pub os_ext_srv_attr_kernel_id: Option<String>,
 
+    /// When servers are launched via multiple create, this is the sequence in
+    /// which the servers were launched. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:launch_index")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:launch_index", wide)]
     pub os_ext_srv_attr_launch_index: Option<i32>,
 
+    /// The UUID of the ramdisk image when using an AMI. Will be null if not.
+    /// By default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:ramdisk_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:ramdisk_id", wide)]
     pub os_ext_srv_attr_ramdisk_id: Option<String>,
 
+    /// The reservation id for the server. This is an id that can be useful in
+    /// tracking groups of servers created with multiple create, that will all
+    /// have the same reservation_id. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:reservation_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:reservation_id", wide)]
     pub os_ext_srv_attr_reservation_id: Option<String>,
 
+    /// The root device name for the instance By default, it appears in the
+    /// response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:root_device_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:root_device_name", wide)]
     pub os_ext_srv_attr_root_device_name: Option<String>,
 
+    /// The user_data the instance was created with. By default, it appears in
+    /// the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:user_data")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:user_data", wide)]
     pub os_ext_srv_attr_user_data: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -229,6 +402,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -268,6 +443,13 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -314,6 +496,8 @@ impl std::str::FromStr for HostStatus {
     }
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {

--- a/types/compute/src/v2/server/response/list_detailed_226.rs
+++ b/types/compute/src/v2/server/response/list_detailed_226.rs
@@ -29,33 +29,83 @@ pub struct ServerResponse {
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// The description of the server. Before microversion 2.19 this was set to
+    /// the server name.
+    ///
+    /// **New in version 2.19**
     #[structable(optional, wide)]
     pub description: Option<String>,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// The host status. Values where next value in list can override the
+    /// previous:
+    ///
+    /// - `UP` if nova-compute up.
+    /// - `UNKNOWN` if nova-compute not reported by servicegroup driver.
+    /// - `DOWN` if nova-compute forced down.
+    /// - `MAINTENANCE` if nova-compute is disabled.
+    /// - Empty string indicates there is no host for server.
+    ///
+    /// This attribute appears in the response only if the policy permits. By
+    /// default, only administrators can get this parameter.
+    ///
+    /// **New in version 2.16**
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub host_status: Option<HostStatus>,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
@@ -63,113 +113,237 @@ pub struct ServerResponse {
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// True if the instance is locked otherwise False.
+    ///
+    /// **New in version 2.9**
     #[structable(wide)]
     pub locked: bool,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hostname of the instance reported in the metadata service. This
+    /// parameter only appears in responses for administrators until
+    /// microversion 2.90, after which it is shown for all users.
+    ///
+    /// Note
+    ///
+    /// This information is published via the metadata service and requires
+    /// application such as `cloud-init` to propagate it through to the
+    /// instance.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hostname", wide)]
     pub os_ext_srv_attr_hostname: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The UUID of the kernel image when using an AMI. Will be null if not. By
+    /// default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:kernel_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:kernel_id", wide)]
     pub os_ext_srv_attr_kernel_id: Option<String>,
 
+    /// When servers are launched via multiple create, this is the sequence in
+    /// which the servers were launched. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:launch_index")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:launch_index", wide)]
     pub os_ext_srv_attr_launch_index: Option<i32>,
 
+    /// The UUID of the ramdisk image when using an AMI. Will be null if not.
+    /// By default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:ramdisk_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:ramdisk_id", wide)]
     pub os_ext_srv_attr_ramdisk_id: Option<String>,
 
+    /// The reservation id for the server. This is an id that can be useful in
+    /// tracking groups of servers created with multiple create, that will all
+    /// have the same reservation_id. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:reservation_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:reservation_id", wide)]
     pub os_ext_srv_attr_reservation_id: Option<String>,
 
+    /// The root device name for the instance By default, it appears in the
+    /// response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:root_device_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:root_device_name", wide)]
     pub os_ext_srv_attr_root_device_name: Option<String>,
 
+    /// The user_data the instance was created with. By default, it appears in
+    /// the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:user_data")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:user_data", wide)]
     pub os_ext_srv_attr_user_data: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// A list of tags. The maximum count of tags in this list is 50.
+    ///
+    /// **New in version 2.26**
     #[structable(serialize, wide)]
     pub tags: Vec<String>,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -234,6 +408,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -273,6 +449,13 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -319,6 +502,8 @@ impl std::str::FromStr for HostStatus {
     }
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {

--- a/types/compute/src/v2/server/response/list_detailed_23.rs
+++ b/types/compute/src/v2/server/response/list_detailed_23.rs
@@ -23,30 +23,65 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// IPv4 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
@@ -54,107 +89,225 @@ pub struct ServerResponse {
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hostname of the instance reported in the metadata service. This
+    /// parameter only appears in responses for administrators until
+    /// microversion 2.90, after which it is shown for all users.
+    ///
+    /// Note
+    ///
+    /// This information is published via the metadata service and requires
+    /// application such as `cloud-init` to propagate it through to the
+    /// instance.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hostname", wide)]
     pub os_ext_srv_attr_hostname: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The UUID of the kernel image when using an AMI. Will be null if not. By
+    /// default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:kernel_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:kernel_id", wide)]
     pub os_ext_srv_attr_kernel_id: Option<String>,
 
+    /// When servers are launched via multiple create, this is the sequence in
+    /// which the servers were launched. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:launch_index")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:launch_index", wide)]
     pub os_ext_srv_attr_launch_index: Option<i32>,
 
+    /// The UUID of the ramdisk image when using an AMI. Will be null if not.
+    /// By default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:ramdisk_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:ramdisk_id", wide)]
     pub os_ext_srv_attr_ramdisk_id: Option<String>,
 
+    /// The reservation id for the server. This is an id that can be useful in
+    /// tracking groups of servers created with multiple create, that will all
+    /// have the same reservation_id. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:reservation_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:reservation_id", wide)]
     pub os_ext_srv_attr_reservation_id: Option<String>,
 
+    /// The root device name for the instance By default, it appears in the
+    /// response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:root_device_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:root_device_name", wide)]
     pub os_ext_srv_attr_root_device_name: Option<String>,
 
+    /// The user_data the instance was created with. By default, it appears in
+    /// the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:user_data")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:user_data", wide)]
     pub os_ext_srv_attr_user_data: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -219,6 +372,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -258,6 +413,13 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -267,6 +429,8 @@ pub struct Flavor {
     pub links: Option<Vec<Links>>,
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {

--- a/types/compute/src/v2/server/response/list_detailed_247.rs
+++ b/types/compute/src/v2/server/response/list_detailed_247.rs
@@ -23,151 +23,328 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// IPv4 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// The description of the server. Before microversion 2.19 this was set to
+    /// the server name.
+    ///
+    /// **New in version 2.19**
     #[structable(optional, wide)]
     pub description: Option<String>,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// The host status. Values where next value in list can override the
+    /// previous:
+    ///
+    /// - `UP` if nova-compute up.
+    /// - `UNKNOWN` if nova-compute not reported by servicegroup driver.
+    /// - `DOWN` if nova-compute forced down.
+    /// - `MAINTENANCE` if nova-compute is disabled.
+    /// - Empty string indicates there is no host for server.
+    ///
+    /// This attribute appears in the response only if the policy permits. By
+    /// default, only administrators can get this parameter.
+    ///
+    /// **New in version 2.16**
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub host_status: Option<HostStatus>,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
 
+    /// The UUID of the server.
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// True if the instance is locked otherwise False.
+    ///
+    /// **New in version 2.9**
     #[structable(wide)]
     pub locked: bool,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hostname of the instance reported in the metadata service. This
+    /// parameter only appears in responses for administrators until
+    /// microversion 2.90, after which it is shown for all users.
+    ///
+    /// Note
+    ///
+    /// This information is published via the metadata service and requires
+    /// application such as `cloud-init` to propagate it through to the
+    /// instance.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hostname", wide)]
     pub os_ext_srv_attr_hostname: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The UUID of the kernel image when using an AMI. Will be null if not. By
+    /// default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:kernel_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:kernel_id", wide)]
     pub os_ext_srv_attr_kernel_id: Option<String>,
 
+    /// When servers are launched via multiple create, this is the sequence in
+    /// which the servers were launched. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:launch_index")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:launch_index", wide)]
     pub os_ext_srv_attr_launch_index: Option<i32>,
 
+    /// The UUID of the ramdisk image when using an AMI. Will be null if not.
+    /// By default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:ramdisk_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:ramdisk_id", wide)]
     pub os_ext_srv_attr_ramdisk_id: Option<String>,
 
+    /// The reservation id for the server. This is an id that can be useful in
+    /// tracking groups of servers created with multiple create, that will all
+    /// have the same reservation_id. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:reservation_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:reservation_id", wide)]
     pub os_ext_srv_attr_reservation_id: Option<String>,
 
+    /// The root device name for the instance By default, it appears in the
+    /// response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:root_device_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:root_device_name", wide)]
     pub os_ext_srv_attr_root_device_name: Option<String>,
 
+    /// The user_data the instance was created with. By default, it appears in
+    /// the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:user_data")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:user_data", wide)]
     pub os_ext_srv_attr_user_data: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// A list of tags. The maximum count of tags in this list is 50.
+    ///
+    /// **New in version 2.26**
     #[structable(serialize, wide)]
     pub tags: Vec<String>,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -232,6 +409,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -242,6 +421,13 @@ pub struct Fault {
     pub message: String,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -321,6 +507,8 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {

--- a/types/compute/src/v2/server/response/list_detailed_263.rs
+++ b/types/compute/src/v2/server/response/list_detailed_263.rs
@@ -29,150 +29,331 @@ pub struct ServerResponse {
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// The description of the server. Before microversion 2.19 this was set to
+    /// the server name.
+    ///
+    /// **New in version 2.19**
     #[structable(optional, wide)]
     pub description: Option<String>,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// The host status. Values where next value in list can override the
+    /// previous:
+    ///
+    /// - `UP` if nova-compute up.
+    /// - `UNKNOWN` if nova-compute not reported by servicegroup driver.
+    /// - `DOWN` if nova-compute forced down.
+    /// - `MAINTENANCE` if nova-compute is disabled.
+    /// - Empty string indicates there is no host for server.
+    ///
+    /// This attribute appears in the response only if the policy permits. By
+    /// default, only administrators can get this parameter.
+    ///
+    /// **New in version 2.16**
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub host_status: Option<HostStatus>,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
 
+    /// The UUID of the server.
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// True if the instance is locked otherwise False.
+    ///
+    /// **New in version 2.9**
     #[structable(wide)]
     pub locked: bool,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hostname of the instance reported in the metadata service. This
+    /// parameter only appears in responses for administrators until
+    /// microversion 2.90, after which it is shown for all users.
+    ///
+    /// Note
+    ///
+    /// This information is published via the metadata service and requires
+    /// application such as `cloud-init` to propagate it through to the
+    /// instance.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hostname", wide)]
     pub os_ext_srv_attr_hostname: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The UUID of the kernel image when using an AMI. Will be null if not. By
+    /// default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:kernel_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:kernel_id", wide)]
     pub os_ext_srv_attr_kernel_id: Option<String>,
 
+    /// When servers are launched via multiple create, this is the sequence in
+    /// which the servers were launched. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:launch_index")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:launch_index", wide)]
     pub os_ext_srv_attr_launch_index: Option<i32>,
 
+    /// The UUID of the ramdisk image when using an AMI. Will be null if not.
+    /// By default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:ramdisk_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:ramdisk_id", wide)]
     pub os_ext_srv_attr_ramdisk_id: Option<String>,
 
+    /// The reservation id for the server. This is an id that can be useful in
+    /// tracking groups of servers created with multiple create, that will all
+    /// have the same reservation_id. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:reservation_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:reservation_id", wide)]
     pub os_ext_srv_attr_reservation_id: Option<String>,
 
+    /// The root device name for the instance By default, it appears in the
+    /// response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:root_device_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:root_device_name", wide)]
     pub os_ext_srv_attr_root_device_name: Option<String>,
 
+    /// The user_data the instance was created with. By default, it appears in
+    /// the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:user_data")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:user_data", wide)]
     pub os_ext_srv_attr_user_data: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// A list of tags. The maximum count of tags in this list is 50.
+    ///
+    /// **New in version 2.26**
     #[structable(serialize, wide)]
     pub tags: Vec<String>,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// A list of trusted certificate IDs, that were used during image
+    /// signature verification to verify the signing certificate. The list is
+    /// restricted to a maximum of 50 IDs. The value is `null` if trusted
+    /// certificate IDs are not set.
+    ///
+    /// **New in version 2.63**
     #[structable(serialize, wide)]
     pub trusted_image_certificates: Vec<String>,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -237,6 +418,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -247,6 +430,13 @@ pub struct Fault {
     pub message: String,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -326,6 +516,8 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {

--- a/types/compute/src/v2/server/response/list_detailed_29.rs
+++ b/types/compute/src/v2/server/response/list_detailed_29.rs
@@ -23,30 +23,65 @@ use structable::{StructTable, StructTableOptions};
 /// Server response representation
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct ServerResponse {
+    /// IPv4 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv4")]
     #[structable(title = "accessIPv4", wide)]
     pub access_ipv4: String,
 
+    /// IPv6 address that should be used to access this server. May be
+    /// automatically set by the provider.
     #[serde(rename = "accessIPv6")]
     #[structable(title = "accessIPv6", wide)]
     pub access_ipv6: String,
 
+    /// The addresses for the server. Servers with status `BUILD` hide their
+    /// addresses information. This view is not updated immediately. Please
+    /// consult with OpenStack Networking API for up-to-date information.
     #[structable(serialize, wide)]
     pub addresses: BTreeMap<String, Vec<AddressesItem>>,
 
+    /// Indicates whether or not a config drive was used for this server. The
+    /// value is `True` or an empty string. An empty string stands for `False`.
     #[structable(serialize, wide)]
     pub config_drive: ConfigDrive,
 
+    /// The date and time when the resource was created. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub created: String,
 
+    /// A fault object. Only displayed when the server status is `ERROR` or
+    /// `DELETED` and a fault occurred.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub fault: Option<Fault>,
 
+    /// Before microversion 2.47 this contains the ID and links for the flavor
+    /// used to boot the server instance. This can be an empty object in case
+    /// flavor information is no longer present in the system.
+    ///
+    /// As of microversion 2.47 this contains a subset of the actual flavor
+    /// information used to create the server instance, represented as a nested
+    /// dictionary.
     #[structable(serialize, wide)]
     pub flavor: Flavor,
 
+    /// An ID string representing the host. This is a hashed value so will not
+    /// actually look like a hostname, and is hashed with data from the
+    /// project_id, so the same physical host as seen by two different
+    /// project_ids, will be different. It is useful when within the same
+    /// project you need to determine if two instances are on the same or
+    /// different physical hosts for the purposes of availability or
+    /// performance.
     #[serde(rename = "hostId")]
     #[structable(title = "hostId", wide)]
     pub host_id: String,
@@ -54,110 +89,231 @@ pub struct ServerResponse {
     #[structable()]
     pub id: String,
 
+    /// The UUID and links for the image for your server instance. The `image`
+    /// object will be an empty string when you boot the server from a volume.
     #[structable(serialize, wide)]
     pub image: ImageEnum,
 
+    /// The name of associated key pair, if any.
     #[structable(optional, wide)]
     pub key_name: Option<String>,
 
+    /// True if the instance is locked otherwise False.
+    ///
+    /// **New in version 2.9**
     #[structable(wide)]
     pub locked: bool,
 
+    /// A dictionary of metadata key-and-value pairs, which is maintained for
+    /// backward compatibility.
     #[structable(serialize, wide)]
     pub metadata: BTreeMap<String, String>,
 
+    /// The server name.
     #[structable(optional)]
     pub name: Option<String>,
 
+    /// Disk configuration. The value is either:
+    ///
+    /// - `AUTO`. The API builds the server with a single partition the size of
+    ///   the target flavor disk. The API automatically adjusts the file system
+    ///   to fit the entire partition.
+    /// - `MANUAL`. The API builds the server by using the partition scheme and
+    ///   file system that is in the source image. If the target flavor disk is
+    ///   larger, The API does not partition the remaining disk space.
     #[serde(rename = "OS-DCF:diskConfig")]
     #[structable(title = "OS-DCF:diskConfig", wide)]
     pub os_dcf_disk_config: String,
 
+    /// The availability zone name.
     #[serde(rename = "OS-EXT-AZ:availability_zone")]
     #[structable(title = "OS-EXT-AZ:availability_zone", wide)]
     pub os_ext_az_availability_zone: String,
 
+    /// The name of the compute host on which this instance is running. Appears
+    /// in the response for administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:host")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:host", wide)]
     pub os_ext_srv_attr_host: Option<String>,
 
+    /// The hostname of the instance reported in the metadata service. This
+    /// parameter only appears in responses for administrators until
+    /// microversion 2.90, after which it is shown for all users.
+    ///
+    /// Note
+    ///
+    /// This information is published via the metadata service and requires
+    /// application such as `cloud-init` to propagate it through to the
+    /// instance.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hostname", wide)]
     pub os_ext_srv_attr_hostname: Option<String>,
 
+    /// The hypervisor host name provided by the Nova virt driver. For the
+    /// Ironic driver, it is the Ironic node uuid. Appears in the response for
+    /// administrative users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:hypervisor_hostname")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:hypervisor_hostname", wide)]
     pub os_ext_srv_attr_hypervisor_hostname: Option<String>,
 
+    /// The instance name. The Compute API generates the instance name from the
+    /// instance name template. Appears in the response for administrative
+    /// users only.
     #[serde(default, rename = "OS-EXT-SRV-ATTR:instance_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:instance_name", wide)]
     pub os_ext_srv_attr_instance_name: Option<String>,
 
+    /// The UUID of the kernel image when using an AMI. Will be null if not. By
+    /// default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:kernel_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:kernel_id", wide)]
     pub os_ext_srv_attr_kernel_id: Option<String>,
 
+    /// When servers are launched via multiple create, this is the sequence in
+    /// which the servers were launched. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:launch_index")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:launch_index", wide)]
     pub os_ext_srv_attr_launch_index: Option<i32>,
 
+    /// The UUID of the ramdisk image when using an AMI. Will be null if not.
+    /// By default, it appears in the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:ramdisk_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:ramdisk_id", wide)]
     pub os_ext_srv_attr_ramdisk_id: Option<String>,
 
+    /// The reservation id for the server. This is an id that can be useful in
+    /// tracking groups of servers created with multiple create, that will all
+    /// have the same reservation_id. By default, it appears in the response
+    /// for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:reservation_id")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:reservation_id", wide)]
     pub os_ext_srv_attr_reservation_id: Option<String>,
 
+    /// The root device name for the instance By default, it appears in the
+    /// response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:root_device_name")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:root_device_name", wide)]
     pub os_ext_srv_attr_root_device_name: Option<String>,
 
+    /// The user_data the instance was created with. By default, it appears in
+    /// the response for administrative users only.
+    ///
+    /// **New in version 2.3**
     #[serde(default, rename = "OS-EXT-SRV-ATTR:user_data")]
     #[structable(optional, title = "OS-EXT-SRV-ATTR:user_data", wide)]
     pub os_ext_srv_attr_user_data: Option<String>,
 
+    /// The power state of the instance. This is an enum value that is mapped
+    /// as:
+    ///
+    /// ```text
+    /// 0: NOSTATE
+    /// 1: RUNNING
+    /// 3: PAUSED
+    /// 4: SHUTDOWN
+    /// 6: CRASHED
+    /// 7: SUSPENDED
+    /// ```
     #[serde(rename = "OS-EXT-STS:power_state")]
     #[structable(title = "OS-EXT-STS:power_state", wide)]
     pub os_ext_sts_power_state: i32,
 
+    /// The task state of the instance.
     #[serde(rename = "OS-EXT-STS:task_state")]
     #[structable(optional, title = "OS-EXT-STS:task_state", wide)]
     pub os_ext_sts_task_state: Option<String>,
 
+    /// The VM state.
     #[serde(rename = "OS-EXT-STS:vm_state")]
     #[structable(optional, title = "OS-EXT-STS:vm_state", wide)]
     pub os_ext_sts_vm_state: Option<String>,
 
+    /// The attached volumes, if any.
     #[serde(rename = "os-extended-volumes:volumes_attached")]
     #[structable(serialize, title = "os-extended-volumes:volumes_attached", wide)]
     pub os_extended_volumes_volumes_attached: Vec<OsExtendedVolumesVolumesAttached>,
 
+    /// The date and time when the server was launched.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`.
+    ///
+    /// The `hh±:mm` value, if included, is the time zone as an offset from
+    /// UTC. If the `deleted_at` date and time stamp is not set, its value is
+    /// `null`.
     #[serde(rename = "OS-SRV-USG:launched_at")]
     #[structable(optional, title = "OS-SRV-USG:launched_at", wide)]
     pub os_srv_usg_launched_at: Option<String>,
 
+    /// The date and time when the server was deleted.
+    ///
+    /// The date and time stamp format is
+    /// [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601):
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. If the `deleted_at`
+    /// date and time stamp is not set, its value is `null`.
     #[serde(rename = "OS-SRV-USG:terminated_at")]
     #[structable(optional, title = "OS-SRV-USG:terminated_at", wide)]
     pub os_srv_usg_terminated_at: Option<String>,
 
+    /// A percentage value of the operation progress. This parameter only
+    /// appears when the server status is `ACTIVE`, `BUILD`, `REBUILD`,
+    /// `RESIZE`, `VERIFY_RESIZE` or `MIGRATING`.
     #[serde(default)]
     #[structable(optional, wide)]
     pub progress: Option<f32>,
 
+    /// One or more security groups objects.
     #[serde(default)]
     #[structable(optional, serialize, wide)]
     pub security_groups: Option<Vec<SecurityGroups>>,
 
+    /// The server status.
     #[structable(serialize)]
     pub status: Status,
 
+    /// The UUID of the tenant in a multi-tenancy cloud.
     #[structable(wide)]
     pub tenant_id: String,
 
+    /// The date and time when the resource was updated. The date and time
+    /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)
+    ///
+    /// ```text
+    /// CCYY-MM-DDThh:mm:ss±hh:mm
+    /// ```
+    ///
+    /// For example, `2015-08-27T09:49:58-05:00`. The `±hh:mm` value, if
+    /// included, is the time zone as an offset from UTC. In the previous
+    /// example, the offset value is `-05:00`.
     #[structable(wide)]
     pub updated: String,
 
+    /// The user ID of the user who owns the server.
     #[structable(wide)]
     pub user_id: String,
 }
@@ -222,6 +378,8 @@ impl std::str::FromStr for ConfigDrive {
     }
 }
 
+/// A fault object. Only displayed when the server status is `ERROR` or
+/// `DELETED` and a fault occurred.
 /// `Fault` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Fault {
@@ -261,6 +419,13 @@ pub struct Links {
     pub rel: Rel,
 }
 
+/// Before microversion 2.47 this contains the ID and links for the flavor used
+/// to boot the server instance. This can be an empty object in case flavor
+/// information is no longer present in the system.
+///
+/// As of microversion 2.47 this contains a subset of the actual flavor
+/// information used to create the server instance, represented as a nested
+/// dictionary.
 /// `Flavor` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Flavor {
@@ -270,6 +435,8 @@ pub struct Flavor {
     pub links: Option<Vec<Links>>,
 }
 
+/// The UUID and links for the image for your server instance. The `image`
+/// object will be an empty string when you boot the server from a volume.
 /// `Image` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Image {


### PR DESCRIPTION
Fixes a KeyError crash in _find_schema_property when traversing
schemas that use 'oneOf' without an explicit 'type' (e.g. server
list/detail response schemas). The bare except block silently
swallowed this crash, causing api-ref description merging to fail
for affected operations and producing non-deterministic YAML output
due to Python hash-seed dependent schema ordering.

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/1000983

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
