### PR TITLE
feat: Extend 'osc auth' commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,6 +3666,7 @@ version = "0.13.8"
 dependencies = [
  "chrono",
  "clap",
+ "dialoguer",
  "eyre",
  "openstack-cli-core",
  "openstack_sdk",

--- a/cli/auth/Cargo.toml
+++ b/cli/auth/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 [dependencies]
 chrono.workspace = true
 clap.workspace = true
+dialoguer.workspace = true
 eyre.workspace = true
 openstack-cli-core.workspace = true
 openstack_sdk = { workspace = true, features = ["async", "identity"] }

--- a/cli/auth/src/cache/clear.rs
+++ b/cli/auth/src/cache/clear.rs
@@ -1,0 +1,163 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Clear the on-disk auth cache
+use std::io::IsTerminal;
+
+use clap::Parser;
+use dialoguer::Confirm;
+use eyre::eyre;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use openstack_cli_core::output::{OutputFor, OutputProcessor};
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+use openstack_sdk_core::state::State;
+use structable::{StructTable, StructTableOptions};
+
+/// Clear the on-disk auth cache.
+///
+/// Without `--all`, only the cache file(s) for the *current* cloud are
+/// removed (never contacts the network). Equivalent to `osc auth logout
+/// --local`.
+///
+/// With `--all`, every cached credential under `~/.osc` is removed,
+/// regardless of cloud/profile, and no cloud connection is required at all.
+#[derive(Debug, Parser)]
+#[command(alias = "drop")]
+pub struct ClearCommand {
+    /// Clear cached credentials for every cloud/profile, not just the
+    /// current one. Destructive across profiles: prompts for confirmation
+    /// unless `--yes` is given.
+    #[arg(long, action=clap::ArgAction::SetTrue)]
+    pub all: bool,
+
+    /// Suppress the confirmation prompt for `--all`.
+    #[arg(short = 'y', long, action=clap::ArgAction::SetTrue)]
+    pub yes: bool,
+}
+
+/// Result of an `osc auth cache clear` invocation.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, StructTable)]
+pub struct CacheClearResult {
+    /// Cache files that were removed.
+    #[structable(serialize)]
+    pub removed: Vec<String>,
+
+    /// Entries under the cache directory that could not be removed.
+    #[structable(serialize)]
+    pub skipped: Vec<String>,
+}
+
+impl ClearCommand {
+    /// Perform command action for the single-cloud (non-`--all`) case.
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        // `--all` is handled entirely by `take_action_offline`, invoked by
+        // the entry point before any cloud is resolved; this path only ever
+        // runs for the current-cloud case.
+        info!("Clear current auth cache");
+
+        let op = OutputProcessor::from_args(parsed_args, Some("auth.cache"), Some("clear"));
+
+        let removed = client
+            .clear_auth_cache()
+            .into_iter()
+            .map(|p| p.display().to_string())
+            .collect();
+
+        let result = CacheClearResult {
+            removed,
+            skipped: Vec::new(),
+        };
+
+        output_result(&op, &result)?;
+        op.show_command_hint()?;
+        Ok(())
+    }
+
+    /// Client-free, cloud-independent path for `--all`. Called directly by
+    /// `openstack_cli`'s entry point before any cloud config is resolved.
+    pub fn take_action_offline<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+    ) -> Result<(), OpenStackCliError> {
+        let op = OutputProcessor::from_args(parsed_args, Some("auth.cache"), Some("clear"));
+
+        let base_dir = State::default_base_dir();
+        let (preview_removed, _preview_skipped) = {
+            // Peek at what's there without deleting yet, so the prompt can
+            // report a count.
+            let entries = std::fs::read_dir(&base_dir)
+                .map(|rd| rd.flatten().count())
+                .unwrap_or(0);
+            (entries, 0)
+        };
+
+        if !self.yes {
+            if std::io::stdin().is_terminal() {
+                let confirmed = Confirm::new()
+                    .with_prompt(format!(
+                        "This will delete {preview_removed} cached credential file(s) in {}, \
+                         affecting all clouds and profiles. Other open sessions will need to \
+                         authenticate again. Continue?",
+                        base_dir.display()
+                    ))
+                    .default(false)
+                    .interact()
+                    .map_err(|err| eyre!(err.to_string()))?;
+                if !confirmed {
+                    return Err(eyre!("aborted").into());
+                }
+            } else {
+                return Err(eyre!(
+                    "refusing to clear all cached credentials non-interactively without --yes"
+                )
+                .into());
+            }
+        }
+
+        let (removed, skipped) = State::clear_all_cache_files(&base_dir);
+        let result = CacheClearResult {
+            removed: removed
+                .into_iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+            skipped: skipped
+                .into_iter()
+                .map(|p| p.display().to_string())
+                .collect(),
+        };
+
+        output_result(&op, &result)?;
+        op.show_command_hint()?;
+        Ok(())
+    }
+}
+
+fn output_result(op: &OutputProcessor, result: &CacheClearResult) -> Result<(), OpenStackCliError> {
+    match op.target {
+        OutputFor::Human => {
+            op.output_human(result)?;
+        }
+        _ => {
+            op.output_machine(serde_json::to_value(result)?)?;
+        }
+    }
+    Ok(())
+}

