### PR TITLE
refactor(tui): Forward load_balancer to gen ResourceBehaviour

### DIFF
--- a/openstack_tui/src/components/load_balancer/health_monitors.rs
+++ b/openstack_tui/src/components/load_balancer/health_monitors.rs
@@ -13,48 +13,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::action::Action;
-use crate::cloud_worker::load_balancer::v2::{
-    LoadBalancerApiRequest, LoadBalancerHealthmonitorApiRequest, LoadBalancerHealthmonitorList,
-};
-use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::{self as cloud_types, ApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
-
-const VIEW_CONFIG_KEY: &str = "load-balancer.healthmonitor";
 
 pub struct LoadBalancerHealthMonitorsBehaviour;
 
 impl ResourceBehaviour for LoadBalancerHealthMonitorsBehaviour {
-    type Filter = LoadBalancerHealthmonitorList;
+    type Filter = cloud_types::LoadBalancerHealthmonitorList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::healthmonitor::Generated::view_key()
     }
     fn title() -> &'static str {
-        "LB HealthMonitors"
+        super::generated::healthmonitor::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::healthmonitor::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(LoadBalancerHealthmonitorApiRequest::List(Box::new(
-            filter.clone(),
-        )))
+        super::generated::healthmonitor::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Healthmonitor(boxreq))
-            if matches!(**boxreq, LoadBalancerHealthmonitorApiRequest::List(_))
-        )
+        super::generated::healthmonitor::Generated::matches_request(request)
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetLoadBalancerHealthMonitorListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
+        super::generated::healthmonitor::Generated::handle_set_filter_action(action)
     }
 }
 
