### PR TITLE
refactor(tui): Forward block_storage to gen ResourceBehaviour

### DIFF
--- a/openstack_tui/src/components/block_storage/backups.rs
+++ b/openstack_tui/src/components/block_storage/backups.rs
@@ -6,46 +6,37 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cloud_worker::block_storage::v3::{
-    BlockStorageApiRequest, BlockStorageBackupApiRequest, BlockStorageBackupList,
-};
-use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::{self as cloud_types, ApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
 
 /// Behaviour implementation for BlockStorageBackups.
 pub struct BlockStorageBackupsBehaviour;
 
 impl ResourceBehaviour for BlockStorageBackupsBehaviour {
-    type Filter = BlockStorageBackupList;
+    type Filter = cloud_types::BlockStorageBackupList;
 
     fn view_key() -> &'static str {
-        "block_storage.backup"
+        super::generated::backup::Generated::view_key()
     }
     fn title() -> &'static str {
-        "Backups"
+        super::generated::backup::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::backup::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(BlockStorageBackupApiRequest::ListDetailed(Box::new(
-            filter.clone(),
-        )))
+        super::generated::backup::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::BlockStorage(BlockStorageApiRequest::Backup(boxreq))
-            if matches!(**boxreq, BlockStorageBackupApiRequest::ListDetailed(_))
-        )
+        super::generated::backup::Generated::matches_request(request)
     }
 }
 