--- a/cli/auth/src/cache/mod.rs
+++ b/cli/auth/src/cache/mod.rs
@@ -1,0 +1,72 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! On-disk auth cache management (`osc auth cache ...`)
+use clap::{Parser, Subcommand};
+
+use openstack_cli_core::{
+    cli::{CliArgs, ConnectionRequirements, ConnectionRequirementsProvider},
+    error::OpenStackCliError,
+};
+use openstack_sdk::AsyncOpenStack;
+
+pub mod clear;
+
+/// On-disk auth cache management
+#[derive(Debug, Parser)]
+pub struct CacheCommand {
+    /// Cache commands
+    #[command(subcommand)]
+    pub command: CacheCommands,
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Subcommand)]
+pub enum CacheCommands {
+    Clear(clear::ClearCommand),
+}
+
+impl ConnectionRequirementsProvider for CacheCommands {
+    fn connection_requirements(&self) -> ConnectionRequirements {
+        // Every `cache` operation is purely local (memory/disk) and never
+        // needs a live/valid session.
+        ConnectionRequirements {
+            needs_auth: false,
+            renew: false,
+        }
+    }
+}
+
+impl CacheCommand {
+    /// Returns `Some(&ClearCommand)` only when this is `cache clear --all`,
+    /// which needs to run before any cloud is resolved (it is
+    /// profile-independent). See `openstack_cli`'s entry point.
+    pub fn as_offline_cache_clear_all(&self) -> Option<&clear::ClearCommand> {
+        match &self.command {
+            CacheCommands::Clear(cmd) if cmd.all => Some(cmd),
+            CacheCommands::Clear(_) => None,
+        }
+    }
+
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        match &self.command {
+            CacheCommands::Clear(cmd) => cmd.take_action(parsed_args, client).await,
+        }
+    }
+}

--- a/cli/auth/src/lib.rs
+++ b/cli/auth/src/lib.rs
@@ -22,7 +22,9 @@ use openstack_cli_core::{
 };
 use openstack_sdk::AsyncOpenStack;
 
+pub mod cache;
 pub mod login;
+pub mod logout;
 pub mod show;
 pub mod status;
 
