### PR TITLE
chore: Add libudev-dev to release job

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -38,8 +43,8 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
-          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }} # <-- GitHub App ID secret name
-          private-key: ${{ secrets.RELEASE_PLZ_PRIVATE_KEY }} # <-- GitHub App private key secret name
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_PRIVATE_KEY }}
           # pull-requests permission is not needed for the `release` command, so restricting it to contents only
           permission-contents: write
 


### PR DESCRIPTION
release-plz is missing the libudev-dev lib when releasing webauthn
crates.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