@@ -74,7 +59,7 @@ mod tests {
         );
         assert_eq!(
             LoadBalancerHealthMonitorsBehaviour::title(),
-            "LB HealthMonitors"
+            "Health Monitors"
         );
         assert_eq!(
             LoadBalancerHealthMonitorsBehaviour::mode(),
@@ -84,18 +69,18 @@ mod tests {
 
     #[test]
     fn request_from_filter_creates_list_request() {
-        let filter = LoadBalancerHealthmonitorList::default();
+        let filter = cloud_types::LoadBalancerHealthmonitorList::default();
         let request = LoadBalancerHealthMonitorsBehaviour::request_from_filter(&filter);
         assert!(matches!(
             request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Healthmonitor(boxreq))
-            if matches!(*boxreq, LoadBalancerHealthmonitorApiRequest::List(_))
+            ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Healthmonitor(boxreq))
+            if matches!(*boxreq, cloud_types::LoadBalancerHealthmonitorApiRequest::List(_))
         ));
     }
 
     #[test]
     fn matches_request_returns_true_for_list() {
-        let filter = LoadBalancerHealthmonitorList::default();
+        let filter = cloud_types::LoadBalancerHealthmonitorList::default();
         let request = LoadBalancerHealthMonitorsBehaviour::request_from_filter(&filter);
         assert!(LoadBalancerHealthMonitorsBehaviour::matches_request(
             &request
@@ -104,17 +89,16 @@ mod tests {
 
     #[test]
     fn matches_request_returns_false_for_unrelated() {
-        let req = ApiRequest::LoadBalancer(LoadBalancerApiRequest::Listener(Box::new(
-            crate::cloud_worker::load_balancer::v2::LoadBalancerListenerApiRequest::List(
-                Box::default(),
-            ),
-        )));
+        let req =
+            ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Listener(Box::new(
+                cloud_types::LoadBalancerListenerApiRequest::List(Box::default()),
+            )));
         assert!(!LoadBalancerHealthMonitorsBehaviour::matches_request(&req));
     }
 
     #[test]
     fn handle_set_filter_action_returns_filter() {
-        let filter = LoadBalancerHealthmonitorList::default();
+        let filter = cloud_types::LoadBalancerHealthmonitorList::default();
         let action = Action::SetLoadBalancerHealthMonitorListFilters(filter);
         let result = LoadBalancerHealthMonitorsBehaviour::handle_set_filter_action(&action);
         assert!(result.is_some());

--- a/openstack_tui/src/components/load_balancer/listeners.rs
+++ b/openstack_tui/src/components/load_balancer/listeners.rs
@@ -13,48 +13,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::action::Action;
-use crate::cloud_worker::load_balancer::v2::{
-    LoadBalancerApiRequest, LoadBalancerListenerApiRequest, LoadBalancerListenerList,
-};
-use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::{self as cloud_types, ApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
-
-const VIEW_CONFIG_KEY: &str = "load-balancer.listener";
 
 pub struct LoadBalancerListenersBehaviour;
 
 impl ResourceBehaviour for LoadBalancerListenersBehaviour {
-    type Filter = LoadBalancerListenerList;
+    type Filter = cloud_types::LoadBalancerListenerList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::listener::Generated::view_key()
     }
     fn title() -> &'static str {
-        "LB Listeners"
+        super::generated::listener::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::listener::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(LoadBalancerListenerApiRequest::List(Box::new(
-            filter.clone(),
-        )))
+        super::generated::listener::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Listener(boxreq))
-            if matches!(**boxreq, LoadBalancerListenerApiRequest::List(_))
-        )
+        super::generated::listener::Generated::matches_request(request)
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetLoadBalancerListenerListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
+        super::generated::listener::Generated::handle_set_filter_action(action)
     }
 }
 
@@ -71,7 +56,7 @@ mod tests {
             LoadBalancerListenersBehaviour::view_key(),
             "load-balancer.listener"
         );
-        assert_eq!(LoadBalancerListenersBehaviour::title(), "LB Listeners");
+        assert_eq!(LoadBalancerListenersBehaviour::title(), "Listeners");
         assert_eq!(
             LoadBalancerListenersBehaviour::mode(),
             Mode::Resource(crate::mode::LB_LISTENER)
@@ -80,33 +65,33 @@ mod tests {
 
     #[test]
     fn request_from_filter_creates_list_request() {
-        let filter = LoadBalancerListenerList::default();
+        let filter = cloud_types::LoadBalancerListenerList::default();
         let request = LoadBalancerListenersBehaviour::request_from_filter(&filter);
         assert!(matches!(
             request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Listener(boxreq))
-            if matches!(*boxreq, LoadBalancerListenerApiRequest::List(_))
+            ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Listener(boxreq))
+            if matches!(*boxreq, cloud_types::LoadBalancerListenerApiRequest::List(_))
         ));
     }
 
     #[test]
     fn matches_request_returns_true_for_list() {
-        let filter = LoadBalancerListenerList::default();
+        let filter = cloud_types::LoadBalancerListenerList::default();
         let request = LoadBalancerListenersBehaviour::request_from_filter(&filter);
         assert!(LoadBalancerListenersBehaviour::matches_request(&request));
     }
 
     #[test]
     fn matches_request_returns_false_for_unrelated() {
-        let req = ApiRequest::LoadBalancer(LoadBalancerApiRequest::Pool(Box::new(
-            crate::cloud_worker::load_balancer::v2::LoadBalancerPoolApiRequest::List(Box::default()),
+        let req = ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Pool(Box::new(
+            cloud_types::LoadBalancerPoolApiRequest::List(Box::default()),
         )));
         assert!(!LoadBalancerListenersBehaviour::matches_request(&req));
     }
 
     #[test]
     fn handle_set_filter_action_returns_filter() {
-        let filter = LoadBalancerListenerList::default();
+        let filter = cloud_types::LoadBalancerListenerList::default();
         let action = Action::SetLoadBalancerListenerListFilters(filter);
         let result = LoadBalancerListenersBehaviour::handle_set_filter_action(&action);
         assert!(result.is_some());

--- a/openstack_tui/src/components/load_balancer/loadbalancers.rs
+++ b/openstack_tui/src/components/load_balancer/loadbalancers.rs
@@ -13,22 +13,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::action::Action;
-use crate::cloud_worker::load_balancer::v2::{
-    LoadBalancerApiRequest, LoadBalancerListenerList, LoadBalancerListenerListBuilder,
-    LoadBalancerLoadbalancerApiRequest, LoadBalancerLoadbalancerList, LoadBalancerPoolList,
-    LoadBalancerPoolListBuilder,
-};
-use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::{self as cloud_types, ApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
 
-const VIEW_CONFIG_KEY: &str = "load-balancer.loadbalancer";
-
-impl TryFrom<&serde_json::Value> for LoadBalancerListenerList {
+impl TryFrom<&serde_json::Value> for cloud_types::LoadBalancerListenerList {
     type Error = crate::cloud_worker::load_balancer::v2::LoadBalancerListenerListBuilderError;
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
-        let mut builder = LoadBalancerListenerListBuilder::default();
+        let mut builder =
+            crate::cloud_worker::load_balancer::v2::LoadBalancerListenerListBuilder::default();
         if let Some(val) = crate::components::view_render::get_str(value, "/id") {
             builder.load_balancer_id(val.to_string());
         }
@@ -39,10 +33,11 @@ impl TryFrom<&serde_json::Value> for LoadBalancerListenerList {
     }
 }
 
-impl TryFrom<&serde_json::Value> for LoadBalancerPoolList {
+impl TryFrom<&serde_json::Value> for cloud_types::LoadBalancerPoolList {
     type Error = crate::cloud_worker::load_balancer::v2::LoadBalancerPoolListBuilderError;
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
-        let mut builder = LoadBalancerPoolListBuilder::default();
+        let mut builder =
+            crate::cloud_worker::load_balancer::v2::LoadBalancerPoolListBuilder::default();
         if let Some(val) = crate::components::view_render::get_str(value, "/id") {
             builder.loadbalancer_id(val.to_string());
         }
@@ -56,35 +51,25 @@ impl TryFrom<&serde_json::Value> for LoadBalancerPoolList {
 pub struct LoadBalancersBehaviour;
 
 impl ResourceBehaviour for LoadBalancersBehaviour {
-    type Filter = LoadBalancerLoadbalancerList;
+    type Filter = cloud_types::LoadBalancerLoadbalancerList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::loadbalancer::Generated::view_key()
     }
     fn title() -> &'static str {
-        "LoadBalancers"
+        super::generated::loadbalancer::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::loadbalancer::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(LoadBalancerLoadbalancerApiRequest::List(Box::new(
-            filter.clone(),
-        )))
+        super::generated::loadbalancer::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Loadbalancer(boxreq))
-            if matches!(**boxreq, LoadBalancerLoadbalancerApiRequest::List(_))
-        )
+        super::generated::loadbalancer::Generated::matches_request(request)
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetLoadBalancerListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
+        super::generated::loadbalancer::Generated::handle_set_filter_action(action)
     }
     fn filter_carry_action(
         action: &Action,
@@ -94,7 +79,7 @@ impl ResourceBehaviour for LoadBalancersBehaviour {
         if let Action::ShowResource(key) = action
             && *key == crate::mode::LB_LISTENER
             && let Some(sel) = selected
-            && let Ok(list) = LoadBalancerListenerList::try_from(sel)
+            && let Ok(list) = cloud_types::LoadBalancerListenerList::try_from(sel)
         {
             return vec![
                 Action::Mode {
@@ -107,7 +92,7 @@ impl ResourceBehaviour for LoadBalancersBehaviour {
         if let Action::ShowResource(key) = action
             && *key == crate::mode::LB_POOL
             && let Some(sel) = selected
-            && let Ok(list) = LoadBalancerPoolList::try_from(sel)
+            && let Ok(list) = cloud_types::LoadBalancerPoolList::try_from(sel)
         {
             return vec![
                 Action::Mode {
@@ -155,7 +140,7 @@ mod tests {
             LoadBalancersBehaviour::view_key(),
             "load-balancer.loadbalancer"
         );
-        assert_eq!(LoadBalancersBehaviour::title(), "LoadBalancers");
+        assert_eq!(LoadBalancersBehaviour::title(), "Load Balancers");
         assert_eq!(
             LoadBalancersBehaviour::mode(),
             Mode::Resource(crate::mode::LB_LOADBALANCER)
@@ -164,35 +149,34 @@ mod tests {
 
     #[test]
     fn request_from_filter_creates_list_request() {
-        let filter = LoadBalancerLoadbalancerList::default();
+        let filter = cloud_types::LoadBalancerLoadbalancerList::default();
         let request = LoadBalancersBehaviour::request_from_filter(&filter);
         assert!(matches!(
             request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Loadbalancer(boxreq))
-            if matches!(*boxreq, LoadBalancerLoadbalancerApiRequest::List(_))
+            ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Loadbalancer(boxreq))
+            if matches!(*boxreq, cloud_types::LoadBalancerLoadbalancerApiRequest::List(_))
         ));
     }
 
     #[test]
     fn matches_request_returns_true_for_list() {
-        let filter = LoadBalancerLoadbalancerList::default();
+        let filter = cloud_types::LoadBalancerLoadbalancerList::default();
         let request = LoadBalancersBehaviour::request_from_filter(&filter);
         assert!(LoadBalancersBehaviour::matches_request(&request));
     }
 
     #[test]
     fn matches_request_returns_false_for_unrelated() {
-        let req = ApiRequest::LoadBalancer(LoadBalancerApiRequest::Listener(Box::new(
-            crate::cloud_worker::load_balancer::v2::LoadBalancerListenerApiRequest::List(
-                Box::default(),
-            ),
-        )));
+        let req =
+            ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Listener(Box::new(
+                cloud_types::LoadBalancerListenerApiRequest::List(Box::default()),
+            )));
         assert!(!LoadBalancersBehaviour::matches_request(&req));
     }
 
     #[test]
     fn handle_set_filter_action_returns_filter() {
-        let filter = LoadBalancerLoadbalancerList::default();
+        let filter = cloud_types::LoadBalancerLoadbalancerList::default();
         let action = Action::SetLoadBalancerListFilters(filter);
         let result = LoadBalancersBehaviour::handle_set_filter_action(&action);
         assert!(result.is_some());
@@ -210,7 +194,7 @@ mod tests {
         let actions = LoadBalancersBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_LISTENER),
             Some(&lb),
-            &LoadBalancerLoadbalancerList::default(),
+            &cloud_types::LoadBalancerLoadbalancerList::default(),
         );
         assert_eq!(actions.len(), 2);
         assert!(matches!(
@@ -232,7 +216,7 @@ mod tests {
         let actions = LoadBalancersBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_POOL),
             Some(&lb),
-            &LoadBalancerLoadbalancerList::default(),
+            &cloud_types::LoadBalancerLoadbalancerList::default(),
         );
         assert_eq!(actions.len(), 2);
         assert!(matches!(
@@ -253,7 +237,7 @@ mod tests {
         let actions = LoadBalancersBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_LISTENER),
             None,
-            &LoadBalancerLoadbalancerList::default(),
+            &cloud_types::LoadBalancerLoadbalancerList::default(),
         );
         assert!(actions.is_empty());
     }
@@ -264,7 +248,7 @@ mod tests {
         let actions = LoadBalancersBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_LOADBALANCER),
             Some(&lb),
-            &LoadBalancerLoadbalancerList::default(),
+            &cloud_types::LoadBalancerLoadbalancerList::default(),
         );
         assert!(actions.is_empty());
     }
@@ -275,7 +259,7 @@ mod tests {
         let actions = LoadBalancersBehaviour::filter_carry_action(
             &Action::Tick,
             Some(&lb),
-            &LoadBalancerLoadbalancerList::default(),
+            &cloud_types::LoadBalancerLoadbalancerList::default(),
         );
         assert!(actions.is_empty());
     }

--- a/openstack_tui/src/components/load_balancer/pools.rs
+++ b/openstack_tui/src/components/load_balancer/pools.rs
@@ -13,22 +13,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::action::Action;
-use crate::cloud_worker::load_balancer::v2::{
-    LoadBalancerApiRequest, LoadBalancerHealthmonitorList, LoadBalancerHealthmonitorListBuilder,
-    LoadBalancerPoolApiRequest, LoadBalancerPoolList, LoadBalancerPoolMemberList,
-    LoadBalancerPoolMemberListBuilder,
-};
-use crate::cloud_worker::types::ApiRequest;
+use crate::cloud_worker::types::{self as cloud_types, ApiRequest};
 use crate::components::generic_resource_view::GenericResourceView;
-use crate::components::resource_behaviour::ResourceBehaviour;
+use crate::components::resource_behaviour::{GeneratedResourceBehaviour, ResourceBehaviour};
 use crate::mode::Mode;
 
-const VIEW_CONFIG_KEY: &str = "load-balancer.pool";
-
-impl TryFrom<&serde_json::Value> for LoadBalancerPoolMemberList {
+impl TryFrom<&serde_json::Value> for cloud_types::LoadBalancerPoolMemberList {
     type Error = crate::cloud_worker::load_balancer::v2::LoadBalancerPoolMemberListBuilderError;
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
-        let mut builder = LoadBalancerPoolMemberListBuilder::default();
+        let mut builder =
+            crate::cloud_worker::load_balancer::v2::LoadBalancerPoolMemberListBuilder::default();
         if let Some(val) = crate::components::view_render::get_str(value, "/id") {
             builder.pool_id(val.to_string());
         }
@@ -39,10 +33,11 @@ impl TryFrom<&serde_json::Value> for LoadBalancerPoolMemberList {
     }
 }
 
-impl TryFrom<&serde_json::Value> for LoadBalancerHealthmonitorList {
+impl TryFrom<&serde_json::Value> for cloud_types::LoadBalancerHealthmonitorList {
     type Error = crate::cloud_worker::load_balancer::v2::LoadBalancerHealthmonitorListBuilderError;
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
-        let mut builder = LoadBalancerHealthmonitorListBuilder::default();
+        let mut builder =
+            crate::cloud_worker::load_balancer::v2::LoadBalancerHealthmonitorListBuilder::default();
         if let Some(val) = crate::components::view_render::get_str(value, "/id") {
             builder.pool_id(val.to_string());
         }
@@ -56,33 +51,25 @@ impl TryFrom<&serde_json::Value> for LoadBalancerHealthmonitorList {
 pub struct LoadBalancerPoolsBehaviour;
 
 impl ResourceBehaviour for LoadBalancerPoolsBehaviour {
-    type Filter = LoadBalancerPoolList;
+    type Filter = cloud_types::LoadBalancerPoolList;
 
     fn view_key() -> &'static str {
-        VIEW_CONFIG_KEY
+        super::generated::pool::Generated::view_key()
     }
     fn title() -> &'static str {
-        "LB Pools"
+        super::generated::pool::Generated::title()
     }
     fn mode() -> Mode {
-        Mode::Resource(Self::view_key())
+        super::generated::pool::Generated::mode()
     }
     fn request_from_filter(filter: &Self::Filter) -> ApiRequest {
-        ApiRequest::from(LoadBalancerPoolApiRequest::List(Box::new(filter.clone())))
+        super::generated::pool::Generated::request_from_filter(filter)
     }
     fn matches_request(request: &ApiRequest) -> bool {
-        matches!(
-            request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Pool(boxreq))
-            if matches!(**boxreq, LoadBalancerPoolApiRequest::List(_))
-        )
+        super::generated::pool::Generated::matches_request(request)
     }
     fn handle_set_filter_action(action: &Action) -> Option<Self::Filter> {
-        if let Action::SetLoadBalancerPoolListFilters(f) = action {
-            Some(f.clone())
-        } else {
-            None
-        }
+        super::generated::pool::Generated::handle_set_filter_action(action)
     }
     fn filter_carry_action(
         action: &Action,
@@ -92,7 +79,7 @@ impl ResourceBehaviour for LoadBalancerPoolsBehaviour {
         if let Action::ShowResource(key) = action
             && *key == crate::mode::LB_POOL_MEMBER
             && let Some(sel) = selected
-            && let Ok(list) = LoadBalancerPoolMemberList::try_from(sel)
+            && let Ok(list) = cloud_types::LoadBalancerPoolMemberList::try_from(sel)
         {
             return vec![
                 Action::Mode {
@@ -105,7 +92,7 @@ impl ResourceBehaviour for LoadBalancerPoolsBehaviour {
         if let Action::ShowResource(key) = action
             && *key == crate::mode::LB_HEALTHMONITOR
             && let Some(sel) = selected
-            && let Ok(list) = LoadBalancerHealthmonitorList::try_from(sel)
+            && let Ok(list) = cloud_types::LoadBalancerHealthmonitorList::try_from(sel)
         {
             return vec![
                 Action::Mode {
@@ -151,7 +138,7 @@ mod tests {
     #[test]
     fn view_key_and_title() {
         assert_eq!(LoadBalancerPoolsBehaviour::view_key(), "load-balancer.pool");
-        assert_eq!(LoadBalancerPoolsBehaviour::title(), "LB Pools");
+        assert_eq!(LoadBalancerPoolsBehaviour::title(), "Pools");
         assert_eq!(
             LoadBalancerPoolsBehaviour::mode(),
             Mode::Resource(crate::mode::LB_POOL)
@@ -160,35 +147,34 @@ mod tests {
 
     #[test]
     fn request_from_filter_creates_list_request() {
-        let filter = LoadBalancerPoolList::default();
+        let filter = cloud_types::LoadBalancerPoolList::default();
         let request = LoadBalancerPoolsBehaviour::request_from_filter(&filter);
         assert!(matches!(
             request,
-            ApiRequest::LoadBalancer(LoadBalancerApiRequest::Pool(boxreq))
-            if matches!(*boxreq, LoadBalancerPoolApiRequest::List(_))
+            ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Pool(boxreq))
+            if matches!(*boxreq, cloud_types::LoadBalancerPoolApiRequest::List(_))
         ));
     }
 
     #[test]
     fn matches_request_returns_true_for_list() {
-        let filter = LoadBalancerPoolList::default();
+        let filter = cloud_types::LoadBalancerPoolList::default();
         let request = LoadBalancerPoolsBehaviour::request_from_filter(&filter);
         assert!(LoadBalancerPoolsBehaviour::matches_request(&request));
     }
 
     #[test]
     fn matches_request_returns_false_for_unrelated() {
-        let req = ApiRequest::LoadBalancer(LoadBalancerApiRequest::Listener(Box::new(
-            crate::cloud_worker::load_balancer::v2::LoadBalancerListenerApiRequest::List(
-                Box::default(),
-            ),
-        )));
+        let req =
+            ApiRequest::LoadBalancer(cloud_types::LoadBalancerApiRequest::Listener(Box::new(
+                cloud_types::LoadBalancerListenerApiRequest::List(Box::default()),
+            )));
         assert!(!LoadBalancerPoolsBehaviour::matches_request(&req));
     }
 
     #[test]
     fn handle_set_filter_action_returns_filter() {
-        let filter = LoadBalancerPoolList::default();
+        let filter = cloud_types::LoadBalancerPoolList::default();
         let action = Action::SetLoadBalancerPoolListFilters(filter);
         let result = LoadBalancerPoolsBehaviour::handle_set_filter_action(&action);
         assert!(result.is_some());
@@ -206,7 +192,7 @@ mod tests {
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_POOL_MEMBER),
             Some(&pool),
-            &LoadBalancerPoolList::default(),
+            &cloud_types::LoadBalancerPoolList::default(),
         );
         assert_eq!(actions.len(), 2);
         assert!(matches!(
@@ -228,7 +214,7 @@ mod tests {
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_HEALTHMONITOR),
             Some(&pool),
-            &LoadBalancerPoolList::default(),
+            &cloud_types::LoadBalancerPoolList::default(),
         );
         assert_eq!(actions.len(), 2);
         assert!(matches!(
@@ -249,7 +235,7 @@ mod tests {
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_POOL_MEMBER),
             None,
-            &LoadBalancerPoolList::default(),
+            &cloud_types::LoadBalancerPoolList::default(),
         );
         assert!(actions.is_empty());
     }
@@ -260,7 +246,7 @@ mod tests {
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
             &Action::ShowResource(crate::mode::LB_POOL),
             Some(&pool),
-            &LoadBalancerPoolList::default(),
+            &cloud_types::LoadBalancerPoolList::default(),
         );
         assert!(actions.is_empty());
     }
@@ -271,7 +257,7 @@ mod tests {
         let actions = LoadBalancerPoolsBehaviour::filter_carry_action(
             &Action::Tick,
             Some(&pool),
-            &LoadBalancerPoolList::default(),
+            &cloud_types::LoadBalancerPoolList::default(),
         );
         assert!(actions.is_empty());
     }


### PR DESCRIPTION
PR #1975 added the generated mechanical tier for the load_balancer
resources but left the hand-written `ResourceBehaviour` impls writing the
six derivable methods inline. Thin each hand file to a one-line forwarder
onto `super::generated::<r>::Generated::<method>`, keeping only the
genuinely custom logic:

- `loadbalancers.rs`: dual `filter_carry_action` drilldown into listeners
  and pools, plus the two `TryFrom<&serde_json::Value>` filter builders.
- `pools.rs`: dual `filter_carry_action` drilldown into members and
  health monitors, plus its two `TryFrom` filter builders.
- `listeners.rs` / `health_monitors.rs`: pure forwarders.

`pool_members.rs` is a nested resource the generator does not emit and is
left untouched. Test title expectations move to the generator's
prefix-stripped form ("Load Balancers", "Pools").

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
