### PR TITLE
fix(rust-types): render nullable arrays as Option

### DIFF
--- a/openstack_types/data/network/v2.29.yaml
+++ b/openstack_types/data/network/v2.29.yaml
@@ -7755,6 +7755,17 @@ paths:
         - $ref: '#/components/parameters/page_reverse'
         - $ref: '#/components/parameters/sort_dir'
         - $ref: '#/components/parameters/sort_key'
+        - $ref: '#/components/parameters/vpnservices_admin_state_up'
+        - $ref: '#/components/parameters/vpnservices_description'
+        - $ref: '#/components/parameters/vpnservices_external_v4_ip'
+        - $ref: '#/components/parameters/vpnservices_external_v6_ip'
+        - $ref: '#/components/parameters/vpnservices_flavor_id'
+        - $ref: '#/components/parameters/vpnservices_id'
+        - $ref: '#/components/parameters/vpnservices_name'
+        - $ref: '#/components/parameters/vpnservices_router_id'
+        - $ref: '#/components/parameters/vpnservices_status'
+        - $ref: '#/components/parameters/vpnservices_subnet_id'
+        - $ref: '#/components/parameters/vpnservices_tenant_id'
       responses:
         '200':
           content:

--- a/openstack_types/data/network/v2.yaml
+++ b/openstack_types/data/network/v2.yaml
@@ -7755,6 +7755,17 @@ paths:
         - $ref: '#/components/parameters/page_reverse'
         - $ref: '#/components/parameters/sort_dir'
         - $ref: '#/components/parameters/sort_key'
+        - $ref: '#/components/parameters/vpnservices_admin_state_up'
+        - $ref: '#/components/parameters/vpnservices_description'
+        - $ref: '#/components/parameters/vpnservices_external_v4_ip'
+        - $ref: '#/components/parameters/vpnservices_external_v6_ip'
+        - $ref: '#/components/parameters/vpnservices_flavor_id'
+        - $ref: '#/components/parameters/vpnservices_id'
+        - $ref: '#/components/parameters/vpnservices_name'
+        - $ref: '#/components/parameters/vpnservices_router_id'
+        - $ref: '#/components/parameters/vpnservices_status'
+        - $ref: '#/components/parameters/vpnservices_subnet_id'
+        - $ref: '#/components/parameters/vpnservices_tenant_id'
       responses:
         '200':
           content:

--- a/openstack_types/data/shared-file-system/v2.yaml
+++ b/openstack_types/data/shared-file-system/v2.yaml
@@ -4067,6 +4067,13 @@ components:
       required: true
       schema:
         type: string
+    shares_migration_progress_id:
+      description: id parameter for /shares/{id}/migration-progress API
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
     snapshot_instances_action_id:
       description: id parameter for /snapshot-instances/{id}/action API
       in: path

