### PR TITLE
fix: CLI error hints for wait combinator failures

### DIFF
--- a/cli/core/src/error.rs
+++ b/cli/core/src/error.rs
@@ -216,4 +216,26 @@ impl OpenStackCliError {
             data,
         }
     }
+
+    /// A short, user-facing hint for errors coming from the SDK's
+    /// `wait`/`wait_deleted`/`wait_for_status` combinators, distinguishing
+    /// timeout, failure, and vanished-resource cases instead of leaving
+    /// them as an opaque, generic API error.
+    pub fn wait_hint(&self) -> Option<&'static str> {
+        let Self::OpenStackApi { source } = self else {
+            return None;
+        };
+        match source {
+            openstack_sdk_core::api::ApiError::WaitTimeout { .. } => Some(
+                "the resource may still be transitioning; re-run the command later or check its current status directly",
+            ),
+            openstack_sdk_core::api::ApiError::WaitFailed { .. } => Some(
+                "the resource reported a failure state while waiting for it; inspect it directly for details",
+            ),
+            openstack_sdk_core::api::ApiError::WaitResourceVanished => Some(
+                "the resource disappeared while waiting for it to reach the desired state (it may have been deleted concurrently)",
+            ),
+            _ => None,
+        }
+    }
 }

--- a/openstack_cli/src/bin/osc.rs
+++ b/openstack_cli/src/bin/osc.rs
@@ -19,6 +19,7 @@
 
 use clap::CommandFactory;
 use clap_complete::CompleteEnv;
+use color_eyre::Help;
 use color_eyre::eyre::{Report, Result};
 use color_eyre::owo_colors::OwoColorize;
 use color_eyre::section::PanicMessage;
@@ -37,7 +38,14 @@ async fn main() -> Result<(), Report> {
             return Ok(());
         }
         Ok(false) | Err(_) => {
-            openstack_cli::entry_point().await?;
+            if let Err(e) = openstack_cli::entry_point().await {
+                let hint = e.wait_hint();
+                let report: Report = e.into();
+                return Err(match hint {
+                    Some(hint) => report.suggestion(hint),
+                    None => report,
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Adds OpenStackCliError::wait_hint (cli/core/src/error.rs), wired into
osc.rs so wait errors surface an actionable hint instead of ApiError's
generic transparent Display.