### PR TITLE
fix(cli): Avoid panic when config fails to load

### DIFF
--- a/openstack_cli/src/cli.rs
+++ b/openstack_cli/src/cli.rs
@@ -97,7 +97,7 @@ pub struct Cli {
     ///
     /// This does not accept parameters at the moment and will always get config from default
     /// location.
-    #[arg(hide = true, long("cli-config"), value_parser = parse_config, default_value_t = Config::new().expect("invalid config"))]
+    #[arg(hide = true, long("cli-config"), value_parser = parse_config, default_value_t = Config::new().unwrap_or_default())]
     pub config: Config,
 }
 


### PR DESCRIPTION
Config::new().expect(...) as a clap default_value_t ran on every CLI
invocation; an unreadable/malformed default config, or an unavailable
config dir, panicked before the actual command ran. Fall back to
Config::default() instead.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