@@ -40,7 +42,9 @@ pub struct AuthCommand {
 #[allow(missing_docs)]
 #[derive(Subcommand)]
 pub enum AuthCommands {
+    Cache(cache::CacheCommand),
     Login(login::LoginCommand),
+    Logout(logout::LogoutCommand),
     Show(show::ShowCommand),
     Status(status::StatusCommand),
 }
@@ -58,12 +62,27 @@ impl ConnectionRequirementsProvider for AuthCommands {
                 needs_auth: false,
                 renew: false,
             },
+            AuthCommands::Logout(_) => ConnectionRequirements {
+                needs_auth: false,
+                renew: false,
+            },
+            AuthCommands::Cache(cache) => cache.command.connection_requirements(),
             _ => ConnectionRequirements::connected(),
         }
     }
 }
 
 impl AuthCommand {
+    /// Returns `Some(&ClearCommand)` only when this is `auth cache clear
+    /// --all`, which must run before any cloud is resolved. See
+    /// `openstack_cli`'s entry point.
+    pub fn as_offline_cache_clear_all(&self) -> Option<&cache::clear::ClearCommand> {
+        match &self.command {
+            AuthCommands::Cache(cache) => cache.as_offline_cache_clear_all(),
+            _ => None,
+        }
+    }
+
     /// Perform command action
     pub async fn take_action<C: CliArgs>(
         &self,
@@ -71,9 +90,69 @@ impl AuthCommand {
         client: &mut AsyncOpenStack,
     ) -> Result<(), OpenStackCliError> {
         match &self.command {
+            AuthCommands::Cache(cmd) => cmd.take_action(parsed_args, client).await,
             AuthCommands::Show(cmd) => cmd.take_action(parsed_args, client).await,
             AuthCommands::Login(cmd) => cmd.take_action(parsed_args, client).await,
+            AuthCommands::Logout(cmd) => cmd.take_action(parsed_args, client).await,
             AuthCommands::Status(cmd) => cmd.take_action(parsed_args, client).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> AuthCommand {
+        let mut full = vec!["auth"];
+        full.extend_from_slice(args);
+        AuthCommand::try_parse_from(full).expect("should parse")
+    }
+
+    #[test]
+    fn logout_parses() {
+        let cmd = parse(&["logout"]);
+        assert!(matches!(
+            cmd.command,
+            AuthCommands::Logout(logout::LogoutCommand { local: false })
+        ));
+        let req = cmd.command.connection_requirements();
+        assert!(!req.needs_auth);
+        assert!(!req.renew);
+    }
+
+    #[test]
+    fn logout_local_parses() {
+        let cmd = parse(&["logout", "--local"]);
+        assert!(matches!(
+            cmd.command,
+            AuthCommands::Logout(logout::LogoutCommand { local: true })
+        ));
+    }
+
+    #[test]
+    fn cache_clear_parses() {
+        let cmd = parse(&["cache", "clear"]);
+        let req = cmd.command.connection_requirements();
+        assert!(!req.needs_auth);
+        assert!(!req.renew);
+        assert!(cmd.as_offline_cache_clear_all().is_none());
+    }
+
+    #[test]
+    fn cache_clear_all_parses() {
+        let cmd = parse(&["cache", "clear", "--all"]);
+        assert!(cmd.as_offline_cache_clear_all().is_some());
+        let req = cmd.command.connection_requirements();
+        assert!(!req.needs_auth);
+        assert!(!req.renew);
+    }
+
+    #[test]
+    fn cache_clear_all_yes_parses() {
+        let cmd = parse(&["cache", "clear", "--all", "--yes"]);
+        let clear = cmd.as_offline_cache_clear_all().expect("is --all");
+        assert!(clear.all);
+        assert!(clear.yes);
     }
 }

--- a/cli/auth/src/logout.rs
+++ b/cli/auth/src/logout.rs
@@ -1,0 +1,95 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Revoke the current token and clear the local auth cache
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+use openstack_cli_core::output::{OutputFor, OutputProcessor};
+use openstack_cli_core::{cli::CliArgs, error::OpenStackCliError};
+use openstack_sdk::AsyncOpenStack;
+use structable::{StructTable, StructTableOptions};
+
+/// Revoke the current token at the cloud and clear the local auth cache.
+///
+/// This command never forces a fresh login: it operates on whatever token is
+/// already cached for the current cloud (never prompting for credentials).
+/// If nothing is cached, it is a harmless no-op.
+#[derive(Debug, Parser)]
+pub struct LogoutCommand {
+    /// Only clear the local auth cache; do not contact the cloud to revoke
+    /// the token. Useful when the cloud is unreachable or the token is
+    /// already known to be dead. Equivalent to `osc auth cache clear`.
+    #[arg(long, action=clap::ArgAction::SetTrue)]
+    pub local: bool,
+}
+
+/// Result of an `osc auth logout` invocation.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize, StructTable)]
+pub struct LogoutResult {
+    /// Whether a token was revoked at the cloud (`false` if `--local` was
+    /// used, or if there was nothing to revoke).
+    #[structable()]
+    pub revoked: bool,
+
+    /// Whether the local auth cache was cleared.
+    #[structable()]
+    pub cache_cleared: bool,
+
+    /// On-disk auth cache file that was cleared, if the cache was enabled.
+    #[structable(optional)]
+    pub cache_file: Option<String>,
+}
+
+impl LogoutCommand {
+    /// Perform command action
+    pub async fn take_action<C: CliArgs>(
+        &self,
+        parsed_args: &C,
+        client: &mut AsyncOpenStack,
+    ) -> Result<(), OpenStackCliError> {
+        info!("Logout");
+
+        let op = OutputProcessor::from_args(parsed_args, Some("auth"), Some("logout"));
+
+        let cache_file = client
+            .get_auth_cache_file()
+            .map(|p| p.display().to_string());
+
+        let revoked = if self.local {
+            client.clear_auth_cache();
+            false
+        } else {
+            client.revoke_current_token().await?
+        };
+
+        let result = LogoutResult {
+            revoked,
+            cache_cleared: true,
+            cache_file,
+        };
+
+        match op.target {
+            OutputFor::Human => {
+                op.output_human(&result)?;
+            }
+            _ => {
+                op.output_machine(serde_json::to_value(&result)?)?;
+            }
+        }
+        op.show_command_hint()?;
+        Ok(())
+    }
+}

--- a/cli/identity/src/v3/auth/token/delete.rs
+++ b/cli/identity/src/v3/auth/token/delete.rs
@@ -45,6 +45,10 @@ pub struct TokenCommand {
     #[command(flatten)]
     query: QueryParameters,
 
+    /// Request Headers parameters
+    #[command(flatten)]
+    headers: HeaderParameters,
+
     /// Path parameters
     #[command(flatten)]
     path: PathParameters,
@@ -53,6 +57,14 @@ pub struct TokenCommand {
 /// Query parameters
 #[derive(Args)]
 struct QueryParameters {}
+
+/// Header parameters
+#[derive(Args)]
+struct HeaderParameters {
+    /// The token to revoke, in the `X-Subject-Token` header.
+    #[arg()]
+    x_subject_token: String,
+}
 
 /// Path parameters
 #[derive(Args)]
@@ -71,7 +83,19 @@ impl TokenCommand {
             OutputProcessor::from_args(parsed_args, Some("identity.auth/token"), Some("delete"));
         op.validate_args(parsed_args)?;
 
-        let ep_builder = delete::Request::builder();
+        let mut ep_builder = delete::Request::builder();
+        // Set header parameters
+
+        // Stop-gap fix (upstream codegenerator bug): this generated file
+        // never sets `X-Subject-Token`, so the DELETE only authenticates as
+        // the caller and revokes nothing. Mirrors the fix in `get.rs`'s
+        // HeaderParameters handling; also lowercased since `HeaderName::
+        // from_static` panics on uppercase. Remove once the codegenerator
+        // template is fixed upstream.
+        ep_builder.header(
+            http::header::HeaderName::from_static("x-subject-token"),
+            http::header::HeaderValue::from_str(&self.headers.x_subject_token)?,
+        );
 
         let ep = ep_builder
             .build()

--- a/cli/identity/src/v3/auth/token/get.rs
+++ b/cli/identity/src/v3/auth/token/get.rs
@@ -91,8 +91,11 @@ impl TokenCommand {
 
         // Set header parameters
 
+        // Stop-gap fix (upstream codegenerator bug): `HeaderName::from_static`
+        // panics on an uppercase literal; header names must be lowercase.
+        // Remove once the codegenerator template is fixed upstream.
         ep_builder.header(
-            http::header::HeaderName::from_static("X-Subject-Token"),
+            http::header::HeaderName::from_static("x-subject-token"),
             http::header::HeaderValue::from_str(&self.headers.x_subject_token)?,
         );
 

--- a/cli/image/src/v2/image/file/upload.rs
+++ b/cli/image/src/v2/image/file/upload.rs
@@ -135,15 +135,19 @@ impl FileCommand {
         ep_builder.image_id(&self.path.image_id);
 
         // Set header parameters
+        //
+        // Stop-gap fix (upstream codegenerator bug): `HeaderName::from_static`
+        // panics on an uppercase literal; header names must be lowercase.
+        // Remove once the codegenerator template is fixed upstream.
         if let Some(val) = &self.headers.content_type {
             ep_builder.header(
-                http::header::HeaderName::from_static("Content-Type"),
+                http::header::HeaderName::from_static("content-type"),
                 http::header::HeaderValue::from_str(val)?,
             );
         }
         if let Some(val) = &self.headers.x_image_meta_store {
             ep_builder.header(
-                http::header::HeaderName::from_static("X-Image-Meta-Store"),
+                http::header::HeaderName::from_static("x-image-meta-store"),
                 http::header::HeaderValue::from_str(val)?,
             );
         }

--- a/openstack_cli/src/lib.rs
+++ b/openstack_cli/src/lib.rs
@@ -77,6 +77,15 @@ pub async fn entry_point() -> Result<(), OpenStackCliError> {
         return args.take_action(&cli).await;
     }
 
+    if let TopLevelCommands::Auth(args) = &cli.command
+        && let Some(cmd) = args.as_offline_cache_clear_all()
+    {
+        // `auth cache clear --all` is profile-independent and must run
+        // before any cloud is resolved (it may be run with no clouds
+        // configured at all).
+        return cmd.take_action_offline(&cli);
+    }
+
     // Initialize tracing layers
     // fmt for console logging
     let log_layer = tracing_subscriber::fmt::layer()

--- a/openstack_sdk/src/openstack.rs
+++ b/openstack_sdk/src/openstack.rs
@@ -316,6 +316,21 @@ impl OpenStack {
         self
     }
 
+    /// Delete all locally cached credentials for this connection (in-memory
+    /// and on-disk, including the discovery cache). Does not contact the
+    /// cloud.
+    pub fn clear_auth_cache(&self) -> Vec<std::path::PathBuf> {
+        self.inner.clear_auth_cache()
+    }
+
+    /// Revoke the connection's current token at Keystone and then purge the
+    /// local cache. Returns `Ok(false)` when there was no token to revoke.
+    #[cfg(feature = "identity")]
+    pub fn revoke_current_token(&self) -> OpenStackResult<bool> {
+        let rt = self.runtime_init();
+        rt.block_on(self.inner.revoke_current_token())
+    }
+
     /// Set the auth helper used for 401 re-authentication.
     pub fn set_auth_helper<A>(&mut self, auth_helper: A)
     where

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -28,7 +28,7 @@ use bytes::Bytes;
 use chrono::TimeDelta;
 use futures::io::{Error as IoError, ErrorKind as IoErrorKind};
 use futures::stream::TryStreamExt;
-use http::{HeaderMap, HeaderValue, Response as HttpResponse, StatusCode, header};
+use http::{HeaderMap, HeaderName, HeaderValue, Response as HttpResponse, StatusCode, header};
 use parking_lot::RwLock;
 use reqwest::{Certificate, Request, Response};
 use secrecy::{ExposeSecret, SecretString};
@@ -819,6 +819,66 @@ impl AsyncOpenStack {
     pub fn disable_auth_cache(&self) -> &Self {
         self.session.write().state.disable_auth_cache();
         self
+    }
+
+    /// Delete all locally cached credentials for this connection (in-memory
+    /// and on-disk, including the discovery cache). Does not contact the
+    /// cloud. Returns the on-disk paths that were actually removed.
+    pub fn clear_auth_cache(&self) -> Vec<std::path::PathBuf> {
+        self.session_write("clear_auth_cache").state.clear_cache_files()
+    }
+
+    /// Revoke the connection's current token at Keystone and then purge the
+    /// local cache, so the dead token can never be replayed.
+    ///
+    /// Returns `Ok(false)` when there was no token to revoke (nothing to do,
+    /// not an error). A `404`/`401` response from Keystone (token already
+    /// invalid) is treated as success. Any other error is propagated, but
+    /// the local cache is cleared regardless — a token we just tried to kill
+    /// must never be left cached as reusable.
+    ///
+    /// Builds the Keystone `DELETE /v3/auth/tokens` request directly here
+    /// (rather than via the generated `osc identity auth token delete`
+    /// command) with a correctly-lowercased `x-subject-token` header, so
+    /// this does not depend on that command's header handling.
+    #[cfg(feature = "identity")]
+    pub async fn revoke_current_token(&self) -> Result<bool, OpenStackError> {
+        use openstack_sdk_core::api::ApiError;
+
+        let Some(token) = self.get_auth_token() else {
+            return Ok(false);
+        };
+
+        let header_value = HeaderValue::from_str(token.expose_secret())
+            .map_err(|err| OpenStackError::from(ApiError::<RestError>::endpoint_builder(err)))?;
+        let ep = crate::api::identity::v3::auth::token::delete::Request::builder()
+            .header(HeaderName::from_static("x-subject-token"), header_value)
+            .build()
+            .map_err(|err| OpenStackError::from(ApiError::<RestError>::endpoint_builder(err)))?;
+
+        let revoke_result = api::ignore(ep).query_async(self).await;
+
+        let outcome = match revoke_result {
+            Ok(()) => Ok(true),
+            Err(ApiError::OpenStack { status, .. })
+            | Err(ApiError::OpenStackService { status, .. })
+            | Err(ApiError::OpenStackUnrecognized { status, .. })
+                if status == StatusCode::UNAUTHORIZED || status == StatusCode::NOT_FOUND =>
+            {
+                debug!("Token was already invalid at revoke time (status {status}); treating as revoked");
+                Ok(true)
+            }
+            Err(source) => Err(OpenStackError::from(source)),
+        };
+
+        // Always drop the local cache and the in-memory token, including on
+        // the hard-error path: a token we just tried to kill must never be
+        // reused, and a long-lived client should not keep reporting a dead
+        // token as authenticated.
+        self.clear_auth_cache();
+        let _ = self.set_auth(Auth::None, true);
+
+        outcome
     }
 
     /// Spawn a background task that proactively re-authenticates `margin`

--- a/openstack_sdk/src/openstack_async.rs
+++ b/openstack_sdk/src/openstack_async.rs
@@ -825,7 +825,9 @@ impl AsyncOpenStack {
     /// and on-disk, including the discovery cache). Does not contact the
     /// cloud. Returns the on-disk paths that were actually removed.
     pub fn clear_auth_cache(&self) -> Vec<std::path::PathBuf> {
-        self.session_write("clear_auth_cache").state.clear_cache_files()
+        self.session_write("clear_auth_cache")
+            .state
+            .clear_cache_files()
     }
 
     /// Revoke the connection's current token at Keystone and then purge the
@@ -865,7 +867,9 @@ impl AsyncOpenStack {
             | Err(ApiError::OpenStackUnrecognized { status, .. })
                 if status == StatusCode::UNAUTHORIZED || status == StatusCode::NOT_FOUND =>
             {
-                debug!("Token was already invalid at revoke time (status {status}); treating as revoked");
+                debug!(
+                    "Token was already invalid at revoke time (status {status}); treating as revoked"
+                );
                 Ok(true)
             }
             Err(source) => Err(OpenStackError::from(source)),

--- a/openstack_sdk/src/test.rs
+++ b/openstack_sdk/src/test.rs
@@ -708,18 +708,22 @@ mod tests {
         let server = MockServer::start_async().await;
 
         let revoke_mock = server.mock(|when, then| {
-            when.method(httpmock::Method::DELETE).path("/v3/auth/tokens");
+            when.method(httpmock::Method::DELETE)
+                .path("/v3/auth/tokens");
             then.status(StatusCode::NO_CONTENT);
         });
 
         let config = helpers::create_test_cloud_config(&server);
-        let client = AsyncOpenStack::new_cache_only(&config)
-            .expect("cache-only client creation failed");
+        let client =
+            AsyncOpenStack::new_cache_only(&config).expect("cache-only client creation failed");
         assert!(client.get_auth_token().is_none());
 
         let result = client.revoke_current_token().await;
         assert!(result.is_ok());
-        assert!(!result.unwrap(), "nothing to revoke should return Ok(false)");
+        assert!(
+            !result.unwrap(),
+            "nothing to revoke should return Ok(false)"
+        );
         assert_eq!(revoke_mock.calls_async().await, 0);
     }
 
@@ -733,7 +737,8 @@ mod tests {
         helpers::mock_identity_catalog(&server);
 
         server.mock(|when, then| {
-            when.method(httpmock::Method::DELETE).path("/v3/auth/tokens");
+            when.method(httpmock::Method::DELETE)
+                .path("/v3/auth/tokens");
             then.status(StatusCode::NOT_FOUND)
                 .body(r#"{"error": {"message": "Not Found"}, "message": "Not Found"}"#);
         });
@@ -764,7 +769,8 @@ mod tests {
         helpers::mock_identity_catalog(&server);
 
         server.mock(|when, then| {
-            when.method(httpmock::Method::DELETE).path("/v3/auth/tokens");
+            when.method(httpmock::Method::DELETE)
+                .path("/v3/auth/tokens");
             then.status(StatusCode::INTERNAL_SERVER_ERROR)
                 .body(r#"{"error": {"message": "boom"}, "message": "boom"}"#);
         });

--- a/openstack_sdk/src/test.rs
+++ b/openstack_sdk/src/test.rs
@@ -635,4 +635,154 @@ mod tests {
             .await;
         assert!(result.is_err(), "Unknown service type should fail");
     }
+
+    /// Happy path: `revoke_current_token()` issues `DELETE /v3/auth/tokens`
+    /// with a correctly-lowercased `x-subject-token` header carrying the
+    /// current token, and reports success. Regression test for the header
+    /// bug found in the generated `osc identity auth token delete` command
+    /// (which never sets `X-Subject-Token` at all).
+    #[cfg(all(feature = "sync", feature = "async", feature = "identity"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_revoke_current_token_async() {
+        let server = MockServer::start_async().await;
+
+        helpers::mock_identity_catalog(&server);
+
+        let revoke_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE)
+                .path("/v3/auth/tokens")
+                .header("x-subject-token", "test-token-from-catalog");
+            then.status(StatusCode::NO_CONTENT);
+        });
+
+        let config = helpers::create_test_cloud_config(&server);
+        let client = AsyncOpenStack::new_with_authentication_helper(
+            &config,
+            crate::auth::auth_helper::Noop::default(),
+            false,
+        )
+        .await
+        .expect("AsyncOpenStack client creation failed");
+
+        let result = client.revoke_current_token().await;
+        assert!(result.is_ok(), "revoke_current_token failed: {result:?}");
+        assert!(result.unwrap());
+        assert_eq!(revoke_mock.calls_async().await, 1);
+        assert!(
+            client.get_auth_token().is_none(),
+            "in-memory token must be cleared after revoke"
+        );
+    }
+
+    /// Sync-facade counterpart, matching the parity convention already
+    /// established for other auth methods (see `test_builder_disable_auth_cache_sync`).
+    #[cfg(all(feature = "sync", feature = "async", feature = "identity"))]
+    #[test]
+    fn test_revoke_current_token_sync() {
+        let server = MockServer::start();
+
+        helpers::mock_identity_catalog(&server);
+
+        let revoke_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE)
+                .path("/v3/auth/tokens")
+                .header("x-subject-token", "test-token-from-catalog");
+            then.status(StatusCode::NO_CONTENT);
+        });
+
+        let config = helpers::create_test_cloud_config(&server);
+        let client = OpenStack::new(&config).expect("OpenStack client creation failed");
+
+        let result = client.revoke_current_token();
+        assert!(result.is_ok(), "revoke_current_token failed: {result:?}");
+        assert!(result.unwrap());
+        revoke_mock.assert();
+        assert!(client.get_auth_token().is_none());
+    }
+
+    /// No cached token: `revoke_current_token()` is a no-op success and
+    /// never hits the network.
+    #[cfg(all(feature = "sync", feature = "async", feature = "identity"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_revoke_current_token_no_token() {
+        let server = MockServer::start_async().await;
+
+        let revoke_mock = server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE).path("/v3/auth/tokens");
+            then.status(StatusCode::NO_CONTENT);
+        });
+
+        let config = helpers::create_test_cloud_config(&server);
+        let client = AsyncOpenStack::new_cache_only(&config)
+            .expect("cache-only client creation failed");
+        assert!(client.get_auth_token().is_none());
+
+        let result = client.revoke_current_token().await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "nothing to revoke should return Ok(false)");
+        assert_eq!(revoke_mock.calls_async().await, 0);
+    }
+
+    /// Keystone `404` (token already invalid/unknown) is treated as a soft
+    /// success — the goal state ("this token is dead") already holds.
+    #[cfg(all(feature = "sync", feature = "async", feature = "identity"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_revoke_current_token_404_is_soft_success() {
+        let server = MockServer::start_async().await;
+
+        helpers::mock_identity_catalog(&server);
+
+        server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE).path("/v3/auth/tokens");
+            then.status(StatusCode::NOT_FOUND)
+                .body(r#"{"error": {"message": "Not Found"}, "message": "Not Found"}"#);
+        });
+
+        let config = helpers::create_test_cloud_config(&server);
+        let client = AsyncOpenStack::new_with_authentication_helper(
+            &config,
+            crate::auth::auth_helper::Noop::default(),
+            false,
+        )
+        .await
+        .expect("AsyncOpenStack client creation failed");
+
+        let result = client.revoke_current_token().await;
+        assert!(result.is_ok(), "404 must be a soft success: {result:?}");
+        assert!(result.unwrap());
+        assert!(client.get_auth_token().is_none());
+    }
+
+    /// A hard Keystone error (`500`) is propagated as an error, but the
+    /// local cache/in-memory token is still cleared — a token we just tried
+    /// to kill must never be left cached as reusable.
+    #[cfg(all(feature = "sync", feature = "async", feature = "identity"))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_revoke_current_token_500_is_error_but_clears_cache() {
+        let server = MockServer::start_async().await;
+
+        helpers::mock_identity_catalog(&server);
+
+        server.mock(|when, then| {
+            when.method(httpmock::Method::DELETE).path("/v3/auth/tokens");
+            then.status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(r#"{"error": {"message": "boom"}, "message": "boom"}"#);
+        });
+
+        let config = helpers::create_test_cloud_config(&server);
+        let client = AsyncOpenStack::new_with_authentication_helper(
+            &config,
+            crate::auth::auth_helper::Noop::default(),
+            false,
+        )
+        .await
+        .expect("AsyncOpenStack client creation failed");
+
+        let result = client.revoke_current_token().await;
+        assert!(result.is_err(), "500 must propagate as an error");
+        assert!(
+            client.get_auth_token().is_none(),
+            "cache must be cleared even when the revoke call itself failed"
+        );
+    }
 }

