### PR TITLE
fix(cli): Disable auto --version flag on plugin subcommands

### DIFF
--- a/cli/plugin/src/info.rs
+++ b/cli/plugin/src/info.rs
@@ -25,6 +25,7 @@ use structable::{StructTable, StructTableOptions};
 /// Show every installed version of a wasm auth plugin, read from the
 /// lockfile.
 #[derive(Debug, Parser)]
+#[command(disable_version_flag = true)]
 pub struct InfoCommand {
     /// Plugin name.
     pub name: String,

--- a/cli/plugin/src/install.rs
+++ b/cli/plugin/src/install.rs
@@ -43,6 +43,7 @@ use crate::confirm;
 /// installing over an already-installed `name@version` fails unless
 /// `--force` is given.
 #[derive(Debug, Parser)]
+#[command(disable_version_flag = true)]
 pub struct InstallCommand {
     /// Plugin to install: `<name>` (latest) or `<name>@<version>` (pinned),
     /// resolved against the registry index. Omit when using `--file`.

--- a/cli/plugin/src/remove.rs
+++ b/cli/plugin/src/remove.rs
@@ -29,6 +29,7 @@ use crate::list::PluginListEntry;
 /// other versions of `name` remain, the most recently installed of those
 /// becomes active.
 #[derive(Debug, Parser)]
+#[command(disable_version_flag = true)]
 pub struct RemoveCommand {
     /// Plugin name to remove.
     pub name: String,

--- a/cli/plugin/src/verify.rs
+++ b/cli/plugin/src/verify.rs
@@ -28,6 +28,7 @@ use structable::{StructTable, StructTableOptions};
 /// Fails on the first version whose on-disk content no longer matches, or
 /// whose file is missing.
 #[derive(Debug, Parser)]
+#[command(disable_version_flag = true)]
 pub struct VerifyCommand {
     /// Plugin name to verify.
     pub name: String,

--- a/openstack_cli/tests/main.rs
+++ b/openstack_cli/tests/main.rs
@@ -40,6 +40,7 @@ mod object_store;
 mod placement;
 
 use assert_cmd::prelude::*;
+use clap::CommandFactory;
 use std::process::Command;
 
 #[test]
@@ -50,4 +51,15 @@ fn help() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success();
 
     Ok(())
+}
+
+/// Walks the whole clap command tree and panics on structural errors —
+/// duplicate arg/group names (e.g. a subcommand field named `version`
+/// colliding with the auto-generated `--version` flag), conflicting
+/// short/long flags, etc. `clap::Command::build()` alone (via `--help`)
+/// does not exercise every subcommand, so a per-subcommand arg collision
+/// can slip past it; `debug_assert()` recurses into every subcommand.
+#[test]
+fn cli_tree_has_no_arg_collisions() {
+    openstack_cli::Cli::command().debug_assert();
 }


### PR DESCRIPTION
install/remove/info/verify each define a `version` argument, which
collides with clap's auto-generated `--version`/`-V` flag on every
derived Parser subcommand. Collision crashed at runtime whenever the
CLI built these commands (e.g. `osc completion`).

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>