@@ -72,28 +63,26 @@ mod tests {
 
     #[test]
     fn request_from_filter_creates_request() {
-        let filter = BlockStorageBackupList::default();
+        let filter = cloud_types::BlockStorageBackupList::default();
         let request = BlockStorageBackupsBehaviour::request_from_filter(&filter);
         assert!(matches!(
             request,
-            ApiRequest::BlockStorage(BlockStorageApiRequest::Backup(boxreq))
-            if matches!(*boxreq, BlockStorageBackupApiRequest::ListDetailed(_))
+            ApiRequest::BlockStorage(cloud_types::BlockStorageApiRequest::Backup(boxreq))
+            if matches!(*boxreq, cloud_types::BlockStorageBackupApiRequest::ListDetailed(_))
         ));
     }
 
     #[test]
     fn matches_request_returns_true_for_matching() {
-        let filter = BlockStorageBackupList::default();
+        let filter = cloud_types::BlockStorageBackupList::default();
         let request = BlockStorageBackupsBehaviour::request_from_filter(&filter);
         assert!(BlockStorageBackupsBehaviour::matches_request(&request));
     }
 
     #[test]
     fn matches_request_returns_false_for_unrelated() {
-        let req = ApiRequest::BlockStorage(BlockStorageApiRequest::Volume(Box::new(
-            crate::cloud_worker::block_storage::v3::BlockStorageVolumeApiRequest::ListDetailed(
-                Box::default(),
-            ),
+        let req = ApiRequest::BlockStorage(cloud_types::BlockStorageApiRequest::Volume(Box::new(
+            cloud_types::BlockStorageVolumeApiRequest::ListDetailed(Box::default()),
         )));
         assert!(!BlockStorageBackupsBehaviour::matches_request(&req));
     }

--- a/openstack_tui/src/components/block_storage/snapshots.rs
+++ b/openstack_tui/src/components/block_storage/snapshots.rs
@@ -6,46 +6,37 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cloud_worker::block_storage::v3::{
-    BlockStorageApiRequest, BlockStorageSnapshotApiRequest, BlockStorageSnapshotList,
-};
-use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::{self as cloud_types, ApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
 
 /// Behaviour implementation for BlockStorageSnapshots.
 pub struct BlockStorageSnapshotsBehaviour;
 
 impl ResourceBehaviour for BlockStorageSnapshotsBehaviour {
-    type Filter = BlockStorageSnapshotList;
+    type Filter = cloud_types::BlockStorageSnapshotList;
 
     fn view_key() -> &'static str {
-        "block_storage.snapshot"
+        super::generated::snapshot::Generated::view_key()
     }
     fn title() -> &'static str {
-        "Snapshots"
+        super::generated::snapshot::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::snapshot::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(BlockStorageSnapshotApiRequest::ListDetailed(Box::new(
-            filter.clone(),
-        )))
+        super::generated::snapshot::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::BlockStorage(BlockStorageApiRequest::Snapshot(boxreq))
-            if matches!(**boxreq, BlockStorageSnapshotApiRequest::ListDetailed(_))
-        )
+        super::generated::snapshot::Generated::matches_request(request)
     }
 }
 
@@ -72,28 +63,26 @@ mod tests {
 
     #[test]
     fn request_from_filter_creates_request() {
-        let filter = BlockStorageSnapshotList::default();
+        let filter = cloud_types::BlockStorageSnapshotList::default();
         let request = BlockStorageSnapshotsBehaviour::request_from_filter(&filter);
         assert!(matches!(
             request,
-            ApiRequest::BlockStorage(BlockStorageApiRequest::Snapshot(boxreq))
-            if matches!(*boxreq, BlockStorageSnapshotApiRequest::ListDetailed(_))
+            ApiRequest::BlockStorage(cloud_types::BlockStorageApiRequest::Snapshot(boxreq))
+            if matches!(*boxreq, cloud_types::BlockStorageSnapshotApiRequest::ListDetailed(_))
         ));
     }
 
     #[test]
     fn matches_request_returns_true_for_matching() {
-        let filter = BlockStorageSnapshotList::default();
+        let filter = cloud_types::BlockStorageSnapshotList::default();
         let request = BlockStorageSnapshotsBehaviour::request_from_filter(&filter);
         assert!(BlockStorageSnapshotsBehaviour::matches_request(&request));
     }
 
     #[test]
     fn matches_request_returns_false_for_unrelated() {
-        let req = ApiRequest::BlockStorage(BlockStorageApiRequest::Volume(Box::new(
-            crate::cloud_worker::block_storage::v3::BlockStorageVolumeApiRequest::ListDetailed(
-                Box::default(),
-            ),
+        let req = ApiRequest::BlockStorage(cloud_types::BlockStorageApiRequest::Volume(Box::new(
+            cloud_types::BlockStorageVolumeApiRequest::ListDetailed(Box::default()),
         )));
         assert!(!BlockStorageSnapshotsBehaviour::matches_request(&req));
     }

--- a/openstack_tui/src/components/block_storage/volumes.rs
+++ b/openstack_tui/src/components/block_storage/volumes.rs
@@ -13,21 +13,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::action::Action;
-use crate::cloud_worker::block_storage::v3::{
-    BlockStorageApiRequest, BlockStorageVolumeApiRequest, BlockStorageVolumeDelete,
-    BlockStorageVolumeDeleteBuilder, BlockStorageVolumeList,
-};
-use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::{self as cloud_types, ApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
 
-const VIEW_CONFIG_KEY: &str = "block_storage.volume";
-
-impl TryFrom<&serde_json::Value> for BlockStorageVolumeDelete {
+impl TryFrom<&serde_json::Value> for cloud_types::BlockStorageVolumeDelete {
     type Error = crate::cloud_worker::block_storage::v3::BlockStorageVolumeDeleteBuilderError;
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
-        let mut builder = BlockStorageVolumeDeleteBuilder::default();
+        let mut builder =
+            crate::cloud_worker::block_storage::v3::BlockStorageVolumeDeleteBuilder::default();
         if let Some(val) = crate::components::view_render::get_str(value, "/id") {
             builder.id(val.to_string());
         }
@@ -41,28 +36,22 @@ impl TryFrom<&serde_json::Value> for BlockStorageVolumeDelete {
 pub struct BlockStorageVolumesBehaviour;
 
 impl ResourceBehaviour for BlockStorageVolumesBehaviour {
-    type Filter = BlockStorageVolumeList;
+    type Filter = cloud_types::BlockStorageVolumeList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::volume::Generated::view_key()
     }
     fn title() -> &'static str {
-        "Volumes"
+        super::generated::volume::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::volume::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(BlockStorageVolumeApiRequest::ListDetailed(Box::new(
-            filter.clone(),
-        )))
+        super::generated::volume::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::BlockStorage(BlockStorageApiRequest::Volume(boxreq))
-            if matches!(**boxreq, BlockStorageVolumeApiRequest::ListDetailed(_))
-        )
+        super::generated::volume::Generated::matches_request(request)
     }
     fn confirm_request(
         action: &Action,
@@ -74,10 +63,10 @@ impl ResourceBehaviour for BlockStorageVolumesBehaviour {
         } = action
             && *key == Self::view_key()
         {
-            let del = BlockStorageVolumeDelete::try_from(selected?).ok()?;
-            Some(ApiRequest::from(BlockStorageVolumeApiRequest::Delete(
-                Box::new(del),
-            )))
+            let del = cloud_types::BlockStorageVolumeDelete::try_from(selected?).ok()?;
+            Some(ApiRequest::from(
+                cloud_types::BlockStorageVolumeApiRequest::Delete(Box::new(del)),
+            ))
         } else {
             None
         }
@@ -133,29 +122,28 @@ mod tests {
 
     #[test]
     fn request_from_filter_creates_list_detailed() {
-        let filter = BlockStorageVolumeList::default();
+        let filter = cloud_types::BlockStorageVolumeList::default();
         let request = BlockStorageVolumesBehaviour::request_from_filter(&filter);
         assert!(matches!(
             request,
-            ApiRequest::BlockStorage(BlockStorageApiRequest::Volume(boxreq))
-            if matches!(*boxreq, BlockStorageVolumeApiRequest::ListDetailed(_))
+            ApiRequest::BlockStorage(cloud_types::BlockStorageApiRequest::Volume(boxreq))
+            if matches!(*boxreq, cloud_types::BlockStorageVolumeApiRequest::ListDetailed(_))
         ));
     }
 
     #[test]
     fn matches_request_returns_true_for_list_detailed() {
-        let filter = BlockStorageVolumeList::default();
+        let filter = cloud_types::BlockStorageVolumeList::default();
         let request = BlockStorageVolumesBehaviour::request_from_filter(&filter);
         assert!(BlockStorageVolumesBehaviour::matches_request(&request));
     }
 
     #[test]
     fn matches_request_returns_false_for_unrelated() {
-        let req = ApiRequest::BlockStorage(BlockStorageApiRequest::Snapshot(Box::new(
-            crate::cloud_worker::block_storage::v3::BlockStorageSnapshotApiRequest::ListDetailed(
-                Box::default(),
-            ),
-        )));
+        let req =
+            ApiRequest::BlockStorage(cloud_types::BlockStorageApiRequest::Snapshot(Box::new(
+                cloud_types::BlockStorageSnapshotApiRequest::ListDetailed(Box::default()),
+            )));
         assert!(!BlockStorageVolumesBehaviour::matches_request(&req));
     }
 
@@ -173,8 +161,8 @@ mod tests {
         let request = result.unwrap();
         assert!(matches!(
             request,
-            ApiRequest::BlockStorage(BlockStorageApiRequest::Volume(boxreq))
-            if matches!(*boxreq, BlockStorageVolumeApiRequest::Delete(_))
+            ApiRequest::BlockStorage(cloud_types::BlockStorageApiRequest::Volume(boxreq))
+            if matches!(*boxreq, cloud_types::BlockStorageVolumeApiRequest::Delete(_))
         ));
     }
 


### PR DESCRIPTION
PR #1975 added the generated mechanical tier for the block_storage
resources. Thin the hand-written `ResourceBehaviour` impls to one-line
forwarders onto `super::generated::<r>::Generated::<method>`, keeping
only custom logic:

- `volumes.rs`: `confirm_request` delete prompt plus its
  `TryFrom<&serde_json::Value>` for the delete request builder.
- `backups.rs` / `snapshots.rs`: pure forwarders; their `view_key()`
  now resolves through `crate::mode::BLOCK_STORAGE_*` via the companion
  instead of a bare string literal.

All three resources use the `list_detailed` operation, so the generated
tier resolves the `ListDetailed` request variant, matching the prior
hand code.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
