### PR TITLE
test(sdk): Disable on-disk auth cache in mock tests

### DIFF
--- a/openstack_sdk/src/test.rs
+++ b/openstack_sdk/src/test.rs
@@ -116,6 +116,14 @@ mod tests {
                 }),
                 region_name: Some("RegionOne".into()),
                 interface: Some("public".into()),
+                // Never touch the on-disk auth/discovery cache (`~/.osc/<hash>`).
+                // httpmock reuses pooled server ports, so consecutive tests get
+                // the same `auth_url` and therefore the same cache hash; a token
+                // or discovery doc persisted by one test would then satisfy a
+                // later test and suppress the HTTP calls it asserts on. This is
+                // why the suite is flaky under `cargo test` but not `nextest`
+                // (one test per process, no predecessor to write the cache).
+                auth_cache: Some(false),
                 ..Default::default()
             }
         }
@@ -560,6 +568,10 @@ mod tests {
             }),
             region_name: Some("RegionOne".into()),
             interface: Some("public".into()),
+            // See `helpers::create_test_cloud_config`: a token/discovery doc
+            // cached on disk by an earlier test sharing this port would make
+            // `new()` succeed and defeat the assertion below.
+            auth_cache: Some(false),
             ..Default::default()
         };
 


### PR DESCRIPTION
The end-to-end tests in openstack_sdk/src/test.rs were flaky under
`cargo test` (often deterministically failing when run serially) while
passing under `cargo nextest`.

httpmock's process-global server pool reuses the same port for
consecutive tests, so each test's `auth_url` and therefore its
`~/.osc/<auth_hash>` cache key are identical. A token or discovery
document persisted by one test then satisfied a later test and
suppressed the HTTP calls it asserts on. nextest hid this by running one
test per process, leaving no predecessor to populate the cache.

Set `auth_cache: Some(false)` on the test CloudConfigs so the suite
never touches disk state.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