--- a/sdk/core/src/state.rs
+++ b/sdk/core/src/state.rs
@@ -42,7 +42,7 @@ use std::fs::{DirBuilder, File, OpenOptions};
 use std::io::prelude::*;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
@@ -165,15 +165,20 @@ pub struct State {
 }
 
 impl State {
+    /// Default cache base directory (`$HOME/.osc`), the same one [`State::new()`] uses.
+    pub fn default_base_dir() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_default()
+            //.expect("Cannot determine users XDG_HOME")
+            .join(".osc")
+    }
+
     pub fn new() -> Self {
         let state = Self {
             auth_hash: String::new(),
             auth_state: Default::default(),
             auth_cache_enabled: false,
-            base_dir: dirs::home_dir()
-                .unwrap_or_default()
-                //.expect("Cannot determine users XDG_HOME")
-                .join(".osc"),
+            base_dir: Self::default_base_dir(),
         };
         DirBuilder::new()
             .recursive(true)
@@ -317,6 +322,72 @@ impl State {
             let _ = std::fs::remove_file(self.get_auth_state_lock_filename(&self.auth_hash));
         }
         self.auth_state.0.clear();
+    }
+
+    /// Removes every on-disk cache file belonging to the current auth hash
+    /// (auth state, discovery state, and their lock files) and drops the
+    /// in-memory token map.
+    ///
+    /// Unlike [`State::clear_all_auth`] (used on the 401-retry/renew hot
+    /// paths, which must not discard the discovery cache), this is meant for
+    /// a user-triggered full logout/cache-clear and also removes the
+    /// discovery cache. Returns the paths that were actually removed.
+    pub fn clear_cache_files(&mut self) -> Vec<PathBuf> {
+        trace!("Clearing all cache files for current auth hash");
+        let mut removed = Vec::new();
+        if self.auth_cache_enabled {
+            let fname = self.get_auth_state_filename(&self.auth_hash);
+            if std::fs::remove_file(&fname).is_ok() {
+                removed.push(fname);
+            }
+            let lock_fname = self.get_auth_state_lock_filename(&self.auth_hash);
+            if std::fs::remove_file(&lock_fname).is_ok() {
+                removed.push(lock_fname);
+            }
+            let discovery_fname = self.get_discovery_state_filename();
+            if std::fs::remove_file(&discovery_fname).is_ok() {
+                removed.push(discovery_fname);
+            }
+            let discovery_lock_fname = self.get_discovery_state_lock_filename();
+            if std::fs::remove_file(&discovery_lock_fname).is_ok() {
+                removed.push(discovery_lock_fname);
+            }
+        }
+        self.auth_state.0.clear();
+        removed
+    }
+
+    /// Removes every cache file under `base_dir` (auth state, discovery
+    /// state, and lock files for *all* auth hashes/profiles), regardless of
+    /// age. Unlike [`State::gc_stale_cache_files`] this is unconditional and
+    /// user-triggered, not an age-based background sweep.
+    ///
+    /// Best-effort and conservative: only regular files directly inside
+    /// `base_dir` are considered for removal; subdirectories and anything
+    /// that fails to be removed are left alone and reported as skipped.
+    /// Returns `(removed_paths, skipped_paths)`.
+    pub fn clear_all_cache_files(base_dir: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {
+        let mut removed = Vec::new();
+        let mut skipped = Vec::new();
+        let Ok(entries) = std::fs::read_dir(base_dir) else {
+            return (removed, skipped);
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(metadata) = entry.metadata() else {
+                skipped.push(path);
+                continue;
+            };
+            if !metadata.is_file() {
+                continue;
+            }
+            if std::fs::remove_file(&path).is_ok() {
+                removed.push(path);
+            } else {
+                skipped.push(path);
+            }
+        }
+        (removed, skipped)
     }
 
     /// Returns the discovery document body previously cached for
@@ -1254,5 +1325,134 @@ mod tests {
         let cached = s2.get_discovery_cache("identity", None, None);
         assert!(cached.is_some());
         assert_eq!(cached.unwrap().1, vec![7, 7]);
+    }
+
+    #[test]
+    fn test_clear_cache_files_removes_auth_and_discovery() {
+        let dir = make_state_dir();
+        let mut s = new_state_in(&dir, 200);
+        let scope = make_project_scope("p200");
+        let token = make_token("tok200");
+        s.set_scope_auth(&scope, &token);
+        s.set_discovery_cache("compute", None, None, "http://example.com/", vec![1]);
+
+        let auth_fname = s.get_auth_state_filename(&s.auth_hash);
+        let auth_lock_fname = s.get_auth_state_lock_filename(&s.auth_hash);
+        let discovery_fname = s.get_discovery_state_filename();
+        let discovery_lock_fname = s.get_discovery_state_lock_filename();
+        assert!(auth_fname.exists());
+        assert!(discovery_fname.exists());
+
+        let removed = s.clear_cache_files();
+        assert!(!auth_fname.exists());
+        assert!(!auth_lock_fname.exists());
+        assert!(!discovery_fname.exists());
+        assert!(!discovery_lock_fname.exists());
+        assert!(removed.contains(&auth_fname));
+        assert!(removed.contains(&discovery_fname));
+        assert!(s.get_scope_auth(&scope).is_none());
+    }
+
+    #[test]
+    fn test_clear_cache_files_noop_when_cache_disabled() {
+        let dir = make_state_dir();
+        let mut s = new_state_in(&dir, 201);
+        s.disable_auth_cache();
+        let removed = s.clear_cache_files();
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn test_clear_cache_files_missing_files_is_ok() {
+        let dir = make_state_dir();
+        let mut s = new_state_in(&dir, 202);
+        let removed = s.clear_cache_files();
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn test_clear_all_auth_keeps_discovery_cache() {
+        let dir = make_state_dir();
+        let mut s = new_state_in(&dir, 203);
+        let scope = make_project_scope("p203");
+        let token = make_token("tok203");
+        s.set_scope_auth(&scope, &token);
+        s.set_discovery_cache("compute", None, None, "http://example.com/", vec![1]);
+        let discovery_fname = s.get_discovery_state_filename();
+        assert!(discovery_fname.exists());
+
+        s.clear_all_auth();
+        assert!(discovery_fname.exists());
+    }
+
+    #[test]
+    fn test_clear_all_cache_files_removes_every_hash() {
+        let dir = make_state_dir();
+        for hash in [300u64, 301, 302] {
+            let mut s = new_state_in(&dir, hash);
+            let scope = make_project_scope(&format!("p{hash}"));
+            let token = make_token(&format!("tok{hash}"));
+            s.set_scope_auth(&scope, &token);
+            s.set_discovery_cache("compute", None, None, "http://example.com/", vec![1]);
+        }
+
+        let entries_before: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+        assert!(!entries_before.is_empty());
+
+        let (removed, skipped) = State::clear_all_cache_files(&dir);
+        assert!(skipped.is_empty());
+        assert!(removed.len() >= 3 * 4); // auth + lock + discovery + discovery.lock per hash
+
+        let entries_after: Vec<_> = std::fs::read_dir(&dir).unwrap().collect();
+        assert!(entries_after.is_empty());
+    }
+
+    #[test]
+    fn test_clear_all_cache_files_skips_subdirectories() {
+        let dir = make_state_dir();
+        let mut s = new_state_in(&dir, 310);
+        let scope = make_project_scope("p310");
+        let token = make_token("tok310");
+        s.set_scope_auth(&scope, &token);
+
+        let subdir = dir.join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        std::fs::write(subdir.join("file"), b"keep me").unwrap();
+
+        let (removed, _skipped) = State::clear_all_cache_files(&dir);
+        assert!(!removed.is_empty());
+        assert!(subdir.exists());
+        assert!(subdir.join("file").exists());
+    }
+
+    #[test]
+    fn test_clear_all_cache_files_missing_dir() {
+        let dir = make_state_dir().join("does-not-exist");
+        let (removed, skipped) = State::clear_all_cache_files(&dir);
+        assert!(removed.is_empty());
+        assert!(skipped.is_empty());
+    }
+
+    #[test]
+    fn test_clear_all_cache_files_ignores_age() {
+        let dir = make_state_dir();
+        let mut s = new_state_in(&dir, 320);
+        let scope = make_project_scope("p320");
+        let token = make_token("tok320");
+        s.set_scope_auth(&scope, &token);
+        let fname = s.get_auth_state_filename(&s.auth_hash);
+        // File was just written (age ~0s, well under MAX_CACHE_FILE_AGE) -
+        // gc_stale_cache_files() would keep it, clear_all_cache_files() must not.
+        assert!(fname.exists());
+
+        let (removed, _skipped) = State::clear_all_cache_files(&dir);
+        assert!(removed.contains(&fname));
+        assert!(!fname.exists());
+    }
+
+    #[test]
+    fn test_default_base_dir_ends_with_osc() {
+        let base = State::default_base_dir();
+        assert_eq!(base.file_name().unwrap(), ".osc");
     }
 }


### PR DESCRIPTION
- **feat(sdk-core): Add State clear cache methods**
- **feat(sdk): Wire cache clean methods to session**
- **feat(cli): Add osc auth logout and cache clear commands**