--- a/types/compute/src/v2/aggregate/response/add_host_21.rs
+++ b/types/compute/src/v2/aggregate/response/add_host_21.rs
@@ -36,8 +36,8 @@ pub struct AggregateResponse {
     #[structable(optional)]
     pub deleted_at: Option<String>,
 
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     #[structable()]
     pub id: i32,

--- a/types/compute/src/v2/aggregate/response/add_host_241.rs
+++ b/types/compute/src/v2/aggregate/response/add_host_241.rs
@@ -36,8 +36,8 @@ pub struct AggregateResponse {
     #[structable(optional)]
     pub deleted_at: Option<String>,
 
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     #[structable()]
     pub id: i32,

--- a/types/compute/src/v2/aggregate/response/get_21.rs
+++ b/types/compute/src/v2/aggregate/response/get_21.rs
@@ -61,8 +61,8 @@ pub struct AggregateResponse {
     pub deleted_at: Option<String>,
 
     /// An array of host information.
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     /// The ID of the host aggregate.
     #[structable()]

--- a/types/compute/src/v2/aggregate/response/get_241.rs
+++ b/types/compute/src/v2/aggregate/response/get_241.rs
@@ -61,8 +61,8 @@ pub struct AggregateResponse {
     pub deleted_at: Option<String>,
 
     /// An array of host information.
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     /// The ID of the host aggregate.
     #[structable()]

--- a/types/compute/src/v2/aggregate/response/list_21.rs
+++ b/types/compute/src/v2/aggregate/response/list_21.rs
@@ -61,8 +61,8 @@ pub struct AggregateResponse {
     pub deleted_at: Option<String>,
 
     /// A list of host ids in this aggregate.
-    #[structable(serialize, wide)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub hosts: Option<Vec<String>>,
 
     /// The ID of the host aggregate.
     #[structable()]

--- a/types/compute/src/v2/aggregate/response/list_241.rs
+++ b/types/compute/src/v2/aggregate/response/list_241.rs
@@ -61,8 +61,8 @@ pub struct AggregateResponse {
     pub deleted_at: Option<String>,
 
     /// A list of host ids in this aggregate.
-    #[structable(serialize, wide)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub hosts: Option<Vec<String>>,
 
     /// The ID of the host aggregate.
     #[structable()]

--- a/types/compute/src/v2/aggregate/response/remove_host_21.rs
+++ b/types/compute/src/v2/aggregate/response/remove_host_21.rs
@@ -36,8 +36,8 @@ pub struct AggregateResponse {
     #[structable(optional)]
     pub deleted_at: Option<String>,
 
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     #[structable()]
     pub id: i32,

--- a/types/compute/src/v2/aggregate/response/remove_host_241.rs
+++ b/types/compute/src/v2/aggregate/response/remove_host_241.rs
@@ -36,8 +36,8 @@ pub struct AggregateResponse {
     #[structable(optional)]
     pub deleted_at: Option<String>,
 
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     #[structable()]
     pub id: i32,

--- a/types/compute/src/v2/aggregate/response/set_21.rs
+++ b/types/compute/src/v2/aggregate/response/set_21.rs
@@ -61,8 +61,8 @@ pub struct AggregateResponse {
     pub deleted_at: Option<String>,
 
     /// An array of host information.
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     /// The ID of the host aggregate.
     #[structable()]

--- a/types/compute/src/v2/aggregate/response/set_241.rs
+++ b/types/compute/src/v2/aggregate/response/set_241.rs
@@ -61,8 +61,8 @@ pub struct AggregateResponse {
     pub deleted_at: Option<String>,
 
     /// An array of host information.
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     /// The ID of the host aggregate.
     #[structable()]

--- a/types/compute/src/v2/aggregate/response/set_metadata_21.rs
+++ b/types/compute/src/v2/aggregate/response/set_metadata_21.rs
@@ -36,8 +36,8 @@ pub struct AggregateResponse {
     #[structable(optional)]
     pub deleted_at: Option<String>,
 
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     #[structable()]
     pub id: i32,

--- a/types/compute/src/v2/aggregate/response/set_metadata_241.rs
+++ b/types/compute/src/v2/aggregate/response/set_metadata_241.rs
@@ -36,8 +36,8 @@ pub struct AggregateResponse {
     #[structable(optional)]
     pub deleted_at: Option<String>,
 
-    #[structable(serialize)]
-    pub hosts: Vec<String>,
+    #[structable(optional, serialize)]
+    pub hosts: Option<Vec<String>>,
 
     #[structable()]
     pub id: i32,

--- a/types/compute/src/v2/server/interface/response/create_21.rs
+++ b/types/compute/src/v2/server/interface/response/create_21.rs
@@ -23,8 +23,8 @@ use structable::{StructTable, StructTableOptions};
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct InterfaceResponse {
     /// Fixed IP addresses with subnet IDs.
-    #[structable(serialize)]
-    pub fixed_ips: Vec<FixedIps>,
+    #[structable(optional, serialize)]
+    pub fixed_ips: Option<Vec<FixedIps>>,
 
     /// The MAC address.
     #[structable()]

--- a/types/compute/src/v2/server/interface/response/create_270.rs
+++ b/types/compute/src/v2/server/interface/response/create_270.rs
@@ -23,8 +23,8 @@ use structable::{StructTable, StructTableOptions};
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct InterfaceResponse {
     /// Fixed IP addresses with subnet IDs.
-    #[structable(serialize)]
-    pub fixed_ips: Vec<FixedIps>,
+    #[structable(optional, serialize)]
+    pub fixed_ips: Option<Vec<FixedIps>>,
 
     /// The MAC address.
     #[structable()]

--- a/types/compute/src/v2/server/interface/response/get_21.rs
+++ b/types/compute/src/v2/server/interface/response/get_21.rs
@@ -23,8 +23,8 @@ use structable::{StructTable, StructTableOptions};
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct InterfaceResponse {
     /// Fixed IP addresses with subnet IDs.
-    #[structable(serialize)]
-    pub fixed_ips: Vec<FixedIps>,
+    #[structable(optional, serialize)]
+    pub fixed_ips: Option<Vec<FixedIps>>,
 
     /// The MAC address.
     #[structable()]

--- a/types/compute/src/v2/server/interface/response/get_270.rs
+++ b/types/compute/src/v2/server/interface/response/get_270.rs
@@ -23,8 +23,8 @@ use structable::{StructTable, StructTableOptions};
 #[derive(Clone, Deserialize, Serialize, StructTable)]
 pub struct InterfaceResponse {
     /// Fixed IP addresses with subnet IDs.
-    #[structable(serialize)]
-    pub fixed_ips: Vec<FixedIps>,
+    #[structable(optional, serialize)]
+    pub fixed_ips: Option<Vec<FixedIps>>,
 
     /// The MAC address.
     #[structable()]

--- a/types/compute/src/v2/server/interface/response/list_21.rs
+++ b/types/compute/src/v2/server/interface/response/list_21.rs
@@ -38,7 +38,7 @@ pub struct FixedIps {
 /// `InterfaceAttachments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InterfaceAttachments {
-    pub fixed_ips: Vec<FixedIps>,
+    pub fixed_ips: Option<Vec<FixedIps>>,
     pub mac_addr: String,
     pub net_id: String,
     pub port_id: String,

--- a/types/compute/src/v2/server/interface/response/list_270.rs
+++ b/types/compute/src/v2/server/interface/response/list_270.rs
@@ -38,7 +38,7 @@ pub struct FixedIps {
 /// `InterfaceAttachments` type
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct InterfaceAttachments {
-    pub fixed_ips: Vec<FixedIps>,
+    pub fixed_ips: Option<Vec<FixedIps>>,
     pub mac_addr: String,
     pub net_id: String,
     pub port_id: String,

--- a/types/compute/src/v2/server/response/get_2100_a.rs
+++ b/types/compute/src/v2/server/response/get_2100_a.rs
@@ -181,8 +181,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/get_263.rs
+++ b/types/compute/src/v2/server/response/get_263.rs
@@ -343,8 +343,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/get_269_a.rs
+++ b/types/compute/src/v2/server/response/get_269_a.rs
@@ -168,8 +168,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/get_271_a.rs
+++ b/types/compute/src/v2/server/response/get_271_a.rs
@@ -171,8 +171,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/get_273_a.rs
+++ b/types/compute/src/v2/server/response/get_273_a.rs
@@ -174,8 +174,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/get_290_a.rs
+++ b/types/compute/src/v2/server/response/get_290_a.rs
@@ -174,8 +174,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/get_296_a.rs
+++ b/types/compute/src/v2/server/response/get_296_a.rs
@@ -177,8 +177,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/get_298_a.rs
+++ b/types/compute/src/v2/server/response/get_298_a.rs
@@ -177,8 +177,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/list_detailed_2100_a.rs
+++ b/types/compute/src/v2/server/response/list_detailed_2100_a.rs
@@ -175,8 +175,8 @@ pub struct ServerResponse {
     #[structable(wide)]
     pub tenant_id: String,
 
-    #[structable(serialize, wide)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable(wide)]
     pub updated: String,

--- a/types/compute/src/v2/server/response/list_detailed_263.rs
+++ b/types/compute/src/v2/server/response/list_detailed_263.rs
@@ -337,8 +337,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize, wide)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/list_detailed_269_a.rs
+++ b/types/compute/src/v2/server/response/list_detailed_269_a.rs
@@ -165,8 +165,8 @@ pub struct ServerResponse {
     #[structable(wide)]
     pub tenant_id: String,
 
-    #[structable(serialize, wide)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable(wide)]
     pub updated: String,

--- a/types/compute/src/v2/server/response/list_detailed_273_a.rs
+++ b/types/compute/src/v2/server/response/list_detailed_273_a.rs
@@ -168,8 +168,8 @@ pub struct ServerResponse {
     #[structable(wide)]
     pub tenant_id: String,
 
-    #[structable(serialize, wide)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable(wide)]
     pub updated: String,

--- a/types/compute/src/v2/server/response/list_detailed_290_a.rs
+++ b/types/compute/src/v2/server/response/list_detailed_290_a.rs
@@ -168,8 +168,8 @@ pub struct ServerResponse {
     #[structable(wide)]
     pub tenant_id: String,
 
-    #[structable(serialize, wide)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable(wide)]
     pub updated: String,

--- a/types/compute/src/v2/server/response/list_detailed_296_a.rs
+++ b/types/compute/src/v2/server/response/list_detailed_296_a.rs
@@ -171,8 +171,8 @@ pub struct ServerResponse {
     #[structable(wide)]
     pub tenant_id: String,
 
-    #[structable(serialize, wide)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable(wide)]
     pub updated: String,

--- a/types/compute/src/v2/server/response/list_detailed_298_a.rs
+++ b/types/compute/src/v2/server/response/list_detailed_298_a.rs
@@ -171,8 +171,8 @@ pub struct ServerResponse {
     #[structable(wide)]
     pub tenant_id: String,
 
-    #[structable(serialize, wide)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize, wide)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable(wide)]
     pub updated: String,

--- a/types/compute/src/v2/server/response/rebuild_2100.rs
+++ b/types/compute/src/v2/server/response/rebuild_2100.rs
@@ -180,8 +180,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/rebuild_263.rs
+++ b/types/compute/src/v2/server/response/rebuild_263.rs
@@ -92,8 +92,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/rebuild_271.rs
+++ b/types/compute/src/v2/server/response/rebuild_271.rs
@@ -95,8 +95,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/rebuild_273.rs
+++ b/types/compute/src/v2/server/response/rebuild_273.rs
@@ -98,8 +98,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/rebuild_275.rs
+++ b/types/compute/src/v2/server/response/rebuild_275.rs
@@ -173,8 +173,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/rebuild_296.rs
+++ b/types/compute/src/v2/server/response/rebuild_296.rs
@@ -176,8 +176,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/rebuild_298.rs
+++ b/types/compute/src/v2/server/response/rebuild_298.rs
@@ -176,8 +176,8 @@ pub struct ServerResponse {
     #[structable()]
     pub tenant_id: String,
 
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     #[structable()]
     pub updated: String,

--- a/types/compute/src/v2/server/response/set_2100.rs
+++ b/types/compute/src/v2/server/response/set_2100.rs
@@ -400,8 +400,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/set_263.rs
+++ b/types/compute/src/v2/server/response/set_263.rs
@@ -157,8 +157,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/set_271.rs
+++ b/types/compute/src/v2/server/response/set_271.rs
@@ -164,8 +164,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/set_273.rs
+++ b/types/compute/src/v2/server/response/set_273.rs
@@ -170,8 +170,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/set_275.rs
+++ b/types/compute/src/v2/server/response/set_275.rs
@@ -383,8 +383,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/set_296.rs
+++ b/types/compute/src/v2/server/response/set_296.rs
@@ -396,8 +396,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)

--- a/types/compute/src/v2/server/response/set_298.rs
+++ b/types/compute/src/v2/server/response/set_298.rs
@@ -396,8 +396,8 @@ pub struct ServerResponse {
     /// certificate IDs are not set.
     ///
     /// **New in version 2.63**
-    #[structable(serialize)]
-    pub trusted_image_certificates: Vec<String>,
+    #[structable(optional, serialize)]
+    pub trusted_image_certificates: Option<Vec<String>>,
 
     /// The date and time when the resource was updated. The date and time
     /// stamp format is [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)


### PR DESCRIPTION
Fields declared as `required` with a type list that includes 'null'
(e.g. `type: [array, null]`) were rendered as plain types because the
field's is_nullable flag was not taken into account when computing the
Rust type hint.

The oneOf conversion already moved the Option wrapper into is_nullable
(and additionally unwrapped the Array for nullable arrays), but
StructFieldResponse.type_hint only wrapped based on is_optional.
Required nullable arrays therefore became `Vec<T>` and failed to
deserialize responses where the API legitimately returns null (e.g.
`trusted_image_certificates`, `hosts`, `fixed_ips`), silently degrading
CLI tables to the minimal fallback schema.

Emit `Option<T>` for nullable fields as well, and mark them as
structable `optional` so `None` values render as empty cells instead of
the string "null".

Changes are triggered by https://review.opendev.org/c/openstack/codegenerator/+/1003297

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
